### PR TITLE
Fixed issue #210: Deleting non-existent folders from the editor.

### DIFF
--- a/Source/Editor/Content/Tree/ContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/ContentTreeNode.cs
@@ -295,7 +295,8 @@ namespace FlaxEditor.Content
                     StartRenaming();
                     return true;
                 case KeyboardKeys.Delete:
-                    Editor.Instance.Windows.ContentWin.Delete(Folder);
+                    if(Folder.Exists)
+                        Editor.Instance.Windows.ContentWin.Delete(Folder);
                     return true;
                 }
                 if (RootWindow.GetKey(KeyboardKeys.Control))
@@ -303,7 +304,8 @@ namespace FlaxEditor.Content
                     switch (key)
                     {
                     case KeyboardKeys.D:
-                        Editor.Instance.Windows.ContentWin.Duplicate(Folder);
+                        if(Folder.Exists)
+                            Editor.Instance.Windows.ContentWin.Duplicate(Folder);
                         return true;
                     }
                 }

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -396,7 +396,7 @@ namespace FlaxEditor.Windows
         /// <param name="item">The item to delete.</param>
         public void Delete(ContentItem item)
         {
-            Delete(new List<ContentItem> { item });
+            Delete(new List<ContentItem>(1) { item });
         }
 
         /// <summary>
@@ -405,42 +405,24 @@ namespace FlaxEditor.Windows
         /// <param name="items">The items to delete.</param>
         public void Delete(List<ContentItem> items)
         {
+            if (items.Count == 0) return;
+
             // TODO: remove items that depend on different items in the list: use wants to remove `folderA` and `folderA/asset.x`, we should just remove `folderA`
             var toDelete = new List<ContentItem>(items);
 
+            string msg = toDelete.Count == 1 ? 
+                  string.Format("Are you sure to delete \'{0}\'?\nThis action cannot be undone. Files will be deleted permanently.", items[0].Path)
+                : string.Format("Are you sure to delete {0} selected items?\nThis action cannot be undone. Files will be deleted permanently.", items.Count);
+
             // Ask user
-            if (toDelete.Count == 1)
-            {
-                // Single item
-                if (MessageBox.Show(string.Format("Are you sure to delete \'{0}\'?\nThis action cannot be undone. Files will be deleted permanently.", items[0].Path),
-                                    "Delete asset(s)",
-                                    MessageBoxButtons.OKCancel,
-                                    MessageBoxIcon.Question)
-                    != DialogResult.OK)
-                {
-                    // Break
-                    return;
-                }
-            }
-            else
-            {
-                // Many items
-                if (MessageBox.Show(string.Format("Are you sure to delete {0} selected items?\nThis action cannot be undone. Files will be deleted permanently.", items.Count),
-                                    "Delete asset(s)",
-                                    MessageBoxButtons.OKCancel,
-                                    MessageBoxIcon.Question)
-                    != DialogResult.OK)
-                {
-                    // Break
-                    return;
-                }
-            }
+            if (MessageBox.Show(msg, "Delete asset(s)", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) != DialogResult.OK)
+                return;
 
             // Clear navigation
             // TODO: just remove invalid locations from the history (those are removed)
             NavigationClearHistory();
 
-            // Delete items
+            // Delete
             for (int i = 0; i < toDelete.Count; i++)
                 Editor.ContentDatabase.Delete(toDelete[i]);
 

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -422,7 +422,7 @@ namespace FlaxEditor.Windows
             // TODO: just remove invalid locations from the history (those are removed)
             NavigationClearHistory();
 
-            // Delete
+            // Delete items
             for (int i = 0; i < toDelete.Count; i++)
                 Editor.ContentDatabase.Delete(toDelete[i]);
 


### PR DESCRIPTION
This will fix the issue described in #210.

The fix mentioned by @SilentCLD would have worked however it was more of a temp fix, I wanted to solve the core issue which was that even if nothing was selected the user could still delete something, a simple check was all that was needed.

Additionally I simplified the code for the MessageBox to avoid duplication.

Thanks to @VNNCC 