### PR TITLE
Fix issue #214: Debug draw with uneven amount of lines crashes

### DIFF
--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -644,7 +644,7 @@ void DebugDraw::DrawLines(const Span<Vector3>& lines, const Matrix& transform, c
 
     if (depthTest) 
         list = duration > 0 ? &DebugDrawDepthTest.DefaultLines : &DebugDrawDepthTest.OneFrameLines;
-    else 
+    else
         list = duration > 0 ? &DebugDrawDefault.DefaultLines : &DebugDrawDefault.OneFrameLines;
 
     list->EnsureCapacity(list->Count() + lines.Length());

--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -19,6 +19,7 @@
 #include "Engine/Graphics/RenderBuffers.h"
 #include "Engine/Animations/AnimationUtils.h"
 #include "Engine/Profiler/Profiler.h"
+#include "Engine/Debug/DebugLog.h"
 
 // Debug draw service configuration
 #define DEBUG_DRAW_INITIAL_VB_CAPACITY (4 * 1024)
@@ -631,7 +632,7 @@ void DebugDraw::DrawLines(const Span<Vector3>& lines, const Matrix& transform, c
 {
     if (lines.Length() % 2 == 0)
     {
-        LOG(Error, "Cannot draw debug lines with uneven amount of items in array");
+        DebugLog::ThrowException("Cannot draw debug lines with uneven amount of items in array");
         return;
     }
 

--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -629,7 +629,11 @@ void DebugDraw::DrawLine(const Vector3& start, const Vector3& end, const Color& 
 
 void DebugDraw::DrawLines(const Span<Vector3>& lines, const Matrix& transform, const Color& color, float duration, bool depthTest)
 {
-    ASSERT(lines.Length() % 2 == 0);
+    if (lines.Length() % 2 == 0)
+    {
+        LOG(Error, "Cannot draw debug lines with uneven amount of items in array");
+        return;
+    }
 
     // Create draw call entry
     DebugLine l = { Vector3::Zero, Vector3::Zero, Color32(color), duration };
@@ -637,10 +641,12 @@ void DebugDraw::DrawLines(const Span<Vector3>& lines, const Matrix& transform, c
     // Add lines
     const Vector3* p = lines.Get();
     Array<DebugLine>* list;
-    if (depthTest)
+
+    if (depthTest) 
         list = duration > 0 ? &DebugDrawDepthTest.DefaultLines : &DebugDrawDepthTest.OneFrameLines;
-    else
+    else 
         list = duration > 0 ? &DebugDrawDefault.DefaultLines : &DebugDrawDefault.OneFrameLines;
+
     list->EnsureCapacity(list->Count() + lines.Length());
     for (int32 i = 0; i < lines.Length(); i += 2)
     {

--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -630,7 +630,7 @@ void DebugDraw::DrawLine(const Vector3& start, const Vector3& end, const Color& 
 
 void DebugDraw::DrawLines(const Span<Vector3>& lines, const Matrix& transform, const Color& color, float duration, bool depthTest)
 {
-    if (lines.Length() % 2 == 0)
+    if (lines.Length() % 2 != 0)
     {
         DebugLog::ThrowException("Cannot draw debug lines with uneven amount of items in array");
         return;


### PR DESCRIPTION
The lines array has to have an even amount of items since for example [0] & [1] count as a single line but when we have an uneven amount we can't draw [2] & [??] as there is no target.

Having an assertion for something like that is a bit of harsh way of ensuring that the array is even, instead simply logging an error and not drawing the lines is probably less annoying.

Also just some very slight amount of formatting to make it a bit more readable.
