### PR TITLE
Fixes Issue #97: Actors not properly flushed on Scene unload

### DIFF
--- a/Source/Engine/Core/ObjectsRemovalService.h
+++ b/Source/Engine/Core/ObjectsRemovalService.h
@@ -52,12 +52,9 @@ public:
     /// <param name="dt">The delta time (in seconds).</param>
     /// <param name="gameDelta">The game update delta time (in seconds).</param>
     static void Flush(float dt, float gameDelta);
-
+    
     /// <summary>
-    /// Forces the flush the all objects from the pool.
+    /// Forces flush all the objects from the pool.
     /// </summary>
-    FORCE_INLINE static void ForceFlush()
-    {
-        Flush(1000, 1000);
-    }
+    static void ForceFlush();
 };

--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -713,7 +713,7 @@ bool LevelImpl::unloadScene(Scene* scene)
     CallSceneEvent(SceneEventType::OnSceneUnloaded, nullptr, sceneId);
 
     // Force flush deleted objects so we actually delete unloaded scene objects (prevent from reloading their managed objects, etc.)
-    ObjectsRemovalService::Flush();
+    ObjectsRemovalService::ForceFlush();
 
     return false;
 }


### PR DESCRIPTION
Ref: #97 

Calling ForceFlush instead of Flush on Scene unload, changing ForceFlush  to no rely on an arbitrary  duration to force evicting object of the pool.