### PR TITLE
[C++] Added FLAXENGINE_API macro on SettingsBase class

### DIFF
--- a/Source/Engine/Core/Config/LayersTagsSettings.h
+++ b/Source/Engine/Core/Config/LayersTagsSettings.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Engine/Core/Config/Settings.h"
+#include "Engine/Serialization/Json.h"
 
 /// <summary>
 /// Layers and objects tags settings.

--- a/Source/Engine/Core/Config/Settings.h
+++ b/Source/Engine/Core/Config/Settings.h
@@ -9,7 +9,7 @@
 /// <summary>
 /// Base class for all global settings containers for the engine. Helps to apply, store and expose properties to c#.
 /// </summary>
-class SettingsBase
+class FLAXENGINE_API SettingsBase
 {
 public:
 


### PR DESCRIPTION
Using any type derived from `SettingsBase` class is causing the link to fail because of this missing symbol:
`Array<SettingsBase*> SettingsBase::Containers`

The link fails because the symbol is not exported in FlaxEngine.lib.
Adding `FLAXENGINE_API` macro before `SettingsBase` drives the compiler/librarian to embed the symbol in the library as expected.