### PR TITLE
Fix Issue #165: Weird normals on plane primitive

### DIFF
--- a/Content/Editor/Primitives/Plane.flax
+++ b/Content/Editor/Primitives/Plane.flax
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ab6d87b9f36f4ad231f38f415223130eea7b411be7ff8fd174b6ff7790258fb
-size 2232
+oid sha256:1aca713de7b568bf29143b98654c06af01d2366c9db1c37c7c2bcc1df1c99185
+size 1468


### PR DESCRIPTION
Fixes issue #165 via 2 ways:
- Removes weird normals, simply imported a fresh new plane from blender.
- Rotates the plane correctly so that it isn't facing the wrong direction anymore.

Plane had some weird normal thing on the top left: (Image by Stefnotch)
![image](https://user-images.githubusercontent.com/63303990/106067497-129ae480-60ff-11eb-8931-f7678a8464ba.png)

Its gone: (visual effect is just a shader)
![image](https://user-images.githubusercontent.com/63303990/106067525-25151e00-60ff-11eb-8445-ffff73f4ffbf.png)
