### PR TITLE
Separate ContainerControl Self/Children draw code.

### DIFF
--- a/Source/Engine/UI/GUI/Common/Border.cs
+++ b/Source/Engine/UI/GUI/Common/Border.cs
@@ -5,7 +5,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Border control that draws the border around the control edges (inner and outer sides).
     /// </summary>
-    public class Border : Control
+    public class Border : ContainerControl
     {
         /// <summary>
         /// Gets or sets the color used to draw border lines.
@@ -30,9 +30,9 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public override void Draw()
+        public override void DrawSelf()
         {
-            base.Draw();
+            base.DrawSelf();
 
             Render2D.DrawRectangle(new Rectangle(Vector2.Zero, Size), BorderColor, BorderWidth);
         }

--- a/Source/Engine/UI/GUI/Common/Button.cs
+++ b/Source/Engine/UI/GUI/Common/Button.cs
@@ -7,7 +7,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Button control
     /// </summary>
-    public class Button : Control
+    public class Button : ContainerControl
     {
         /// <summary>
         /// The default height fro the buttons.
@@ -171,7 +171,7 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public override void Draw()
+        public override void DrawSelf()
         {
             // Cache data
             Rectangle clientRect = new Rectangle(Vector2.Zero, Size);

--- a/Source/Engine/UI/GUI/Common/Image.cs
+++ b/Source/Engine/UI/GUI/Common/Image.cs
@@ -80,10 +80,10 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public override void Draw()
+        public override void DrawSelf()
         {
-            base.Draw();
-
+            base.DrawSelf();
+            
             if (Brush == null)
                 return;
 

--- a/Source/Engine/UI/GUI/Common/ProgressBar.cs
+++ b/Source/Engine/UI/GUI/Common/ProgressBar.cs
@@ -8,7 +8,7 @@ namespace FlaxEngine.GUI
     /// Progress bar control shows visual progress of the action or set of actions.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.Control" />
-    public class ProgressBar : Control
+    public class ProgressBar : ContainerControl
     {
         /// <summary>
         /// The value.
@@ -160,9 +160,9 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public override void Draw()
+        public override void DrawSelf()
         {
-            base.Draw();
+            base.DrawSelf();
 
             float progressNormalized = (_current - _minimum) / _maximum;
             if (progressNormalized > 0.001f)

--- a/Source/Engine/UI/GUI/Common/RenderToTextureControl.cs
+++ b/Source/Engine/UI/GUI/Common/RenderToTextureControl.cs
@@ -105,7 +105,7 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public override void Draw()
+        public override void DrawSelf()
         {
             // Draw cached texture
             if (_texture && !_invalid && !_isDuringTextureDraw)
@@ -119,7 +119,7 @@ namespace FlaxEngine.GUI
             }
 
             // Draw default UI directly
-            base.Draw();
+            base.DrawSelf();
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
@@ -220,7 +220,7 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public override void Draw()
+        public override void DrawSelf()
         {
             // Cache data
             var rect = new Rectangle(Vector2.Zero, Size);

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -132,7 +132,7 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public override void Draw()
+        public override void DrawSelf()
         {
             // Cache data
             var rect = new Rectangle(Vector2.Zero, Size);

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -9,7 +9,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Base class for all text box controls which can gather text input from the user.
     /// </summary>
-    public abstract class TextBoxBase : Control
+    public abstract class TextBoxBase : ContainerControl
     {
         /// <summary>
         /// The text separators (used for words skipping).

--- a/Source/Engine/UI/GUI/ContainerControl.cs
+++ b/Source/Engine/UI/GUI/ContainerControl.cs
@@ -616,32 +616,35 @@ namespace FlaxEngine.GUI
             }
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Draw the control and the children.
+        /// </summary>
         public override void Draw()
         {
-            base.Draw();
+            DrawSelf();
+            DrawChildren();
+        }
 
+        /// <summary>
+        /// Draws the control.
+        /// </summary>
+        public virtual void DrawSelf()
+        {
+            base.Draw();    
+        }
+        
+        /// <summary>
+        /// Draws the children. Can be overridden to provide some customizations. Draw is performed with applied clipping mask for the client area.
+        /// </summary>
+        protected virtual void DrawChildren()
+        {
             // Push clipping mask
             if (ClipChildren)
             {
                 GetDesireClientArea(out var clientArea);
                 Render2D.PushClip(ref clientArea);
             }
-
-            DrawChildren();
-
-            // Pop clipping mask
-            if (ClipChildren)
-            {
-                Render2D.PopClip();
-            }
-        }
-
-        /// <summary>
-        /// Draws the children. Can be overridden to provide some customizations. Draw is performed with applied clipping mask for the client area.
-        /// </summary>
-        protected virtual void DrawChildren()
-        {
+            
             // Draw all visible child controls
             if (CullChildren)
             {
@@ -675,6 +678,12 @@ namespace FlaxEngine.GUI
                         Render2D.PopTransform();
                     }
                 }
+            }
+            
+            // Pop clipping mask
+            if (ClipChildren)
+            {
+                Render2D.PopClip();
             }
         }
 


### PR DESCRIPTION
Enable us to change how `ContainerControl` and his children are rendered.
If you inherits from `ContainerControl` you can now override `DrawSelf` for custom drawing in place of `Draw`.

`ContainerControl.Draw` is now responsible for draw ordering, we can override it to create funky things like overlay.

Default order : 
![image](https://user-images.githubusercontent.com/7458848/111530998-43dd7b80-8764-11eb-90cc-0199e880afc1.png)

Example from `ProgressBar` (now use `DrawSelf`): 
![image](https://user-images.githubusercontent.com/7458848/111531490-e72e9080-8764-11eb-8dc7-381824726030.png)
*Call `base.DrawSelf` in place of `base.Draw`.*

For simple `Control`, you can just use `Draw` like before.

**This is not a breaking change, custom `ContainerControl` that override `Draw` will continue to work, but i recommend you to modify them in order to use `DrawSelf`** 

*Fix #312 Image order issue