### PR TITLE
[Editor/Docking] Bring window to front on focus

### DIFF
--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -307,6 +307,14 @@ namespace FlaxEditor.GUI.Docking
             _dockedTo?.SelectTab(this, autoFocus);
         }
 
+        /// <summary>
+        /// Brings the window to the front of the Z order.
+        /// </summary>
+        public void BringToFront()
+        {
+            _dockedTo?.RootWindow?.BringToFront();
+        }
+
         internal void OnUnlinkInternal()
         {
             OnUnlink();
@@ -412,6 +420,7 @@ namespace FlaxEditor.GUI.Docking
             base.Focus();
 
             SelectTab();
+            BringToFront();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
With this PR dock windows will be brought to the front of the screen when Focus() is called.
Tested with both floating and docked windows, both work as expected.

https://user-images.githubusercontent.com/5685257/106934558-2901fb00-6712-11eb-95a0-3275536a06b5.mp4