### PR TITLE
Only build bindings for project references with C#-only projects

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -1009,7 +1009,7 @@ namespace Flax.Build
                     {
                         using (new ProfileEventScope(reference.Project.Name))
                         {
-                            if (Configuration.BuildBindingsOnly || reference.Project.IsCSharpOnlyProject || !platform.HasRequiredSDKsInstalled)
+                            if (Configuration.BuildBindingsOnly || project.IsCSharpOnlyProject || reference.Project.IsCSharpOnlyProject || !platform.HasRequiredSDKsInstalled)
                             {
                                 BuildTargetReferenceNativeCppBindingsOnly(buildContext, buildData, reference);
                             }


### PR DESCRIPTION
This should skip the C++ #include parsing step of C++ references while building projects with only C#-script files.

In my tests, this change reduces the script compilation times from ~1.5 seconds down to ~0.8 seconds.