### PR TITLE
Prevent file dialogs from changing the working directory

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsFileSystem.cpp
+++ b/Source/Engine/Platform/Windows/WindowsFileSystem.cpp
@@ -213,7 +213,7 @@ bool WindowsFileSystem::ShowOpenFileDialog(Window* parentWindow, const StringVie
     of.lpstrFilter = filter.HasChars() ? filter.Get() : nullptr;
     of.lpstrFile = fileNamesBuffer.Get();
     of.nMaxFile = maxFilenamesSize;
-    of.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_ENABLESIZING;
+    of.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_ENABLESIZING | OFN_NOCHANGEDIR;
     of.lpstrTitle = title.HasChars() ? title.Get() : nullptr;
     of.lpstrInitialDir = initialDirectory.HasChars() ? initialDirectory.Get() : nullptr;
     if (parentWindow)
@@ -260,7 +260,7 @@ bool WindowsFileSystem::ShowSaveFileDialog(Window* parentWindow, const StringVie
     of.lpstrFilter = filter.HasChars() ? filter.Get() : nullptr;
     of.lpstrFile = fileNamesBuffer.Get();
     of.nMaxFile = maxFilenamesSize;
-    of.Flags = OFN_EXPLORER | OFN_ENABLESIZING | OFN_OVERWRITEPROMPT;
+    of.Flags = OFN_EXPLORER | OFN_ENABLESIZING | OFN_OVERWRITEPROMPT | OFN_NOCHANGEDIR;
     of.lpstrTitle = title.HasChars() ? title.Get() : nullptr;
     of.lpstrInitialDir = initialDirectory.HasChars() ? initialDirectory.Get() : nullptr;
     if (parentWindow)


### PR DESCRIPTION
Fixes the issue whenever something was imported to the project, script compilation stops working due to missing files. This is caused by the sudden change of process working directory which the Windows file dialogs does by default and the build tool inherits the current working directory from the editor leading to this issue. This behavior can be easily disabled with the `OFN_NOCHANGEDIR` flag when constructing the dialog.