### PR TITLE
Fix fullscreen dx11/dx12.

### DIFF
--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.cpp
@@ -208,7 +208,7 @@ bool GPUSwapChainDX11::Resize(int32 width, int32 height)
         ASSERT(_swapChain);
 
         // Disable DXGI changes to the window
-        VALIDATE_DIRECTX_RESULT(dxgi->MakeWindowAssociation(_windowHandle, DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER));
+        VALIDATE_DIRECTX_RESULT(dxgi->MakeWindowAssociation(_windowHandle, 0));
 #else
         auto dxgiFactory = (IDXGIFactory2*)_device->GetDXGIFactory();
         VALIDATE_DIRECTX_RESULT(dxgiFactory->CreateSwapChainForCoreWindow(_device->GetDevice(), static_cast<IUnknown*>(_windowHandle), &swapChainDesc, nullptr, &_swapChain));

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.cpp
@@ -99,8 +99,6 @@ void GPUSwapChainDX11::SetFullscreen(bool isFullscreen)
             swapChainDesc.BufferDesc = outputDX.DesktopViewMode;
         }
 
-        releaseBackBuffer();
-
         if (FAILED(_swapChain->ResizeTarget(&swapChainDesc.BufferDesc)))
         {
             LOG(Warning, "Swapchain resize failed.");
@@ -110,10 +108,6 @@ void GPUSwapChainDX11::SetFullscreen(bool isFullscreen)
         {
             LOG(Warning, "Cannot change fullscreen mode for '{0}' to {1}.", ToString(), isFullscreen);
         }
-
-        VALIDATE_DIRECTX_RESULT(_swapChain->ResizeBuffers(swapChainDesc.BufferCount, _width, _height, swapChainDesc.BufferDesc.Format, swapChainDesc.Flags));
-
-        getBackBuffer();
     }
 #else
     LOG(Info, "Cannot change fullscreen mode on this platform");

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
@@ -124,8 +124,6 @@ void GPUSwapChainDX12::SetFullscreen(bool isFullscreen)
             swapChainDesc.BufferDesc = outputDX.DesktopViewMode;
         }
 
-        releaseBackBuffer();
-
         if (FAILED(_swapChain->ResizeTarget(&swapChainDesc.BufferDesc)))
         {
             LOG(Warning, "Swapchain resize failed.");
@@ -135,10 +133,6 @@ void GPUSwapChainDX12::SetFullscreen(bool isFullscreen)
         {
             LOG(Warning, "Cannot change fullscreen mode for '{0}' to {1}.", ToString(), isFullscreen);
         }
-
-        VALIDATE_DIRECTX_RESULT(_swapChain->ResizeBuffers(swapChainDesc.BufferCount, _width, _height, swapChainDesc.BufferDesc.Format, swapChainDesc.Flags));
-
-        getBackBuffer();
 
         _isFullscreen = isFullscreen;
     }

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
@@ -217,7 +217,7 @@ bool GPUSwapChainDX12::Resize(int32 width, int32 height)
         _backBuffers.Resize(swapChainDesc.BufferCount);
 
         // Disable DXGI changes to the window
-        dxgiFactory->MakeWindowAssociation(_windowHandle, DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER);
+        dxgiFactory->MakeWindowAssociation(_windowHandle, 0);
     }
     else
     {


### PR DESCRIPTION
Fix the fullscreen crash on dx11/dx12.
Little tweak, we can now use ALT + ENTER to go fullscreen !

#333 