### PR TITLE
Fix DPI regression: use the overrideable RootWindow instead of _root

### DIFF
--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -313,7 +313,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets the control DPI scale factor (1 is default). Includes custom DPI scale.
         /// </summary>
-        public float DpiScale => _root?.RootWindow?.Window.DpiScale ?? Platform.DpiScale;
+        public float DpiScale => RootWindow?.Window.DpiScale ?? Platform.DpiScale;
 
         /// <summary>
         /// Gets screen position of the control (upper left corner).


### PR DESCRIPTION
No idea how I didn't catch this one sooner.