### PR TITLE
Fix Issue #127: Get Node Transform

### DIFF
--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -872,7 +872,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Get Node Transform (model space)",
                 Description = "Samples the skeleton node transformation (in model space)",
                 Flags = NodeFlags.AnimGraph,
-                Size = new Vector2(250, 40),
+                Size = new Vector2(324, 40),
                 DefaultValues = new object[]
                 {
                     string.Empty,
@@ -882,7 +882,8 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, string.Empty, true, typeof(void), 0),
                     NodeElementArchetype.Factory.SkeletonNodeNameSelect(40, Surface.Constants.LayoutOffsetY * 1, 120, 0),
                     NodeElementArchetype.Factory.Text(0, Surface.Constants.LayoutOffsetY * 1, "Node:"),
-                    NodeElementArchetype.Factory.Output(0, "Transform", typeof(Transform), 1),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(void), 0),
+                    NodeElementArchetype.Factory.Output(1, "Transform", typeof(Transform), 1),
                 }
             },
             new NodeArchetype
@@ -913,7 +914,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Get Node Transform (local space)",
                 Description = "Samples the skeleton node transformation (in local space)",
                 Flags = NodeFlags.AnimGraph,
-                Size = new Vector2(250, 40),
+                Size = new Vector2(316, 40),
                 DefaultValues = new object[]
                 {
                     string.Empty,
@@ -923,7 +924,8 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, string.Empty, true, typeof(void), 0),
                     NodeElementArchetype.Factory.SkeletonNodeNameSelect(40, Surface.Constants.LayoutOffsetY * 1, 120, 0),
                     NodeElementArchetype.Factory.Text(0, Surface.Constants.LayoutOffsetY * 1, "Node:"),
-                    NodeElementArchetype.Factory.Output(0, "Transform", typeof(Transform), 1),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(void), 0),
+                    NodeElementArchetype.Factory.Output(1, "Transform", typeof(Transform), 1),
                 }
             },
             new NodeArchetype


### PR DESCRIPTION
Fixes issue #127 in which the Get Node Transform has a missing execution pin and incorrect size.

Before:
![image](https://user-images.githubusercontent.com/63303990/105495381-669b6880-5cbc-11eb-9ff6-47202df7fb42.png)


After:
![image](https://user-images.githubusercontent.com/63303990/105495132-11f7ed80-5cbc-11eb-9df4-97f599d5c05d.png)
