### PR TITLE
Adding Camera Orientation to editor view menu.

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -510,6 +510,17 @@ namespace FlaxEditor.Viewport
                     debugView.VisibleChanged += WidgetViewModeShowHide;
                 }
 
+                // Camera Orientation
+                {
+                    var cameraView = ViewWidgetButtonMenu.AddChildMenu("Camera Orientation").ContextMenu;
+                    for (int i = 0; i < EditorViewportCameraOrientationValues.Length; i++)
+                    {
+                        var co = EditorViewportCameraOrientationValues[i];
+                        var button = cameraView.AddButton(co.Name);
+                        button.Tag = co.Orientation;
+                    }
+                    cameraView.ButtonClicked += button => ViewOrientation = Quaternion.Euler((Vector3)button.Tag);
+                }
                 ViewWidgetButtonMenu.AddSeparator();
 
                 // Orthographic
@@ -1193,6 +1204,28 @@ namespace FlaxEditor.Viewport
             base.OnDestroy();
         }
 
+        private struct CameraOrientation
+        {
+            public readonly string Name;
+            public readonly Vector3 Orientation;
+
+            public CameraOrientation(string name, Vector3 orientation)
+            {
+                Name = name;
+                Orientation = orientation;
+            }
+        }
+        
+        private readonly CameraOrientation[] EditorViewportCameraOrientationValues =
+        {
+            new CameraOrientation("Front", new Vector3(0,0,0)),
+            new CameraOrientation("Back", new Vector3(0,180,0)),
+            new CameraOrientation("Left", new Vector3(0,90,0)),
+            new CameraOrientation("Right", new Vector3(0,-90,0)),
+            new CameraOrientation("Top", new Vector3(-90,0,0)),
+            new CameraOrientation("Bottom", new Vector3(90,0,0))
+        };
+        
         private readonly float[] EditorViewportCameraSpeedValues =
         {
             0.1f,


### PR DESCRIPTION
Basic support for editor camera orientation : Front, Back, Left, Right, Top, Bottom.

It just rotate the camera to the requested direction, it's up to the user to use ortho or persp.

![image](https://user-images.githubusercontent.com/7458848/104106052-fef41f00-52b2-11eb-9cd5-621001563809.png)
