### PR TITLE
Fix more DPI issues

### DIFF
--- a/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
@@ -124,7 +124,7 @@ namespace FlaxEngine.GUI
                 var font = textBlock.Style.Font.GetFont();
                 if (font)
                 {
-                    height = font.Height / Platform.DpiScale;
+                    height = font.Height / RootWindow.DpiScale;
                     return textBlock.Bounds.UpperLeft;
                 }
             }
@@ -136,7 +136,7 @@ namespace FlaxEngine.GUI
                 var font = textBlock.Style.Font.GetFont();
                 if (font)
                 {
-                    height = font.Height / Platform.DpiScale;
+                    height = font.Height / RootWindow.DpiScale;
                     return textBlock.Bounds.UpperRight;
                 }
             }
@@ -151,7 +151,7 @@ namespace FlaxEngine.GUI
                     var font = textBlock.Style.Font.GetFont();
                     if (!font)
                         break;
-                    height = font.Height / Platform.DpiScale;
+                    height = font.Height / RootWindow.DpiScale;
                     return textBlock.Bounds.Location + font.GetCharPosition(_text, ref textBlock.Range, index - textBlock.Range.StartIndex);
                 }
             }
@@ -166,7 +166,7 @@ namespace FlaxEngine.GUI
                     var font = textBlock.Style.Font.GetFont();
                     if (!font)
                         break;
-                    height = font.Height / Platform.DpiScale;
+                    height = font.Height / RootWindow.DpiScale;
                     return textBlock.Bounds.UpperRight;
                 }
             }
@@ -280,7 +280,7 @@ namespace FlaxEngine.GUI
                 {
                     Vector2 leftEdge = selection.StartIndex <= textBlock.Range.StartIndex ? textBlock.Bounds.UpperLeft : font.GetCharPosition(_text, selection.StartIndex);
                     Vector2 rightEdge = selection.EndIndex >= textBlock.Range.EndIndex ? textBlock.Bounds.UpperRight : font.GetCharPosition(_text, selection.EndIndex);
-                    float height = font.Height / Platform.DpiScale;
+                    float height = font.Height / RootWindow.DpiScale;
                     float alpha = Mathf.Min(1.0f, Mathf.Cos(_animateTime * BackgroundSelectedFlashSpeed) * 0.5f + 1.3f);
                     alpha *= alpha;
                     Color selectionColor = Color.White * alpha;
@@ -330,7 +330,7 @@ namespace FlaxEngine.GUI
                 if (textBlock.Style.UnderlineBrush != null)
                 {
                     var underLineHeight = 2.0f;
-                    var height = font.Height / Platform.DpiScale;
+                    var height = font.Height / RootWindow.DpiScale;
                     var underlineRect = new Rectangle(textBlock.Bounds.Location.X, textBlock.Bounds.Location.Y + height - underLineHeight * 0.5f, textBlock.Bounds.Width, underLineHeight);
                     textBlock.Style.UnderlineBrush.Draw(underlineRect, textBlock.Style.Color);
                 }

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -107,7 +107,7 @@ namespace FlaxEngine.GUI
                 return Vector2.Zero;
             }
 
-            height = font.Height / Platform.DpiScale;
+            height = font.Height / RootWindow.DpiScale;
             return font.GetCharPosition(_text, index, ref _layout);
         }
 
@@ -159,7 +159,7 @@ namespace FlaxEngine.GUI
             {
                 Vector2 leftEdge = font.GetCharPosition(_text, SelectionLeft, ref _layout);
                 Vector2 rightEdge = font.GetCharPosition(_text, SelectionRight, ref _layout);
-                float fontHeight = font.Height / Platform.DpiScale;
+                float fontHeight = font.Height / RootWindow.DpiScale;
 
                 // Draw selection background
                 float alpha = Mathf.Min(1.0f, Mathf.Cos(_animateTime * BackgroundSelectedFlashSpeed) * 0.5f + 1.3f);

--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -218,7 +218,7 @@ namespace FlaxEngine
             var camera = Camera.MainCamera;
             if (camera)
             {
-                ray = camera.ConvertMouseToRay(location);
+                ray = camera.ConvertMouseToRay(location * Platform.DpiScale);
             }
             else
             {


### PR DESCRIPTION
Makes sure to call the `RootWindow.DpiScale` getter in a few more places, that way it's per-monitor DPI aware.

Also implements a simple fix for the world space UICanvas DPI issue.