### PR TITLE
Viewpoint shortcuts.

### DIFF
--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -151,6 +151,30 @@ namespace FlaxEditor.Options
         [DefaultValue(typeof(InputBinding), "Q")]
         [EditorDisplay("Viewport"), EditorOrder(1550)]
         public InputBinding Down = new InputBinding(KeyboardKeys.Q);
+        
+        [DefaultValue(typeof(InputBinding), "Numpad0")]
+        [EditorDisplay("Viewport"), EditorOrder(1600)]
+        public InputBinding ViewpointFront = new InputBinding(KeyboardKeys.Numpad0);
+        
+        [DefaultValue(typeof(InputBinding), "Numpad5")]
+        [EditorDisplay("Viewport"), EditorOrder(1610)]
+        public InputBinding ViewpointBack = new InputBinding(KeyboardKeys.Numpad5);
+        
+        [DefaultValue(typeof(InputBinding), "Numpad4")]
+        [EditorDisplay("Viewport"), EditorOrder(1620)]
+        public InputBinding ViewpointLeft = new InputBinding(KeyboardKeys.Numpad4);
+        
+        [DefaultValue(typeof(InputBinding), "Numpad6")]
+        [EditorDisplay("Viewport"), EditorOrder(1630)]
+        public InputBinding ViewpointRight = new InputBinding(KeyboardKeys.Numpad6);
+        
+        [DefaultValue(typeof(InputBinding), "Numpad8")]
+        [EditorDisplay("Viewport"), EditorOrder(1640)]
+        public InputBinding ViewpointTop = new InputBinding(KeyboardKeys.Numpad8);
+        
+        [DefaultValue(typeof(InputBinding), "Numpad2")]
+        [EditorDisplay("Viewport"), EditorOrder(1650)]
+        public InputBinding ViewpointBottom = new InputBinding(KeyboardKeys.Numpad2);
 
         #endregion
 

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
 
 using System;
+using System.Linq;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Input;
 using FlaxEditor.Options;
@@ -649,6 +650,13 @@ namespace FlaxEditor.Viewport
                 }
             }
 
+            InputActions.Add(options => options.ViewpointTop, () => OrientViewport(Quaternion.Euler(EditorViewportCameraViewpointValues.First(vp => vp.Name == "Top").Orientation)));
+            InputActions.Add(options => options.ViewpointBottom, () => OrientViewport(Quaternion.Euler(EditorViewportCameraViewpointValues.First(vp => vp.Name == "Bottom").Orientation)));
+            InputActions.Add(options => options.ViewpointFront, () => OrientViewport(Quaternion.Euler(EditorViewportCameraViewpointValues.First(vp => vp.Name == "Front").Orientation)));
+            InputActions.Add(options => options.ViewpointBack, () => OrientViewport(Quaternion.Euler(EditorViewportCameraViewpointValues.First(vp => vp.Name == "Back").Orientation)));
+            InputActions.Add(options => options.ViewpointRight, () => OrientViewport(Quaternion.Euler(EditorViewportCameraViewpointValues.First(vp => vp.Name == "Right").Orientation)));
+            InputActions.Add(options => options.ViewpointLeft, () => OrientViewport(Quaternion.Euler(EditorViewportCameraViewpointValues.First(vp => vp.Name == "Left").Orientation)));
+
             // Link for task event
             task.Begin += OnRenderBegin;
         }
@@ -657,6 +665,16 @@ namespace FlaxEditor.Viewport
         /// Gets a value indicating whether this viewport is using mouse currently (eg. user moving objects).
         /// </summary>
         protected virtual bool IsControllingMouse => false;
+
+        /// <summary>
+        /// Orients the viewport.
+        /// </summary>
+        /// <param name="orientation">The orientation.</param>
+        protected void OrientViewport(Quaternion orientation)
+        {
+            var quat = orientation;
+            OrientViewport(ref quat);
+        }
 
         /// <summary>
         /// Orients the viewport.

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -657,10 +657,19 @@ namespace FlaxEditor.Viewport
         /// </summary>
         public void FocusSelection()
         {
+            var orientation = ViewOrientation;
+            FocusSelection(ref orientation);
+        }
+        
+        /// <summary>
+        /// Focuses the viewport on the current selection of the gizmo.
+        /// </summary>
+        /// <param name="orientation">The target view orientation.</param>
+        public void FocusSelection(ref Quaternion orientation)
+        {
             if (TransformGizmo.SelectedParents.Count == 0)
                 return;
 
-            var orientation = ViewOrientation;
             var gizmoBounds = Gizmos.Active.FocusBounds;
             if (gizmoBounds != BoundingSphere.Empty)
                 ((FPSCamera)ViewportCamera).ShowSphere(ref gizmoBounds, ref orientation);
@@ -725,9 +734,10 @@ namespace FlaxEditor.Viewport
         /// <inheritdoc />
         protected override void OrientViewport(ref Quaternion orientation)
         {
-            FocusSelection();
-
-            base.OrientViewport(ref orientation);
+            if (TransformGizmo.SelectedParents.Count != 0)
+                FocusSelection(ref orientation);
+            else
+                base.OrientViewport(ref orientation);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -788,10 +788,19 @@ namespace FlaxEditor.Viewport
         /// </summary>
         public void FocusSelection()
         {
+            var orientation = ViewOrientation;
+            FocusSelection(ref orientation);
+        }
+        
+        /// <summary>
+        /// Focuses the viewport on the current selection of the gizmo.
+        /// </summary>
+        /// <param name="orientation">The target view orientation.</param>
+        public void FocusSelection(ref Quaternion orientation)
+        {
             if (TransformGizmo.SelectedParents.Count == 0)
                 return;
 
-            var orientation = ViewOrientation;
             var gizmoBounds = Gizmos.Active.FocusBounds;
             if (gizmoBounds != BoundingSphere.Empty)
                 ((FPSCamera)ViewportCamera).ShowSphere(ref gizmoBounds, ref orientation);
@@ -802,9 +811,10 @@ namespace FlaxEditor.Viewport
         /// <inheritdoc />
         protected override void OrientViewport(ref Quaternion orientation)
         {
-            FocusSelection();
-
-            base.OrientViewport(ref orientation);
+            if (TransformGizmo.SelectedParents.Count != 0)
+                FocusSelection(ref orientation);
+            else
+                base.OrientViewport(ref orientation);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Add Viewpoint shortcuts in `Tools -> Options -> Input -> Viewport`.

Works in Editor / Prefab windows.

![FlaxEditor_vZcgpzNs51](https://user-images.githubusercontent.com/7458848/120078442-d9c04b80-c0af-11eb-8ea3-6dcec6cfc3f1.png)
