### PR TITLE
Change FontReference to reference type

### DIFF
--- a/Source/Editor/Windows/Assets/FontWindow.cs
+++ b/Source/Editor/Windows/Assets/FontWindow.cs
@@ -135,7 +135,7 @@ namespace FlaxEditor.Windows.Assets
         /// <inheritdoc />
         protected override void UnlinkItem()
         {
-            _textPreview.Font = new FontReference();
+            _textPreview.Font = null;
 
             base.UnlinkItem();
         }

--- a/Source/Engine/Render2D/FontReference.cs
+++ b/Source/Engine/Render2D/FontReference.cs
@@ -7,7 +7,7 @@ namespace FlaxEngine
     /// <summary>
     /// Font reference that defines the font asset and font size to use.
     /// </summary>
-    public struct FontReference
+    public class FontReference
     {
         [NoSerialize]
         private FontAsset _font;
@@ -96,9 +96,9 @@ namespace FlaxEngine
         /// <c>true</c> if the specified <see cref="FontReference" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(ref FontReference other)
+        public bool Equals(FontReference other)
         {
-            return _font == other._font && _size == other._size;
+            return !(other is null) && _font == other._font && _size == other._size;
         }
 
         /// <summary>
@@ -109,7 +109,9 @@ namespace FlaxEngine
         /// <returns>True if font references are equal, otherwise false.</returns>
         public static bool operator ==(FontReference lhs, FontReference rhs)
         {
-            return lhs.Equals(ref rhs);
+            if (lhs is null)
+                return rhs is null;
+            return lhs.Equals(rhs);
         }
 
         /// <summary>
@@ -120,7 +122,9 @@ namespace FlaxEngine
         /// <returns>True if font references are not equal, otherwise false.</returns>
         public static bool operator !=(FontReference lhs, FontReference rhs)
         {
-            return !lhs.Equals(ref rhs);
+            if (lhs is null)
+                return !(rhs is null);
+            return !lhs.Equals(rhs);
         }
 
         /// <inheritdoc />
@@ -129,7 +133,7 @@ namespace FlaxEngine
             if (!(other is FontReference))
                 return false;
             var fontReference = (FontReference)other;
-            return Equals(ref fontReference);
+            return Equals(fontReference);
         }
 
         /// <inheritdoc />
@@ -137,7 +141,7 @@ namespace FlaxEngine
         {
             unchecked
             {
-                int hashCode = _font.GetHashCode();
+                int hashCode = _font ? _font.GetHashCode() : 0;
                 hashCode = (hashCode * 397) ^ _size;
                 return hashCode;
             }

--- a/Source/Engine/UI/GUI/Common/Border.cs
+++ b/Source/Engine/UI/GUI/Common/Border.cs
@@ -24,9 +24,12 @@ namespace FlaxEngine.GUI
         /// </summary>
         public Border()
         {
+            BorderWidth = 2.0f;
+
+#if FLAX_EDITOR
             var style = Style.Current;
             BorderColor = style.BorderNormal;
-            BorderWidth = 2.0f;
+#endif
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/Button.cs
+++ b/Source/Engine/UI/GUI/Common/Button.cs
@@ -124,6 +124,7 @@ namespace FlaxEngine.GUI
         public Button(float x, float y, float width = 120, float height = DefaultHeight)
         : base(x, y, width, height)
         {
+#if FLAX_EDITOR
             var style = Style.Current;
             if (style != null)
             {
@@ -136,6 +137,7 @@ namespace FlaxEngine.GUI
                 BackgroundColorHighlighted = style.BackgroundHighlighted;
                 BorderColorHighlighted = style.BorderHighlighted;
             }
+#endif
         }
 
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/CheckBox.cs
+++ b/Source/Engine/UI/GUI/Common/CheckBox.cs
@@ -163,12 +163,14 @@ namespace FlaxEngine.GUI
             _state = isChecked ? CheckBoxState.Checked : CheckBoxState.Default;
             _boxSize = Mathf.Min(16.0f, size);
 
+#if FLAX_EDITOR
             var style = Style.Current;
             ImageColor = style.BorderSelected * 1.2f;
             BorderColor = style.BorderNormal;
             BorderColorHighlighted = style.BorderSelected;
             CheckedImage = new SpriteBrush(style.CheckBoxTick);
             IntermediateImage = new SpriteBrush(style.CheckBoxIntermediate);
+#endif
 
             CacheBox();
         }

--- a/Source/Engine/UI/GUI/Common/Dropdown.cs
+++ b/Source/Engine/UI/GUI/Common/Dropdown.cs
@@ -235,6 +235,7 @@ namespace FlaxEngine.GUI
         {
             AutoFocus = false;
 
+#if FLAX_EDITOR
             var style = Style.Current;
             Font = new FontReference(style.FontMedium);
             TextColor = style.Foreground;
@@ -249,6 +250,7 @@ namespace FlaxEngine.GUI
             ArrowColorSelected = style.BackgroundSelected;
             ArrowColorHighlighted = style.Foreground;
             CheckedImage = new SpriteBrush(style.CheckBoxTick);
+#endif
         }
 
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/Label.cs
+++ b/Source/Engine/UI/GUI/Common/Label.cs
@@ -183,10 +183,13 @@ namespace FlaxEngine.GUI
         : base(0, 0, 100, 20)
         {
             AutoFocus = false;
+
+#if FLAX_EDITOR
             var style = Style.Current;
             Font = new FontReference(style.FontMedium);
-            TextColor = Style.Current.Foreground;
-            TextColorHighlighted = Style.Current.Foreground;
+            TextColor = style.Foreground;
+            TextColorHighlighted = style.Foreground;
+#endif
         }
 
         /// <inheritdoc />
@@ -194,10 +197,13 @@ namespace FlaxEngine.GUI
         : base(x, y, width, height)
         {
             AutoFocus = false;
+
+#if FLAX_EDITOR
             var style = Style.Current;
             Font = new FontReference(style.FontMedium);
-            TextColor = Style.Current.Foreground;
-            TextColorHighlighted = Style.Current.Foreground;
+            TextColor = style.Foreground;
+            TextColorHighlighted = style.Foreground;
+#endif
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/ProgressBar.cs
+++ b/Source/Engine/UI/GUI/Common/ProgressBar.cs
@@ -123,11 +123,13 @@ namespace FlaxEngine.GUI
         : base(x, y, width, height)
         {
             AutoFocus = false;
+            BarMargin = new Margin(1);
 
+#if FLAX_EDITOR
             var style = Style.Current;
             BackgroundColor = style.Background;
             BarColor = style.ProgressNormal;
-            BarMargin = new Margin(1);
+#endif
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/RichTextBox.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBox.cs
@@ -9,12 +9,7 @@ namespace FlaxEngine.GUI
     /// </summary>
     public class RichTextBox : RichTextBoxBase
     {
-        private TextBlockStyle _textStyle = new TextBlockStyle
-        {
-            Font = new FontReference(Style.Current.FontMedium),
-            Color = Style.Current.Foreground,
-            BackgroundSelectedBrush = new SolidColorBrush(Style.Current.BackgroundSelected),
-        };
+        private TextBlockStyle _textStyle;
 
         /// <summary>
         /// The text style applied to the whole text.
@@ -28,6 +23,22 @@ namespace FlaxEngine.GUI
                 _textStyle = value;
                 UpdateTextBlocks();
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Label"/> class.
+        /// </summary>
+        public RichTextBox()
+        : base()
+        {
+            _textStyle = new TextBlockStyle();
+
+#if FLAX_EDITOR
+            var style = Style.Current;
+            _textStyle.Font = new FontReference(style.FontMedium);
+            _textStyle.Color = style.Foreground;
+            _textStyle.BackgroundSelectedBrush = new SolidColorBrush(style.BackgroundSelected);
+#endif
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -87,11 +87,13 @@ namespace FlaxEngine.GUI
             _layout.TextWrapping = TextWrapping.NoWrap;
             _layout.Bounds = new Rectangle(DefaultMargin, 1, Width - 2 * DefaultMargin, Height - 2);
 
+#if FLAX_EDITOR
             var style = Style.Current;
             Font = new FontReference(style.FontMedium);
             TextColor = style.Foreground;
             WatermarkTextColor = style.ForegroundDisabled;
             SelectionColor = style.BackgroundSelected;
+#endif
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -433,12 +433,14 @@ namespace FlaxEngine.GUI
             _selectionStart = _selectionEnd = -1;
             AutoFocus = false;
 
+#if FLAX_EDITOR
             var style = Style.Current;
             CaretColor = style.Foreground;
             BorderColor = Color.Transparent;
             BorderSelectedColor = style.BackgroundSelected;
             BackgroundColor = style.TextBoxBackground;
             BackgroundSelectedColor = style.TextBoxBackgroundSelected;
+#endif
         }
 
         /// <summary>

--- a/Source/Engine/UI/GUI/Panels/DropPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/DropPanel.cs
@@ -228,6 +228,7 @@ namespace FlaxEngine.GUI
         {
             AutoFocus = false;
 
+#if FLAX_EDITOR
             var style = Style.Current;
             HeaderColor = style.BackgroundNormal;
             HeaderColorMouseOver = style.BackgroundHighlighted;
@@ -235,6 +236,7 @@ namespace FlaxEngine.GUI
             HeaderTextColor = style.Foreground;
             ArrowImageOpened = new SpriteBrush(style.ArrowDown);
             ArrowImageClosed = new SpriteBrush(style.ArrowRight);
+#endif
         }
 
         /// <summary>

--- a/Source/Engine/UI/GUI/Style.cs
+++ b/Source/Engine/UI/GUI/Style.cs
@@ -22,7 +22,7 @@ namespace FlaxEngine.GUI
         [EditorOrder(10)]
         public Font FontTitle
         {
-            get => _fontTitle.GetFont();
+            get => _fontTitle?.GetFont();
             set => _fontTitle = new FontReference(value);
         }
 
@@ -36,7 +36,7 @@ namespace FlaxEngine.GUI
         [EditorOrder(20)]
         public Font FontLarge
         {
-            get => _fontLarge.GetFont();
+            get => _fontLarge?.GetFont();
             set => _fontLarge = new FontReference(value);
         }
 
@@ -50,7 +50,7 @@ namespace FlaxEngine.GUI
         [EditorOrder(30)]
         public Font FontMedium
         {
-            get => _fontMedium.GetFont();
+            get => _fontMedium?.GetFont();
             set => _fontMedium = new FontReference(value);
         }
 
@@ -64,7 +64,7 @@ namespace FlaxEngine.GUI
         [EditorOrder(40)]
         public Font FontSmall
         {
-            get => _fontSmall.GetFont();
+            get => _fontSmall?.GetFont();
             set => _fontSmall = new FontReference(value);
         }
 


### PR DESCRIPTION
FontReference is mutating itself by storing the cached font for later reuse, but this is not working as intended because FontReference is returned as a value type in UIControls so the cached font is actually stored in a copy of the FontReference and not in the original property.

I am not entirely sure why the original code works in some cases, but without this change, the text in TextBox sometimes flickers when garbage collection is triggered (once every few seconds), and this can be verified by forcing garbage collection for every frame which returns in TextBox not rendering properly or at all. Again I'm not sure about the exact conditions when this occurs, but for me it happens when the font size of the TextBox is reasonably large (>100pt or so).

