### PR TITLE
Spelling fixes.

### DIFF
--- a/Source/Editor/Surface/AnimGraphSurface.cs
+++ b/Source/Editor/Surface/AnimGraphSurface.cs
@@ -65,8 +65,8 @@ namespace FlaxEditor.Surface
                         NodeElementArchetype.Factory.Output(0, "Length", typeof(float), 0),
                         NodeElementArchetype.Factory.Output(1, "Time", typeof(float), 1),
                         NodeElementArchetype.Factory.Output(2, "Normalized Time", typeof(float), 2),
-                        NodeElementArchetype.Factory.Output(3, "Reaming Time", typeof(float), 3),
-                        NodeElementArchetype.Factory.Output(4, "Reaming Normalized Time", typeof(float), 4),
+                        NodeElementArchetype.Factory.Output(3, "Remaining Time", typeof(float), 3),
+                        NodeElementArchetype.Factory.Output(4, "Remaining Normalized Time", typeof(float), 4),
                     }
                 },
             }

--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -764,8 +764,8 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Output(0, "Length", typeof(float), 0),
                     NodeElementArchetype.Factory.Output(1, "Time", typeof(float), 1),
                     NodeElementArchetype.Factory.Output(2, "Normalized Time", typeof(float), 2),
-                    NodeElementArchetype.Factory.Output(3, "Reaming Time", typeof(float), 3),
-                    NodeElementArchetype.Factory.Output(4, "Reaming Normalized Time", typeof(float), 4),
+                    NodeElementArchetype.Factory.Output(3, "Remaining Time", typeof(float), 3),
+                    NodeElementArchetype.Factory.Output(4, "Remaining Normalized Time", typeof(float), 4),
                 }
             },
             new NodeArchetype

--- a/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
+++ b/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
@@ -1489,11 +1489,11 @@ void AnimGraphExecutor::ProcessGroupAnimation(Box* boxBase, Node* nodeBase, Valu
         case 2:
             value = transitionsData.Position / transitionsData.Length;
             break;
-            // Reaming Time
+            // Remaining Time
         case 3:
             value = transitionsData.Length - transitionsData.Position;
             break;
-            // Reaming Normalized Time
+            // Remaining Normalized Time
         case 4:
             value = 1.0f - (transitionsData.Position / transitionsData.Length);
             break;


### PR DESCRIPTION
Fixed misspellings reported on discord by by Richard D.
"Reaming Time" and "Reaming Normalized Time" was changed to "Remaining...".