### PR TITLE
Use Stopwatch instead of DateTime.Now for increased accuracy

### DIFF
--- a/Source/Tools/Flax.Build/Build/Profiling.cs
+++ b/Source/Tools/Flax.Build/Build/Profiling.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using System.Diagnostics;
 
 namespace Flax.Build
 {
@@ -71,6 +72,8 @@ namespace Flax.Build
 
         private static int _depth;
         private static readonly List<Event> _events = new List<Event>(1024);
+        private static readonly DateTime _startTime = DateTime.Now;
+        private static readonly Stopwatch _stopwatch = Stopwatch.StartNew(); // https://stackoverflow.com/questions/1416139/how-to-get-timestamp-of-tick-precision-in-net-c
 
         /// <summary>
         /// Begins the profiling event.
@@ -81,7 +84,7 @@ namespace Flax.Build
         {
             Event e;
             e.Name = name;
-            e.StartTime = DateTime.Now;
+            e.StartTime = _startTime.AddTicks(_stopwatch.Elapsed.Ticks);
             e.Duration = TimeSpan.Zero;
             e.Depth = _depth++;
             e.ThreadId = Thread.CurrentThread.ManagedThreadId;
@@ -95,7 +98,7 @@ namespace Flax.Build
         /// <param name="id">The event identifier returned by <see cref="Begin"/>.</param>
         public static void End(int id)
         {
-            var endTime = DateTime.Now;
+            var endTime = _startTime.AddTicks(_stopwatch.Elapsed.Ticks);
             var e = _events[id];
             e.Duration = endTime - e.StartTime;
             _events[id] = e;

--- a/Source/Tools/Flax.Build/Program.cs
+++ b/Source/Tools/Flax.Build/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -25,7 +26,7 @@ namespace Flax.Build
             }
 
             Mutex singleInstanceMutex = null;
-            var startTime = DateTime.Now;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             bool failed = false;
 
             try
@@ -166,9 +167,8 @@ namespace Flax.Build
                     singleInstanceMutex.Dispose();
                     singleInstanceMutex = null;
                 }
-
-                var endTime = DateTime.Now;
-                Log.Info(string.Format("Total time: {0}", endTime - startTime));
+                stopwatch.Stop();
+                Log.Info(string.Format("Total time: {0}", stopwatch.Elapsed));
                 Log.Verbose("End.");
                 Log.Dispose();
             }

--- a/Source/Tools/Flax.Build/Utilities/Utilities.cs
+++ b/Source/Tools/Flax.Build/Utilities/Utilities.cs
@@ -326,7 +326,7 @@ namespace Flax.Build
                 }
             }
 
-            var startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             if (!options.HasFlag(RunOptions.NoLoggingOfRunCommand))
             {
                 Log.Verbose("Running: " + app + " " + (string.IsNullOrEmpty(commandLine) ? "" : commandLine));
@@ -397,11 +397,11 @@ namespace Flax.Build
 
             if (!options.HasFlag(RunOptions.NoWaitForExit))
             {
-                var buildDuration = (DateTime.UtcNow - startTime).TotalMilliseconds;
+                stopwatch.Stop();
                 result = proc.ExitCode;
                 if (!options.HasFlag(RunOptions.NoLoggingOfRunCommand) || options.HasFlag(RunOptions.NoLoggingOfRunDuration))
                 {
-                    Log.Info(string.Format("Took {0}s to run {1}, ExitCode={2}", buildDuration / 1000, Path.GetFileName(app), result));
+                    Log.Info(string.Format("Took {0}s to run {1}, ExitCode={2}", stopwatch.Elapsed.TotalSeconds, Path.GetFileName(app), result));
                 }
             }
 


### PR DESCRIPTION
This adds slightly more precise timings, which might be useful when micro-optimizing Flax.Build