### PR TITLE
Return focus to the previous control when closing a context menu

### DIFF
--- a/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
@@ -45,6 +45,7 @@ namespace FlaxEditor.GUI.ContextMenu
         private bool _isSubMenu;
         private ContextMenuBase _childCM;
         private Window _window;
+        private Control _previouslyFocused;
 
         /// <summary>
         /// Returns true if context menu is opened
@@ -185,6 +186,7 @@ namespace FlaxEditor.GUI.ContextMenu
                 return;
             _window.Show();
             PerformLayout();
+            _previouslyFocused = parentWin.FocusedControl;
             Focus();
             OnShow();
         }
@@ -220,6 +222,10 @@ namespace FlaxEditor.GUI.ContextMenu
                 _parentCM._childCM = null;
                 _parentCM = null;
             }
+
+            // Return focus
+            _previouslyFocused?.RootWindow?.Focus();
+            _previouslyFocused?.Focus();
 
             // Hide
             Visible = false;


### PR DESCRIPTION
This PR makes sure that upon hiding a context menu, the previously focused thing becomes focused again.

Fixes the fancy Visject input stuff. Now you can finally open a random material and type stuff like `uv * 3` again