### PR TITLE
Fix double extensions when user specifies one during asset creation

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -318,7 +318,7 @@ namespace FlaxEditor.Windows
 
             // Cache data
             var extension = Path.GetExtension(item.Path);
-            var newPath = StringUtils.CombinePaths(item.ParentFolder.Path, newShortName + extension);
+            var newPath = StringUtils.CombinePaths(item.ParentFolder.Path, Path.ChangeExtension(newShortName, extension));
 
             // Check if was renaming mock element
             // Note: we create `_newElement` and then rename it to create new asset


### PR DESCRIPTION
When creating C# asset and manually specifiying extension (`TestScript.cs`) resulting file would be `.cs.cs` this PR should avoid any duplicate extensions.

Although side consequences of this might be some wrongful extension replacement. So we might want to replace (or not append) the extension if file already contains specific extension. Although currently selected method was cleanest and shortest solution.