### PR TITLE
OnAwake before all OnStarts

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -794,6 +794,15 @@ void Actor::PostSpawn()
     {
         Children[i]->PostSpawn();
     }
+        
+    // Fire events for scripting
+    for (auto* script : Scripts)
+    {
+        CHECK_EXECUTE_IN_EDITOR
+        {
+            script->OnAwake();
+        }
+    }
 }
 
 void Actor::BeginPlay(SceneBeginData* data)

--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -759,6 +759,15 @@ void Actor::PostLoad()
     // Use lazy creation for the managed instance, just register the object
     if (!IsRegistered())
         RegisterObject();
+    
+    // Fire events for scripting
+    for (auto* script : Scripts)
+    {
+        CHECK_EXECUTE_IN_EDITOR
+        {
+            script->OnAwake();
+        }
+    }
 }
 
 void Actor::PostSpawn()
@@ -821,14 +830,6 @@ void Actor::BeginPlay(SceneBeginData* data)
             Children[i]->BeginPlay(data);
     }
 
-    // Fire events for scripting
-    for (auto* script : Scripts)
-    {
-        CHECK_EXECUTE_IN_EDITOR
-        {
-            script->OnAwake();
-        }
-    }
     if (IsActiveInHierarchy() && GetScene() && !_isEnabled)
     {
         OnEnable();

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -985,6 +985,7 @@ public:
     void BreakPrefabLink() override;
     void PostLoad() override;
     void PostSpawn() override;
+    void Setup() override;
     void BeginPlay(SceneBeginData* data) override;
     void EndPlay() override;
     void Serialize(SerializeStream& stream, const void* otherObj) override;

--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -148,6 +148,7 @@ bool LevelImpl::spawnActor(Actor* actor, Actor* parent)
         actor->PostSpawn();
         actor->OnTransformChanged();
         {
+            actor->Setup();
             SceneBeginData beginData;
             actor->BeginPlay(&beginData);
             beginData.OnDone();
@@ -1063,6 +1064,7 @@ bool Level::loadScene(rapidjson_flax::Value& data, int32 engineBuild, bool autoI
 
         if (autoInitialize)
         {
+            scene->Setup();
             SceneBeginData beginData;
             scene->BeginPlay(&beginData);
             beginData.OnDone();

--- a/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
@@ -418,8 +418,6 @@ bool PrefabInstanceData::SynchronizePrefabInstances(Array<PrefabInstanceData>& p
 
                     if (Script* script = dynamic_cast<Script*>(obj))
                     {
-                        if (Editor::IsPlayMode || script->_executeInEditor)
-                            script->OnAwake();
                         if (script->GetParent() && !script->_wasEnableCalled && script->GetParent()->IsActiveInHierarchy() && script->GetParent()->GetScene())
                             script->Enable();
                     }

--- a/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
@@ -414,6 +414,14 @@ bool PrefabInstanceData::SynchronizePrefabInstances(Array<PrefabInstanceData>& p
                 SceneObject* obj = sceneObjects.Value->At(i);
                 if (!obj->IsDuringPlay() && sceneObjects->Find(obj->GetParent()) < i)
                 {
+                    obj->Setup();
+                }
+            }
+            for (int32 i = existingObjectsCount; i < sceneObjects->Count(); i++)
+            {
+                SceneObject* obj = sceneObjects.Value->At(i);
+                if (!obj->IsDuringPlay() && sceneObjects->Find(obj->GetParent()) < i)
+                {
                     obj->BeginPlay(&beginData);
 
                     if (Script* script = dynamic_cast<Script*>(obj))

--- a/Source/Engine/Level/Prefabs/PrefabManager.cpp
+++ b/Source/Engine/Level/Prefabs/PrefabManager.cpp
@@ -292,6 +292,7 @@ Actor* PrefabManager::SpawnPrefab(Prefab* prefab, Actor* parent, Dictionary<Guid
     if (parent && parent->IsDuringPlay())
     {
         // Begin play
+        root->Setup();
         SceneBeginData beginData;
         root->BeginPlay(&beginData);
         beginData.OnDone();

--- a/Source/Engine/Level/SceneObject.h
+++ b/Source/Engine/Level/SceneObject.h
@@ -222,6 +222,11 @@ public:
     virtual void PostSpawn() = 0;
 
     /// <summary>
+    /// Batch called before BeginPlay.
+    /// </summary>
+    virtual void Setup() = 0;
+
+    /// <summary>
     /// Called when adding object to the game.
     /// </summary>
     /// <param name="data">The initialization data (e.g. used to collect joints to link after begin).</param>

--- a/Source/Engine/Scripting/Script.cpp
+++ b/Source/Engine/Scripting/Script.cpp
@@ -285,6 +285,15 @@ void Script::PostSpawn()
     if (!HasManagedInstance())
         CreateManaged();
 }
+void Script::Setup() {
+
+    ASSERT(!IsDuringPlay());
+
+    CHECK_EXECUTE_IN_EDITOR
+    {
+        OnAwake();
+    }
+}
 
 void Script::BeginPlay(SceneBeginData* data)
 {

--- a/Source/Engine/Scripting/Script.h
+++ b/Source/Engine/Scripting/Script.h
@@ -145,6 +145,7 @@ public:
     void SetOrderInParent(int32 index) override;
     void PostLoad() override;
     void PostSpawn() override;
+    void Setup() override;
     void BeginPlay(SceneBeginData* data) override;
     void EndPlay() override;
     void Serialize(SerializeStream& stream, const void* otherObj) override;


### PR DESCRIPTION
As proposed in discord. This calls all OnAwakes before all OnStarts.
Scripts can now properly setup themselfs and after that, they can talk to each other fully initialized.