### PR TITLE
[CLEAN] Add missing include and undef redefined macro

### DIFF
--- a/Source/Engine/Core/DeleteMe.h
+++ b/Source/Engine/Core/DeleteMe.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "Engine/Core/Compiler.h"
+
 /// <summary>
 /// Helper class used to delete another object.
 /// </summary>

--- a/Source/Engine/Serialization/JsonTools.h
+++ b/Source/Engine/Serialization/JsonTools.h
@@ -386,6 +386,8 @@ public:
     DECLARE_GETTER(Plane);
     DECLARE_GETTER(DateTime);
 
+#undef DECLARE_GETTER
+
 #define DECLARE_GETTER(type) \
 	FORCE_INLINE static void Get##type(type& result, const Value& node, const char* name) \
 	{ \


### PR DESCRIPTION
The missing include defines the FORCE_INLINE macro used in the class