### PR TITLE
Optimisied Blend Normal Node

### DIFF
--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -342,10 +342,14 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Blend Normals
     case 26:
     {
-        const auto baseNormal = tryGetValue(node->GetBox(0), Value::Zero).AsVector3();
-        const auto additionalNormal = tryGetValue(node->GetBox(1), Value::Zero).AsVector3();
-        const String text = String::Format(TEXT("float3((float2({0}.xy) + float2({1}.xy) * 2.0), sqrt(saturate(1.0 - dot((float2({0}.xy) + float2({1}.xy) * 2.0).xy, (float2({0}.xy) + float2({1}.xy) * 2.0).xy))))"), baseNormal.Value, additionalNormal.Value);
-        value = writeLocal(ValueType::Vector3, text, node);
+        const auto baseNormal = tryGetValue(node->GetBox(0), getNormalZero).AsVector3();
+        const auto additionalNormal = tryGetValue(node->GetBox(1), getNormalZero).AsVector3();
+
+        const String text1 = String::Format(TEXT("(float2({0}.xy) + float2({1}.xy) * 2.0)"), baseNormal.Value, additionalNormal.Value);
+        const auto appendXY = writeLocal(ValueType::Vector2, text1, node);
+
+        const String text2 = String::Format(TEXT("float3({0}, sqrt(saturate(1.0 - dot({0}.xy, {0}.xy))))"), appendXY.Value);
+        value = writeLocal(ValueType::Vector3, text2, node);
         break;
     }
         // Rotator

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
@@ -27,6 +27,7 @@ enum MaterialTemplateInputsMapping
 MaterialValue MaterialGenerator::getUVs(VariantType::Vector2, TEXT("input.TexCoord"));
 MaterialValue MaterialGenerator::getTime(VariantType::Float, TEXT("TimeParam"));
 MaterialValue MaterialGenerator::getNormal(VariantType::Vector3, TEXT("input.TBN[2]"));
+MaterialValue MaterialGenerator::getNormalZero(VariantType::Vector3, TEXT("float3(.5, .5, 1)"));
 MaterialValue MaterialGenerator::getVertexColor(VariantType::Vector4, TEXT("GetVertexColor(input)"));
 
 MaterialGenerator::MaterialGenerator()

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
@@ -27,7 +27,7 @@ enum MaterialTemplateInputsMapping
 MaterialValue MaterialGenerator::getUVs(VariantType::Vector2, TEXT("input.TexCoord"));
 MaterialValue MaterialGenerator::getTime(VariantType::Float, TEXT("TimeParam"));
 MaterialValue MaterialGenerator::getNormal(VariantType::Vector3, TEXT("input.TBN[2]"));
-MaterialValue MaterialGenerator::getNormalZero(VariantType::Vector3, TEXT("float3(.5, .5, 1)"));
+MaterialValue MaterialGenerator::getNormalZero(VariantType::Vector3, TEXT("float3(0, 0, 1)"));
 MaterialValue MaterialGenerator::getVertexColor(VariantType::Vector4, TEXT("GetVertexColor(input)"));
 
 MaterialGenerator::MaterialGenerator()

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.h
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.h
@@ -205,6 +205,7 @@ public:
     static MaterialValue getUVs;
     static MaterialValue getTime;
     static MaterialValue getNormal;
+    static MaterialValue getNormalZero;
     static MaterialValue getVertexColor;
     static MaterialGraphBoxesMapping MaterialGraphBoxesMappings[];
 


### PR DESCRIPTION
I've also added a getNormalZero to get a normal that has zeroed out, i.e. it faces directly outwards from the face. This enables the user to not have to input a vector for either the Base or Additional Normal inputs and still get a result that is acceptable. This is handy if you want to "wash out" a normal.