### PR TITLE
Add localization for Editor

### DIFF
--- a/Source/Editor/Localization/LanguageFormats.cs
+++ b/Source/Editor/Localization/LanguageFormats.cs
@@ -15,16 +15,16 @@ namespace FlaxEditor.LocalizationServices
         /// <summary>
         /// The Polish language
         /// </summary>
-        Polish, //TODO: Add support
+        Polish,
 
         /// <summary>
         /// The German language
         /// </summary>
-        German, //TODO: Add support
+        German,
 
         /// <summary>
         /// The French language
         /// </summary>
-        French  //TODO: Add support
+        French
     }
 }

--- a/Source/Editor/Localization/LanguageFormats.cs
+++ b/Source/Editor/Localization/LanguageFormats.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
+
+namespace FlaxEditor.LocalizationServices
+{
+    /// <summary>
+    /// All supported languages the editor provides
+    /// </summary>
+    public enum Languages
+    {
+        /// <summary>
+        /// The English language
+        /// </summary>
+        English,
+
+        /// <summary>
+        /// The Polish language
+        /// </summary>
+        Polish, //TODO: Add support
+
+        /// <summary>
+        /// The German language
+        /// </summary>
+        German, //TODO: Add support
+
+        /// <summary>
+        /// The French language
+        /// </summary>
+        French  //TODO: Add support
+    }
+}

--- a/Source/Editor/Localization/Languages/English.json
+++ b/Source/Editor/Localization/Languages/English.json
@@ -1,10 +1,26 @@
-[
-  {
-    "Key": "T_CM_FILE",
-    "Value": "File"
-  },
-  {
-    "Key": "T_CM_SAVEALL",
-    "Value": "Save All"
-  }
-]
+{
+  "Namespaces": 
+  [
+    {
+      "Namespace": "N_1",
+      "Entries": 
+      [
+        {
+          "Key": "T_CM_FILE",
+          "Value": "File :D"
+        }
+      ]
+    },
+
+    {
+      "Namespace": "N_2",
+      "Entries": 
+      [
+        {
+          "Key": "T_CM_FILE",
+          "Value": "File D:"
+        }
+      ]
+    }
+  ]
+}

--- a/Source/Editor/Localization/Languages/English.json
+++ b/Source/Editor/Localization/Languages/English.json
@@ -1,24 +1,35 @@
 {
-  "Namespaces": 
-  [
+  "Namespaces": [
     {
-      "Namespace": "N_1",
-      "Entries": 
-      [
+      "Namespace": "T_CM",
+      "Entries": [
         {
-          "Key": "T_CM_FILE",
-          "Value": "File :D"
-        }
-      ]
-    },
-
-    {
-      "Namespace": "N_2",
-      "Entries": 
-      [
+          "Key": "FILE",
+          "Value": "File"
+        },
         {
-          "Key": "T_CM_FILE",
-          "Value": "File D:"
+          "Key": "EDIT",
+          "Value": "Edit"
+        },
+        {
+          "Key": "SCENE",
+          "Value": "Scene"
+        },
+        {
+          "Key": "GAME",
+          "Value": "Game"
+        },
+        {
+          "Key": "TOOLS",
+          "Value": "Tools"
+        },
+        {
+          "Key": "WINDOW",
+          "Value": "Window"
+        },
+        {
+          "Key": "HELP",
+          "Value": "Help"
         }
       ]
     }

--- a/Source/Editor/Localization/Languages/English.json
+++ b/Source/Editor/Localization/Languages/English.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "T_CM_FILE",
+    "Value": "File"
+  },
+  {
+    "Key": "T_CM_SAVEALL",
+    "Value": "Save All"
+  }
+]

--- a/Source/Editor/Localization/Languages/French.json
+++ b/Source/Editor/Localization/Languages/French.json
@@ -1,6 +1,37 @@
-[
-  {
-    "Key": "T_CM_FILE",
-    "Value": "Fichier"
-  }
-]
+{
+  "Namespaces": [
+    {
+      "Namespace": "T_CM",
+      "Entries": [
+        {
+          "Key": "FILE",
+          "Value": "Fichier"
+        },
+        {
+          "Key": "EDIT",
+          "Value": "Éditer"
+        },
+        {
+          "Key": "SCENE",
+          "Value": "Scène"
+        },
+        {
+          "Key": "GAME",
+          "Value": "Jeu"
+        },
+        {
+          "Key": "TOOLS",
+          "Value": "Outils"
+        },
+        {
+          "Key": "WINDOW",
+          "Value": "Fenêtre"
+        },
+        {
+          "Key": "HELP",
+          "Value": "Aide"
+        }
+      ]
+    }
+  ]
+}

--- a/Source/Editor/Localization/Languages/French.json
+++ b/Source/Editor/Localization/Languages/French.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Key": "T_CM_FILE",
+    "Value": "Fichier"
+  }
+]

--- a/Source/Editor/Localization/Languages/German.json
+++ b/Source/Editor/Localization/Languages/German.json
@@ -1,6 +1,37 @@
-[
-  {
-    "Key": "T_CM_FILE",
-    "Value": "Datei"
-  }
-]
+{
+  "Namespaces": [
+    {
+      "Namespace": "T_CM",
+      "Entries": [
+        {
+          "Key": "FILE",
+          "Value": "Datei"
+        },
+        {
+          "Key": "EDIT",
+          "Value": "Bearbeiten"
+        },
+        {
+          "Key": "SCENE",
+          "Value": "Szene"
+        },
+        {
+          "Key": "GAME",
+          "Value": "Spiel"
+        },
+        {
+          "Key": "TOOLS",
+          "Value": "Extras"
+        },
+        {
+          "Key": "WINDOW",
+          "Value": "Fenster"
+        },
+        {
+          "Key": "HELP",
+          "Value": "Hilfe"
+        }
+      ]
+    }
+  ]
+}

--- a/Source/Editor/Localization/Languages/German.json
+++ b/Source/Editor/Localization/Languages/German.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Key": "T_CM_FILE",
+    "Value": "Datei"
+  }
+]

--- a/Source/Editor/Localization/Languages/Polish.json
+++ b/Source/Editor/Localization/Languages/Polish.json
@@ -1,68 +1,35 @@
 {
   "Namespaces": [
     {
-      "Namespace": "N_1",
+      "Namespace": "T_CM",
       "Entries": [
         {
-          "Key": "T_CM_FILE",
+          "Key": "FILE",
           "Value": "Plik"
         },
         {
-          "Key": "T_CM_EDIT",
+          "Key": "EDIT",
           "Value": "Edytować"
         },
         {
-          "Key": "T_CM_SCENE",
+          "Key": "SCENE",
           "Value": "Scena"
         },
         {
-          "Key": "T_CM_GAME",
+          "Key": "GAME",
           "Value": "Gra"
         },
         {
-          "Key": "T_CM_TOOLS",
+          "Key": "TOOLS",
           "Value": "Przybory"
         },
         {
-          "Key": "T_CM_WINDOW",
+          "Key": "WINDOW",
           "Value": "Okno"
         },
         {
-          "Key": "T_CM_HELP",
+          "Key": "HELP",
           "Value": "Wsparcie"
-        }
-      ]
-    },
-    {
-      "Namespace": "N_2",
-      "Entries": [
-        {
-          "Key": "T_CM_FILE",
-          "Value": "Plik2"
-        },
-        {
-          "Key": "T_CM_EDIT",
-          "Value": "Edytować2"
-        },
-        {
-          "Key": "T_CM_SCENE",
-          "Value": "Scena2"
-        },
-        {
-          "Key": "T_CM_GAME",
-          "Value": "Gra2"
-        },
-        {
-          "Key": "T_CM_TOOLS",
-          "Value": "Przybory2"
-        },
-        {
-          "Key": "T_CM_WINDOW",
-          "Value": "Okno2"
-        },
-        {
-          "Key": "T_CM_HELP",
-          "Value": "Wsparcie2"
         }
       ]
     }

--- a/Source/Editor/Localization/Languages/Polish.json
+++ b/Source/Editor/Localization/Languages/Polish.json
@@ -1,30 +1,70 @@
-[
-  {
-    "Key": "T_CM_FILE",
-    "Value": "Plik"
-  },
-  {
-    "Key": "T_CM_EDIT",
-    "Value": "Edytować"
-  },
-  {
-    "Key": "T_CM_SCENE",
-    "Value": "Scena"
-  },
-  {
-    "Key": "T_CM_GAME",
-    "Value": "Gra"
-  },
-  {
-    "Key": "T_CM_TOOLS",
-    "Value": "Przybory"
-  },
-  {
-    "Key": "T_CM_WINDOW",
-    "Value": "Okno"
-  },
-  {
-    "Key": "T_CM_HELP",
-    "Value": "Wsparcie"
-  }
-]
+{
+  "Namespaces": [
+    {
+      "Namespace": "N_1",
+      "Entries": [
+        {
+          "Key": "T_CM_FILE",
+          "Value": "Plik"
+        },
+        {
+          "Key": "T_CM_EDIT",
+          "Value": "Edytować"
+        },
+        {
+          "Key": "T_CM_SCENE",
+          "Value": "Scena"
+        },
+        {
+          "Key": "T_CM_GAME",
+          "Value": "Gra"
+        },
+        {
+          "Key": "T_CM_TOOLS",
+          "Value": "Przybory"
+        },
+        {
+          "Key": "T_CM_WINDOW",
+          "Value": "Okno"
+        },
+        {
+          "Key": "T_CM_HELP",
+          "Value": "Wsparcie"
+        }
+      ]
+    },
+    {
+      "Namespace": "N_2",
+      "Entries": [
+        {
+          "Key": "T_CM_FILE",
+          "Value": "Plik2"
+        },
+        {
+          "Key": "T_CM_EDIT",
+          "Value": "Edytować2"
+        },
+        {
+          "Key": "T_CM_SCENE",
+          "Value": "Scena2"
+        },
+        {
+          "Key": "T_CM_GAME",
+          "Value": "Gra2"
+        },
+        {
+          "Key": "T_CM_TOOLS",
+          "Value": "Przybory2"
+        },
+        {
+          "Key": "T_CM_WINDOW",
+          "Value": "Okno2"
+        },
+        {
+          "Key": "T_CM_HELP",
+          "Value": "Wsparcie2"
+        }
+      ]
+    }
+  ]
+}

--- a/Source/Editor/Localization/Languages/Polish.json
+++ b/Source/Editor/Localization/Languages/Polish.json
@@ -1,0 +1,30 @@
+[
+  {
+    "Key": "T_CM_FILE",
+    "Value": "Plik"
+  },
+  {
+    "Key": "T_CM_EDIT",
+    "Value": "Edytować"
+  },
+  {
+    "Key": "T_CM_SCENE",
+    "Value": "Scena"
+  },
+  {
+    "Key": "T_CM_GAME",
+    "Value": "Gra"
+  },
+  {
+    "Key": "T_CM_TOOLS",
+    "Value": "Przybory"
+  },
+  {
+    "Key": "T_CM_WINDOW",
+    "Value": "Okno"
+  },
+  {
+    "Key": "T_CM_HELP",
+    "Value": "Wsparcie"
+  }
+]

--- a/Source/Editor/Localization/Localization.cs
+++ b/Source/Editor/Localization/Localization.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
+
+using FlaxEngine;
+using FlaxEngine.Assertions;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System;
+
+namespace FlaxEditor.LocalizationServices
+{
+    /// <summary>
+    /// Provides localization services to the editor
+    /// </summary>
+    public static class Localization
+    {
+        /// <inheritdoc />
+        public static void SelectLanguage(Languages language)
+        {
+            m_SelectedLanguage = language;
+
+            // Avoid picking the same the language
+            if (m_Languages.TryGetValue(language, out _))
+                return;
+
+            Load(Path.Combine(Globals.BinariesFolder, "Localizations"), language);
+        }
+
+        /// <inheritdoc />
+        public static string GetValue(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException($"'{nameof(key)}' cannot be null or empty", nameof(key));
+
+            // If key has value, use it.
+            if (m_Languages.TryGetValue(m_SelectedLanguage, out var map) && map.TryGetValue(key, out var value))
+                return value;
+
+            // Use as fallback if no value.
+            Editor.LogWarning($"Specified key `{key}` was not found, using key as fallback value.");
+            return key;
+        }
+
+        /// <inheritdoc />
+        public static void Load(string directory, Languages language)
+        {
+            string path = Path.Combine(directory, language.ToString() + ".json");
+
+            if (!File.Exists(path))
+            {
+                Assert.IsTrue(false, $"Language file `{language}` was not found");
+                return;
+            }
+
+            var json = JsonSerializer.CreateDefault(new JsonSerializerSettings()
+            {
+                Culture = CultureInfo.InvariantCulture
+            });
+
+            m_Languages.Add(language, new Dictionary<string, string>());
+
+            using (JsonReader reader = new JsonTextReader(new StreamReader(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite), true)))
+            {
+                try
+                {
+                    var entries = json.Deserialize<LocalizationEntry[]>(reader);
+
+                    // Add the values to that language
+                    foreach (var entry in entries)
+                        SetValue(entry.Key, entry.Value);
+                }
+                catch
+                {
+                    Assert.IsFalse(true, $"Couldn't read language file `{language}` ({path})");
+                }
+            }
+
+        }
+
+        /// <inheritdoc />
+        public static bool SetValue(string key, string value)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException($"'{nameof(key)}' cannot be null or empty", nameof(key));
+
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentException($"'{nameof(value)}' cannot be null or empty", nameof(value));
+
+            // Get the language
+            if (m_Languages.TryGetValue(m_SelectedLanguage, out var map))
+            {
+                if (map.ContainsKey(key))
+                {
+                    // Update
+                    map[key] = value;
+                    return true;
+                }
+                else
+                {
+                    // Add
+                    map.Add(key, value);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public static Languages SelectedLanguage
+        {
+            get => m_SelectedLanguage;
+
+            set => SelectLanguage(value);
+        }
+
+        /// <summary>
+        /// Localization entry for the JSON format
+        /// </summary>
+        private struct LocalizationEntry
+        {
+            [JsonProperty(nameof(Key))]
+            public string Key { get; set; }
+
+            [JsonProperty(nameof(Value))]
+            public string Value { get; set; }
+        }
+
+        private static Dictionary<Languages, Dictionary<string, string>> m_Languages = new Dictionary<Languages, Dictionary<string, string>>();
+        private static Languages m_SelectedLanguage;
+    }
+}

--- a/Source/Editor/Localization/LocalizationLayout.cs
+++ b/Source/Editor/Localization/LocalizationLayout.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
+
+using Newtonsoft.Json;
+
+namespace FlaxEditor.LocalizationServices
+{
+    /// <summary>
+    /// The layout of a localization file
+    /// </summary>
+    public struct LocalizationAsset
+    {
+        /// <summary>
+        /// A collection of all existing namespaces
+        /// </summary>
+        [JsonProperty(nameof(Namespaces))]
+        public LocalizationNamespace[] Namespaces { get; set; }
+    }
+
+    /// <summary>
+    /// A name space with localization entries
+    /// </summary>
+    public struct LocalizationNamespace
+    {
+        /// <summary>
+        /// The name of the namespace
+        /// </summary>
+        [JsonProperty(nameof(Namespace))]
+        public string Namespace { get; set; }
+
+        /// <summary>
+        /// The localization entries of the given namespace
+        /// </summary>
+        [JsonProperty(nameof(Entries))]
+        public LocalizationEntry[] Entries { get; set; }
+    }
+
+    /// <summary>
+    /// An entry that holds a key which associates a given string
+    /// </summary>
+    public struct LocalizationEntry
+    {
+        [JsonProperty(nameof(Key))]
+        public string Key { get; set; }
+
+        [JsonProperty(nameof(Value))]
+        public string Value { get; set; }
+    }
+}

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -8,6 +8,7 @@ using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Dialogs;
 using FlaxEditor.GUI.Input;
+using FlaxEditor.LocalizationServices;
 using FlaxEditor.Progress.Handlers;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.SceneGraph.Actors;
@@ -384,7 +385,7 @@ namespace FlaxEditor.Modules
             };
 
             // File
-            MenuFile = MainMenu.AddButton("File");
+            MenuFile = MainMenu.AddButton(Localization.GetValue("N_2", "T_CM_FILE"));
             var cm = MenuFile.ContextMenu;
             cm.VisibleChanged += OnMenuFileShowHide;
             cm.AddButton("Save All", "Ctrl+S", Editor.SaveAll);

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -385,7 +385,7 @@ namespace FlaxEditor.Modules
             };
 
             // File
-            MenuFile = MainMenu.AddButton(Localization.GetValue("N_2", "T_CM_FILE"));
+            MenuFile = MainMenu.AddButton(Localization.GetValue("T_CM", "FILE"));
             var cm = MenuFile.ContextMenu;
             cm.VisibleChanged += OnMenuFileShowHide;
             cm.AddButton("Save All", "Ctrl+S", Editor.SaveAll);

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
 
 using System.ComponentModel;
+using FlaxEditor.LocalizationServices;
 using FlaxEngine;
 
 namespace FlaxEditor.Options
@@ -36,6 +37,13 @@ namespace FlaxEditor.Options
             /// </summary>
             TimeSinceStartup,
         }
+
+        /// <summary>
+        /// Gets or sets the Editor's localization.
+        /// </summary>
+        [DefaultValue(Languages.English)]
+        [EditorDisplay("Interface"), EditorOrder(0), Tooltip("The Language used for the engine. Editor restart required.")]
+        public Languages Language { get; set; } = Languages.English;
 
         /// <summary>
         /// Gets or sets the Editor User Interface scale. Applied to all UI elements, windows and text. Can be used to scale the interface up on a bigger display. Editor restart required.

--- a/Source/Editor/Options/OptionsModule.cs
+++ b/Source/Editor/Options/OptionsModule.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using FlaxEditor.LocalizationServices;
 using FlaxEditor.Modules;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -263,6 +264,9 @@ namespace FlaxEditor.Options
             Editor.Log("Options file path: " + _optionsFilePath);
             Load();
             SetupStyle();
+
+            Editor.Log("Launching localization service...");
+            Localization.SelectLanguage(Editor.Instance.Options.Options.Interface.Language);
         }
     }
 }

--- a/Source/FlaxEditor.Build.cs
+++ b/Source/FlaxEditor.Build.cs
@@ -2,6 +2,7 @@
 
 using System.IO;
 using Flax.Build;
+using Flax.Build.Graph;
 using Flax.Build.NativeCpp;
 
 /// <summary>
@@ -36,6 +37,27 @@ public class FlaxEditor : EngineTarget
         Modules.Add("ShadersCompilation");
         Modules.Add("ContentExporters");
         Modules.Add("ContentImporters");
+    }
+
+    /// <inheritdoc />
+    public override void PreBuild(TaskGraph graph, BuildOptions buildOptions)
+    {
+        base.PreBuild(graph, buildOptions);
+
+        // Register localization dependency
+        string locDir = Path.Combine(Globals.EngineRoot, "Source", "Editor", "Localization", "Languages");
+        buildOptions.AdvancedDependencies.Add(new BuildOptions.DependencyFileEntry()
+        {
+            IsFolder = true,
+            DestinationNames = new[]
+            {
+                Path.Combine("Localization")
+            },
+            SourcePaths = new[]
+            {
+                locDir
+            }
+        });
     }
 
     /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -91,6 +91,11 @@ namespace Flax.Build.NativeCpp
         public HashSet<string> DependencyFiles = new HashSet<string>();
 
         /// <summary>
+        /// The dependency files with more control how they are being handled
+        /// </summary>
+        public HashSet<DependencyFileEntry> AdvancedDependencies = new HashSet<DependencyFileEntry>();
+
+        /// <summary>
         /// The optional dependency files to include with output (additional debug files, dynamic libraries, etc.). Missing files won't fail the build.
         /// </summary>
         public HashSet<string> OptionalDependencyFiles = new HashSet<string>();
@@ -134,6 +139,34 @@ namespace Flax.Build.NativeCpp
         /// The full path to the dependencies folder for the current build platform, configuration, and architecture.
         /// </summary>
         public string DepsFolder => Path.Combine(Globals.EngineRoot, "Source", "Platforms", Platform.Target.ToString(), "Binaries", "ThirdParty", Architecture.ToString());
+
+        /// <summary>
+        /// Dependency file entry
+        /// </summary>
+        public struct DependencyFileEntry
+        {
+            /// <summary>
+            /// File source path
+            /// </summary>
+            public string[] SourcePaths;
+
+            /// <summary>
+            /// Destination file name
+            /// </summary>
+            public string[] DestinationNames;
+
+            /// <summary>
+            /// Is dependent folder
+            /// </summary>
+            /// <remarks>Sub-folders won't be included.</remarks>
+            public bool IsFolder;
+
+            /// <summary>
+            /// If the destination is already the full path specified, there won't be any concats
+            /// </summary>
+            public bool IsDestinationFullPath;
+        }
+
 
         /// <summary>
         /// The scripting API building options.

--- a/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
+++ b/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
@@ -165,6 +165,7 @@ namespace Flax.Deploy
                     DeployFile(src, dst, "FlaxEngine.CSharp.xml");
                     DeployFile(src, dst, "Newtonsoft.Json.pdb");
                     DeployFiles(src, dst, "*.dll");
+                    DeployFolder(src, dst, "Localization");
 
                     // Deploy debug symbols files
                     DeployFiles(src, dstDebug, "*.pdb");


### PR DESCRIPTION
# Localization? What is this PR?

`NOTE: I'll make sure to actually check on which branch I am next time I update my fork...`

Firstly, I'd like to thank @VNNCC for helping me out with the build and deploy stuff!

This PR should add the ability to localize strings using JSON files in order to support almost any language! Currently the entire engine is hardcoded to english, and with this PR it would allow to support any language.

The internal `EditorLocalization` class provides a singleton `Manager` that allows access to the services provided by the class itself that can be used through the editor, however not for games. *A restart is required to apply a language change*. 

Additionally we had to make quite a bit of work to the `Builder.NativeCPP` to support all the moving of JSON files from A to B which includes creating a whole new type of dependency that allows for a bit more control over how they get handled. Finally we cleaned up some additional code here and there.

## Status ☑️ 

### TODOs:
- [x] Simplify access instead of `EditorLocalization.Manager.GetValue()` it should be smth like `Localization.GetValue()`
- [ ] Swap to C++ a module, change C# side with Internal function calls instead 
- [ ] Use JSON Assets instead of JSON Files
- [x] Introduce namespaces

### Languages
- [ ] English
- [ ] German
- [ ] Polish
- [ ] French
- [ ] Others...

### Conversions
It will take some additional time to replace all existing strings into localized ones.
Currenlty a whopping 0.01% is localized!

As of now, no language is fully implemented at all, this will take the most time.

## How would you go on about adding a localized string?
We can access the string instead depending on which language is selected:

```cs
// Currently for example the File context menu is setup like this.
MenuFile = MainMenu.AddButton("File");

// Instead we simply use the manager to return the value of the given key!
MenuFile = MainMenu.AddButton(Localization.GetValue("T_CM", "FILE"));

```

To add a value we need to go the language files under `FlaxEngine->Editor->Localization->Languages` there you will find the appropriate languages supported by Flax. Next you simply add a new element:
![image](https://user-images.githubusercontent.com/63303990/108313517-be909680-71b8-11eb-9148-af1d1081c308.png)

All that is needed now is to just build and that should be really it.
Just gotta make sure you have selected the correct language under `Options->Interface` which shows all the supported languages.

![image](https://user-images.githubusercontent.com/63303990/108319109-306cde00-71c1-11eb-9d86-e553ce1a852c.png)

Final result:
![image](https://user-images.githubusercontent.com/63303990/108315273-76bf3e80-71bb-11eb-8156-200728227a0d.png)
