### PR TITLE
Disable CTRL+W in game mode

### DIFF
--- a/Source/Editor/Options/InputBinding.cs
+++ b/Source/Editor/Options/InputBinding.cs
@@ -143,7 +143,30 @@ namespace FlaxEditor.Options
         {
             var root = control.Root;
 
-            if (root.GetKeyDown(Key))
+            if (root.GetKey(Key))
+            {
+                if (Modifier1 == KeyboardKeys.None || root.GetKey(Modifier1))
+                {
+                    if (Modifier2 == KeyboardKeys.None || root.GetKey(Modifier2))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Processes this input binding to check if state matches.
+        /// </summary>
+        /// <param name="control">The input providing control.</param>
+        /// <returns>True if input has been processed, otherwise false.</returns>
+        public bool Process(Control control, KeyboardKeys key)
+        {
+            var root = control.Root;
+
+            if (key == Key)
             {
                 if (Modifier1 == KeyboardKeys.None || root.GetKey(Modifier1))
                 {
@@ -435,16 +458,10 @@ namespace FlaxEditor.Options
             for (int i = 0; i < _bindings.Count; i++)
             {
                 var binding = _bindings[i].Binder(options);
-                if (binding.Key == key)
+                if (binding.Process(control, key))
                 {
-                    if (binding.Modifier1 == KeyboardKeys.None || root.GetKey(binding.Modifier1))
-                    {
-                        if (binding.Modifier2 == KeyboardKeys.None || root.GetKey(binding.Modifier2))
-                        {
-                            _bindings[i].Callback();
-                            return true;
-                        }
-                    }
+                    _bindings[i].Callback();
+                    return true;
                 }
             }
 

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -387,8 +387,9 @@ namespace FlaxEditor.Windows
             }
             }
 
+
             // Prevent closing the game window tab during a play session
-            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(Root))
+            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(this, key))
             {
                 return true;
             }

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -387,6 +387,12 @@ namespace FlaxEditor.Windows
             }
             }
 
+            // Prevent closing the game window tab during a play session
+            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(Root))
+            {
+                return true;
+            }
+
             return base.OnKeyDown(key);
         }
 


### PR DESCRIPTION
During play mode, it checks if the pressed shortcut was CTRL+W. If yes, don't close the game window.

I also tweaked the key processing code a bit. Hopefully that's ok

Fix #96