### PR TITLE
Fix missing pins for Get Node Transform

### DIFF
--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -882,7 +882,8 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, string.Empty, true, typeof(void), 0),
                     NodeElementArchetype.Factory.SkeletonNodeNameSelect(40, Surface.Constants.LayoutOffsetY * 1, 160, 0),
                     NodeElementArchetype.Factory.Text(0, Surface.Constants.LayoutOffsetY * 1, "Node:"),
-                    NodeElementArchetype.Factory.Output(0, "Transform", typeof(Transform), 1),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(void), 0),
+                    NodeElementArchetype.Factory.Output(1, "Transform", typeof(Transform), 1),
                 }
             },
             new NodeArchetype
@@ -923,7 +924,8 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, string.Empty, true, typeof(void), 0),
                     NodeElementArchetype.Factory.SkeletonNodeNameSelect(40, Surface.Constants.LayoutOffsetY * 1, 120, 0),
                     NodeElementArchetype.Factory.Text(0, Surface.Constants.LayoutOffsetY * 1, "Node:"),
-                    NodeElementArchetype.Factory.Output(0, "Transform", typeof(Transform), 1),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, typeof(void), 0),
+                    NodeElementArchetype.Factory.Output(1, "Transform", typeof(Transform), 1),
                 }
             },
             new NodeArchetype


### PR DESCRIPTION
A commit removed the fix provided by #127, which caused an issue to popup again mentioned in #262.