### PR TITLE
Fix wrong engine path with RegisterEng. as Admin.

### DIFF
--- a/RegisterEngineLocation.bat
+++ b/RegisterEngineLocation.bat
@@ -20,7 +20,7 @@ goto Done
 
 rem Register the location (append to the end)
 :notfound
-echo Location '%EngineLocation%' is not registered. Adding it to the lsit of engine versions.
+echo Location '%EngineLocation%' is not registered. Adding it to the list of engine versions.
 echo %EngineLocation%>>"%appdata%\Flax\Versions.txt"
 goto Done
 

--- a/RegisterEngineLocation.bat
+++ b/RegisterEngineLocation.bat
@@ -3,7 +3,7 @@
 rem Copyright (c) 2012-2020 Wojciech Figat. All rights reserved.
 
 setlocal
-pushd
+pushd %~dp0
 echo Registering Flax Engine project files...
 
 rem Check the current versions config


### PR DESCRIPTION
Fix RegisterEngineLocation registering wrong path when launched as administrator.

![](https://cdn.discordapp.com/attachments/538664104856911883/790624501658419240/unknown.png)