### PR TITLE
Fixing Windows position (on startup) for multi screens.

### DIFF
--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -276,8 +276,8 @@ namespace FlaxEditor.Modules
                 // Get metadata
                 int version = int.Parse(root.Attributes["Version"].Value, CultureInfo.InvariantCulture);
                 var virtualDesktopBounds = Platform.VirtualDesktopBounds;
-                var virtualDesktopSafeLeftCorner = virtualDesktopBounds.Location + new Vector2(0, 23); // 23 is a window strip size
-                var virtualDesktopSafeRightCorner = virtualDesktopBounds.BottomRight - new Vector2(50, 50); // apply some safe area
+                var virtualDesktopSafeLeftCorner = virtualDesktopBounds.Location;
+                var virtualDesktopSafeRightCorner = virtualDesktopBounds.BottomRight;
 
                 switch (version)
                 {


### PR DESCRIPTION
Multi screens users will no longer have the main window spawn on the top left corner ( virtual space ).
Now the window will be opened where it was closed.