### PR TITLE
Fix InputText & Typo.

### DIFF
--- a/Source/Engine/Input/Keyboard.h
+++ b/Source/Engine/Input/Keyboard.h
@@ -13,7 +13,7 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(Keyboard);
 public:
 
     /// <summary>
-    /// The mouse state.
+    /// The keyboard state.
     /// </summary>
     struct State
     {
@@ -157,6 +157,7 @@ public:
         if (UpdateState())
             return true;
 
+        _state.InputTextLength = 0;
         // Handle events
         for (int32 i = 0; i < _queue.Count(); i++)
         {


### PR DESCRIPTION
The InputText was not cleared between updates.

Putting 0 in InputTextLength at the start of the update fix it.