### PR TITLE
Collisions helper enhancement

### DIFF
--- a/Source/Engine/Core/Math/CollisionsHelper.cpp
+++ b/Source/Engine/Core/Math/CollisionsHelper.cpp
@@ -41,6 +41,28 @@ void CollisionsHelper::ClosestPointPointLine(const Vector2& point, const Vector2
     }
 }
 
+Vector3 CollisionsHelper::ClosestPointPointLine(const Vector3& point, const Vector3& p0, const Vector3& p1)
+{
+    const Vector3 p = point - p0;
+    Vector3 n = p1 - p0;
+    const float length = n.Length();
+    if (length < 1e-10)
+    {
+        return p0;
+    }
+    n /= length;
+    const float dot = Vector3::Dot(n, p);
+    if (dot <= 0.0)
+    {
+        return p0;
+    }
+    else if (dot >= length)
+    {
+        return p1;
+    }
+    return p0 + n * dot;
+}
+
 void CollisionsHelper::ClosestPointPointTriangle(const Vector3& point, const Vector3& vertex1, const Vector3& vertex2, const Vector3& vertex3, Vector3& result)
 {
     // Source: Real-Time Collision Detection by Christer Ericson

--- a/Source/Engine/Core/Math/CollisionsHelper.cpp
+++ b/Source/Engine/Core/Math/CollisionsHelper.cpp
@@ -41,26 +41,44 @@ void CollisionsHelper::ClosestPointPointLine(const Vector2& point, const Vector2
     }
 }
 
-Vector3 CollisionsHelper::ClosestPointPointLine(const Vector3& point, const Vector3& p0, const Vector3& p1)
+Vector2 CollisionsHelper::ClosestPointPointLine(const Vector2& point, const Vector2& p0, const Vector2& p1)
+{
+    Vector2 result;
+    ClosestPointPointLine(point, p0, p1, result);
+    return result;
+}
+
+
+void CollisionsHelper::ClosestPointPointLine(const Vector3& point, const Vector3& p0, const Vector3& p1, Vector3& result)
 {
     const Vector3 p = point - p0;
     Vector3 n = p1 - p0;
     const float length = n.Length();
     if (length < 1e-10)
     {
-        return p0;
+        result = p0;
+        return;
     }
     n /= length;
     const float dot = Vector3::Dot(n, p);
     if (dot <= 0.0)
     {
-        return p0;
+        result = p0;
+        return;
     }
     else if (dot >= length)
     {
-        return p1;
+        result = p1;
+        return;
     }
-    return p0 + n * dot;
+    result = p0 + n * dot;
+}
+
+Vector3 CollisionsHelper::ClosestPointPointLine(const Vector3& point, const Vector3& p0, const Vector3& p1)
+{
+    Vector3 result;
+    ClosestPointPointLine(point, p0, p1, result);
+    return result;
 }
 
 void CollisionsHelper::ClosestPointPointTriangle(const Vector3& point, const Vector3& vertex1, const Vector3& vertex2, const Vector3& vertex3, Vector3& result)
@@ -123,6 +141,13 @@ void CollisionsHelper::ClosestPointPointTriangle(const Vector3& point, const Vec
     result = vertex1 + ab * v2 + ac * w2; //= u*vertex1 + v*vertex2 + w*vertex3, u = va * denom = 1.0f - v - w
 }
 
+Vector3 CollisionsHelper::ClosestPointPointTriangle(const Vector3& point, const Vector3& vertex1, const Vector3& vertex2, const Vector3& vertex3)
+{
+    Vector3 result;
+    ClosestPointPointTriangle(point, vertex1, vertex2, vertex3, result);
+    return result;
+}
+
 void CollisionsHelper::ClosestPointPlanePoint(const Plane& plane, const Vector3& point, Vector3& result)
 {
     // Source: Real-Time Collision Detection by Christer Ericson
@@ -132,6 +157,13 @@ void CollisionsHelper::ClosestPointPlanePoint(const Plane& plane, const Vector3&
     const float t = dot - plane.D;
 
     result = point - t * plane.Normal;
+}
+
+Vector3 CollisionsHelper::ClosestPointPlanePoint(const Plane& plane, const Vector3& point)
+{
+    Vector3 result;
+    ClosestPointPlanePoint(plane, point, result);
+    return result;
 }
 
 void CollisionsHelper::ClosestPointBoxPoint(const BoundingBox& box, const Vector3& point, Vector3& result)
@@ -144,12 +176,26 @@ void CollisionsHelper::ClosestPointBoxPoint(const BoundingBox& box, const Vector
     Vector3::Min(temp, box.Maximum, result);
 }
 
+Vector3 CollisionsHelper::ClosestPointBoxPoint(const BoundingBox& box, const Vector3& point)
+{
+    Vector3 result;
+    ClosestPointBoxPoint(box, point, result);
+    return result;
+}
+
 void CollisionsHelper::ClosestPointRectanglePoint(const Rectangle& rect, const Vector2& point, Vector2& result)
 {
     Vector2 temp, end;
     Vector2::Add(rect.Location, rect.Size, end);
     Vector2::Max(point, rect.Location, temp);
     Vector2::Min(temp, end, result);
+}
+
+Vector2 CollisionsHelper::ClosestPointRectanglePoint(const Rectangle& rect, const Vector2& point)
+{
+    Vector2 result;
+    ClosestPointRectanglePoint(rect, point, result);
+    return result;
 }
 
 void CollisionsHelper::ClosestPointSpherePoint(const BoundingSphere& sphere, const Vector3& point, Vector3& result)
@@ -169,6 +215,13 @@ void CollisionsHelper::ClosestPointSpherePoint(const BoundingSphere& sphere, con
     result += sphere.Center;
 }
 
+Vector3 CollisionsHelper::ClosestPointSpherePoint(const BoundingSphere& sphere, const Vector3& point)
+{
+    Vector3 result;
+    ClosestPointSpherePoint(sphere, point, result);
+    return result;
+}
+
 void CollisionsHelper::ClosestPointSphereSphere(const BoundingSphere& sphere1, const BoundingSphere& sphere2, Vector3& result)
 {
     // Source: Jorgy343
@@ -184,6 +237,13 @@ void CollisionsHelper::ClosestPointSphereSphere(const BoundingSphere& sphere1, c
 
     //Add the first sphere's center to the direction to get a point on the first sphere.
     result += sphere1.Center;
+}
+
+Vector3 CollisionsHelper::ClosestPointSphereSphere(const BoundingSphere& sphere1, const BoundingSphere& sphere2)
+{
+    Vector3 result;
+    ClosestPointSphereSphere(sphere1, sphere2, result);
+    return result;
 }
 
 float CollisionsHelper::DistancePlanePoint(const Plane& plane, const Vector3& point)

--- a/Source/Engine/Core/Math/CollisionsHelper.h
+++ b/Source/Engine/Core/Math/CollisionsHelper.h
@@ -73,6 +73,15 @@ public:
     static void ClosestPointPointLine(const Vector2& point, const Vector2& p0, const Vector2& p1, Vector2& result);
 
     /// <summary>
+    /// Determines the closest point between a point and a line.
+    /// </summary>
+    /// <param name="point">The point to test.</param>
+    /// <param name="p0">The line first point.</param>
+    /// <param name="p1">The line second point.</param>
+    /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
+    static Vector3 ClosestPointPointLine(const Vector3& point, const Vector3& p0, const Vector3& p1);
+
+    /// <summary>
     /// Determines the closest point between a point and a triangle.
     /// </summary>
     /// <param name="point">The point to test.</param>

--- a/Source/Engine/Core/Math/CollisionsHelper.h
+++ b/Source/Engine/Core/Math/CollisionsHelper.h
@@ -78,7 +78,25 @@ public:
     /// <param name="point">The point to test.</param>
     /// <param name="p0">The line first point.</param>
     /// <param name="p1">The line second point.</param>
+    /// <returns>The closest point between the two objects.</result>
+    static Vector2 ClosestPointPointLine(const Vector2& point, const Vector2& p0, const Vector2& p1);
+
+    /// <summary>
+    /// Determines the closest point between a point and a line.
+    /// </summary>
+    /// <param name="point">The point to test.</param>
+    /// <param name="p0">The line first point.</param>
+    /// <param name="p1">The line second point.</param>
     /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
+    static void ClosestPointPointLine(const Vector3& point, const Vector3& p0, const Vector3& p1, Vector3& result);
+
+    /// <summary>
+    /// Determines the closest point between a point and a line.
+    /// </summary>
+    /// <param name="point">The point to test.</param>
+    /// <param name="p0">The line first point.</param>
+    /// <param name="p1">The line second point.</param>
+    /// <returns>The closest point between the two objects.</result>
     static Vector3 ClosestPointPointLine(const Vector3& point, const Vector3& p0, const Vector3& p1);
 
     /// <summary>
@@ -92,12 +110,30 @@ public:
     static void ClosestPointPointTriangle(const Vector3& point, const Vector3& vertex1, const Vector3& vertex2, const Vector3& vertex3, Vector3& result);
 
     /// <summary>
+    /// Determines the closest point between a point and a triangle.
+    /// </summary>
+    /// <param name="point">The point to test.</param>
+    /// <param name="vertex1">The first vertex to test.</param>
+    /// <param name="vertex2">The second vertex to test.</param>
+    /// <param name="vertex3">The third vertex to test.</param>
+    /// <returns>The closest point between the two objects.</returns>
+    static Vector3 ClosestPointPointTriangle(const Vector3& point, const Vector3& vertex1, const Vector3& vertex2, const Vector3& vertex3);
+
+    /// <summary>
     /// Determines the closest point between a <see cref="Plane" /> and a point.
     /// </summary>
     /// <param name="plane">The plane to test.</param>
     /// <param name="point">The point to test.</param>
     /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
     static void ClosestPointPlanePoint(const Plane& plane, const Vector3& point, Vector3& result);
+    
+    /// <summary>
+    /// Determines the closest point between a <see cref="Plane" /> and a point.
+    /// </summary>
+    /// <param name="plane">The plane to test.</param>
+    /// <param name="point">The point to test.</param>
+    /// <returns>The closest point between the two objects.</returns>
+    static Vector3 ClosestPointPlanePoint(const Plane& plane, const Vector3& point);
 
     /// <summary>
     /// Determines the closest point between a <see cref="BoundingBox" /> and a point.
@@ -106,6 +142,14 @@ public:
     /// <param name="point">The point to test.</param>
     /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
     static void ClosestPointBoxPoint(const BoundingBox& box, const Vector3& point, Vector3& result);
+    
+    /// <summary>
+    /// Determines the closest point between a <see cref="BoundingBox" /> and a point.
+    /// </summary>
+    /// <param name="box">The box to test.</param>
+    /// <param name="point">The point to test.</param>
+    /// <returns>The closest point between the two objects.</returns>
+    static Vector3 ClosestPointBoxPoint(const BoundingBox& box, const Vector3& point);
 
     /// <summary>
     /// Determines the closest point between a <see cref="Rectangle" /> and a point.
@@ -114,6 +158,14 @@ public:
     /// <param name="point">The point to test.</param>
     /// <param name="result">When the method completes, contains the closest point between the two objects.</param>
     static void ClosestPointRectanglePoint(const Rectangle& rect, const Vector2& point, Vector2& result);
+    
+    /// <summary>
+    /// Determines the closest point between a <see cref="Rectangle" /> and a point.
+    /// </summary>
+    /// <param name="rect">The rectangle to test.</param>
+    /// <param name="point">The point to test.</param>
+    /// <returns>The closest point between the two objects.</returns>
+    static Vector2 ClosestPointRectanglePoint(const Rectangle& rect, const Vector2& point);
 
     /// <summary>
     /// Determines the closest point between a <see cref="BoundingSphere" /> and a point.
@@ -122,6 +174,14 @@ public:
     /// <param name="point">The point to test.</param>
     /// <param name="result">When the method completes, contains the closest point between the two objects; or, if the point is directly in the center of the sphere, contains <see cref="Vector3.Zero" />.</param>
     static void ClosestPointSpherePoint(const BoundingSphere& sphere, const Vector3& point, Vector3& result);
+    
+    /// <summary>
+    /// Determines the closest point between a <see cref="BoundingSphere" /> and a point.
+    /// </summary>
+    /// <param name="sphere">The sphere to test.</param>
+    /// <param name="point">The point to test.</param>
+    /// <returns>The closest point between the two objects; or, if the point is directly in the center of the sphere, contains <see cref="Vector3.Zero" />.</return>
+    static Vector3 ClosestPointSpherePoint(const BoundingSphere& sphere, const Vector3& point);
 
     /// <summary>
     /// Determines the closest point between a <see cref="BoundingSphere" /> and a <see cref="BoundingSphere" />.
@@ -135,6 +195,19 @@ public:
     /// intersection.
     /// </remarks>
     static void ClosestPointSphereSphere(const BoundingSphere& sphere1, const BoundingSphere& sphere2, Vector3& result);
+    
+    /// <summary>
+    /// Determines the closest point between a <see cref="BoundingSphere" /> and a <see cref="BoundingSphere" />.
+    /// </summary>
+    /// <param name="sphere1">The first sphere to test.</param>
+    /// <param name="sphere2">The second sphere to test.</param>
+    /// <returns>The closest point between the two objects; or, if the point is directly in the center of the sphere, contains <see cref="Vector3.Zero" />.</returns>
+    /// <remarks>
+    /// If the two spheres are overlapping, but not directly on top of each other, the closest point
+    /// is the 'closest' point of intersection. This can also be considered is the deepest point of
+    /// intersection.
+    /// </remarks>
+    static Vector3 ClosestPointSphereSphere(const BoundingSphere& sphere1, const BoundingSphere& sphere2);
 
     /// <summary>
     /// Determines the distance between a <see cref="Plane" /> and a point.


### PR DESCRIPTION
For each function with a single output parameter of type Vector2 or Vector3 in CollisionsHelper, added an additional overload that returns the result instead. 

The affected functions are:

- ClosestPointPointLine
- ClosestPointPointTriangle
- ClosestPointPlanePoint
- ClosestPointBoxPoint
- ClosestPointRectanglePoint
- ClosestPointSpherePoint
- ClosestPointSphereSphere

I also added Vector3 versions of ClosestPointPointLine() (its basically the same code).
I added these for my own personal use because I prefer that syntax. 
Maybe you omitted these deliberately to avoid the clutter, but I added the pull request in case you wanted to incorporate them into the engine.
I did not test extensively due to the basic nature of the changes.
It's mostly just a lot of:

>     Vector2 result;
>     ClosestPointPointLine(point, p0, p1, result);
>     return result;

I also copied over the documentation but changed the output parameter to "returns".