### PR TITLE
Character Controller Value Dependency fix

### DIFF
--- a/Source/Engine/Physics/Colliders/CharacterController.cpp
+++ b/Source/Engine/Physics/Colliders/CharacterController.cpp
@@ -47,6 +47,9 @@ void CharacterController::SetHeight(const float value)
 
     _height = value;
 
+    if (GetStepOffset() > value)
+        SetStepOffset(value);
+
     UpdateSize();
     UpdateBounds();
 }
@@ -77,6 +80,9 @@ void CharacterController::SetStepOffset(float value)
         return;
 
     _stepOffset = value;
+
+    if (GetHeight() < value)
+        SetHeight(value);
 
     if (_controller)
         _controller->setStepOffset(value);


### PR DESCRIPTION
Step Offset can never be higher than height of character controller
This way if one changes above the other, the other gets adjusted.
-> No crashes just because of that YAY