### PR TITLE
Fix to disable terrain and foliage buttons if no scene is present

### DIFF
--- a/Source/Editor/Tools/Foliage/FoliageTab.cs
+++ b/Source/Editor/Tools/Foliage/FoliageTab.cs
@@ -21,6 +21,7 @@ namespace FlaxEditor.Tools.Foliage
         private readonly Tabs _modes;
         private readonly ContainerControl _noFoliagePanel;
         private int _selectedFoliageTypeIndex = -1;
+        private Button _createNewFoliage;
 
         /// <summary>
         /// The editor instance.
@@ -99,6 +100,7 @@ namespace FlaxEditor.Tools.Foliage
         public FoliageTab(SpriteHandle icon, Editor editor)
         : base(string.Empty, icon)
         {
+            Level.SceneLoaded += this.OnSceneLoaded;
             Editor = editor;
             Editor.SceneEditing.SelectionChanged += OnSelectionChanged;
 
@@ -135,14 +137,31 @@ namespace FlaxEditor.Tools.Foliage
                 Offsets = Margin.Zero,
                 Parent = _noFoliagePanel
             };
-            var noFoliageButton = new Button
+            _createNewFoliage = new Button
             {
                 Text = "Create new foliage",
                 AnchorPreset = AnchorPresets.MiddleCenter,
                 Offsets = new Margin(-60, 120, -12, 24),
                 Parent = _noFoliagePanel,
+                Enabled = false
             };
-            noFoliageButton.Clicked += OnCreateNewFoliageClicked;
+            _createNewFoliage.Clicked += OnCreateNewFoliageClicked;
+        }
+
+        private void OnSceneLoaded(Scene arg1, Guid arg2)
+        {
+            _createNewFoliage.Enabled = true;
+
+            Level.SceneUnloaded += this.OnSceneUnloaded;
+            Level.SceneLoaded -= OnSceneLoaded;
+        }
+
+        private void OnSceneUnloaded(Scene arg1, Guid arg2)
+        {
+            _createNewFoliage.Enabled = false;
+
+            Level.SceneLoaded += OnSceneLoaded;
+            Level.SceneUnloaded -= this.OnSceneUnloaded;
         }
 
         private void OnSelected(Tab tab)

--- a/Source/Editor/Tools/Terrain/CarveTab.cs
+++ b/Source/Editor/Tools/Terrain/CarveTab.cs
@@ -18,6 +18,7 @@ namespace FlaxEditor.Tools.Terrain
     {
         private readonly Tabs _modes;
         private readonly ContainerControl _noTerrainPanel;
+        private readonly Button _createTerrainButton;
 
         /// <summary>
         /// The editor instance.
@@ -57,6 +58,7 @@ namespace FlaxEditor.Tools.Terrain
         public CarveTab(SpriteHandle icon, Editor editor)
         : base(string.Empty, icon)
         {
+            Level.SceneLoaded += this.OnSceneLoaded;
             Editor = editor;
             Editor.SceneEditing.SelectionChanged += OnSelectionChanged;
 
@@ -93,14 +95,31 @@ namespace FlaxEditor.Tools.Terrain
                 Offsets = Margin.Zero,
                 Parent = _noTerrainPanel
             };
-            var noTerrainButton = new Button
+            _createTerrainButton = new Button
             {
                 Text = "Create new terrain",
                 AnchorPreset = AnchorPresets.MiddleCenter,
                 Offsets = new Margin(-60, 120, -12, 24),
-                Parent = _noTerrainPanel
+                Parent = _noTerrainPanel,
+                Enabled = false
             };
-            noTerrainButton.Clicked += OnCreateNewTerrainClicked;
+            _createTerrainButton.Clicked += OnCreateNewTerrainClicked;
+        }
+        
+        private void OnSceneLoaded(Scene arg1, Guid arg2)
+        {
+            _createTerrainButton.Enabled = true;
+
+            Level.SceneUnloaded += this.OnSceneUnloaded;
+            Level.SceneLoaded -= OnSceneLoaded;
+        }
+
+        private void OnSceneUnloaded(Scene arg1, Guid arg2)
+        {
+            _createTerrainButton.Enabled = false;
+
+            Level.SceneLoaded += OnSceneLoaded;
+            Level.SceneUnloaded -= this.OnSceneUnloaded;
         }
 
         private void OnSelected(Tab tab)
@@ -117,6 +136,9 @@ namespace FlaxEditor.Tools.Terrain
 
         private void OnCreateNewTerrainClicked()
         {
+            if (!Level.IsAnySceneLoaded)
+                return;
+
             Editor.UI.CreateTerrain();
         }
 

--- a/Source/Editor/Tools/Terrain/CarveTab.cs
+++ b/Source/Editor/Tools/Terrain/CarveTab.cs
@@ -136,9 +136,6 @@ namespace FlaxEditor.Tools.Terrain
 
         private void OnCreateNewTerrainClicked()
         {
-            if (!Level.IsAnySceneLoaded)
-                return;
-
             Editor.UI.CreateTerrain();
         }
 


### PR DESCRIPTION
This will fix the issues described in #99.

Bind to the `Level.SceneLoaded` and `Level.SceneUnloaded` events to update the button ``Enabled`` state.