### PR TITLE
Game Plugin Editor Deinitiliazitation order

### DIFF
--- a/Source/Editor/States/PlayingState.cs
+++ b/Source/Editor/States/PlayingState.cs
@@ -158,6 +158,8 @@ namespace FlaxEditor.States
         public override void OnExit(State nextState)
         {
             IsPaused = true;
+            
+            PluginManager.DeinitializeGamePlugins();
 
             // Remove references to the scene objects
             Editor.Scene.ClearRefsToSceneObjects();
@@ -176,8 +178,6 @@ namespace FlaxEditor.States
                 win.Cursor = CursorType.Default;
             IsPaused = true;
             RestoreSelection();
-
-            PluginManager.DeinitializeGamePlugins();
             
             Editor.OnPlayEnd();
         }


### PR DESCRIPTION
Given that the GamePlugins are initialized last, I think they should be deinitialized first