### PR TITLE
Fix building engine with latest Windows platform toolset only

### DIFF
--- a/Source/Tools/Flax.Build/Platforms/UWP/UWPPlatform.cs
+++ b/Source/Tools/Flax.Build/Platforms/UWP/UWPPlatform.cs
@@ -31,9 +31,12 @@ namespace Flax.Build.Platforms
             if (sdk10 == null)
                 _hasRequiredSDKsInstalled = false;
 
-            // Need v141 toolset
-            if (!GetToolsets().ContainsKey(WindowsPlatformToolset.v141))
+            // Need v141+ toolset
+            if (!GetToolsets().ContainsKey(WindowsPlatformToolset.v141) &&
+                !GetToolsets().ContainsKey(WindowsPlatformToolset.v142))
+            {
                 _hasRequiredSDKsInstalled = false;
+            }
         }
 
         /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Platforms/UWP/UWPToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/UWP/UWPToolchain.cs
@@ -26,7 +26,7 @@ namespace Flax.Build.Platforms
         /// <param name="architecture">The target architecture.</param>
         /// <param name="toolsetVer">The target platform toolset version.</param>
         /// <param name="sdkVer">The target platform SDK version.</param>
-        public UWPToolchain(UWPPlatform platform, TargetArchitecture architecture, WindowsPlatformToolset toolsetVer = WindowsPlatformToolset.v141, WindowsPlatformSDK sdkVer = WindowsPlatformSDK.Latest)
+        public UWPToolchain(UWPPlatform platform, TargetArchitecture architecture, WindowsPlatformToolset toolsetVer = WindowsPlatformToolset.Latest, WindowsPlatformSDK sdkVer = WindowsPlatformSDK.Latest)
         : base(platform, architecture, toolsetVer, sdkVer)
         {
             var visualStudio = VisualStudioInstance.GetInstances().FirstOrDefault(x => x.Version == VisualStudioVersion.VisualStudio2017 || x.Version == VisualStudioVersion.VisualStudio2019);

--- a/Source/Tools/Flax.Build/Platforms/Windows/WindowsPlatform.cs
+++ b/Source/Tools/Flax.Build/Platforms/Windows/WindowsPlatform.cs
@@ -34,10 +34,12 @@ namespace Flax.Build.Platforms
                 return;
             }
 
-            // Need v140 toolset
-            if (!GetToolsets().ContainsKey(WindowsPlatformToolset.v140))
+            // Need v140+ toolset
+            if (!GetToolsets().ContainsKey(WindowsPlatformToolset.v140) &&
+                !GetToolsets().ContainsKey(WindowsPlatformToolset.v141) &&
+                !GetToolsets().ContainsKey(WindowsPlatformToolset.v142))
             {
-                Log.Warning("Missing MSVC toolset v140 (VS 2015 C++ build tools). Cannot build for Windows platform.");
+                Log.Warning("Missing MSVC toolset v140 or later (VS 2015 or later C++ build tools). Cannot build for Windows platform.");
                 _hasRequiredSDKsInstalled = false;
             }
         }


### PR DESCRIPTION
These checks explicitly checks for presence of v140 toolset even though the engine should build just fine with later versions of the toolset.