### PR TITLE
[EDITOR] Fixed layer matrix order ( issue #153 )

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/LayersMatrixEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/LayersMatrixEditor.cs
@@ -76,7 +76,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 upperRightCell.AddChild(new Label
                 {
                     Height = labelsHeight,
-                    Text = layerNames[layerIndex],
+                    Text = layerNames[layerNames.Length - layerIndex - 1],
                     HorizontalAlignment = TextAlignment.Near,
                 });
                 bottomLeftCell.AddChild(new Label


### PR DESCRIPTION
Inverts the order of filling of the top right names so it matches the matrix.
I tested that the behavior is correct and that the right names are inverted:
![image](https://user-images.githubusercontent.com/9052852/107562017-8f3dc080-6bdf-11eb-8ecc-124608ddcbef.png)
Bottom cubes are lines, top cubes are column