### PR TITLE
Improve Visual Studio Code solution generation

### DIFF
--- a/Source/Editor/Modules/SourceCodeEditing/InBuildSourceCodeEditor.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/InBuildSourceCodeEditor.cs
@@ -75,7 +75,7 @@ namespace FlaxEditor.Modules.SourceCodeEditing
                 switch (Type)
                 {
                 case CodeEditorTypes.VSCodeInsiders:
-                case CodeEditorTypes.VSCode: return "-vscode";
+                case CodeEditorTypes.VSCode: return "-vscode -vs2019";
                 case CodeEditorTypes.Rider: return "-vs2019";
                 default: return null;
                 }

--- a/Source/Editor/Scripting/CodeEditors/VisualStudioCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/VisualStudioCodeEditor.cpp
@@ -82,8 +82,15 @@ String VisualStudioCodeEditor::GetName() const
 
 void VisualStudioCodeEditor::OpenFile(const String& path, int32 line)
 {
+    // Generate VS solution files for intellisense
+    if (!FileSystem::FileExists(Globals::ProjectFolder / Editor::Project->Name + TEXT(".sln")))
+    {
+        ScriptsBuilder::GenerateProject(TEXT("-vs2019"));
+    }
+
     // Generate project files if missing
-    if (!FileSystem::FileExists(Globals::ProjectFolder / TEXT(".vscode/tasks.json")))
+    if (!FileSystem::FileExists(Globals::ProjectFolder / TEXT(".vscode/tasks.json")) ||
+        !FileSystem::FileExists(_workspacePath))
     {
         ScriptsBuilder::GenerateProject(TEXT("-vscode"));
     }
@@ -96,8 +103,15 @@ void VisualStudioCodeEditor::OpenFile(const String& path, int32 line)
 
 void VisualStudioCodeEditor::OpenSolution()
 {
+    // Generate VS solution files for intellisense
+    if (!FileSystem::FileExists(Globals::ProjectFolder / Editor::Project->Name + TEXT(".sln")))
+    {
+        ScriptsBuilder::GenerateProject(TEXT("-vs2019"));
+    }
+
     // Generate project files if solution is missing
-    if (!FileSystem::FileExists(Globals::ProjectFolder / TEXT(".vscode/tasks.json")))
+    if (!FileSystem::FileExists(Globals::ProjectFolder / TEXT(".vscode/tasks.json")) ||
+        !FileSystem::FileExists(_workspacePath))
     {
         ScriptsBuilder::GenerateProject(TEXT("-vscode"));
     }

--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -156,18 +156,34 @@ namespace Flax.Build
             using (new ProfileEventScope("GenerateProjects"))
             {
                 // Pick the project format
-                ProjectFormat projectFormat = Platform.BuildPlatform.DefaultProjectFormat;
-                if (Configuration.ProjectFormatVS2019)
-                    projectFormat = ProjectFormat.VisualStudio2019;
-                else if (Configuration.ProjectFormatVS2017)
-                    projectFormat = ProjectFormat.VisualStudio2017;
-                else if (Configuration.ProjectFormatVS2015)
-                    projectFormat = ProjectFormat.VisualStudio2015;
-                else if (Configuration.ProjectFormatVSCode)
-                    projectFormat = ProjectFormat.VisualStudioCode;
-                else if (!string.IsNullOrEmpty(Configuration.ProjectFormatCustom))
-                    projectFormat = ProjectFormat.Custom;
+                List<ProjectFormat> projectFormats = new List<ProjectFormat>();
 
+                if (Configuration.ProjectFormatVS2019)
+                    projectFormats.Add(ProjectFormat.VisualStudio2019);
+                if (Configuration.ProjectFormatVS2017)
+                    projectFormats.Add(ProjectFormat.VisualStudio2017);
+                if (Configuration.ProjectFormatVS2015)
+                    projectFormats.Add(ProjectFormat.VisualStudio2015);
+                if (Configuration.ProjectFormatVSCode)
+                    projectFormats.Add(ProjectFormat.VisualStudioCode);
+                if (!string.IsNullOrEmpty(Configuration.ProjectFormatCustom))
+                    projectFormats.Add(ProjectFormat.Custom);
+
+                if (projectFormats.Count == 0)
+                    projectFormats.Add(Platform.BuildPlatform.DefaultProjectFormat);
+
+                foreach (ProjectFormat projectFormat in projectFormats)
+                    GenerateProject(projectFormat);
+            }
+        }
+
+        /// <summary>
+        /// Generates project files for the specified format.
+        /// </summary>
+        public static void GenerateProject(ProjectFormat projectFormat)
+        {
+            using (new ProfileEventScope("GenerateProject" + projectFormat.ToString()))
+            {
                 // Setup
                 var rules = GenerateRulesAssembly();
                 var rootProject = Globals.Project;

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -509,6 +509,7 @@ namespace Flax.Build.Projects.VisualStudioCode
                 json.AddField("gulp.autoDetect", "off");
                 json.AddField("jake.autoDetect", "off");
                 json.AddField("grunt.autoDetect", "off");
+                json.AddField("omnisharp.defaultLaunchSolution", solution.Name + ".sln");
                 json.EndObject();
 
                 // Folders


### PR DESCRIPTION
Visual Studio solution files are now generated for the VSCode solution so the C# Omnisharp extension can use the code completion information from these project files. 

Attempts to improve #115 (automates the workaround part), but Intellisense is still not fully working with these changes. The generated binding files are completely ignored, so some of the overridable methods can't be found, not sure if this is due to bad support in Omnisharp for multiple C# solutions in the workspace or something else.