### PR TITLE
Fix build scenes toolstrip button enabled state

### DIFF
--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -161,7 +161,7 @@ namespace FlaxEditor.Modules
             var undoRedo = Editor.Undo;
             var gizmo = Editor.MainTransformGizmo;
             var state = Editor.StateMachine.CurrentState;
-            var canEditScene = state.CanEditScene;
+            var canEditScene = state.CanEditScene && Level.IsAnySceneLoaded;
             var canUseUndoRedo = state.CanUseUndoRedo;
             var canEnterPlayMode = state.CanEnterPlayMode && Level.IsAnySceneLoaded;
             var isPlayMode = Editor.StateMachine.IsPlayMode;
@@ -179,7 +179,7 @@ namespace FlaxEditor.Modules
             _toolStripRotate.Checked = gizmoMode == TransformGizmoBase.Mode.Rotate;
             _toolStripScale.Checked = gizmoMode == TransformGizmoBase.Mode.Scale;
             //
-            _toolStripBuildScenes.Enabled = canEditScene && !isPlayMode;
+            _toolStripBuildScenes.Enabled = (canEditScene && !isPlayMode) || Editor.StateMachine.BuildingScenesState.IsActive;
             //
             var play = _toolStripPlay;
             var pause = _toolStripPause;


### PR DESCRIPTION
**Bug description:** The toolstrip button for building scenes data is enabled while no scene is loaded.

The local variable _canEditScene_  doesn't check if any scene is loaded, the _EditingSceneState_ type overrides the _CanEditScene_ property to always return true which makes the check necessary.

**Fix:** Check whether a scene is loaded and apply the same check as in the menu item to check whether _Editor.StateMachine.BuildingScenesState_ is active, in order to have the possibility to abort the operation if necessary.

**Remarks:** There are possible other differences from the menu items and the according toolstrip buttons, which probably shouldn't be.

![button](https://user-images.githubusercontent.com/52937757/103326784-39a7bd00-4a52-11eb-9be6-367245a84583.png)
