### PR TITLE
Added rotator node for material editor

### DIFF
--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -657,6 +657,21 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Output(0, "Result", typeof(Vector3), 2)
                 }
             },
+            new NodeArchetype
+            {
+                TypeID = 27,
+                Title = "Rotator",
+                Description = "Rotates UV coordinates according to a scalar angle (0-1)",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Vector2(150, 55),
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "UV", true, typeof(Vector2), 0),
+                    NodeElementArchetype.Factory.Input(1, "Center", true, typeof(Vector2), 1),
+                    NodeElementArchetype.Factory.Input(2, "Rotation Angle", true, typeof(float), 2),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(Vector2), 3),
+                }
+            },
         };
     }
 }

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -339,12 +339,29 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
     case 25:
         value = Value(VariantType::Vector3, TEXT("GetObjectSize(input)"));
         break;
+        // Normal blend
     case 26:
     {
         const auto baseNormal = tryGetValue(node->GetBox(0), Value::Zero).AsVector3();
         const auto additionalNormal = tryGetValue(node->GetBox(1), Value::Zero).AsVector3();
         const String text = String::Format(TEXT("float3((float2({0}.xy) + float2({1}.xy) * 2.0), sqrt(saturate(1.0 - dot((float2({0}.xy) + float2({1}.xy) * 2.0).xy, (float2({0}.xy) + float2({1}.xy) * 2.0).xy))))"), baseNormal.Value, additionalNormal.Value);
         value = writeLocal(ValueType::Vector3, text, node);
+        break;
+    }
+        // Rotator
+    case 27:
+    {
+        auto UV = tryGetValue(node->GetBox(0), Value::Zero).AsVector2();
+        auto center = tryGetValue(node->GetBox(1), Value::Zero).AsVector2();
+        auto rotationAngle = tryGetValue(node->GetBox(2), Value::Zero).AsFloat();
+
+        const auto x1 = writeLocal(ValueType::Vector2, String::Format(TEXT("({0} * -1) + {1}"), center.Value, UV.Value), node);
+        const auto RACosSin = writeLocal(ValueType::Vector2, String::Format(TEXT("float2(cos({0}), sin({0}))"), rotationAngle.Value), node);
+
+        const auto DotB1 = writeLocal(ValueType::Vector2, String::Format(TEXT("float2({0}.x, {0}.y * -1)"), RACosSin.Value), node);
+        const auto DotB2 = writeLocal(ValueType::Vector2, String::Format(TEXT("float2({0}.y, {0}.x)"), RACosSin.Value), node);
+
+        value = writeLocal(ValueType::Vector2, String::Format(TEXT("{3} + float2(dot({0},{1}), dot({0},{2}))"), x1.Value, DotB1.Value, DotB2.Value, center.Value), node);
         break;
     }
     default:


### PR DESCRIPTION
Finished a feature on [trello](https://trello.com/c/mBEAJjHk/179-materials-and-shaders-roadmap) which listed a rotator material node.

Well here it is! The node takes texture coordinates and rotates them along a scalar angle, as well as being able to define the point of rotation.

https://user-images.githubusercontent.com/63303990/105632978-5ae3a980-5e56-11eb-9dcb-c1fea1f049bd.mp4