### PR TITLE
Command line -play argument.

### DIFF
--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -519,6 +519,11 @@ bool Editor::Init()
         return true;
     }
 
+    if (CommandLine::Options.Game.HasValue())
+    {
+        CommandLine::Options.SkipCompile.SetValue(true);
+    }
+    
     // If during last lightmaps baking engine crashed we could try to restore the progress
     ShadowsOfMordor::Builder::Instance()->CheckIfRestoreState();
 
@@ -534,6 +539,11 @@ bool Editor::Init()
     // Initialize managed editor
     Managed->Init();
 
+    if (CommandLine::Options.Game.HasValue())
+    {
+        Managed->RequestStartPlay();
+    }
+    
     return false;
 }
 

--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -543,7 +543,7 @@ bool Editor::Init()
     // Start play if requested by cmd line
     if (CommandLine::Options.Game.HasValue())
     {
-        Managed->RequestStartPlay();
+        Managed->RequestStartPlayOnEditMode();
     }
     
     return false;

--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -519,6 +519,7 @@ bool Editor::Init()
         return true;
     }
 
+    // Skip compilation if play on start
     if (CommandLine::Options.Game.HasValue())
     {
         CommandLine::Options.SkipCompile.SetValue(true);
@@ -539,6 +540,7 @@ bool Editor::Init()
     // Initialize managed editor
     Managed->Init();
 
+    // Start play if requested by cmd line
     if (CommandLine::Options.Game.HasValue())
     {
         Managed->RequestStartPlay();

--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -518,12 +518,6 @@ bool Editor::Init()
         exit(failed ? 1 : 0);
         return true;
     }
-
-    // Skip compilation if play on start
-    if (CommandLine::Options.Game.HasValue())
-    {
-        CommandLine::Options.SkipCompile.SetValue(true);
-    }
     
     // If during last lightmaps baking engine crashed we could try to restore the progress
     ShadowsOfMordor::Builder::Instance()->CheckIfRestoreState();
@@ -541,7 +535,7 @@ bool Editor::Init()
     Managed->Init();
 
     // Start play if requested by cmd line
-    if (CommandLine::Options.Game.HasValue())
+    if (CommandLine::Options.Play.HasValue())
     {
         Managed->RequestStartPlayOnEditMode();
     }

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -1320,9 +1320,18 @@ namespace FlaxEditor
             AnimGraphDebugFlow?.Invoke(debugFlow);
         }
 
-        internal static void Internal_RequestStartPlay()
+        private static void RequestStartPlayOnStartup()
         {
-            Instance.Simulation.RequestStartPlay();
+            if (Instance.StateMachine.IsEditMode)
+            {
+                Instance.Simulation.RequestStartPlay();
+                Instance.StateMachine.StateChanged -= RequestStartPlayOnStartup;
+            }
+        }
+        
+        internal static void Internal_RequestStartPlayOnStartup()
+        {
+            Instance.StateMachine.StateChanged += RequestStartPlayOnStartup;
         }
         
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -271,10 +271,14 @@ namespace FlaxEditor
                 module.OnEndInit();
         }
 
-        internal void Init(bool isHeadless, bool skipCompile)
+        private Guid _startupSceneArgument;
+        
+        internal void Init(bool isHeadless, bool skipCompile, Guid sceneId)
         {
+            Debug.Log("sceneId string : " + JsonSerializer.GetStringID(sceneId));
             EnsureState<LoadingState>();
             _isHeadlessMode = isHeadless;
+            _startupSceneArgument = sceneId;
             Log("Editor init");
             if (isHeadless)
                 Log("Running in headless mode");
@@ -332,6 +336,17 @@ namespace FlaxEditor
             }
 
             // Load scene
+            
+            // scene cmd line argument
+            var scene = ContentDatabase.Find(_startupSceneArgument);
+            if (scene is SceneItem)
+            {
+                Editor.Log("Loading scene specified in command line");
+                Scene.OpenScene(_startupSceneArgument);
+                return;
+            }
+
+            // if no scene cmd line argument is provided
             var startupSceneMode = Options.Options.General.StartupSceneMode;
             if (startupSceneMode == GeneralOptions.StartupSceneModes.LastOpened && !ProjectCache.HasCustomData(ProjectDataLastScene))
             {

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -1307,6 +1307,11 @@ namespace FlaxEditor
             AnimGraphDebugFlow?.Invoke(debugFlow);
         }
 
+        internal static void Internal_RequestStartPlay()
+        {
+            Instance.Simulation.RequestStartPlay();
+        }
+        
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern int Internal_ReadOutputLogs(string[] outMessages, byte[] outLogTypes, long[] outLogTimes);
 

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -1323,12 +1323,11 @@ namespace FlaxEditor
         private static void RequestStartPlayOnEditMode()
         {
             if (Instance.StateMachine.IsEditMode)
-            {
                 Instance.Simulation.RequestStartPlay();
+            if (Instance.StateMachine.IsPlayMode)
                 Instance.StateMachine.StateChanged -= RequestStartPlayOnEditMode;
-            }
         }
-        
+
         internal static void Internal_RequestStartPlayOnEditMode()
         {
             Instance.StateMachine.StateChanged += RequestStartPlayOnEditMode;

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -1320,18 +1320,18 @@ namespace FlaxEditor
             AnimGraphDebugFlow?.Invoke(debugFlow);
         }
 
-        private static void RequestStartPlayOnStartup()
+        private static void RequestStartPlayOnEditMode()
         {
             if (Instance.StateMachine.IsEditMode)
             {
                 Instance.Simulation.RequestStartPlay();
-                Instance.StateMachine.StateChanged -= RequestStartPlayOnStartup;
+                Instance.StateMachine.StateChanged -= RequestStartPlayOnEditMode;
             }
         }
         
         internal static void Internal_RequestStartPlayOnEditMode()
         {
-            Instance.StateMachine.StateChanged += RequestStartPlayOnStartup;
+            Instance.StateMachine.StateChanged += RequestStartPlayOnEditMode;
         }
         
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -46,6 +46,7 @@ namespace FlaxEditor
         private bool _isAfterInit, _areModulesInited, _areModulesAfterInitEnd, _isHeadlessMode;
         private string _projectToOpen;
         private float _lastAutoSaveTimer;
+        private Guid _startupSceneCmdLine;
 
         private const string ProjectDataLastScene = "LastScene";
         private const string ProjectDataLastSceneSpawn = "LastSceneSpawn";
@@ -271,14 +272,11 @@ namespace FlaxEditor
                 module.OnEndInit();
         }
 
-        private Guid _startupSceneArgument;
-        
-        internal void Init(bool isHeadless, bool skipCompile, Guid sceneId)
+        internal void Init(bool isHeadless, bool skipCompile, Guid startupScene)
         {
-            Debug.Log("sceneId string : " + JsonSerializer.GetStringID(sceneId));
             EnsureState<LoadingState>();
             _isHeadlessMode = isHeadless;
-            _startupSceneArgument = sceneId;
+            _startupSceneCmdLine = startupScene;
             Log("Editor init");
             if (isHeadless)
                 Log("Running in headless mode");
@@ -338,11 +336,11 @@ namespace FlaxEditor
             // Load scene
             
             // scene cmd line argument
-            var scene = ContentDatabase.Find(_startupSceneArgument);
+            var scene = ContentDatabase.Find(_startupSceneCmdLine);
             if (scene is SceneItem)
             {
                 Editor.Log("Loading scene specified in command line");
-                Scene.OpenScene(_startupSceneArgument);
+                Scene.OpenScene(_startupSceneCmdLine);
                 return;
             }
 

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -1329,7 +1329,7 @@ namespace FlaxEditor
             }
         }
         
-        internal static void Internal_RequestStartPlayOnStartup()
+        internal static void Internal_RequestStartPlayOnEditMode()
         {
             Instance.StateMachine.StateChanged += RequestStartPlayOnStartup;
         }

--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -488,7 +488,7 @@ bool ManagedEditor::OnAppExit()
     return MUtils::Unbox<bool>(Internal_OnAppExit->Invoke(GetManagedInstance(), nullptr, nullptr));
 }
 
-void ManagedEditor::RequestStartPlay()
+void ManagedEditor::RequestStartPlayOnEditMode()
 {
     if (!HasManagedInstance())
         return;

--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -35,7 +35,7 @@ MMethod* Internal_GetGameWindowSize = nullptr;
 MMethod* Internal_OnAppExit = nullptr;
 MMethod* Internal_OnVisualScriptingDebugFlow = nullptr;
 MMethod* Internal_OnAnimGraphDebugFlow = nullptr;
-MMethod* Internal_RequestStartPlayOnStartup = nullptr;
+MMethod* Internal_RequestStartPlayOnEditMode = nullptr;
 
 void OnLightmapsBake(ShadowsOfMordor::BuildProgressStep step, float stepProgress, float totalProgress, bool isProgressEvent)
 {
@@ -492,12 +492,12 @@ void ManagedEditor::RequestStartPlay()
 {
     if (!HasManagedInstance())
         return;
-    if (Internal_RequestStartPlayOnStartup == nullptr)
+    if (Internal_RequestStartPlayOnEditMode == nullptr)
     {
-        Internal_RequestStartPlayOnStartup = GetClass()->GetMethod("Internal_RequestStartPlayOnStartup");
-        ASSERT(Internal_RequestStartPlayOnStartup);
+        Internal_RequestStartPlayOnEditMode = GetClass()->GetMethod("Internal_RequestStartPlayOnEditMode");
+        ASSERT(Internal_RequestStartPlayOnEditMode);
     }
-    Internal_RequestStartPlayOnStartup->Invoke(GetManagedInstance(), nullptr, nullptr);
+    Internal_RequestStartPlayOnEditMode->Invoke(GetManagedInstance(), nullptr, nullptr);
 }
 
 void ManagedEditor::OnEditorAssemblyLoaded(MAssembly* assembly)

--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -35,6 +35,7 @@ MMethod* Internal_GetGameWindowSize = nullptr;
 MMethod* Internal_OnAppExit = nullptr;
 MMethod* Internal_OnVisualScriptingDebugFlow = nullptr;
 MMethod* Internal_OnAnimGraphDebugFlow = nullptr;
+MMethod* Internal_RequestStartPlay = nullptr;
 
 void OnLightmapsBake(ShadowsOfMordor::BuildProgressStep step, float stepProgress, float totalProgress, bool isProgressEvent)
 {
@@ -479,6 +480,18 @@ bool ManagedEditor::OnAppExit()
         ASSERT(Internal_OnAppExit);
     }
     return MUtils::Unbox<bool>(Internal_OnAppExit->Invoke(GetManagedInstance(), nullptr, nullptr));
+}
+
+void ManagedEditor::RequestStartPlay()
+{
+    if (!HasManagedInstance())
+        return;
+    if (Internal_RequestStartPlay == nullptr)
+    {
+        Internal_RequestStartPlay = GetClass()->GetMethod("Internal_RequestStartPlay");
+        ASSERT(Internal_RequestStartPlay);
+    }
+    Internal_RequestStartPlay->Invoke(GetManagedInstance(), nullptr, nullptr);
 }
 
 void ManagedEditor::OnEditorAssemblyLoaded(MAssembly* assembly)

--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -232,7 +232,7 @@ void ManagedEditor::Init()
     args[0] = &isHeadless;
     args[1] = &skipCompile;
     Guid sceneId;
-    if (CommandLine::Options.Game.HasValue() && Guid::Parse(CommandLine::Options.Game.GetValue(), sceneId))
+    if (!CommandLine::Options.Game.HasValue() || (CommandLine::Options.Game.HasValue() && Guid::Parse(CommandLine::Options.Game.GetValue(), sceneId)))
     {
         sceneId = Guid::Empty;
     }

--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -232,11 +232,11 @@ void ManagedEditor::Init()
     args[0] = &isHeadless;
     args[1] = &skipCompile;
     Guid sceneId;
-    if (!CommandLine::Options.Game.HasValue() || (CommandLine::Options.Game.HasValue() && Guid::Parse(CommandLine::Options.Game.GetValue(), sceneId)))
+    if (!CommandLine::Options.Play.HasValue() || (CommandLine::Options.Play.HasValue() && Guid::Parse(CommandLine::Options.Play.GetValue(), sceneId)))
     {
         sceneId = Guid::Empty;
     }
-    args[2] = CommandLine::Options.Game.HasValue() ? &sceneId : nullptr;
+    args[2] = &sceneId;
     initMethod->Invoke(instance, args, &exception);
     if (exception)
     {

--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -35,7 +35,7 @@ MMethod* Internal_GetGameWindowSize = nullptr;
 MMethod* Internal_OnAppExit = nullptr;
 MMethod* Internal_OnVisualScriptingDebugFlow = nullptr;
 MMethod* Internal_OnAnimGraphDebugFlow = nullptr;
-MMethod* Internal_RequestStartPlay = nullptr;
+MMethod* Internal_RequestStartPlayOnStartup = nullptr;
 
 void OnLightmapsBake(ShadowsOfMordor::BuildProgressStep step, float stepProgress, float totalProgress, bool isProgressEvent)
 {
@@ -232,7 +232,7 @@ void ManagedEditor::Init()
     args[0] = &isHeadless;
     args[1] = &skipCompile;
     Guid sceneId;
-    if (Guid::Parse(CommandLine::Options.Game.GetValue(), sceneId))
+    if (CommandLine::Options.Game.HasValue() && Guid::Parse(CommandLine::Options.Game.GetValue(), sceneId))
     {
         sceneId = Guid::Empty;
     }
@@ -492,12 +492,12 @@ void ManagedEditor::RequestStartPlay()
 {
     if (!HasManagedInstance())
         return;
-    if (Internal_RequestStartPlay == nullptr)
+    if (Internal_RequestStartPlayOnStartup == nullptr)
     {
-        Internal_RequestStartPlay = GetClass()->GetMethod("Internal_RequestStartPlay");
-        ASSERT(Internal_RequestStartPlay);
+        Internal_RequestStartPlayOnStartup = GetClass()->GetMethod("Internal_RequestStartPlayOnStartup");
+        ASSERT(Internal_RequestStartPlayOnStartup);
     }
-    Internal_RequestStartPlay->Invoke(GetManagedInstance(), nullptr, nullptr);
+    Internal_RequestStartPlayOnStartup->Invoke(GetManagedInstance(), nullptr, nullptr);
 }
 
 void ManagedEditor::OnEditorAssemblyLoaded(MAssembly* assembly)

--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -210,7 +210,7 @@ ManagedEditor::~ManagedEditor()
 void ManagedEditor::Init()
 {
     // Note: editor modules should perform quite fast init, any longer things should be done in async during 'editor splash screen time
-    void* args[2];
+    void* args[3];
     MClass* mclass = GetClass();
     if (mclass == nullptr)
     {
@@ -231,6 +231,12 @@ void ManagedEditor::Init()
     bool skipCompile = CommandLine::Options.SkipCompile.IsTrue();
     args[0] = &isHeadless;
     args[1] = &skipCompile;
+    Guid sceneId;
+    if (Guid::Parse(CommandLine::Options.Game.GetValue(), sceneId))
+    {
+        sceneId = Guid::Empty;
+    }
+    args[2] = CommandLine::Options.Game.HasValue() ? &sceneId : nullptr;
     initMethod->Invoke(instance, args, &exception);
     if (exception)
     {

--- a/Source/Editor/Managed/ManagedEditor.h
+++ b/Source/Editor/Managed/ManagedEditor.h
@@ -134,9 +134,9 @@ public:
     bool OnAppExit();
 
     /// <summary>
-    /// Requests switch to play mode.
+    /// Requests play mode when the editor is in edit mode ( once ).
     /// </summary>
-    void RequestStartPlay();
+    void RequestStartPlayOnEditMode();
 
 private:
 

--- a/Source/Editor/Managed/ManagedEditor.h
+++ b/Source/Editor/Managed/ManagedEditor.h
@@ -133,6 +133,11 @@ public:
     /// <returns>True if exit engine, otherwise false.</returns>
     bool OnAppExit();
 
+    /// <summary>
+    /// Requests switch to play mode.
+    /// </summary>
+    void RequestStartPlay();
+
 private:
 
     void OnEditorAssemblyLoaded(MAssembly* assembly);

--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -151,7 +151,7 @@ bool CommandLine::Parse(const Char* cmdLine)
     PARSE_ARG_SWITCH("-build ", Build);
     PARSE_BOOL_SWITCH("-skipcompile ", SkipCompile);
     PARSE_BOOL_SWITCH("-shaderdebug ", ShaderDebug);
-    PARSE_ARG_OPT_SWITCH("-game ", Game);
+    PARSE_ARG_OPT_SWITCH("-play ", Play);
 
 #endif
 

--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -102,6 +102,23 @@ bool CommandLine::Parse(const Char* cmdLine)
 			*(end - len) = 0; \
 			end -= len; \
 		}
+    
+#define PARSE_ARG_OPT_SWITCH(text, field) \
+		pos = (Char*)StringUtils::FindIgnoreCase(buffer.Get(), TEXT(text)); \
+		if (pos) \
+		{ \
+			len = ARRAY_COUNT(text) - 1; \
+			if (ParseArg(pos + len, argStart, argEnd)) \
+				Options.field = String::Empty; \
+			else \
+            { \
+			    Options.field = String(argStart, static_cast<int32>(argEnd - argStart)); \
+			    len = static_cast<int32>((argEnd - pos) + 1); \
+			    Platform::MemoryCopy(pos, pos + len, (end - pos - len) * 2); \
+			    *(end - len) = 0; \
+			    end -= len; \
+			} \
+		}
 
     PARSE_BOOL_SWITCH("-windowed ", Windowed);
     PARSE_BOOL_SWITCH("-fullscreen ", Fullscreen);

--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -151,6 +151,7 @@ bool CommandLine::Parse(const Char* cmdLine)
     PARSE_ARG_SWITCH("-build ", Build);
     PARSE_BOOL_SWITCH("-skipcompile ", SkipCompile);
     PARSE_BOOL_SWITCH("-shaderdebug ", ShaderDebug);
+    PARSE_ARG_OPT_SWITCH("-game ", Game);
 
 #endif
 

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -156,7 +156,7 @@ public:
         Nullable<bool> ShaderDebug;
 
         /// <summary>
-        /// -game !scene! ( Scene to play, can be null to use default )
+        /// -game !scene! ( Scene to play, can be empty to use default )
         /// </summary>
         Nullable<String> Game;
 

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -155,6 +155,11 @@ public:
         /// </summary>
         Nullable<bool> ShaderDebug;
 
+        /// <summary>
+        /// -game !scene! ( Scene to play, can be null to use default )
+        /// </summary>
+        Nullable<String> Game;
+
 #endif
     };
 

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -156,9 +156,9 @@ public:
         Nullable<bool> ShaderDebug;
 
         /// <summary>
-        /// -game !scene! ( Scene to play, can be empty to use default )
+        /// -play !guid! ( Scene to play, can be empty to use default )
         /// </summary>
-        Nullable<String> Game;
+        Nullable<String> Play;
 
 #endif
     };

--- a/Source/Engine/Graphics/Models/Mesh.cpp
+++ b/Source/Engine/Graphics/Models/Mesh.cpp
@@ -404,9 +404,6 @@ void Mesh::Draw(const RenderContext& renderContext, MaterialBase* material, cons
 
 void Mesh::Draw(const RenderContext& renderContext, const DrawInfo& info, float lodDitherFactor) const
 {
-    if (!IsInitialized())
-        return;
-    
     // Cache data
     const auto& entry = info.Buffer->At(_materialSlotIndex);
     if (!entry.Visible || !IsInitialized())

--- a/Source/Engine/Graphics/Models/Mesh.cpp
+++ b/Source/Engine/Graphics/Models/Mesh.cpp
@@ -363,7 +363,8 @@ void Mesh::GetDrawCallGeometry(DrawCall& drawCall) const
 
 void Mesh::Render(GPUContext* context) const
 {
-    ASSERT(IsInitialized());
+    if (!IsInitialized())
+        return;
 
     context->BindVB(ToSpan((GPUBuffer**)_vertexBuffers, 3));
     context->BindIB(_indexBuffer);
@@ -372,7 +373,7 @@ void Mesh::Render(GPUContext* context) const
 
 void Mesh::Draw(const RenderContext& renderContext, MaterialBase* material, const Matrix& world, StaticFlags flags, bool receiveDecals, DrawPass drawModes, float perInstanceRandom) const
 {
-    if (!material || !material->IsSurface())
+    if (!material || !material->IsSurface() || !IsInitialized())
         return;
 
     // Submit draw call
@@ -403,6 +404,9 @@ void Mesh::Draw(const RenderContext& renderContext, MaterialBase* material, cons
 
 void Mesh::Draw(const RenderContext& renderContext, const DrawInfo& info, float lodDitherFactor) const
 {
+    if (!IsInitialized())
+        return;
+    
     // Cache data
     const auto& entry = info.Buffer->At(_materialSlotIndex);
     if (!entry.Visible || !IsInitialized())


### PR DESCRIPTION
`-play` as command line argument enable us to directly jump into play mode. The editor will skip script compilation.

A specific scene can be loaded using the scene guid : `-play 316098fa4b0cc2ead5196dad2827b437`

If the id is invalid or not provided the editor will play the scene based on editor settings ( Default or Last opened ).

Looks like it generates many `[Warning] GPU Async Task UploadBuffer (Running) has been canceled before a sync`.