### PR TITLE
Declaration sorting of script members

### DIFF
--- a/Source/Editor/Content/Items/VisualScriptItem.cs
+++ b/Source/Editor/Content/Items/VisualScriptItem.cs
@@ -75,6 +75,8 @@ namespace FlaxEditor.Content
             }
         }
 
+        public int MetadataToken => 0;
+
         /// <inheritdoc />
         public bool HasAttribute(Type attributeType, bool inherit)
         {
@@ -194,6 +196,8 @@ namespace FlaxEditor.Content
 
         /// <inheritdoc />
         public ScriptType ValueType => _returnType;
+
+        public int MetadataToken => 0;
 
         /// <inheritdoc />
         public bool HasAttribute(Type attributeType, bool inherit)

--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -173,8 +173,16 @@ namespace FlaxEditor.CustomEditors.Editors
                             return string.Compare(Display.Group, other.Display.Group, StringComparison.InvariantCulture);
                     }
 
-                    // By name
-                    return string.Compare(Info.Name, other.Info.Name, StringComparison.InvariantCulture);
+                    // By declaration order
+                    if (Info.MetadataToken > other.Info.MetadataToken)
+                        return 1;
+                    else if (Info.MetadataToken < other.Info.MetadataToken)
+                        return -1;
+                    else
+                    {
+                        // By name
+                        return string.Compare(Info.Name, other.Info.Name, StringComparison.InvariantCulture);
+                    }
                 }
 
                 return 0;

--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -173,16 +173,16 @@ namespace FlaxEditor.CustomEditors.Editors
                             return string.Compare(Display.Group, other.Display.Group, StringComparison.InvariantCulture);
                     }
 
-                    // By declaration order
-                    if (Info.MetadataToken > other.Info.MetadataToken)
-                        return 1;
-                    else if (Info.MetadataToken < other.Info.MetadataToken)
-                        return -1;
-                    else
+                    if(Editor.Instance.Options.Options.General.ScritpMembersOrder == Options.GeneralOptions.MembersOrder.Declaration)
                     {
-                        // By name
-                        return string.Compare(Info.Name, other.Info.Name, StringComparison.InvariantCulture);
+                        // By declaration order
+                        if (Info.MetadataToken > other.Info.MetadataToken)
+                            return 1;
+                        else if (Info.MetadataToken < other.Info.MetadataToken)
+                            return -1;
                     }
+                    // By name
+                    return string.Compare(Info.Name, other.Info.Name, StringComparison.InvariantCulture);
                 }
 
                 return 0;

--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -173,7 +173,7 @@ namespace FlaxEditor.CustomEditors.Editors
                             return string.Compare(Display.Group, other.Display.Group, StringComparison.InvariantCulture);
                     }
 
-                    if(Editor.Instance.Options.Options.General.ScritpMembersOrder == Options.GeneralOptions.MembersOrder.Declaration)
+                    if(Editor.Instance.Options.Options.General.ScriptMembersOrder == Options.GeneralOptions.MembersOrder.Declaration)
                     {
                         // By declaration order
                         if (Info.MetadataToken > other.Info.MetadataToken)

--- a/Source/Editor/Options/GeneralOptions.cs
+++ b/Source/Editor/Options/GeneralOptions.cs
@@ -138,8 +138,8 @@ namespace FlaxEditor.Options
         /// Gets or sets a value indicating whether automatically save the Visual Script asset editors when starting the play mode in editor.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Scripting", "Scritp Members Order"), EditorOrder(503), Tooltip("Sets the order of script properties/fields")]
-        public MembersOrder ScritpMembersOrder { get; set; } = MembersOrder.Alphabetical;
+        [EditorDisplay("Scripting", "Script Members Order"), EditorOrder(503), Tooltip("Sets the order of script properties/fields")]
+        public MembersOrder ScriptMembersOrder { get; set; } = MembersOrder.Alphabetical;
 
         /// <summary>
         /// Gets or sets a value indicating whether automatically save the Visual Script asset editors when starting the play mode in editor.

--- a/Source/Editor/Options/GeneralOptions.cs
+++ b/Source/Editor/Options/GeneralOptions.cs
@@ -69,6 +69,24 @@ namespace FlaxEditor.Options
         }
 
         /// <summary>
+        /// Order of script members show in editor
+        /// </summary>
+        public enum MembersOrder
+        {
+            /// <summary>
+            /// Shows properties/fields in alphabetical order
+            /// </summary>
+            [Tooltip("Shows properties/fields in alphabetical order")]
+            Alphabetical,
+
+            /// <summary>
+            /// Shows properties/fields in declaration order
+            /// </summary>
+            [Tooltip("Shows properties/fields in declaration order")]
+            Declaration
+        }
+
+        /// <summary>
         /// Gets or sets the scene to load on editor startup.
         /// </summary>
         [DefaultValue(StartupSceneModes.LastOpened)]
@@ -115,6 +133,13 @@ namespace FlaxEditor.Options
         [DefaultValue(true)]
         [EditorDisplay("Scripting", "Force Script Compilation On Startup"), EditorOrder(501), Tooltip("Determines whether automatically compile game scripts before starting the editor.")]
         public bool ForceScriptCompilationOnStartup { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether automatically save the Visual Script asset editors when starting the play mode in editor.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Scripting", "Scritp Members Order"), EditorOrder(503), Tooltip("Sets the order of script properties/fields")]
+        public MembersOrder ScritpMembersOrder { get; set; } = MembersOrder.Alphabetical;
 
         /// <summary>
         /// Gets or sets a value indicating whether automatically save the Visual Script asset editors when starting the play mode in editor.

--- a/Source/Editor/Scripting/ScriptType.cs
+++ b/Source/Editor/Scripting/ScriptType.cs
@@ -41,6 +41,22 @@ namespace FlaxEditor.Scripting
         public string Name => _managed?.Name ?? _custom?.Name;
 
         /// <summary>
+        /// Gets a metadata token for sorting so it may not be the actual token.
+        /// </summary>
+        public int MetadataToken
+        {
+            get
+            {
+                if (_managed != null && IsProperty)
+                {
+                    ScriptMemberInfo finfo =  DeclaringType.GetField(string.Format("<{0}>k__BackingField", Name), BindingFlags.Instance | BindingFlags.NonPublic);
+                    return finfo.MetadataToken;
+                }
+                return _managed?.MetadataToken ?? _custom?.MetadataToken ?? 0;
+            }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the type is declared public.
         /// </summary>
         public bool IsPublic
@@ -1443,6 +1459,11 @@ namespace FlaxEditor.Scripting
         /// Gets a member name (eg. name of the field or method without leading class name nor namespace prefixes).
         /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Gets a metadata token for sorting so it may not be the actual token.
+        /// </summary>
+        int MetadataToken { get; }
 
         /// <summary>
         /// Gets a value indicating whether the type is declared public.

--- a/Source/Editor/Scripting/ScriptType.cs
+++ b/Source/Editor/Scripting/ScriptType.cs
@@ -47,12 +47,17 @@ namespace FlaxEditor.Scripting
         {
             get
             {
+                int standardToken = _managed?.MetadataToken ?? _custom?.MetadataToken ?? 0;
                 if (_managed != null && IsProperty)
                 {
                     ScriptMemberInfo finfo =  DeclaringType.GetField(string.Format("<{0}>k__BackingField", Name), BindingFlags.Instance | BindingFlags.NonPublic);
+                    if(finfo.MetadataToken == 0)
+                    {
+                        return standardToken;
+                    }
                     return finfo.MetadataToken;
                 }
-                return _managed?.MetadataToken ?? _custom?.MetadataToken ?? 0;
+                return standardToken;
             }
         }
 


### PR DESCRIPTION
Its not perfect, handles
fields and auto generated properties
I believe there is no built-in way to sort normal properties as this information is absent from the resulting assembly
related: #301 