### PR TITLE
Fix typo and use GetID for the log

### DIFF
--- a/Source/Engine/Scripting/ScriptingObject.cpp
+++ b/Source/Engine/Scripting/ScriptingObject.cpp
@@ -131,7 +131,7 @@ MonoObject* ScriptingObject::CreateManagedInternal()
     MClass* monoClass = GetClass();
     if (monoClass == nullptr)
     {
-        LOG(Warning, "Missing managed class for objecct '{0}'.", ToString());
+        LOG(Warning, "Missing managed class for object with id {0}", GetID());
         return nullptr;
     }
 


### PR DESCRIPTION
As described in #26, ScriptingObject::ToString() will use GetClass()->ToString() but at the time the method is being used GetClass() will return a nullptr. To fix this issue temporarily use the ScriptingObject id for the log.