### PR TITLE
Fix "This" node output type.

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -672,6 +672,24 @@ namespace FlaxEditor.Surface.Archetypes
             }
         }
 
+        private class ThisNode : SurfaceNode
+        {
+            /// <inheritdoc />
+            public ThisNode(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
+            : base(id, context, nodeArch, groupArch)
+            {}
+
+            /// <inheritdoc />
+            public override void OnLoaded()
+            {
+                base.OnLoaded();
+                var vss = (VisualScriptSurface)this.Context.Surface;
+                var type = TypeUtils.GetType(vss.Script.ScriptTypeName);
+                var box = (OutputBox)GetBox(0);
+                box.CurrentType = type ? type : new ScriptType(typeof(VisualScript));
+            }
+        }
+        
         private class AssetReferenceNode : SurfaceNode
         {
             /// <inheritdoc />
@@ -1366,6 +1384,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 19,
                 Title = "This Instance",
+                Create = (id, context, arch, groupArch) => new ThisNode(id, context, arch, groupArch),
                 Description = "Gets the reference to this script object instance (self).",
                 Flags = NodeFlags.VisualScriptGraph,
                 Size = new Vector2(140, 20),


### PR DESCRIPTION
Before ( Output type : VisualScript ) : 
![image](https://user-images.githubusercontent.com/7458848/114300298-e49f2c80-9abf-11eb-88c8-4a97d41558fb.png)


After ( Output type : The real script type ) : 
![image](https://user-images.githubusercontent.com/7458848/114300284-c46f6d80-9abf-11eb-9f0c-9b674bba32ac.png)

I'm not sure about how it will behave on already created visual script, so 1.2.