### PR TITLE
Build Issue rissen from moving AssetsContainer

### DIFF
--- a/Source/Engine/Content/Content.Build.cs
+++ b/Source/Engine/Content/Content.Build.cs
@@ -37,6 +37,5 @@ public class Content : EngineModule
         files.AddRange(Directory.GetFiles(Path.Combine(FolderPath, "Assets"), "*.h", SearchOption.TopDirectoryOnly));
         files.AddRange(Directory.GetFiles(Path.Combine(FolderPath, "Cache"), "*.h", SearchOption.TopDirectoryOnly));
         files.AddRange(Directory.GetFiles(Path.Combine(FolderPath, "Storage"), "*.h", SearchOption.TopDirectoryOnly));
-        files.Add(Path.Combine(FolderPath, "Utilities/AssetsContainer.h"));
     }
 }


### PR DESCRIPTION
AssetContainer has been moved, but the build file does not account for this change, so errors in build will happen
This PR addressed this very issue in the easiest and most elegant way possible