### PR TITLE
Added Remap node for all graphs

### DIFF
--- a/Source/Editor/Surface/Archetypes/Math.cs
+++ b/Source/Editor/Surface/Archetypes/Math.cs
@@ -404,6 +404,29 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Output(0, "A | B", null, 2),
                 }
             },
+            new NodeArchetype
+            {
+                TypeID = 48,
+                Title = "Remap",
+                Description = "Remaps a value from one range to another, so for example having 25 in a range of 0 to 100 being remapped to 0 to 1 would return 0.25",
+                Flags = NodeFlags.AllGraphs,
+                Size = new Vector2(175, 75),
+                DefaultValues = new object[]
+                {
+                    25.0f,
+                    new Vector2(0.0f, 100.0f),
+                    new Vector2(0.0f, 1.0f),
+                    false
+                },
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Value", true, typeof(float), 0, 0),
+                    NodeElementArchetype.Factory.Input(1, "In Range", true, typeof(Vector2), 1, 1),
+                    NodeElementArchetype.Factory.Input(2, "Out Range", true, typeof(Vector2), 2, 2),
+                    NodeElementArchetype.Factory.Input(3, "Clamp", true, typeof(bool), 3, 3),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(float), 4),
+                }
+            },
         };
     }
 }

--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -405,17 +405,12 @@ void ShaderGenerator::ProcessGroupMath(Box* box, Node* node, Value& value)
         // Remap
     case 48:
     {
-        auto inVal  = tryGetValue(node->GetBox(0), node->Values[0].AsFloat);
-        auto rangeA = tryGetValue(node->GetBox(1), node->Values[1].AsVector2());
-        auto rangeB = tryGetValue(node->GetBox(2), node->Values[2].AsVector2());
+        const auto inVal  = tryGetValue(node->GetBox(0), node->Values[0].AsFloat);
+        const auto rangeA = tryGetValue(node->GetBox(1), node->Values[1].AsVector2());
+        const auto rangeB = tryGetValue(node->GetBox(2), node->Values[2].AsVector2());
 
-        // Clamp value?
-        if (node->Values[3].AsBool)
-        {
-            value = writeLocal(ValueType::Float, String::Format(TEXT("clamp({2}.x + ({0} - {1}.x) * ({2}.y - {2}.x) / ({1}.y - {1}.x), {2}.x, {2}.y)"), inVal.Value, rangeA.Value, rangeB.Value), node);
-            break;
-        }
-        value = writeLocal(ValueType::Float, String::Format(TEXT("{2}.x + ({0} - {1}.x) * ({2}.y - {2}.x) / ({1}.y - {1}.x)"), inVal.Value, rangeA.Value, rangeB.Value), node);
+        const auto mapFunc = String::Format(TEXT("{2}.x + ({0} - {1}.x) * ({2}.y - {2}.x) / ({1}.y - {1}.x)"), inVal.Value, rangeA.Value, rangeB.Value);
+        value = writeLocal(ValueType::Float, node->Values[3].AsBool ? String::Format(TEXT("clamp({0}, {1}.x, {1}.y)"), mapFunc, rangeB.Value) : mapFunc, node);
         break;
     }
     default:

--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -405,9 +405,9 @@ void ShaderGenerator::ProcessGroupMath(Box* box, Node* node, Value& value)
         // Remap
     case 48:
     {
-        auto inVal  = tryGetValue(node->GetBox(0), node->Values[0]);
-        auto rangeA = tryGetValue(node->GetBox(1), node->Values[1]);
-        auto rangeB = tryGetValue(node->GetBox(2), node->Values[2]);
+        auto inVal  = tryGetValue(node->GetBox(0), node->Values[0].AsFloat);
+        auto rangeA = tryGetValue(node->GetBox(1), node->Values[1].AsVector2());
+        auto rangeB = tryGetValue(node->GetBox(2), node->Values[2].AsVector2());
 
         // Clamp value?
         if (node->Values[3].AsBool)

--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -408,9 +408,10 @@ void ShaderGenerator::ProcessGroupMath(Box* box, Node* node, Value& value)
         const auto inVal  = tryGetValue(node->GetBox(0), node->Values[0].AsFloat);
         const auto rangeA = tryGetValue(node->GetBox(1), node->Values[1].AsVector2());
         const auto rangeB = tryGetValue(node->GetBox(2), node->Values[2].AsVector2());
+        const auto clamp  = tryGetValue(node->GetBox(3), node->Values[3]).AsBool();
 
         const auto mapFunc = String::Format(TEXT("{2}.x + ({0} - {1}.x) * ({2}.y - {2}.x) / ({1}.y - {1}.x)"), inVal.Value, rangeA.Value, rangeB.Value);
-        value = writeLocal(ValueType::Float, node->Values[3].AsBool ? String::Format(TEXT("clamp({0}, {1}.x, {1}.y)"), mapFunc, rangeB.Value) : mapFunc, node);
+        value = writeLocal(ValueType::Float, String::Format(TEXT("{2} ? clamp({0}, {1}.x, {1}.y) : {0}"), mapFunc, rangeB.Value, clamp.Value), node);
         break;
     }
     default:

--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -402,6 +402,22 @@ void ShaderGenerator::ProcessGroupMath(Box* box, Node* node, Value& value)
         value = writeFunction1(node, tryGetValue(node->GetBox(0), Value::Zero), TEXT("radians"));
         break;
     }
+        // Remap
+    case 48:
+    {
+        auto inVal  = tryGetValue(node->GetBox(0), node->Values[0]);
+        auto rangeA = tryGetValue(node->GetBox(1), node->Values[1]);
+        auto rangeB = tryGetValue(node->GetBox(2), node->Values[2]);
+
+        // Clamp value?
+        if (node->Values[3].AsBool)
+        {
+            value = writeLocal(ValueType::Float, String::Format(TEXT("clamp({2}.x + ({0} - {1}.x) * ({2}.y - {2}.x) / ({1}.y - {1}.x), {2}.x, {2}.y)"), inVal.Value, rangeA.Value, rangeB.Value), node);
+            break;
+        }
+        value = writeLocal(ValueType::Float, String::Format(TEXT("{2}.x + ({0} - {1}.x) * ({2}.y - {2}.x) / ({1}.y - {1}.x)"), inVal.Value, rangeA.Value, rangeB.Value), node);
+        break;
+    }
     default:
         break;
     }

--- a/Source/Engine/Visject/VisjectGraph.cpp
+++ b/Source/Engine/Visject/VisjectGraph.cpp
@@ -378,13 +378,10 @@ void VisjectExecutor::ProcessGroupMath(Box* box, Node* node, Value& value)
         const Vector2 rangeA = tryGetValue(node->GetBox(1), node->Values[1]).AsVector2();
         const Vector2 rangeB = tryGetValue(node->GetBox(2), node->Values[2]).AsVector2();
 
+        auto mapFunc = rangeB.X + (inVal - rangeA.X) * (rangeB.Y - rangeB.X) / (rangeA.Y - rangeA.X);
+        
         // Clamp value?
-        if (node->Values[3].AsBool) 
-        {
-            value = Math::Clamp(rangeB.X + (inVal - rangeA.X) * (rangeB.Y - rangeB.X) / (rangeA.Y - rangeA.X), rangeB.X, rangeB.Y);
-            break;
-        }
-        value = rangeB.X + (inVal - rangeA.X) * (rangeB.Y - rangeB.X) / (rangeA.Y - rangeA.X);
+        value = node->Values[3].AsBool ? Math::Clamp(mapFunc, rangeB.X, rangeB.Y) : mapFunc;
         break;
     }
     default:

--- a/Source/Engine/Visject/VisjectGraph.cpp
+++ b/Source/Engine/Visject/VisjectGraph.cpp
@@ -371,6 +371,22 @@ void VisjectExecutor::ProcessGroupMath(Box* box, Node* node, Value& value)
         if (value.Type.Type == VariantType::Enum)
             value.AsUint64 = value.AsUint64 | (uint64)tryGetValue(node->GetBox(1), Value::Zero);
         break;
+
+    case 48:
+    {
+        const float inVal  = tryGetValue(node->GetBox(0), node->Values[0]).AsFloat;
+        const Vector2 rangeA = tryGetValue(node->GetBox(1), node->Values[1]).AsVector2();
+        const Vector2 rangeB = tryGetValue(node->GetBox(2), node->Values[2]).AsVector2();
+
+        // Use clamp?
+        if (node->Values[3].AsBool) 
+        {
+            value = Math::Clamp(rangeB.X + (inVal - rangeA.X) * (rangeB.Y - rangeB.X) / (rangeA.Y - rangeA.X), rangeB.X, rangeB.Y);
+            break;
+        }
+        value = rangeB.X + (inVal - rangeA.X) * (rangeB.Y - rangeB.X) / (rangeA.Y - rangeA.X);
+        break;
+    }
     default:
         break;
     }

--- a/Source/Engine/Visject/VisjectGraph.cpp
+++ b/Source/Engine/Visject/VisjectGraph.cpp
@@ -378,7 +378,7 @@ void VisjectExecutor::ProcessGroupMath(Box* box, Node* node, Value& value)
         const Vector2 rangeA = tryGetValue(node->GetBox(1), node->Values[1]).AsVector2();
         const Vector2 rangeB = tryGetValue(node->GetBox(2), node->Values[2]).AsVector2();
 
-        // Use clamp?
+        // Clamp value?
         if (node->Values[3].AsBool) 
         {
             value = Math::Clamp(rangeB.X + (inVal - rangeA.X) * (rangeB.Y - rangeB.X) / (rangeA.Y - rangeA.X), rangeB.X, rangeB.Y);

--- a/Source/Engine/Visject/VisjectGraph.cpp
+++ b/Source/Engine/Visject/VisjectGraph.cpp
@@ -371,17 +371,18 @@ void VisjectExecutor::ProcessGroupMath(Box* box, Node* node, Value& value)
         if (value.Type.Type == VariantType::Enum)
             value.AsUint64 = value.AsUint64 | (uint64)tryGetValue(node->GetBox(1), Value::Zero);
         break;
-
+        // Remap
     case 48:
     {
         const float inVal  = tryGetValue(node->GetBox(0), node->Values[0]).AsFloat;
         const Vector2 rangeA = tryGetValue(node->GetBox(1), node->Values[1]).AsVector2();
         const Vector2 rangeB = tryGetValue(node->GetBox(2), node->Values[2]).AsVector2();
+        const bool clamp = tryGetValue(node->GetBox(3), node->Values[3]).AsBool;
 
         auto mapFunc = rangeB.X + (inVal - rangeA.X) * (rangeB.Y - rangeB.X) / (rangeA.Y - rangeA.X);
         
         // Clamp value?
-        value = node->Values[3].AsBool ? Math::Clamp(mapFunc, rangeB.X, rangeB.Y) : mapFunc;
+        value = clamp ? Math::Clamp(mapFunc, rangeB.X, rangeB.Y) : mapFunc;
         break;
     }
     default:


### PR DESCRIPTION
Added the remap node since it was listed on trello specifically for the material editor. However, I also went ahead and added it for all graphs since its a general purpose node. The node is under the math category.

**Shadergraph:**

https://user-images.githubusercontent.com/63303990/105702427-1286c300-5f0c-11eb-838e-aa7a1c20ab3d.mp4


**Visjectgraph:**
![image](https://user-images.githubusercontent.com/63303990/105702349-f7b44e80-5f0b-11eb-823a-06f4d4a92871.png)

