### PR TITLE
Matrix3x3.cs documentation fixes

### DIFF
--- a/Source/Engine/Core/Math/Matrix3x3.cs
+++ b/Source/Engine/Core/Math/Matrix3x3.cs
@@ -1566,7 +1566,7 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Creates a Matrix3x3 that scales along the x-axis, y-axis, and y-axis.
+        /// Creates a Matrix3x3 that scales along the x-axis, y-axis, and z-axis.
         /// </summary>
         /// <param name="scale">Scaling factor for all three axes.</param>
         /// <returns>The created scaling Matrix3x3.</returns>
@@ -1577,7 +1577,7 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Creates a Matrix3x3 that scales along the x-axis, y-axis, and y-axis.
+        /// Creates a Matrix3x3 that scales along the x-axis, y-axis, and z-axis.
         /// </summary>
         /// <param name="x">Scaling factor that is applied along the x-axis.</param>
         /// <param name="y">Scaling factor that is applied along the y-axis.</param>
@@ -1605,9 +1605,9 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Creates a Matrix3x3 that uniformly scales along all three axis.
+        /// Creates a Matrix3x3 that uniformly scales along all three axes.
         /// </summary>
-        /// <param name="scale">The uniform scale that is applied along all axis.</param>
+        /// <param name="scale">The uniform scale that is applied along all axes.</param>
         /// <param name="result">When the method completes, contains the created scaling Matrix3x3.</param>
         public static void Scaling(float scale, out Matrix3x3 result)
         {
@@ -1616,9 +1616,9 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Creates a Matrix3x3 that uniformly scales along all three axis.
+        /// Creates a Matrix3x3 that uniformly scales along all three axes.
         /// </summary>
-        /// <param name="scale">The uniform scale that is applied along all axis.</param>
+        /// <param name="scale">The uniform scale that is applied along all axes.</param>
         /// <returns>The created scaling Matrix3x3.</returns>
         public static Matrix3x3 Scaling(float scale)
         {


### PR DESCRIPTION
I wonder if adding a note about scaling `Vector2`s (like in UIs) would be useful as well. As in, when you have a `Vector2`, you only want to scale it along the `x` and `y` axis.