### PR TITLE
Fix issue #460

### DIFF
--- a/Source/Engine/UI/GUI/Tooltip.cs
+++ b/Source/Engine/UI/GUI/Tooltip.cs
@@ -155,7 +155,7 @@ namespace FlaxEngine.GUI
         /// <param name="dt">The delta time.</param>
         public void OnMouseOverControl(Control target, float dt)
         {
-            if (!Visible)
+            if (!Visible && _timeToPopupLeft > 0.0f)
             {
                 _lastTarget = target;
                 _timeToPopupLeft -= dt;


### PR DESCRIPTION
Do not allow a tooltip to attempt to show itself if its `_timeToPopupLeft` has expired.

Since `Show()` calls `Hide()`, the tooltip would flicker. See issue #460 