### PR TITLE
Sleep between frames to save CPU cycles

### DIFF
--- a/Source/Engine/Engine/Time.cpp
+++ b/Source/Engine/Engine/Time.cpp
@@ -70,6 +70,7 @@ void Time::TickData::OnBeforeRun(float targetFps, double currentTime)
     LastLength = static_cast<double>(DeltaTime.Ticks) / Constants::TicksPerSecond;
     LastBegin = currentTime - LastLength;
     LastEnd = currentTime;
+    NextBegin = targetFps > ZeroTolerance ? LastBegin + (1.0f / targetFps) : 0.0;
 }
 
 void Time::TickData::OnReset(float targetFps, double currentTime)
@@ -91,10 +92,18 @@ bool Time::TickData::OnTickBegin(float targetFps, float maxDeltaTime)
     }
     else
     {
-        deltaTime = Math::Clamp(time - LastBegin, 0.0, (double)maxDeltaTime);
-        const double minDeltaTime = targetFps > ZeroTolerance ? 1.0 / (double)targetFps : 0.0;
-        if (deltaTime < minDeltaTime)
+        if (time < NextBegin)
             return false;
+
+        deltaTime = Math::Max((time - LastBegin), 0.0);
+        if (deltaTime > maxDeltaTime)
+        {
+            deltaTime = (double)maxDeltaTime;
+            NextBegin = time;
+        }
+
+        if (targetFps > ZeroTolerance)
+            NextBegin += (1.0 / targetFps);
     }
 
     // Update data
@@ -135,10 +144,19 @@ bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime)
     }
     else
     {
-        deltaTime = Math::Clamp(time - LastBegin, 0.0, (double)maxDeltaTime);
-        minDeltaTime = targetFps > ZeroTolerance ? 1.0 / (double)targetFps : 0.0;
-        if (deltaTime < minDeltaTime)
+        if (time < NextBegin)
             return false;
+
+        minDeltaTime = targetFps > ZeroTolerance ? 1.0 / targetFps : 0.0;
+        deltaTime = Math::Max((time - LastBegin), 0.0);
+        if (deltaTime > maxDeltaTime)
+        {
+            deltaTime = (double)maxDeltaTime;
+            NextBegin = time;
+        }
+
+        if (targetFps > ZeroTolerance)
+            NextBegin += (1.0 / targetFps);
     }
     Samples.Add(deltaTime);
 
@@ -158,26 +176,23 @@ bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime)
     return true;
 }
 
-Time::TickData* Time::GetHighestFrequency(float& fps)
+double Time::GetNextTick()
 {
-    const auto updateFps = UpdateFPS;
-    const auto drawFps = DrawFPS;
-    const auto physicsFps = PhysicsFPS;
+    const double nextUpdate = Time::Update.NextBegin;
+    const double nextPhysics = Time::Physics.NextBegin;
+    const double nextDraw = Time::Draw.NextBegin;
 
-    if (physicsFps >= drawFps && physicsFps >= updateFps)
-    {
-        fps = physicsFps;
-        return &Physics;
-    }
+    double nextTick = MAX_double;
+    if (UpdateFPS > 0 && nextUpdate < nextTick)
+        nextTick = nextUpdate;
+    if (PhysicsFPS > 0 && nextPhysics < nextTick)
+        nextTick = nextPhysics;
+    if (DrawFPS > 0 && nextDraw < nextTick)
+        nextTick = nextDraw;
 
-    if (drawFps >= physicsFps && drawFps >= updateFps)
-    {
-        fps = drawFps;
-        return &Draw;
-    }
-
-    fps = updateFps;
-    return &Update;
+    if (nextTick == MAX_double)
+        return 0.0;
+    return nextTick;
 }
 
 void Time::SetGamePaused(bool value)

--- a/Source/Engine/Engine/Time.h
+++ b/Source/Engine/Engine/Time.h
@@ -49,6 +49,11 @@ public:
         double LastLength;
 
         /// <summary>
+        /// The next tick start time.
+        /// </summary>
+        double NextBegin;
+
+        /// <summary>
         /// The delta time.
         /// </summary>
         TimeSpan DeltaTime;
@@ -167,11 +172,10 @@ public:
     }
 
     /// <summary>
-    /// Gets the tick data that uses the highest frequency for the ticking.
+    /// Gets the time of next upcoming tick data of ticking group with defined update frequency.
     /// </summary>
-    /// <param name="fps">The FPS rate of the highest frequency ticking group.</param>
-    /// <returns>The tick data.</returns>
-    static TickData* GetHighestFrequency(float& fps);
+    /// <returns>The time of next tick.</returns>
+    static double GetNextTick();
 
     /// <summary>
     /// Gets the value indicating whenever game logic is paused (physics, script updates, etc.).
@@ -185,7 +189,7 @@ public:
     /// <summary>
     /// Sets the value indicating whenever game logic is paused (physics, script updates, etc.).
     /// </summary>
-    /// <param name="value">>True if pause game logic, otherwise false.</param>
+    /// <param name="value">True if pause game logic, otherwise false.</param>
     API_PROPERTY() static void SetGamePaused(bool value);
 
     /// <summary>

--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -18,6 +18,7 @@
 #include "../Win32/IncludeWindowsHeaders.h"
 #include <VersionHelpers.h>
 #include <ShellAPI.h>
+#include <timeapi.h>
 #include <Psapi.h>
 #include <objbase.h>
 #if CRASH_LOG_ENABLE
@@ -577,6 +578,12 @@ bool WindowsPlatform::Init()
     {
         Platform::Fatal(TEXT("Flax Engine requires Windows Vista SP1 or higher."));
         return true;
+    }
+
+    // Set lowest possible timer resolution for previous Windows versions
+    if (VersionMajor < 10 || (VersionMajor == 10 && VersionBuild < 17134))
+    {
+        timeBeginPeriod(1);
     }
 
     DWORD tmp;


### PR DESCRIPTION
The engine should now sleep between frames if there's at least a 2ms window between scheduled timers. The Windows scheduler is not accurate enough to guarantee sleep time of 1ms always lasts 1ms, but in reality averages anywhere between 1-2ms depending upon what the current timer resolution is set to.

In later builds of Windows 10, we can use higher resolution waitable timer for sleeping without changing the timer resolution at all. For older Windows builds the timer resolution is set to 1ms and normal waitable timer is used instead (this is what `Sleep` is using internally).