### PR TITLE
Tooltip background.

### DIFF
--- a/Source/Engine/UI/GUI/Tooltip.cs
+++ b/Source/Engine/UI/GUI/Tooltip.cs
@@ -223,8 +223,6 @@ namespace FlaxEngine.GUI
                               TextAlignment.Center,
                               TextWrapping.WrapWords
                              );
-
-            base.Draw();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Remove the call to Control.Draw since background are already drawn by Tooltip.Draw.

Issue #167 .