### PR TITLE
Add Icon size settings in styles

### DIFF
--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -65,9 +65,9 @@ namespace FlaxEditor.GUI
         /// Gets the height for the items.
         /// </summary>
         public float ItemsHeight => Height + itemScale * DefaultMarginV;
-
         private float itemScale;
-        /// <summarys
+        
+        /// <summary>
         /// Initializes a new instance of the <see cref="ToolStrip"/> class.
         /// </summary>
         public ToolStrip()

--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -64,15 +64,15 @@ namespace FlaxEditor.GUI
         /// <summary>
         /// Gets the height for the items.
         /// </summary>
-        public float ItemsHeight => Height - itemScale * DefaultMarginV;
+        public float ItemsHeight => Height + itemScale * DefaultMarginV;
 
-        private float itemScale = 2;
-        /// <summary>
+        private float itemScale;
+        /// <summarys
         /// Initializes a new instance of the <see cref="ToolStrip"/> class.
         /// </summary>
         public ToolStrip()
         {
-            itemScale = Editor.Instance.Options.Options.Interface.ToolStripScale;
+            itemScale = Style.Current.IconSizeExtra;
             AutoFocus = false;
             AnchorPreset = AnchorPresets.HorizontalStretchTop;
             BackgroundColor = Style.Current.LightBackground;

--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2020 Wojciech Figat. All rights reserved.
 
 using System;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -20,7 +21,7 @@ namespace FlaxEditor.GUI
         /// <summary>
         /// The default margin horizontally.
         /// </summary>
-        public const int DefaultMarginH = 2;
+        public const int DefaultMarginH = 4;
 
         /// <summary>
         /// Event fired when button gets clicked.
@@ -63,13 +64,15 @@ namespace FlaxEditor.GUI
         /// <summary>
         /// Gets the height for the items.
         /// </summary>
-        public float ItemsHeight => Height - 2 * DefaultMarginV;
+        public float ItemsHeight => Height - itemScale * DefaultMarginV;
 
+        private float itemScale = 2;
         /// <summary>
         /// Initializes a new instance of the <see cref="ToolStrip"/> class.
         /// </summary>
         public ToolStrip()
         {
+            itemScale = Editor.Instance.Options.Options.Interface.ToolStripScale;
             AutoFocus = false;
             AnchorPreset = AnchorPresets.HorizontalStretchTop;
             BackgroundColor = Style.Current.LightBackground;

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -45,6 +45,20 @@ namespace FlaxEditor.Options
         public float InterfaceScale { get; set; } = 1.0f;
 
         /// <summary>
+        /// Gets or sets the ToolStrip item scale. Applied to ToolStrip UI elements, windows and text. Can be used to scale the toolstrip size to fit display needs. Editor restart required..
+        /// </summary>
+        [DefaultValue(2.0f), Limit(1f, 10.0f)]
+        [EditorDisplay("Interface"), EditorOrder(20), Tooltip("Editor ToolStrip scale. Applied to ToolStrip UI elements, windows and text. Can be used to scale the toolstrip size to fit display needs. Editor restart required.")]
+        public float ToolStripScale { get; set; } = 2.0f;
+
+        /// <summary>
+        /// Gets or sets the ToolBox Icon scale. Editor ToolBox Icon scale. Applied to ToolBox Icon UI elements. Can be used to scale the toolbox icon size to fit display needs. Editor restart required.
+        /// </summary>
+        [DefaultValue(32.0f), Limit(1f, 64.0f)]
+        [EditorDisplay("Interface"), EditorOrder(30), Tooltip("Editor ToolBox Icon scale. Applied to ToolBox Icon UI elements. Can be used to scale the toolbox icon size to fit display needs. Editor restart required.")]
+        public float ToolBoxIconScale { get; set; } = 32.0f;
+
+        /// <summary>
         /// Gets or sets a value indicating whether use native window title bar. Editor restart required.
         /// </summary>
         [DefaultValue(false)]

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -45,20 +45,6 @@ namespace FlaxEditor.Options
         public float InterfaceScale { get; set; } = 1.0f;
 
         /// <summary>
-        /// Gets or sets the ToolStrip item scale. Applied to ToolStrip UI elements, windows and text. Can be used to scale the toolstrip size to fit display needs. Editor restart required..
-        /// </summary>
-        [DefaultValue(2.0f), Limit(1f, 10.0f)]
-        [EditorDisplay("Interface"), EditorOrder(20), Tooltip("Editor ToolStrip scale. Applied to ToolStrip UI elements, windows and text. Can be used to scale the toolstrip size to fit display needs. Editor restart required.")]
-        public float ToolStripScale { get; set; } = 2.0f;
-
-        /// <summary>
-        /// Gets or sets the ToolBox Icon scale. Editor ToolBox Icon scale. Applied to ToolBox Icon UI elements. Can be used to scale the toolbox icon size to fit display needs. Editor restart required.
-        /// </summary>
-        [DefaultValue(32.0f), Limit(1f, 64.0f)]
-        [EditorDisplay("Interface"), EditorOrder(30), Tooltip("Editor ToolBox Icon scale. Applied to ToolBox Icon UI elements. Can be used to scale the toolbox icon size to fit display needs. Editor restart required.")]
-        public float ToolBoxIconScale { get; set; } = 32.0f;
-
-        /// <summary>
         /// Gets or sets a value indicating whether use native window title bar. Editor restart required.
         /// </summary>
         [DefaultValue(false)]

--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -308,7 +308,7 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override void OnInit()
         {
-           float tabSize = Editor.Instance.Options.Options.Interface.ToolBoxIconScale;
+            float tabSize = Editor.Options.Options.Interface.ToolBoxIconScale;
             TabsControl = new Tabs
             {
                 AnchorPreset = AnchorPresets.StretchAll,

--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -308,11 +308,12 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override void OnInit()
         {
+           float tabSize = Editor.Instance.Options.Options.Interface.ToolBoxIconScale;
             TabsControl = new Tabs
             {
                 AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = Margin.Zero,
-                TabsSize = new Vector2(48, 48),
+                TabsSize = new Vector2(tabSize, tabSize),
                 Parent = this
             };
 

--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -308,7 +308,7 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override void OnInit()
         {
-            float tabSize = Editor.Options.Options.Interface.ToolBoxIconScale;
+            float tabSize = 48 + Style.Current.IconSizeExtra;
             TabsControl = new Tabs
             {
                 AnchorPreset = AnchorPresets.StretchAll,

--- a/Source/Engine/UI/GUI/Style.cs
+++ b/Source/Engine/UI/GUI/Style.cs
@@ -69,6 +69,12 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
+        /// Size of toolbar icons
+        /// </summary>
+        [EditorOrder(50)]
+        public int IconSizeExtra;
+
+        /// <summary>
         /// The background color.
         /// </summary>
         [EditorOrder(60)]


### PR DESCRIPTION
Add options to editor settings window to control scaling of toolstrip and toolbox icons (tab, buttons) in styles

![image](https://user-images.githubusercontent.com/21057342/103079732-8c374280-4628-11eb-91b7-8b6782248be9.png)
