### PR TITLE
Battery information.

### DIFF
--- a/Source/Engine/Platform/Base/PlatformBase.cpp
+++ b/Source/Engine/Platform/Base/PlatformBase.cpp
@@ -19,6 +19,7 @@
 #include "Engine/Engine/CommandLine.h"
 #include "Engine/Engine/Engine.h"
 #include "Engine/Utilities/StringConverter.h"
+#include "Engine/Platform/BatteryInfo.h"
 #include <iostream>
 
 // Check types sizes
@@ -379,6 +380,11 @@ void PlatformBase::CheckFailed(const char* message, const char* file, int line)
 
 void PlatformBase::SetHighDpiAwarenessEnabled(bool enable)
 {
+}
+
+BatteryInfo PlatformBase::GetBatteryInfo()
+{
+    return BatteryInfo();
 }
 
 int32 PlatformBase::GetDpi()

--- a/Source/Engine/Platform/Base/PlatformBase.h
+++ b/Source/Engine/Platform/Base/PlatformBase.h
@@ -11,6 +11,7 @@ struct CPUInfo;
 struct MemoryStats;
 struct ProcessMemoryStats;
 struct CreateWindowSettings;
+struct BatteryInfo;
 
 // ReSharper disable CppFunctionIsNotImplemented
 
@@ -547,6 +548,11 @@ public:
     /// Sets the High DPI awareness.
     /// </summary>
     static void SetHighDpiAwarenessEnabled(bool enable);
+
+    /// <summary>
+    /// Gets the battery information.
+    /// </summary>
+    API_PROPERTY() static BatteryInfo GetBatteryInfo();
 
     /// <summary>
     /// Gets the screen DPI setting.

--- a/Source/Engine/Platform/BatteryInfo.h
+++ b/Source/Engine/Platform/BatteryInfo.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2012-2020 Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#include "Engine/Core/Types/BaseTypes.h"
+
+API_STRUCT() struct BatteryInfo
+{
+DECLARE_SCRIPTING_TYPE_MINIMAL(BatteryInfo);
+
+    API_FIELD() byte ACLineStatus;
+
+    API_FIELD() byte BatteryLifePercent;
+
+    API_FIELD() uint32 BatteryLifeTime;
+};

--- a/Source/Engine/Platform/BatteryInfo.h
+++ b/Source/Engine/Platform/BatteryInfo.h
@@ -4,13 +4,44 @@
 
 #include "Engine/Core/Types/BaseTypes.h"
 
+/// <summary>
+/// Power supply status.
+/// </summary>
+API_ENUM() enum class ACLineStatus : byte
+{
+    /// <summary>
+    /// Power supply is not connected.
+    /// </summary>
+    Offline = 0,
+    /// <summary>
+    /// Power supply is connected.
+    /// </summary>
+    Online = 1,
+    /// <summary>
+    /// Unknown status.
+    /// </summary>
+    Unknown = 255
+};
+
+/// <summary>
+/// Contains information about power supply (Battery).
+/// </summary>
 API_STRUCT() struct BatteryInfo
 {
 DECLARE_SCRIPTING_TYPE_MINIMAL(BatteryInfo);
 
-    API_FIELD() byte ACLineStatus;
+    /// <summary>
+    /// Power supply status.
+    /// </summary>
+    API_FIELD() ACLineStatus ACLineStatus;
 
+    /// <summary>
+    /// Battery percentage left.
+    /// </summary>
     API_FIELD() byte BatteryLifePercent;
 
+    /// <summary>
+    /// Remaining battery life time in second.
+    /// </summary>
     API_FIELD() uint32 BatteryLifeTime;
 };

--- a/Source/Engine/Platform/BatteryInfo.h
+++ b/Source/Engine/Platform/BatteryInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 Wojciech Figat. All rights reserved.
+// Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
 
 #pragma once
 

--- a/Source/Engine/Platform/Win32/Win32Platform.cpp
+++ b/Source/Engine/Platform/Win32/Win32Platform.cpp
@@ -5,6 +5,7 @@
 #include "Engine/Platform/Platform.h"
 #include "Engine/Platform/MemoryStats.h"
 #include "Engine/Platform/CPUInfo.h"
+#include "Engine/Platform/BatteryInfo.h"
 #include "Engine/Core/Types/Guid.h"
 #include "Engine/Core/Types/String.h"
 #include "Engine/Core/Math/Math.h"
@@ -15,6 +16,7 @@
 #include <WinSock2.h>
 #include <IPHlpApi.h>
 #include <oleauto.h>
+#include <WinBase.h>
 #pragma comment(lib, "Iphlpapi.lib")
 
 namespace
@@ -306,6 +308,17 @@ bool Win32Platform::Is64BitPlatform()
 	IsWow64Process(GetCurrentProcess(), &result);
 	return result == TRUE;
 #endif
+}
+
+BatteryInfo Win32Platform::GetBatteryInfo()
+{
+    BatteryInfo info;
+    SYSTEM_POWER_STATUS status;
+    GetSystemPowerStatus(&status);
+    info.ACLineStatus = status.ACLineStatus;
+    info.BatteryLifePercent = status.BatteryLifePercent;
+    info.BatteryLifeTime = status.BatteryLifeTime;
+    return info;
 }
 
 CPUInfo Win32Platform::GetCPUInfo()

--- a/Source/Engine/Platform/Win32/Win32Platform.cpp
+++ b/Source/Engine/Platform/Win32/Win32Platform.cpp
@@ -315,7 +315,7 @@ BatteryInfo Win32Platform::GetBatteryInfo()
     BatteryInfo info;
     SYSTEM_POWER_STATUS status;
     GetSystemPowerStatus(&status);
-    info.ACLineStatus = status.ACLineStatus;
+    info.ACLineStatus = (ACLineStatus)status.ACLineStatus;
     info.BatteryLifePercent = status.BatteryLifePercent;
     info.BatteryLifeTime = status.BatteryLifeTime;
     return info;

--- a/Source/Engine/Platform/Win32/Win32Platform.h
+++ b/Source/Engine/Platform/Win32/Win32Platform.h
@@ -43,6 +43,7 @@ public:
         _aligned_free(ptr);
     }
     static bool Is64BitPlatform();
+    static BatteryInfo GetBatteryInfo();
     static CPUInfo GetCPUInfo();
     static int32 GetCacheLineSize();
     static MemoryStats GetMemoryStats();


### PR DESCRIPTION
You can now query for battery information.
For now, there is three info : SupplyLine status, Battery Percentage, Remaining life time in second.

Since it's unfinished, please wait before merging it. I need to implement it for others platforms ( only implemented for Win32/Windows/UWP).

Regarding whats other platforms give me, i will add more info in BatteryInfo struct.