### PR TITLE
Fix NearEqual (GPU Particle) missing implementation.

### DIFF
--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -387,7 +387,7 @@ void ShaderGenerator::ProcessGroupMath(Box* box, Node* node, Value& value)
         Value v1 = tryGetValue(node->GetBox(0), Value::Zero);
         Value v2 = tryGetValue(node->GetBox(1), Value::Zero).Cast(v1.Type);
         Value epsilon = tryGetValue(node->GetBox(2), 2, Value::Zero);
-        value = writeLocal(ValueType::Bool, String::Format(TEXT("(distance({0},{1}) < {2})"), v1.Value, v2.Value, epsilon.Value), node);
+        value = writeLocal(ValueType::Bool, String::Format(TEXT("distance({0},{1}) < {2}"), v1.Value, v2.Value, epsilon.Value), node);
         break;
     }
         // Degrees

--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -381,6 +381,15 @@ void ShaderGenerator::ProcessGroupMath(Box* box, Node* node, Value& value)
         value = writeFunction2(node, v1, v2, TEXT("atan2"));
         break;
     }
+        // Near Equal
+    case 42:
+    {
+        Value v1 = tryGetValue(node->GetBox(0), Value::Zero);
+        Value v2 = tryGetValue(node->GetBox(1), Value::Zero).Cast(v1.Type);
+        Value epsilon = tryGetValue(node->GetBox(2), 2, Value::Zero);
+        value = writeLocal(ValueType::Bool, String::Format(TEXT("(distance({0},{1}) < {2})"), v1.Value, v2.Value, epsilon.Value), node);
+        break;
+    }
         // Degrees
     case 43:
     {
@@ -911,7 +920,7 @@ void ShaderGenerator::ProcessGroupComparisons(Box* box, Node* node, Value& value
         const Value condition = tryGetValue(node->GetBox(0), Value::False).AsBool();
         const Value onTrue = tryGetValue(node->GetBox(2), 1, Value::Zero);
         const Value onFalse = tryGetValue(node->GetBox(1), 0, Value::Zero).Cast(onTrue.Type);
-        value = writeLocal(onTrue.Type, String::Format(TEXT("({0}) ? ({1}) : ({2})"), condition.Value, onTrue.Value, onFalse.Value), node);
+        value = writeLocal(onTrue.Type, String::Format(TEXT("{0} ? {1} : {2}"), condition.Value, onTrue.Value, onFalse.Value), node);
         break;
     }
     }


### PR DESCRIPTION
 Fix NearEqual (GPU Particle) missing implementation.

Using NearEqual no longer throw "[Error] GPU Particles graph error: Unknown box to resolve.".

```[ 00:14:20.736 ]: [Info] Reloading asset FlaxEngine.ParticleEmitter: 8529b0e54a31db62959513ac2a2a5761, 'C:\Users/jimiv/AppData/Local/Temp/890191db-4b88-ea79-3354-ff868fb1c70e/8529b0e5db624a31ac13959561572a2a.flax', Refs: 2
[ 00:14:20.736 ]: [Error] GPU Particles graph error: Unknown box to resolve. (Node:196650:28, Box:3)
[ 00:14:20.736 ]: [Info] Creating package at 'C:\Users/jimiv/AppData/Local/Temp/890191db-4b88-ea79-3354-ff868fb1c70e/8529b0e5db624a31ac13959561572a2a.flax'. Silent Mode: false
[ 00:14:20.736 ]: [Info] File 'C:\Users/jimiv/AppData/Local/Temp/890191db-4b88-ea79-3354-ff868fb1c70e/8529b0e5db624a31ac13959561572a2a.flax' is in use. Trying to release handle to it.
[ 00:14:20.741 ]: [Info] Compiling shader 'C:\Users/jimiv/AppData/Local/Temp/890191db-4b88-ea79-3354-ff868fb1c70e/8529b0e5db624a31ac13959561572a2a.flax':8529b0e54a31db62959513ac2a2a5761...
[ 00:14:20.745 ]: [Error] Failed to compile '8529b0e5db624a31ac13959561572a2a'. D:\Ubercube\Game\8529b0e5db624a31ac13959561572a2a(243,19): error X3000: syntax error: unexpected token ')'
D:\Ubercube\Game\8529b0e5db624a31ac13959561572a2a(249,10-54): warning X3206: implicit truncation of vector type

[ 00:14:20.745 ]: [Error] Failed to compile 'CS_Main'
[ 00:14:20.745 ]: [Error] Failed to compile shader 'FlaxEngine.ParticleEmitter: 8529b0e54a31db62959513ac2a2a5761, 'C:\Users/jimiv/AppData/Local/Temp/890191db-4b88-ea79-3354-ff868fb1c70e/8529b0e5db624a31ac13959561572a2a.flax', Refs: 3'
[ 00:14:20.745 ]: [Error] Cannot load 'FlaxEngine.ParticleEmitter: 8529b0e54a31db62959513ac2a2a5761, 'C:\Users/jimiv/AppData/Local/Temp/890191db-4b88-ea79-3354-ff868fb1c70e/8529b0e5db624a31ac13959561572a2a.flax', Refs: 3' shader cache.
[ 00:14:20.745 ]: [Error] Loading asset 'FlaxEngine.ParticleEmitter: 8529b0e54a31db62959513ac2a2a5761, 'C:\Users/jimiv/AppData/Local/Temp/890191db-4b88-ea79-3354-ff868fb1c70e/8529b0e5db624a31ac13959561572a2a.flax', Refs: 3' result: Failed.
[ 00:14:20.745 ]: [Warning] 'Content Load Task LoadAsset (Running)' failed with result: AssetLoadError
```



Hurray !!