### PR TITLE
Added Node to Mix Normal Maps

### DIFF
--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -642,6 +642,22 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Output(0, "XYZ", typeof(Vector3), 0),
                 }
             },
+            new NodeArchetype
+            {
+                TypeID = 26,
+                Title = "Blend Normals",
+                Description = "Blend two normal maps to create a single normal map",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Vector2(170, 40),
+                ConnectionsHints = ConnectionsHint.Vector,
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Base Normal", true, typeof(Vector3), 0),
+                    NodeElementArchetype.Factory.Input(1, "Additional Normal", true, typeof(Vector3), 1),
+                    NodeElementArchetype.Factory.Output(0, "Result", typeof(Vector3), 2)
+                }
+            },
+
         };
     }
 }

--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -676,7 +676,7 @@ void InputService::Update()
     const auto lockMode = Screen::GetCursorLock();
     if (lockMode == CursorLockMode::Locked)
     {
-        Input::SetMousePosition(Screen::GetSize() * 0.5f);
+        Input::SetMousePosition(Screen::GetSize() * 0.5f * Platform::GetDpiScale());
     }
 
     // Send events for the active actions (send events only in play mode)

--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -676,7 +676,7 @@ void InputService::Update()
     const auto lockMode = Screen::GetCursorLock();
     if (lockMode == CursorLockMode::Locked)
     {
-        Input::SetMousePosition(Screen::GetSize() * 0.5f * Platform::GetDpiScale());
+        Input::SetMousePosition(Screen::GetSize() * 0.5f);
     }
 
     // Send events for the active actions (send events only in play mode)

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -337,6 +337,14 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
     case 25:
         value = Value(VariantType::Vector3, TEXT("GetObjectSize(input)"));
         break;
+    case 26:
+    {
+        const auto BaseNormal = tryGetValue(node->GetBox(0), Value::Zero).AsVector3();
+        const auto AdditionalNormal = tryGetValue(node->GetBox(1), Value::Zero).AsVector3();
+        const String text = String::Format(TEXT("float3((float2({0}.xy) + float2({1}.xy) * 2.0), sqrt(saturate(1.0 - dot((float2({0}.xy) + float2({1}.xy) * 2.0).xy, (float2({0}.xy) + float2({1}.xy) * 2.0).xy))))"), BaseNormal.Value, AdditionalNormal.Value);
+        value = writeLocal(ValueType::Vector3, text, node);
+        break;
+    }
     default:
         break;
     }


### PR DESCRIPTION
I've created a material node that mixes two normal maps together. I'll work on optimising it in the future when I get better at navigating the engine.
