### PR TITLE
Fix UI - mouse capturing and tree node hovering

### DIFF
--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -21,7 +21,7 @@ namespace FlaxEditor.GUI.Tree
         /// <summary>
         /// The default node offset on Y axis.
         /// </summary>
-        public const float DefaultNodeOffsetY = 1;
+        public const float DefaultNodeOffsetY = 0;
 
         private Tree _tree;
 
@@ -539,7 +539,7 @@ namespace FlaxEditor.GUI.Tree
         {
             if (new Rectangle(_headerRect.X, _headerRect.Y - DefaultDragInsertPositionMargin - DefaultNodeOffsetY, _headerRect.Width, DefaultDragInsertPositionMargin * 2.0f).Contains(location))
                 _dragOverMode = DragItemPositioning.Above;
-            else if (IsCollapsed && new Rectangle(_headerRect.X, _headerRect.Bottom - DefaultDragInsertPositionMargin, _headerRect.Width, DefaultDragInsertPositionMargin * 2.0f).Contains(location))
+            else if ((IsCollapsed || !HasAnyVisibleChild) && new Rectangle(_headerRect.X, _headerRect.Bottom - DefaultDragInsertPositionMargin, _headerRect.Width, DefaultDragInsertPositionMargin * 2.0f).Contains(location))
                 _dragOverMode = DragItemPositioning.Below;
             else
                 _dragOverMode = DragItemPositioning.At;

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -284,6 +284,7 @@ protected:
 
     Vector2 _trackingMouseOffset;
     bool _isUsingMouseOffset;
+    Rectangle _mouseOffsetScreenSize;
     bool _isTrackingMouse;
 
     explicit WindowBase(const CreateWindowSettings& settings);

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -479,6 +479,10 @@ void WindowsWindow::StartTrackingMouse(bool useMouseScreenOffset)
         _trackingMouseOffset = Vector2::Zero;
         _isUsingMouseOffset = useMouseScreenOffset;
 
+        int32 x = 0 , y = 0, width = 0, height = 0;
+        GetScreenInfo(x, y, width, height);
+        _mouseOffsetScreenSize = Rectangle(x, y, width, height);
+
         SetCapture(_handle);
     }
 }
@@ -712,18 +716,20 @@ LRESULT WindowsWindow::WndProc(UINT msg, WPARAM wParam, LPARAM lParam)
         if (_isTrackingMouse && _isUsingMouseOffset)
         {
             // Check if move mouse to another edge of the desktop
-            Vector2 destopSize = Platform::GetVirtualDesktopSize();
+            Vector2 desktopLocation = _mouseOffsetScreenSize.Location;
+            Vector2 destopSize = _mouseOffsetScreenSize.GetBottomRight();
+
             const Vector2 mousePos(static_cast<float>(WINDOWS_GET_X_LPARAM(lParam)), static_cast<float>(WINDOWS_GET_Y_LPARAM(lParam)));
             Vector2 mousePosition = ClientToScreen(mousePos);
             Vector2 newMousePosition = mousePosition;
-            if (mousePosition.X <= 1)
+            if (mousePosition.X <= desktopLocation.X + 2)
                 newMousePosition.X = destopSize.X - 2;
             else if (mousePosition.X >= destopSize.X - 1)
-                newMousePosition.X = 2;
-            if (mousePosition.Y <= 1)
+                newMousePosition.X = desktopLocation.X + 2;
+            if (mousePosition.Y <= desktopLocation.Y + 2)
                 newMousePosition.Y = destopSize.Y - 2;
             else if (mousePosition.Y >= destopSize.Y - 1)
-                newMousePosition.Y = 2;
+                newMousePosition.Y = desktopLocation.Y + 2;
             if (!Vector2::NearEqual(mousePosition, newMousePosition))
             {
                 _trackingMouseOffset -= newMousePosition - mousePosition;


### PR DESCRIPTION
This PR fixes some UI issues that I've stumbled upon while hunting down other UI issues

1. When you have a secondary monitor to the left, the mouse coordinates can be negative. Which causes issues for `StartMouseCapture(true)`
2. When hovering over TreeNodes, the `DefaultNodeOffsetY` caused some small spaces between the nodes where you couldn't hover. 
3. When hovering over TreeNodes, you couldn't hover below a node when you added a child to the node and removed it again.