### PR TITLE
Make constants use the actual const keyword

### DIFF
--- a/Source/Editor/Utilities/Constants.cs
+++ b/Source/Editor/Utilities/Constants.cs
@@ -7,12 +7,12 @@ namespace FlaxEditor.Utilities
     /// </summary>
     internal class Constants
     {
-        public static readonly string DiscordUrl = "https://flaxengine.com/discord";
-        public static readonly string DocsUrl = "https://docs.flaxengine.com/";
-        public static readonly string BugTrackerUrl = "https://github.com/FlaxEngine/FlaxEngine/issues";
-        public static readonly string WebsiteUrl = "https://flaxengine.com";
-        public static readonly string FacebookUrl = "https://facebook.com/FlaxEngine";
-        public static readonly string YoutubeUrl = "https://youtube.com/c/FlaxEngine";
-        public static readonly string TwitterUrl = "https://twitter.com/FlaxEngine";
+        public const string DiscordUrl = "https://flaxengine.com/discord";
+        public const string DocsUrl = "https://docs.flaxengine.com/";
+        public const string BugTrackerUrl = "https://github.com/FlaxEngine/FlaxEngine/issues";
+        public const string WebsiteUrl = "https://flaxengine.com";
+        public const string FacebookUrl = "https://facebook.com/FlaxEngine";
+        public const string YoutubeUrl = "https://youtube.com/c/FlaxEngine";
+        public const string TwitterUrl = "https://twitter.com/FlaxEngine";
     }
 }

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Api.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Api.cs
@@ -11,16 +11,16 @@ namespace Flax.Build.Bindings
     {
         private static class ApiTokens
         {
-            public static readonly string Enum = "API_ENUM";
-            public static readonly string Class = "API_CLASS";
-            public static readonly string Struct = "API_STRUCT";
-            public static readonly string Function = "API_FUNCTION";
-            public static readonly string Property = "API_PROPERTY";
-            public static readonly string Field = "API_FIELD";
-            public static readonly string Event = "API_EVENT";
-            public static readonly string Param = "API_PARAM";
-            public static readonly string InjectCppCode = "API_INJECT_CPP_CODE";
-            public static readonly string AutoSerialization = "API_AUTO_SERIALIZATION";
+            public const string Enum = "API_ENUM";
+            public const string Class = "API_CLASS";
+            public const string Struct = "API_STRUCT";
+            public const string Function = "API_FUNCTION";
+            public const string Property = "API_PROPERTY";
+            public const string Field = "API_FIELD";
+            public const string Event = "API_EVENT";
+            public const string Param = "API_PARAM";
+            public const string InjectCppCode = "API_INJECT_CPP_CODE";
+            public const string AutoSerialization = "API_AUTO_SERIALIZATION";
 
             public static readonly string[] SearchTags =
             {


### PR DESCRIPTION
All references are baked into the assembly with the corresponding IL instruction when compiling. Because no lookup will take place, it will "increase" the performance.