### PR TITLE
Add Sign, Any, All and Blackbody shader nodes

### DIFF
--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -805,9 +805,13 @@ namespace FlaxEditor.Surface.Archetypes
                 Description = "Simulates black body radiation via a given temperature in kelvin",
                 Flags = NodeFlags.MaterialGraph,
                 Size = new Vector2(120, 25),
+                DefaultValues = new object[]
+                {
+                    0.0f,
+                },
                 Elements = new[]
                 {
-                    NodeElementArchetype.Factory.Input(0, "Temp", true, typeof(float), 0),
+                    NodeElementArchetype.Factory.Input(0, "Temp", true, typeof(float), 0, 0),
                     NodeElementArchetype.Factory.Output(0, string.Empty, typeof(Vector3), 1),
                 }
             },

--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -725,7 +725,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 30,
                 Title = "DDX",
-                Description = "Returns the partial derivative of the specified value with respect to the screen-space x-coordinate.",
+                Description = "Returns the partial derivative of the specified value with respect to the screen-space x-coordinate",
                 Flags = NodeFlags.MaterialGraph,
                 Size = new Vector2(90, 25),
                 ConnectionsHints = ConnectionsHint.Numeric,
@@ -741,7 +741,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 31,
                 Title = "DDY",
-                Description = "Returns the partial derivative of the specified value with respect to the screen-space y-coordinate.",
+                Description = "Returns the partial derivative of the specified value with respect to the screen-space y-coordinate",
                 Flags = NodeFlags.MaterialGraph,
                 Size = new Vector2(90, 25),
                 ConnectionsHints = ConnectionsHint.Numeric,
@@ -751,6 +751,64 @@ namespace FlaxEditor.Surface.Archetypes
                 {
                     NodeElementArchetype.Factory.Input(0, "Value", true, null, 0),
                     NodeElementArchetype.Factory.Output(0, string.Empty, null, 1),
+                }
+            },
+            new NodeArchetype
+            {
+                TypeID = 32,
+                Title = "Sign",
+                Description = "Returns -1 if value is less than zero; 0 if value equals zero; and 1 if value is greater than zero",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Vector2(90, 25),
+                ConnectionsHints = ConnectionsHint.Numeric,
+                IndependentBoxes = new[] { 0 },
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Value", true, null, 0),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(float), 1),
+                }
+            },
+            new NodeArchetype
+            {
+                TypeID = 33,
+                Title = "Any",
+                Description = "True if any components of value are non-zero; otherwise, false",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Vector2(90, 25),
+                ConnectionsHints = ConnectionsHint.Numeric,
+                IndependentBoxes = new[] { 0 },
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Value", true, null, 0),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(bool), 1),
+                }
+            },
+            new NodeArchetype
+            {
+                TypeID = 34,
+                Title = "All",
+                Description = "Determines if all components of the specified value are non-zero",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Vector2(90, 25),
+                ConnectionsHints = ConnectionsHint.Numeric,
+                IndependentBoxes = new[] { 0 },
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Value", true, null, 0),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(bool), 1),
+                }
+            },
+            new NodeArchetype
+            {
+                TypeID = 35,
+                Title = "Black Body",
+                Description = "Simulates black body radiation via a given temperature in kelvin",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Vector2(120, 25),
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Temp", true, typeof(float), 0),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(Vector3), 1),
                 }
             },
         };

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -435,6 +435,8 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Blackbody
     case 35:
     {
+        // Based on unity's implementation by using data gathered by Mitchell Charity.
+
         const auto temperature = tryGetValue(node->GetBox(0), node->Values[0]).AsFloat();
 
         // Value X

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -438,10 +438,10 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         const auto temperature = tryGetValue(node->GetBox(0), node->Values[0]).AsFloat();
 
         // Value X
-        auto x = writeLocal(ValueType::Float, String::Format(TEXT("56100000.0f * pow({0}, (-3.0f / 2.0f)) + 148.0f"), temperature.Value), node);
+        auto x = writeLocal(ValueType::Float, String::Format(TEXT("56100000.0f * pow({0}, -1) + 148.0f"), temperature.Value), node);
 
         // Value Y
-        auto y = writeLocal(ValueType::Float, String::Format(TEXT("{0} > 6500.0f ? 35200000.0f * pow({0}, (-3.0f / 2.0f)) + 184.0f : 100.04f * log({0}) - 623.6f"), temperature.Value), node);
+        auto y = writeLocal(ValueType::Float, String::Format(TEXT("{0} > 6500.0f ? 35200000.0f * pow({0}, -1) + 184.0f : 100.04f * log({0}) - 623.6f"), temperature.Value), node);
 
         // Value Z
         auto z = writeLocal(ValueType::Float, String::Format(TEXT("194.18f * log({0}) - 1448.6f"), temperature.Value), node);

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -351,15 +351,15 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Rotator
     case 27:
     {
-        auto uv = tryGetValue(node->GetBox(0), getUVs).AsVector2();
-        auto center = tryGetValue(node->GetBox(1), Value::Zero).AsVector2();
-        auto rotationAngle = tryGetValue(node->GetBox(2), Value::Zero).AsFloat();
+        const auto uv = tryGetValue(node->GetBox(0), getUVs).AsVector2();
+        const auto center = tryGetValue(node->GetBox(1), Value::Zero).AsVector2();
+        const auto rotationAngle = tryGetValue(node->GetBox(2), Value::Zero).AsFloat();
 
-        const auto x1 = writeLocal(ValueType::Vector2, String::Format(TEXT("({0} * -1) + {1}"), center.Value, uv.Value), node);
-        const auto raCosSin = writeLocal(ValueType::Vector2, String::Format(TEXT("float2(cos({0}), sin({0}))"), rotationAngle.Value), node);
+        auto x1 = writeLocal(ValueType::Vector2, String::Format(TEXT("({0} * -1) + {1}"), center.Value, uv.Value), node);
+        auto raCosSin = writeLocal(ValueType::Vector2, String::Format(TEXT("float2(cos({0}), sin({0}))"), rotationAngle.Value), node);
 
-        const auto dotB1 = writeLocal(ValueType::Vector2, String::Format(TEXT("float2({0}.x, {0}.y * -1)"), raCosSin.Value), node);
-        const auto dotB2 = writeLocal(ValueType::Vector2, String::Format(TEXT("float2({0}.y, {0}.x)"), raCosSin.Value), node);
+        auto dotB1 = writeLocal(ValueType::Vector2, String::Format(TEXT("float2({0}.x, {0}.y * -1)"), raCosSin.Value), node);
+        auto dotB2 = writeLocal(ValueType::Vector2, String::Format(TEXT("float2({0}.y, {0}.x)"), raCosSin.Value), node);
 
         value = writeLocal(ValueType::Vector2, String::Format(TEXT("{3} + float2(dot({0},{1}), dot({0},{2}))"), x1.Value, dotB1.Value, dotB2.Value, center.Value), node);
         break;
@@ -367,11 +367,11 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Sphere Mask
     case 28:
     {
-        Value a = tryGetValue(node->GetBox(0), 0, Value::Zero);
-        Value b = tryGetValue(node->GetBox(1), 1, Value::Zero).Cast(a.Type);
-        Value radius = tryGetValue(node->GetBox(2), node->Values[0]).AsFloat();
-        Value hardness = tryGetValue(node->GetBox(3), node->Values[1]).AsFloat();
-        Value invert = tryGetValue(node->GetBox(4), node->Values[2]).AsBool();
+        const auto a = tryGetValue(node->GetBox(0), 0, Value::Zero);
+        const auto b = tryGetValue(node->GetBox(1), 1, Value::Zero).Cast(a.Type);
+        const auto radius = tryGetValue(node->GetBox(2), node->Values[0]).AsFloat();
+        const auto hardness = tryGetValue(node->GetBox(3), node->Values[1]).AsFloat();
+        const auto invert = tryGetValue(node->GetBox(4), node->Values[2]).AsBool();
 
         // Get distance and apply radius
         auto x1 = writeLocal(ValueType::Float, String::Format(TEXT("distance({0},{1}) * (1 / {2})"), a.Value, b.Value, radius.Value), node);
@@ -385,9 +385,9 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Tiling & Offset
     case 29:
     {
-        auto uv = tryGetValue(node->GetBox(0), getUVs).AsVector2();
-        auto tiling = tryGetValue(node->GetBox(1), node->Values[0]).AsVector2();
-        auto offset = tryGetValue(node->GetBox(2), node->Values[1]).AsVector2();
+        const auto uv = tryGetValue(node->GetBox(0), getUVs).AsVector2();
+        const auto tiling = tryGetValue(node->GetBox(1), node->Values[0]).AsVector2();
+        const auto offset = tryGetValue(node->GetBox(2), node->Values[1]).AsVector2();
 
         value = writeLocal(ValueType::Vector2, String::Format(TEXT("{0} * {1} + {2}"), uv.Value, tiling.Value, offset.Value), node);
         break;
@@ -395,7 +395,7 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // DDX
     case 30:
     {
-        auto inValue = tryGetValue(node->GetBox(0), 0, Value::Zero);
+        const auto inValue = tryGetValue(node->GetBox(0), 0, Value::Zero);
 
         value = writeLocal(inValue.Type, String::Format(TEXT("ddx({0})"), inValue.Value), node);
         break;
@@ -403,9 +403,38 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // DDY
     case 31:
     {
-        auto inValue = tryGetValue(node->GetBox(0), 0, Value::Zero);
+        const auto inValue = tryGetValue(node->GetBox(0), 0, Value::Zero);
 
         value = writeLocal(inValue.Type, String::Format(TEXT("ddy({0})"), inValue.Value), node);
+        break;
+    }
+        // Sign
+    case 32:
+    {
+        const auto inValue = tryGetValue(node->GetBox(0), 0, Value::Zero);
+
+        value = writeLocal(ValueType::Float, String::Format(TEXT("sign({0})"), inValue.Value), node);
+        break;
+    }
+        // Any
+    case 33:
+    {
+        const auto inValue = tryGetValue(node->GetBox(0), 0, Value::Zero);
+
+        value = writeLocal(ValueType::Bool, String::Format(TEXT("any({0})"), inValue.Value), node);
+        break;
+    }
+        // All
+    case 34:
+    {
+        const auto inValue = tryGetValue(node->GetBox(0), 0, Value::Zero);
+
+        value = writeLocal(ValueType::Bool, String::Format(TEXT("all({0})"), inValue.Value), node);
+        break;
+    }
+        // Blackbody
+    case 35:
+    {
         break;
     }
     default:

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -435,7 +435,7 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Blackbody
     case 35:
     {
-        // Based on unity's implementation by using data gathered by Mitchell Charity.
+        // Reference: Mitchell Charity, http://www.vendian.org/mncharity/dir3/blackbody/
 
         const auto temperature = tryGetValue(node->GetBox(0), node->Values[0]).AsFloat();
 
@@ -451,9 +451,7 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Final color
         auto color = writeLocal(ValueType::Vector3, String::Format(TEXT("float3({0}, {1}, {2})"), x.Value, y.Value, z.Value), node);
         color = writeLocal(ValueType::Vector3, String::Format(TEXT("clamp({0}, 0.0f, 255.0f) / 255.0f"), color.Value), node);
-        color = writeLocal(ValueType::Vector3, String::Format(TEXT("{1} < 1000.0f ? {0} * {1}/1000.0f : {0}"), color.Value, temperature.Value), node);
-
-        value = color;
+        value = writeLocal(ValueType::Vector3, String::Format(TEXT("{1} < 1000.0f ? {0} * {1}/1000.0f : {0}"), color.Value, temperature.Value), node);
         break;
     }
     default:

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -435,6 +435,23 @@ void MaterialGenerator::ProcessGroupMaterial(Box* box, Node* node, Value& value)
         // Blackbody
     case 35:
     {
+        const auto temperature = tryGetValue(node->GetBox(0), node->Values[0]).AsFloat();
+
+        // Value X
+        auto x = writeLocal(ValueType::Float, String::Format(TEXT("56100000.0f * pow({0}, (-3.0f / 2.0f)) + 148.0f"), temperature.Value), node);
+
+        // Value Y
+        auto y = writeLocal(ValueType::Float, String::Format(TEXT("{0} > 6500.0f ? 35200000.0f * pow({0}, (-3.0f / 2.0f)) + 184.0f : 100.04f * log({0}) - 623.6f"), temperature.Value), node);
+
+        // Value Z
+        auto z = writeLocal(ValueType::Float, String::Format(TEXT("194.18f * log({0}) - 1448.6f"), temperature.Value), node);
+
+        // Final color
+        auto color = writeLocal(ValueType::Vector3, String::Format(TEXT("float3({0}, {1}, {2})"), x.Value, y.Value, z.Value), node);
+        color = writeLocal(ValueType::Vector3, String::Format(TEXT("clamp({0}, 0.0f, 255.0f) / 255.0f"), color.Value), node);
+        color = writeLocal(ValueType::Vector3, String::Format(TEXT("{1} < 1000.0f ? {0} * {1}/1000.0f : {0}"), color.Value, temperature.Value), node);
+
+        value = color;
         break;
     }
     default:


### PR DESCRIPTION
Probably the last shader node PR? Who knows!

While I was adding the nodes I also wanted to establish some form of consistency, for all the previous nodes since it was a bit here and there, by making box inputs as `const auto` and other things like shader functions as `auto`.

This PR adds all these nodes which were listed on trello:
-Sign
-Any
-All
-Blackbody

![image](https://user-images.githubusercontent.com/63303990/106369602-1de64e00-6353-11eb-83b9-ecd4b4b2b04c.png)

Blackbody Example:

https://user-images.githubusercontent.com/63303990/106369608-29d21000-6353-11eb-8c8d-a02ad406547d.mp4

