### PR TITLE
Escapes backslashes in generated tooltip descriptions

### DIFF
--- a/Source/Engine/Input/KeyboardKeys.h
+++ b/Source/Engine/Input/KeyboardKeys.h
@@ -745,7 +745,7 @@ API_ENUM() enum class KeyboardKeys
     LeftBracket = 0xDB,
 
     /// <summary>
-    /// Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard the '\\|' key
+    /// Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard the '\|' key
     /// </summary>
     Backslash = 0xDC,
 

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -469,9 +469,8 @@ namespace Flax.Build.Bindings
                         if (comment[i - 1].StartsWith("/// "))
                             tooltip += " " + comment[i - 1].Substring(4);
                     }
-                    if (tooltip.IndexOf('\"') != -1)
-                        tooltip = tooltip.Replace("\"", "\\\"");
-                    contents.Append(indent).Append("[Tooltip(\"").Append(tooltip).Append("\")]").AppendLine();
+                    tooltip = tooltip.Replace("\"", "\"\"");
+                    contents.Append(indent).Append("[Tooltip(@\"").Append(tooltip).Append("\")]").AppendLine();
                 }
             }
             if (writeDefaultValue)


### PR DESCRIPTION
Only character that needs to be manually escaped is the double quotation marks.