### PR TITLE
Set minimum width and height for texture description in motion blur

### DIFF
--- a/Source/Engine/Renderer/MotionBlurPass.cpp
+++ b/Source/Engine/Renderer/MotionBlurPass.cpp
@@ -339,6 +339,13 @@ void MotionBlurPass::Render(RenderContext& renderContext, GPUTexture*& input, GP
     // Downscale motion vectors texture down to tileSize/tileSize (with max velocity calculation NxN kernel)
     rtDesc.Width = motionVectorsWidth / tileSize;
     rtDesc.Height = motionVectorsHeight / tileSize;
+    
+    if (rtDesc.Width < 1)
+        rtDesc.Width = 1;
+    
+    if (rtDesc.Height < 1)
+        rtDesc.Height = 1;
+
     auto vMaxBuffer = RenderTargetPool::Get(rtDesc);
     context->ResetRenderTarget();
     context->SetRenderTarget(vMaxBuffer->View());


### PR DESCRIPTION
The issue in #158 is that the calculations for the texture description width and height will result in 0.
(`motionVectorsWidth / tileSize`)

The fix is to set minimum width and height to 1.

After applying the minimum width and height to 1, I couldn't reproduce the bug anymore.