### PR TITLE
Fixed Typos and padding for about window

### DIFF
--- a/Source/Editor/Content/Import/ModelImportEntry.cs
+++ b/Source/Editor/Content/Import/ModelImportEntry.cs
@@ -262,9 +262,9 @@ namespace FlaxEditor.Content.Import
         public int BaseLOD { get; set; } = 0;
 
         /// <summary>
-        /// The amount of LODs to include in the model (all reaming ones starting from Base LOD will be generated).
+        /// The amount of LODs to include in the model (all remaining ones starting from Base LOD will be generated).
         /// </summary>
-        [EditorOrder(1120), DefaultValue(4), Limit(1, Model.MaxLODs), EditorDisplay("Level Of Detail", "LOD Count"), Tooltip("The amount of LODs to include in the model (all reaming ones starting from Base LOD will be generated).")]
+        [EditorOrder(1120), DefaultValue(4), Limit(1, Model.MaxLODs), EditorDisplay("Level Of Detail", "LOD Count"), Tooltip("The amount of LODs to include in the model (all remaining ones starting from Base LOD will be generated).")]
         public int LODCount { get; set; } = 4;
 
         /// <summary>

--- a/Source/Editor/GUI/Docking/MasterDockPanel.cs
+++ b/Source/Editor/GUI/Docking/MasterDockPanel.cs
@@ -64,7 +64,7 @@ namespace FlaxEditor.GUI.Docking
             for (int i = 0; i < childPanels.Length; i++)
                 childPanels[i].Dispose();
 
-            // Delete reaming controls (except tabs proxy)
+            // Delete remaining controls (except tabs proxy)
             if (TabsProxy != null)
                 TabsProxy.Parent = null;
             DisposeChildren();

--- a/Source/Editor/History/HistoryStack.cs
+++ b/Source/Editor/History/HistoryStack.cs
@@ -74,7 +74,7 @@ namespace FlaxEditor.History
                     _reverseActions.PushBack(reverse[i]);
                 }
 
-                // Cleanup reaming actions
+                // Cleanup remaining actions
                 for (int i = _historyActionsLimit; i < history.Length; i++)
                 {
                     history[i].Dispose();

--- a/Source/Editor/Scripting/ScriptsBuilder.cpp
+++ b/Source/Editor/Scripting/ScriptsBuilder.cpp
@@ -567,7 +567,7 @@ bool ScriptsBuilderService::Init()
         LOG(Warning, "Missing EditorTarget property in opened project, using deducted target name {0}", Editor::Project->EditorTarget);
     }
 
-    // Remove any reaming files from previous Editor run hot-reloads
+    // Remove any remaining files from previous Editor run hot-reloads
     const Char *target, *platform, *architecture, *configuration;
     ScriptsBuilder::GetBinariesConfiguration(target, platform, architecture, configuration);
     if (target)

--- a/Source/Editor/Windows/AboutDialog.cs
+++ b/Source/Editor/Windows/AboutDialog.cs
@@ -115,7 +115,7 @@ namespace FlaxEditor.Windows
         {
             var thirdPartyPanel = new Panel(ScrollBars.Vertical)
             {
-                Bounds = new Rectangle(0, topParentControl.Bottom + 4, Width, Height - topParentControl.Bottom - 24),
+                Bounds = new Rectangle(4, topParentControl.Bottom + 4, Width - 8, Height - topParentControl.Bottom - 24),
                 Parent = this
             };
             var thirdPartyEntries = new[]

--- a/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
@@ -490,7 +490,7 @@ namespace FlaxEditor.Windows.Assets
                     }
                     if (_player.IsStopped || _player.Time >= _options.EndTime)
                     {
-                        // End rendering but perform reaming copies of the staging textures so all data is captured (from GPU to CPU)
+                        // End rendering but perform remaining copies of the staging textures so all data is captured (from GPU to CPU)
                         _state = States.Staging;
                         break;
                     }

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -222,7 +222,7 @@ namespace FlaxEditor.Windows
 
         private void PlayingStateOnSceneDuplicating()
         {
-            // Remove reaming GUI controls so loaded scene can add own GUI
+            // Remove remaining GUI controls so loaded scene can add own GUI
             //_guiRoot.DisposeChildren();
 
             // Show GUI
@@ -231,7 +231,7 @@ namespace FlaxEditor.Windows
 
         private void PlayingStateOnSceneRestored()
         {
-            // Remove reaming GUI controls so loaded scene can add own GUI
+            // Remove remaining GUI controls so loaded scene can add own GUI
             //_guiRoot.DisposeChildren();
 
             // Hide GUI

--- a/Source/Engine/Content/Loading/ContentLoadingManager.cpp
+++ b/Source/Engine/Content/Loading/ContentLoadingManager.cpp
@@ -208,7 +208,7 @@ void ContentLoadingManagerService::Dispose()
     MainThread = nullptr;
     ThisThread = nullptr;
 
-    // Cancel all reaming tasks (no chance to execute them)
+    // Cancel all remaining tasks (no chance to execute them)
     Tasks.CancelAll();
 }
 

--- a/Source/Engine/Core/Log.cpp
+++ b/Source/Engine/Core/Log.cpp
@@ -51,18 +51,18 @@ bool Log::Logger::Init()
     {
         // Check if there are any files to delete
         const int32 maxLogFiles = 20;
-        int32 reaming = oldLogs.Count() - maxLogFiles + 1;
-        if (reaming > 0)
+        int32 remaining = oldLogs.Count() - maxLogFiles + 1;
+        if (remaining > 0)
         {
             Sorting::QuickSort(oldLogs.Get(), oldLogs.Count());
 
             // Delete the oldest logs
             int32 i = 0;
-            while (reaming > 0)
+            while (remaining > 0)
             {
                 FileSystem::DeleteFile(oldLogs[i++]);
                 filesDeleted++;
-                reaming--;
+                remaining--;
             }
         }
     }

--- a/Source/Engine/Core/ObjectsRemovalService.cpp
+++ b/Source/Engine/Core/ObjectsRemovalService.cpp
@@ -193,7 +193,7 @@ void ObjectsRemovalServiceService::Dispose()
     // Collect new objects
     ObjectsRemovalService::Flush();
 
-    // Delete all reaming objects
+    // Delete all remaining objects
     {
         ScopeLock lock(PoolLocker);
         for (auto i = Pool.Begin(); i.IsNotEnd(); ++i)

--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -463,7 +463,7 @@ void Engine::OnExit()
 
     LOG_FLUSH();
 
-    // Kill all reaming threads
+    // Kill all remaining threads
     ThreadRegistry::KillEmAll();
 
     // Cleanup

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUContextDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUContextDX12.cpp
@@ -216,7 +216,7 @@ uint64 GPUContextDX12::Execute(bool waitForCompletion)
     ASSERT(_currentAllocator != nullptr);
     auto queue = _device->GetCommandQueue();
 
-    // Flush reaming and buffered commands
+    // Flush remaining and buffered commands
     FlushState();
     _currentState = nullptr;
 

--- a/Source/Engine/GraphicsDevice/DirectX/IncludeDirectXHeaders.h
+++ b/Source/Engine/GraphicsDevice/DirectX/IncludeDirectXHeaders.h
@@ -8,7 +8,7 @@
 #include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
 #include "Engine/Platform/Windows/ComPtr.h"
 
-// Helper define to dispose the COM object with reaming references counter checking
+// Helper define to dispose the COM object with remaining references counter checking
 #define DX_SAFE_RELEASE_CHECK(x, refs) if(x) { auto res = (x)->Release(); (x) = nullptr; CHECK(res == refs); }
 
 #endif

--- a/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.cpp
@@ -44,7 +44,7 @@ void CmdBufferVulkan::End()
     ASSERT(IsOutsideRenderPass());
 
 #if GPU_ALLOW_PROFILE_EVENTS
-    // End reaming events
+    // End remaining events
     while (_eventsBegin--)
         vkCmdEndDebugUtilsLabelEXT(GetHandle());
 #endif

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
@@ -1155,7 +1155,7 @@ void GPUContextVulkan::FlushState()
 
 void GPUContextVulkan::Flush()
 {
-    // Flush reaming and buffered commands
+    // Flush remaining and buffered commands
     FlushState();
     _currentState = nullptr;
 

--- a/Source/Engine/Particles/ParticleManager.cpp
+++ b/Source/Engine/Particles/ParticleManager.cpp
@@ -1172,7 +1172,7 @@ void ParticleManagerService::Update()
             // Update bounds after first system update
             updateBounds = true;
         }
-        // TODO: if using fixed timestep quantize the dt and accumulate reaming part for the next update?
+        // TODO: if using fixed timestep quantize the dt and accumulate remaining part for the next update?
         if (dt <= 1.0f / 240.0f)
             continue;
         dt *= effect->SimulationSpeed;

--- a/Source/Engine/Platform/Base/WindowsManager.cpp
+++ b/Source/Engine/Platform/Base/WindowsManager.cpp
@@ -77,7 +77,7 @@ void WindowsManagerService::Update()
 
 void WindowsManagerService::Dispose()
 {
-    // Close reaming windows
+    // Close remaining windows
     WindowsManager::WindowsLocker.Lock();
     auto windows = WindowsManager::Windows;
     for (auto& win : windows)

--- a/Source/Engine/Render2D/FontAsset.cpp
+++ b/Source/Engine/Render2D/FontAsset.cpp
@@ -55,7 +55,7 @@ void FontAsset::unload(bool isReloading)
     // Ensure to cleanup child font objects
     if (_fonts.HasItems())
     {
-        LOG(Warning, "Font asset {0} is unloading but has {1} reaming font objects created", ToString(), _fonts.Count());
+        LOG(Warning, "Font asset {0} is unloading but has {1} remaining font objects created", ToString(), _fonts.Count());
         for (auto font : _fonts)
         {
             font->_asset = nullptr;

--- a/Source/Engine/Utilities/RectPack.h
+++ b/Source/Engine/Utilities/RectPack.h
@@ -25,7 +25,7 @@ struct RectPack
     SizeType Width;
     SizeType Height;
 
-    // The reaming space amount inside this slot (updated on every insertion, initial it equal to width*height).
+    // The remaining space amount inside this slot (updated on every insertion, initial it equal to width*height).
     SizeType SpaceLeft;
 
     // True, if slot has been allocated, otherwise it's free.


### PR DESCRIPTION
The padding on the about page was a bit weird so I adjusted it.
Also while I was at it fixed a typo that occured multiple times.

**Before:**
![image](https://user-images.githubusercontent.com/63303990/104836533-c524a900-58ae-11eb-8e47-412592c1fa7d.png)


**After:**
![image](https://user-images.githubusercontent.com/63303990/104836517-b3430600-58ae-11eb-88e2-5152dcb5eff0.png)