### PR TITLE
Prevent loading 'null' style

### DIFF
--- a/Source/Editor/Options/OptionsModule.cs
+++ b/Source/Editor/Options/OptionsModule.cs
@@ -196,9 +196,9 @@ namespace FlaxEditor.Options
 
             // If a non-default style was chosen, switch to that style
             string styleName = themeOptions.SelectedStyle;
-            if (styleName != "Default" && themeOptions.Styles.ContainsKey(styleName))
+            if (styleName != "Default" && themeOptions.Styles.TryGetValue(styleName, out var style) && style != null)
             {
-                Style.Current = themeOptions.Styles[themeOptions.SelectedStyle];
+                Style.Current = style;
             }
             else
             {


### PR DESCRIPTION
Someone on Discord reported that his Flax crashes on first restart after having messed with his styles. It was a null pointer exception. 

This prevents styles that are `null` from being loaded and should fix that issue.