### PR TITLE
Improve build times in development configuration

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/CompileEnvironment.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/CompileEnvironment.cs
@@ -57,6 +57,11 @@ namespace Flax.Build.NativeCpp
         public bool Optimization = false;
 
         /// <summary>
+        /// Enables the whole program optimization.
+        /// </summary>
+        public bool WholeProgramOptimization = false;
+
+        /// <summary>
         /// Enables functions level linking support.
         /// </summary>
         public bool FunctionLevelLinking = false;
@@ -131,6 +136,7 @@ namespace Flax.Build.NativeCpp
                 RuntimeTypeInfo = RuntimeTypeInfo,
                 Inlining = Inlining,
                 Optimization = Optimization,
+                WholeProgramOptimization = WholeProgramOptimization,
                 FunctionLevelLinking = FunctionLevelLinking,
                 DebugInformation = DebugInformation,
                 UseDebugCRT = UseDebugCRT,

--- a/Source/Tools/Flax.Build/Build/Target.cs
+++ b/Source/Tools/Flax.Build/Build/Target.cs
@@ -256,6 +256,7 @@ namespace Flax.Build
                 options.CompileEnv.IntrinsicFunctions = false;
                 options.CompileEnv.BufferSecurityCheck = true;
                 options.CompileEnv.Inlining = false;
+                options.CompileEnv.WholeProgramOptimization = false;
 
                 options.LinkEnv.DebugInformation = true;
                 options.LinkEnv.LinkTimeCodeGeneration = false;
@@ -273,11 +274,11 @@ namespace Flax.Build
                 options.CompileEnv.IntrinsicFunctions = true;
                 options.CompileEnv.BufferSecurityCheck = true;
                 options.CompileEnv.Inlining = true;
-                //options.CompileEnv.WholeProgramOptimization = true;
+                options.CompileEnv.WholeProgramOptimization = false;
 
                 options.LinkEnv.DebugInformation = true;
-                options.LinkEnv.LinkTimeCodeGeneration = true;
-                options.LinkEnv.UseIncrementalLinking = false;
+                options.LinkEnv.LinkTimeCodeGeneration = false;
+                options.LinkEnv.UseIncrementalLinking = true;
                 options.LinkEnv.Optimization = true;
                 break;
             case TargetConfiguration.Release:
@@ -291,7 +292,7 @@ namespace Flax.Build
                 options.CompileEnv.IntrinsicFunctions = true;
                 options.CompileEnv.BufferSecurityCheck = false;
                 options.CompileEnv.Inlining = true;
-                //options.CompileEnv.WholeProgramOptimization = true;
+                options.CompileEnv.WholeProgramOptimization = true;
 
                 options.LinkEnv.DebugInformation = false;
                 options.LinkEnv.LinkTimeCodeGeneration = true;

--- a/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchainBase.cs
+++ b/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchainBase.cs
@@ -467,8 +467,11 @@ namespace Flax.Build.Platforms
                     // Frame-Pointer Omission
                     commonArgs.Add("/Oy");
 
-                    // Whole Program Optimization
-                    commonArgs.Add("/GL");
+                    if (compileEnvironment.WholeProgramOptimization)
+                    {
+                        // Whole Program Optimization
+                        commonArgs.Add("/GL");
+                    }
                 }
                 else
                 {

--- a/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchainBase.cs
+++ b/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchainBase.cs
@@ -724,7 +724,7 @@ namespace Flax.Build.Platforms
                     args.Add("/PDBALTPATH:%_PDB%");
 
                     // Optimize
-                    if (linkEnvironment.Optimization)
+                    if (linkEnvironment.Optimization && !linkEnvironment.UseIncrementalLinking)
                     {
                         // Generate an EXE checksum
                         args.Add("/RELEASE");


### PR DESCRIPTION
These changes will disable the slowest optimization flags in development builds, leading to much faster build times with no noticeable performance loss in editor or games. I believe the development builds should hit the perfect middle ground in both these factors, to be fast for iterative builds (like debug configuration) without sacrificing too much runtime performance (like release configuration).

Right now building the engine in development configuration takes as much time as it would take to build it in release configuration. The main culprits for these slow build times in this case are the Whole Program Optimization and Link-Time Code Generation flags.

This commit changes the default build flags for development builds but also exposes the Whole Program Optimization flag and prevents using linker optimization flags when LTCG is enabled (otherwise the linker would show tons of confusing warnings when optimizations and LTCG are both enabled at the same time).