### PR TITLE
Add Dockwindow icons

### DIFF
--- a/Source/Editor/GUI/Docking/DockPanelProxy.cs
+++ b/Source/Editor/GUI/Docking/DockPanelProxy.cs
@@ -194,11 +194,22 @@ namespace FlaxEditor.GUI.Docking
                 bool isMouseOver = IsMouseOver && headerRect.Contains(MousePosition);
                 Render2D.FillRectangle(headerRect, containsFocus ? style.BackgroundSelected : isMouseOver ? style.BackgroundHighlighted : style.LightBackground);
 
+                float iconWidth = tab.Icon.IsValid ? DockPanel.DefaultButtonsSize + DockPanel.DefaultLeftTextMargin : 0;
+
+                if (tab.Icon.IsValid)
+                {
+                    Render2D.DrawSprite(
+                        tab.Icon,
+                        new Rectangle(DockPanel.DefaultLeftTextMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize),
+                        style.Foreground);
+
+                }
+
                 // Draw text
                 Render2D.DrawText(
                     style.FontMedium,
                     tab.Title,
-                    new Rectangle(DockPanel.DefaultLeftTextMargin, 0, Width - DockPanel.DefaultLeftTextMargin - DockPanel.DefaultButtonsSize - 2 * DockPanel.DefaultButtonsMargin, DockPanel.DefaultHeaderHeight),
+                    new Rectangle(DockPanel.DefaultLeftTextMargin + iconWidth, 0, Width - DockPanel.DefaultLeftTextMargin - DockPanel.DefaultButtonsSize - 2 * DockPanel.DefaultButtonsMargin, DockPanel.DefaultHeaderHeight),
                     style.Foreground,
                     TextAlignment.Near,
                     TextAlignment.Center);
@@ -223,7 +234,8 @@ namespace FlaxEditor.GUI.Docking
                     var tab = _panel.GetTab(i);
                     Color tabColor = Color.Black;
                     var titleSize = tab.TitleSize;
-                    float width = titleSize.X + DockPanel.DefaultButtonsSize + 2 * DockPanel.DefaultButtonsMargin + DockPanel.DefaultLeftTextMargin + DockPanel.DefaultRightTextMargin;
+                    float iconWidth = tab.Icon.IsValid ? DockPanel.DefaultButtonsSize + DockPanel.DefaultLeftTextMargin : 0;
+                    float width = titleSize.X + DockPanel.DefaultButtonsSize + 2 * DockPanel.DefaultButtonsMargin + DockPanel.DefaultLeftTextMargin + DockPanel.DefaultRightTextMargin + iconWidth;
                     var tabRect = new Rectangle(x, 0, width, DockPanel.DefaultHeaderHeight);
                     bool isMouseOver = IsMouseOver && tabRect.Contains(MousePosition);
                     bool isSelected = _panel.SelectedTab == tab;
@@ -241,11 +253,20 @@ namespace FlaxEditor.GUI.Docking
                         Render2D.FillRectangle(tabRect, tabColor);
                     }
 
+                    if (tab.Icon.IsValid)
+                    {
+                        Render2D.DrawSprite(
+                            tab.Icon,
+                            new Rectangle(x + DockPanel.DefaultLeftTextMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize),
+                            style.Foreground);
+
+                    }
+
                     // Draw text
                     Render2D.DrawText(
                         style.FontMedium,
                         tab.Title,
-                        new Rectangle(x + DockPanel.DefaultLeftTextMargin, 0, 10000, DockPanel.DefaultHeaderHeight),
+                        new Rectangle(x + DockPanel.DefaultLeftTextMargin + iconWidth, 0, 10000, DockPanel.DefaultHeaderHeight),
                         style.Foreground,
                         TextAlignment.Near,
                         TextAlignment.Center);

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -89,6 +89,11 @@ namespace FlaxEditor.GUI.Docking
         }
 
         /// <summary>
+        /// Gets or sets the window icon
+        /// </summary>
+        public SpriteHandle Icon { get; set; }
+
+        /// <summary>
         /// Gets the size of the title.
         /// </summary>
         public Vector2 TitleSize => _titleSize;

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -66,6 +66,7 @@ namespace FlaxEditor.Windows
         : base(editor, true, ScrollBars.None)
         {
             Title = "Content";
+            Icon = editor.Icons.Folder64;
 
             // Content database events
             editor.ContentDatabase.WorkspaceModified += () => _isWorkspaceDirty = true;


### PR DESCRIPTION
This PR adds
- Optional icons to `DockWindow`s
- An icon to the content window
- A changing icon to the log window
  - That icon should always reflect on the state of the new/unseen log. For example, if a new warning gets logged, the icon changes to a warning until the user clicks on it
  - One issue is that the info icon and the error icon currently look extremely similar

It also slightly tweaks the styling of log messages
 
I would love to add something like that to the output window as well, but I'm not quite sure how to best hook into it https://github.com/FlaxEngine/FlaxEngine/blob/115d6e46a86acdebb7ce926848854d0250359f0d/Source/Engine/Core/Log.h#L83

