### PR TITLE
Reroute Nodes and Arrow Key Navigation

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1011,8 +1011,7 @@ namespace FlaxEditor.Surface.Archetypes
                 inputBox.Location = Vector2.Zero;
                 outputBox.Location = Vector2.Zero;
 
-                inputBox.Visible = false;
-                outputBox.Visible = false;
+                UpdateBoxes();
             }
 
             /// <inheritdoc />
@@ -1020,6 +1019,11 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 base.ConnectionTick(box);
 
+                UpdateBoxes();
+            }
+
+            private void UpdateBoxes()
+            {
                 var inputBox = GetBox(0);
                 var outputBox = GetBox(1);
 
@@ -1036,7 +1040,8 @@ namespace FlaxEditor.Surface.Archetypes
 
                 if (_deleteNode)
                 {
-                    Surface.Delete(this);
+                    _deleteNode = false;
+                    // Surface.Delete(this); // Doesn't work with undo-ing
                 }
             }
 
@@ -1071,7 +1076,7 @@ namespace FlaxEditor.Surface.Archetypes
 
                 if (!inputBox.HasAnyConnection)
                 {
-                    Render2D.FillRectangle(new Rectangle(-barHorizontalOffset - barHeight * 4, (DefaultSize.Y - barHeight) / 2, barHeight * 2, barHeight), connectionColor);
+                    Render2D.FillRectangle(new Rectangle(-barHorizontalOffset - barHeight * 2, (DefaultSize.Y - barHeight) / 2, barHeight * 2, barHeight), connectionColor);
                 }
 
                 if (!outputBox.HasAnyConnection)

--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1023,37 +1023,22 @@ namespace FlaxEditor.Surface.Archetypes
                 var inputBox = GetBox(0);
                 var outputBox = GetBox(1);
 
-                _deleteNode = !inputBox.HasAnyConnection;
+                inputBox.Visible = !inputBox.HasAnyConnection;
                 outputBox.Visible = !outputBox.HasAnyConnection;
+
+                _deleteNode = !inputBox.HasAnyConnection && !outputBox.HasAnyConnection;
             }
 
-            /*public override void OnDeleted()
-            {
-                var inputBox = GetBox(0);
-                var outputBox = GetBox(1);
-
-                var connectionA = inputBox.HasAnyConnection ? inputBox.Connections[0] : null; // This doesn't work
-                var connectionB = outputBox.HasAnyConnection ? outputBox.Connections[0] : null;
-
-                base.OnDeleted();
-
-                if (connectionA != null && connectionB != null)
-                {
-                    connectionA.CreateConnection(connectionB); // TODO: handle undo
-                }
-            }*/
-
+            /// <inheritdoc />
             public override void Update(float deltaTime)
             {
                 base.Update(deltaTime);
 
                 if (_deleteNode)
                 {
-                    _deleteNode = false;
-                    Surface.Delete(this); // TODO: handle undo
+                    Surface.Delete(this);
                 }
             }
-
 
             /// <inheritdoc />
             public override bool CanSelect(ref Vector2 location)
@@ -1073,7 +1058,10 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 var style = Surface.Style;
                 var inputBox = GetBox(0);
+                var outputBox = GetBox(1);
                 var connectionColor = style.Colors.Default;
+                float barHorizontalOffset = -2;
+                float barHeight = 3;
 
                 if (inputBox.HasAnyConnection)
                 {
@@ -1081,14 +1069,25 @@ namespace FlaxEditor.Surface.Archetypes
                     Surface.Style.GetConnectionColor(inputBox.Connections[0].CurrentType, hints, out connectionColor);
                 }
 
-                //float barHeight = 4;
-                //Render2D.FillRectangle(new Rectangle(DefaultSize.X / 2, (DefaultSize.Y - barHeight) / 2, barHeight * 4, barHeight), connectionColor);
+                if (!inputBox.HasAnyConnection)
+                {
+                    Render2D.FillRectangle(new Rectangle(-barHorizontalOffset - barHeight * 4, (DefaultSize.Y - barHeight) / 2, barHeight * 2, barHeight), connectionColor);
+                }
 
-                SpriteHandle icon = style.Icons.BoxClose;
-                Render2D.DrawSprite(icon, new Rectangle(Vector2.Zero, DefaultSize), connectionColor);
+                if (!outputBox.HasAnyConnection)
+                {
+                    Render2D.FillRectangle(new Rectangle(DefaultSize.X + barHorizontalOffset, (DefaultSize.Y - barHeight) / 2, barHeight * 2, barHeight), connectionColor);
+                }
+
+                if (inputBox.HasAnyConnection && outputBox.HasAnyConnection)
+                {
+                    var hints = inputBox.Connections[0].ParentNode.Archetype.ConnectionsHints;
+                    Surface.Style.GetConnectionColor(inputBox.Connections[0].CurrentType, hints, out connectionColor);
+                    SpriteHandle icon = style.Icons.BoxClose;
+                    Render2D.DrawSprite(icon, new Rectangle(Vector2.Zero, DefaultSize), connectionColor);
+                }
 
                 base.Draw();
-
             }
         }
 

--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -987,8 +987,6 @@ namespace FlaxEditor.Surface.Archetypes
         {
             public static readonly Vector2 DefaultSize = new Vector2(16);
 
-            private bool _deleteNode;
-
             /// <inheritdoc />
             protected override bool ShowTooltip => false;
 
@@ -1029,20 +1027,6 @@ namespace FlaxEditor.Surface.Archetypes
 
                 inputBox.Visible = !inputBox.HasAnyConnection;
                 outputBox.Visible = !outputBox.HasAnyConnection;
-
-                _deleteNode = !inputBox.HasAnyConnection && !outputBox.HasAnyConnection;
-            }
-
-            /// <inheritdoc />
-            public override void Update(float deltaTime)
-            {
-                base.Update(deltaTime);
-
-                if (_deleteNode)
-                {
-                    _deleteNode = false;
-                    // Surface.Delete(this); // Doesn't work with undo-ing
-                }
             }
 
             /// <inheritdoc />
@@ -1565,7 +1549,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Input(0, string.Empty, true, null, 0),
-                    NodeElementArchetype.Factory.Output(0, string.Empty, null, 1),
+                    NodeElementArchetype.Factory.Output(0, string.Empty, null, 1, true),
                 }
             },
         };

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -159,6 +159,7 @@ namespace FlaxEditor.Surface.ContextMenu
                     var start = font.GetCharPosition(_archetype.Title, 0);
                     var end = font.GetCharPosition(_archetype.Title, _archetype.Title.Length - 1);
                     _highlights.Add(new Rectangle(start.X + 2, 0, end.X - start.X, Height));
+                    _isFullMatch = true;
                     Visible = true;
                 }
                 else if (NodeArchetype.TryParseText != null && NodeArchetype.TryParseText(filterText, out var data))

--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -2,6 +2,7 @@
 
 using FlaxEngine;
 using FlaxEngine.GUI;
+using System;
 
 namespace FlaxEditor.Surface.Elements
 {
@@ -43,10 +44,86 @@ namespace FlaxEditor.Surface.Elements
             */
         }
 
+        private static bool IsRight(ref Vector2 a, ref Vector2 b, ref Vector2 point)
+        {
+            return ((b.X - a.X) * (point.Y - a.Y) - (b.Y - a.Y) * (point.X - a.X)) <= 0;
+        }
+
+        /// <summary>
+        /// Checks if a point intersects a bezier curve
+        /// </summary>
+        /// <param name="start">The start location.</param>
+        /// <param name="end">The end location.</param>
+        /// <param name="point">The point</param>
+        /// <param name="distance">Distance at which its an intersection</param>
+        public static bool IntersectsConnection(ref Vector2 start, ref Vector2 end, ref Vector2 point, float distance)
+        {
+            if ((point.X - start.X) * (end.X - point.X) < 0) return false;
+
+            var dst = (end - start) * new Vector2(0.25f, 0.05f); // Purposefully tweaked to 0.25
+            Vector2 control1 = new Vector2(start.X + dst.X, start.Y + dst.Y);
+            Vector2 control2 = new Vector2(end.X - dst.X, end.Y + dst.Y);
+
+            // I'm ignoring the start.Y + dst.Y
+
+            Vector2 direction = end - start;
+            float offset = Mathf.Sign(direction.Y) * distance;
+
+            Vector2 pointAbove1 = new Vector2(control1.X, start.Y - offset);
+            Vector2 pointAbove2 = new Vector2(end.X, end.Y - offset);
+            Vector2 pointBelow1 = new Vector2(start.X, start.Y + offset);
+            Vector2 pointBelow2 = new Vector2(control2.X, end.Y + offset);
+
+            /*  Render2D.DrawLine(pointAbove1, pointAbove2, Color.Red);
+              Render2D.DrawRectangle(new Rectangle(pointAbove2 - new Vector2(5), new Vector2(10)), Color.Red);
+              Render2D.DrawLine(pointBelow1, pointBelow2, Color.Green);
+              Render2D.DrawRectangle(new Rectangle(pointBelow2 - new Vector2(5), new Vector2(10)), Color.Green);
+            */
+            // TODO: are they parallel ^?
+
+            return IsRight(ref pointAbove1, ref pointAbove2, ref point) == IsRight(ref pointBelow2, ref pointBelow1, ref point);
+
+
+            // Taken from the Render2D.DrawBezier code
+            float squaredDistance = distance;
+
+            Vector2 d1 = control1 - start;
+            Vector2 d2 = control2 - control1;
+            Vector2 d3 = end - control2;
+            float len = d1.Length + d2.Length + d3.Length;
+            int segmentCount = Math.Min(Math.Max(Mathf.CeilToInt(len * 0.05f), 1), 100);
+            float segmentCountInv = 1.0f / segmentCount;
+
+            Bezier(ref start, ref control1, ref control2, ref end, 0, out Vector2 p);
+            for (int i = 1; i <= segmentCount; i++)
+            {
+                Vector2 oldp = p;
+                float t = i * segmentCountInv;
+                Bezier(ref start, ref control1, ref control2, ref end, t, out p);
+
+                CollisionsHelper.ClosestPointPointLine(ref point, ref oldp, ref p, out Vector2 result);
+                if (Vector2.DistanceSquared(point, result) <= squaredDistance)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static void Bezier(ref Vector2 p0, ref Vector2 p1, ref Vector2 p2, ref Vector2 p3, float alpha, out Vector2 result)
+        {
+            Vector2.Lerp(ref p0, ref p1, alpha, out var p01);
+            Vector2.Lerp(ref p1, ref p2, alpha, out var p12);
+            Vector2.Lerp(ref p2, ref p3, alpha, out var p23);
+            Vector2.Lerp(ref p01, ref p12, alpha, out var p012);
+            Vector2.Lerp(ref p12, ref p23, alpha, out var p123);
+            Vector2.Lerp(ref p012, ref p123, alpha, out result);
+        }
+
         /// <summary>
         /// Draw all connections coming from this box.
         /// </summary>
-        public void DrawConnections()
+        public void DrawConnections(ref Vector2 mousePosition)
         {
             // Draw all the connections
             var center = Size * 0.5f;
@@ -60,8 +137,29 @@ namespace FlaxEditor.Surface.Elements
                 Vector2 endPos = targetBox.Parent.PointToParent(ref tmp);
                 var highlight = 1 + Mathf.Max(startHighlight, targetBox.ConnectionsHighlightIntensity);
                 var color = _currentTypeColor * highlight;
+
+                // if (PointInRectangle(ref startPos, ref endPos, ref mousePosition))
+                {
+                    for (int ix = 0; ix < 10000; ix++)
+                    {
+                        OutputBox.IntersectsConnection(ref startPos, ref endPos, ref mousePosition, 30f);
+                    }
+                    if (OutputBox.IntersectsConnection(ref startPos, ref endPos, ref mousePosition, 30f))
+                    {
+                        highlight += 2;
+                    }
+                }
+
+
                 DrawConnection(ref startPos, ref endPos, ref color, highlight);
             }
+        }
+
+        private bool PointInRectangle(ref Vector2 a, ref Vector2 b, ref Vector2 point)
+        {
+            // This has the convenient property that it doesn't matter if a and b are switched
+            Vector2 signs = (point - a) * (b - point);
+            return signs.X >= 0 && signs.Y >= 0;
         }
 
         /// <summary>

--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -136,7 +136,7 @@ namespace FlaxEditor.Surface.Elements
                 // TODO: Figure out how to only draw the topmost connection
                 if (IntersectsConnection(ref startPos, ref endPos, ref mousePosition, mouseOverDistance))
                 {
-                    highlight += 1;
+                    highlight += 0.5f;
                 }
 
                 DrawConnection(ref startPos, ref endPos, ref color, highlight);
@@ -151,7 +151,7 @@ namespace FlaxEditor.Surface.Elements
             // Draw all the connections
             var startPos = Parent.PointToParent(Center);
             Vector2 endPos = targetBox.Parent.PointToParent(targetBox.Center);
-            DrawConnection(ref startPos, ref endPos, ref _currentTypeColor, 2);
+            DrawConnection(ref startPos, ref endPos, ref _currentTypeColor, 2.5f);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -1010,7 +1010,7 @@ namespace FlaxEditor.Surface
             }
 
             // Secondary Context Menu
-            if (button == MouseButton.Right && false)
+            if (button == MouseButton.Right)
             {
                 if (!IsSelected)
                     Surface.Select(this);

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -758,7 +758,7 @@ namespace FlaxEditor.Surface
             {
                 if (Elements[j] is OutputBox ob && ob.HasAnyConnection)
                 {
-                    ob.DrawConnections();
+                    ob.DrawConnections(ref mousePosition);
                 }
             }
 

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -763,27 +763,57 @@ namespace FlaxEditor.Surface
                 }
             }
 
+        }
+
+        /// <summary>
+        /// Draws all selected connections between surface objects related to this node.
+        /// </summary>
+        /// <param name="selectedConnectionIndex">The index of the currently selected connection.</param>
+        public void DrawSelectedConnections(int selectedConnectionIndex)
+        {
             if (_isSelected)
             {
-                bool hasBoxesSelection = HasBoxesSelection;
-                for (int j = 0; j < Elements.Count; j++)
+                if (HasBoxesSelection)
                 {
-                    if (Elements[j] is Box box && box.HasAnyConnection && (!hasBoxesSelection || box.IsSelected))
+                    for (int j = 0; j < Elements.Count; j++)
                     {
-                        if (box is OutputBox ob)
+                        if (Elements[j] is Box box && box.IsSelected && selectedConnectionIndex < box.Connections.Count)
                         {
-                            for (int i = 0; i < ob.Connections.Count; i++)
+                            if (box is OutputBox ob)
                             {
-                                ob.DrawSelectedConnection(ob.Connections[i]);
+                                ob.DrawSelectedConnection(ob.Connections[selectedConnectionIndex]);
                             }
-                        }
-                        else
-                        {
-                            for (int i = 0; i < box.Connections.Count; i++)
+                            else
                             {
-                                if (box.Connections[i] is OutputBox outputBox)
+                                if (box.Connections[selectedConnectionIndex] is OutputBox outputBox)
                                 {
                                     outputBox.DrawSelectedConnection(box);
+                                }
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    for (int j = 0; j < Elements.Count; j++)
+                    {
+                        if (Elements[j] is Box box)
+                        {
+                            if (box is OutputBox ob)
+                            {
+                                for (int i = 0; i < ob.Connections.Count; i++)
+                                {
+                                    ob.DrawSelectedConnection(ob.Connections[i]);
+                                }
+                            }
+                            else
+                            {
+                                for (int i = 0; i < box.Connections.Count; i++)
+                                {
+                                    if (box.Connections[i] is OutputBox outputBox)
+                                    {
+                                        outputBox.DrawSelectedConnection(box);
+                                    }
                                 }
                             }
                         }

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -553,19 +553,22 @@ namespace FlaxEditor.Surface
 
         internal Box GetNextBox(Box box)
         {
-            int i = 0;
-            for (; i < Elements.Count; i++)
+            // Get the one after it
+            for (int i = box.IndexInParent + 1; i < Elements.Count; i++)
             {
-                if (Elements[i] == box)
+                if (Elements[i] is Box b)
                 {
-                    // We found the box
-                    break;
+                    return b;
                 }
             }
 
-            // Get the one after it
-            i++;
-            for (; i < Elements.Count; i++)
+            return null;
+        }
+
+        internal Box GetPreviousBox(Box box)
+        {
+            // Get the one before it
+            for (int i = box.IndexInParent - 1; i >= 0; i--)
             {
                 if (Elements[i] is Box b)
                 {

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -125,6 +125,7 @@ namespace FlaxEditor.Surface
             AutoFocus = false;
             TooltipText = nodeArch.Description;
             CullChildren = false;
+            BackgroundColor = Style.Current.BackgroundNormal;
 
             if (Archetype.DefaultValues != null)
             {
@@ -947,7 +948,7 @@ namespace FlaxEditor.Surface
 
             // Background
             var backgroundRect = new Rectangle(Vector2.Zero, Size);
-            Render2D.FillRectangle(backgroundRect, style.BackgroundNormal);
+            Render2D.FillRectangle(backgroundRect, BackgroundColor);
 
             // Breakpoint hit
             if (Breakpoint.Hit)

--- a/Source/Editor/Surface/Undo/BoxHandle.cs
+++ b/Source/Editor/Surface/Undo/BoxHandle.cs
@@ -10,7 +10,7 @@ namespace FlaxEditor.Surface.Undo
     /// The helper structure for Surface node box handle.
     /// </summary>
     [HideInEditor]
-    public struct BoxHandle
+    public struct BoxHandle : IEquatable<BoxHandle>
     {
         private readonly uint _nodeId;
         private readonly int _boxId;
@@ -50,6 +50,28 @@ namespace FlaxEditor.Surface.Undo
             if (box == null)
                 throw new Exception("Missing box.");
             return box;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return obj is BoxHandle handle && Equals(handle);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(BoxHandle other)
+        {
+            return _nodeId == other._nodeId &&
+                   _boxId == other._boxId;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (_nodeId.GetHashCode() * 397) ^ _boxId.GetHashCode();
+            }
         }
     }
 }

--- a/Source/Editor/Surface/Undo/ConnectBoxesAction.cs
+++ b/Source/Editor/Surface/Undo/ConnectBoxesAction.cs
@@ -104,9 +104,12 @@ namespace FlaxEditor.Surface.Undo
             }
             for (int i = 0; i < output.Length; i++)
             {
-                var box = output[i].Get(context);
-                oB.Connections.Add(box);
-                box.Connections.Add(oB);
+                if (!output[i].Equals(_input))
+                {
+                    var box = output[i].Get(context);
+                    oB.Connections.Add(box);
+                    box.Connections.Add(oB);
+                }
             }
 
             toUpdate.AddRange(iB.Connections);

--- a/Source/Editor/Surface/VisjectSurface.CopyPaste.cs
+++ b/Source/Editor/Surface/VisjectSurface.CopyPaste.cs
@@ -103,7 +103,7 @@ namespace FlaxEditor.Surface
                 {
                     for (int j = 0; j < node.Elements.Count; j++)
                     {
-                        if (node.Elements[j] is Box box)
+                        if (node.Elements[j] is Box box && box.Connections.Count > 0)
                         {
                             var dataModelBox = new DataModelBox
                             {

--- a/Source/Editor/Surface/VisjectSurface.Draw.cs
+++ b/Source/Editor/Surface/VisjectSurface.Draw.cs
@@ -103,6 +103,7 @@ namespace FlaxEditor.Surface
             for (int i = 0; i < Nodes.Count; i++)
             {
                 Nodes[i].DrawConnections(ref mousePosition);
+                Nodes[i].DrawSelectedConnections(_selectedConnectionIndex);
             }
         }
 

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -527,6 +527,101 @@ namespace FlaxEditor.Surface
                     }
                     return true;
                 }
+
+                if (key == KeyboardKeys.ArrowUp)
+                {
+                    Box selectedBox = GetSelectedBox(SelectedNodes);
+                    Box toSelect = selectedBox?.ParentNode.GetPreviousBox(selectedBox);
+
+                    if (toSelect != null)
+                    {
+                        if (toSelect.Connections.Count > 1)
+                        {
+                            // Box has multiple connections
+                        }
+
+                        if (toSelect.IsOutput != selectedBox.IsOutput)
+                        {
+                            // Jump up (nodes)
+                        }
+                        else
+                        {
+                            Select(toSelect.ParentNode);
+                            toSelect.ParentNode.SelectBox(toSelect);
+                        }
+                    }
+
+                    return true;
+                }
+                if (key == KeyboardKeys.ArrowDown)
+                {
+                    Box selectedBox = GetSelectedBox(SelectedNodes);
+                    Box toSelect = selectedBox?.ParentNode.GetNextBox(selectedBox);
+
+                    if (toSelect != null)
+                    {
+                        if (toSelect.Connections.Count > 1)
+                        {
+                            // Box has multiple connections
+                        }
+
+                        if (toSelect.IsOutput != selectedBox.IsOutput)
+                        {
+                            // Jump down (nodes)
+                        }
+                        else
+                        {
+                            Select(toSelect.ParentNode);
+                            toSelect.ParentNode.SelectBox(toSelect);
+                        }
+                    }
+
+                    return true;
+                }
+
+                if (key == KeyboardKeys.ArrowRight || key == KeyboardKeys.ArrowLeft)
+                {
+                    Box selectedBox = GetSelectedBox(SelectedNodes);
+                    if (selectedBox == null) return false;
+
+                    Box toSelect = null;
+
+                    if (key == KeyboardKeys.ArrowRight && selectedBox.IsOutput || key == KeyboardKeys.ArrowLeft && !selectedBox.IsOutput)
+                    {
+                        if (selectedBox.Connections.Count > 1)
+                        {
+                            // Box has multiple connections
+                        }
+                        else if (selectedBox.Connections.Count == 1)
+                        {
+                            toSelect = selectedBox.Connections[0];
+                        }
+                    }
+                    else
+                    {
+                        // Use the node with the closest Y-level
+                        // Since there are cases like 3 nodes on one side and only 1 node on the other side
+
+                        var elements = selectedBox?.ParentNode.Elements;
+                        float distance = float.PositiveInfinity;
+                        for (int i = 0; i < elements.Count; i++)
+                        {
+                            if (elements[i] is Box box && box.IsOutput != selectedBox.IsOutput && Mathf.Abs(box.Y - selectedBox.Y) < distance)
+                            {
+                                toSelect = box;
+                                distance = Mathf.Abs(box.Y - selectedBox.Y);
+                            }
+                        }
+                    }
+
+                    if (toSelect != null)
+                    {
+                        Select(toSelect.ParentNode);
+                        toSelect.ParentNode.SelectBox(toSelect);
+
+                    }
+                    return true;
+                }
             }
 
             return false;

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -39,6 +39,7 @@ namespace FlaxEditor.Surface
         private GroupArchetype _customNodesGroup;
         private List<NodeArchetype> _customNodes;
         private Action _onSave;
+        private int _selectedConnectionIndex;
 
         internal int _isUpdatingBoxTypes;
 
@@ -361,6 +362,8 @@ namespace FlaxEditor.Surface
 
             Context.ControlSpawned += OnSurfaceControlSpawned;
             Context.ControlDeleted += OnSurfaceControlDeleted;
+
+            SelectionChanged += () => { _selectedConnectionIndex = 0; };
 
             // Init drag handlers
             DragHandlers.Add(_dragAssets = new DragAssets<DragDropEventArgs>(ValidateDragItem));

--- a/Source/Engine/Engine/Time.h
+++ b/Source/Engine/Engine/Time.h
@@ -121,8 +121,11 @@ public:
     API_FIELD() static float PhysicsFPS;
 
     /// <summary>
-    /// The target amount of the frames rendered per second (actual game FPS).
+    /// The target amount of the frames rendered per second (target game FPS).
     /// </summary>
+    /// <remarks>
+    /// To get the actual game FPS use <see cref="Engine.FramesPerSecond"/>
+    /// </remarks>
     API_FIELD() static float DrawFPS;
 
     /// <summary>

--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -764,6 +764,11 @@ void ShaderGenerator::ProcessGroupTools(Box* box, Node* node, Value& value)
 #undef PLATFORM_CASE
         break;
     }
+    case 29:
+    {
+        value = tryGetValue(node->GetBox(0), Value::Zero);
+        break;
+    }
     default:
         break;
     }

--- a/Source/Engine/Visject/VisjectGraph.cpp
+++ b/Source/Engine/Visject/VisjectGraph.cpp
@@ -732,6 +732,12 @@ void VisjectExecutor::ProcessGroupTools(Box* box, Node* node, Value& value)
         value = Scripting::FindObject<Actor>((Guid)node->Values[0]);
         break;
     }
+
+    case 29:
+    {
+        value = tryGetValue(node->GetBox(0), Value::Zero);
+        break;
+    }
     default:
         break;
     }


### PR DESCRIPTION
Continues improving the state of https://github.com/FlaxEngine/FlaxEngine/issues/50 

- Adds point-bezier intersections for the Visject connections
- Adds reroute nodes
- Adds arrow key navigation when clicking on a box
- Slightly tweaks the item priority so that `uv` now shows the texture coordinates as the top suggestion again
- Slightly tweaks the Visject comment serialization to produce slightly smaller outputs
- Fixes redoing creating a Visject connection
- Also, it changes the `Time.DrawFPS` documentation comment. I suppose I should have put that into another PR, but ah well.

[The documentation](https://docs.flaxengine.com/manual/graphics/materials/material-editor/index.html#mouse-controls) is eventually going to have to be updated with those shortcuts.