### PR TITLE
Rename exe on Windows and Fix logic on Linux

### DIFF
--- a/Source/Editor/Cooker/Platform/Linux/LinuxPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Linux/LinuxPlatformTools.cpp
@@ -66,7 +66,7 @@ bool LinuxPlatformTools::OnDeployBinaries(CookingData& data)
 #if !BUILD_DEBUG
 	const String outputExePath = outputPath / TEXT("FlaxGame");
 	const String gameExePath = outputPath / gameSettings->ProductName;
-	if (FileSystem::FileExists(outputExePath) && gameExePath.Compare(outputExePath, StringSearchCase::IgnoreCase) == 0)
+	if (FileSystem::FileExists(outputExePath) && gameExePath.Compare(outputExePath, StringSearchCase::IgnoreCase) != 0)
 	{
 		if (FileSystem::MoveFile(gameExePath, outputExePath, true))
 		{


### PR DESCRIPTION
I've implmented exe renaming the same way it's done on Linux(I know we discussed this, but I truly couldnt find it)
Other thing to note, I think the logic was inverted, the if statement should check if the names aren't equal, as if they were it would be pointless to rename.