### PR TITLE
Bug Fix: UI game window preview + global bounds

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -294,7 +294,7 @@ namespace FlaxEditor.Windows
             {
                 if (Editor.Instance.SceneEditing.Selection[i].EditableObject is UIControl controlActor && controlActor.Control != null)
                 {
-                    Render2D.DrawRectangle(controlActor.Control.Bounds, Editor.Instance.Options.Options.Visual.SelectionOutlineColor0, Editor.Instance.Options.Options.Visual.UISelectionOutlineSize);
+                    Render2D.DrawRectangle(controlActor.Control.GlobalBounds, Editor.Instance.Options.Options.Visual.SelectionOutlineColor0, Editor.Instance.Options.Options.Visual.UISelectionOutlineSize);
                 }
             }
 

--- a/Source/Engine/UI/GUI/Control.Bounds.cs
+++ b/Source/Engine/UI/GUI/Control.Bounds.cs
@@ -229,6 +229,24 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
+        /// Gets global controls bounds rectangle.(Recursing all parents)
+        /// </summary>
+        [HideInEditor, NoSerialize]
+        public Rectangle GlobalBounds
+        {
+            get {
+                if(Parent != null && !(Parent is CanvasContainer))
+                {
+                    Rectangle bnds = _bounds;
+                    bnds.X += Parent.GlobalBounds.X;
+                    bnds.Y += Parent.GlobalBounds.Y;
+                    return bnds;
+                }
+                return Bounds;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the scale.
         /// </summary>
         [EditorDisplay("Transform"), Limit(float.MinValue, float.MaxValue, 0.1f), EditorOrder(1020), Tooltip("The control scale parameter.")]


### PR DESCRIPTION
Game window now shows correct outline even for children. And I added GlobalBounds, which recurse all parents except CanvasContainer, gets its Bounds location and combines it with theirs.