### PR TITLE
Add Initializer lists support for arrays

### DIFF
--- a/Source/Engine/Core/Collections/Array.h
+++ b/Source/Engine/Core/Collections/Array.h
@@ -5,6 +5,7 @@
 #include "Engine/Platform/Platform.h"
 #include "Engine/Core/Memory/Memory.h"
 #include "Engine/Core/Memory/Allocation.h"
+#include <initializer_list>
 
 /// <summary>
 /// Template for dynamic array with variable capacity.
@@ -45,6 +46,16 @@ public:
     {
         if (capacity > 0)
             _allocation.Allocate(capacity);
+    }
+
+    Array(std::initializer_list<T> initList)
+    {
+        _count = _capacity = (int32)initList.size();
+        if (_count > 0)
+        {
+            _allocation.Allocate(_count);
+            Memory::ConstructItems(Get(), initList.begin(), _count);
+        }
     }
 
     /// <summary>
@@ -121,6 +132,24 @@ public:
         other._count = 0;
         other._capacity = 0;
         _allocation.Swap(other._allocation);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="initList"></param>
+    /// <returns></returns>
+    Array& operator=(std::initializer_list<T> initList) noexcept
+    {
+        Memory::DestructItems(Get(), _count);
+
+        _count = _capacity = (int32)initList.size();
+        if (_capacity > 0)
+        {
+            _allocation.Allocate(_capacity);
+            Memory::ConstructItems(Get(), initList.begin(), _count);
+        }
+        return *this;
     }
 
     /// <summary>

--- a/Source/Engine/Core/Collections/Array.h
+++ b/Source/Engine/Core/Collections/Array.h
@@ -48,6 +48,10 @@ public:
             _allocation.Allocate(capacity);
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Array"/> class.
+    /// </summary>
+    /// <param name="initList">The initial values defined in the array.</param>
     Array(std::initializer_list<T> initList)
     {
         _count = _capacity = (int32)initList.size();
@@ -135,10 +139,10 @@ public:
     }
 
     /// <summary>
-    /// 
+    /// The assignment operator that deletes the current collection of items and the copies items from the initializer list.
     /// </summary>
-    /// <param name="initList"></param>
-    /// <returns></returns>
+    /// <param name="initList">The other collection to copy.</param>
+    /// <returns>The reference to this.</returns>
     Array& operator=(std::initializer_list<T> initList) noexcept
     {
         Memory::DestructItems(Get(), _count);

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -411,6 +411,10 @@ namespace Flax.Build.Bindings
             if (value.Contains("::"))
                 return false;
 
+            // Initializer lists (eg. Array<int> foo = {1, 2, 3, 4}
+            if (value.Contains('{') && value.Contains('}'))
+                return false;
+
             return true;
         }
 

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -411,7 +411,7 @@ namespace Flax.Build.Bindings
             if (value.Contains("::"))
                 return false;
 
-            // Initializer lists (eg. Array<int> foo = {1, 2, 3, 4}
+            // Initializer lists (eg. Array<int> foo = {1, 2, 3, 4})
             if (value.Contains('{') && value.Contains('}'))
                 return false;
 


### PR DESCRIPTION
Something I consider to be quite essential and kind of surprised this wasn't there so I added it.

Allows you do initilize arrays in C++ like this:

```cpp
// For instance in a .h file
API_FIELD() Array<int> foo = {1, 2, 3, 4};
```