### PR TITLE
Catch potential runtime error from locale::global

### DIFF
--- a/Source/Engine/Localization/Localization.cpp
+++ b/Source/Engine/Localization/Localization.cpp
@@ -189,7 +189,12 @@ void LocalizationService::OnLocalizationChanged()
             localeName[currentCulture.Length() + 5] = '8';
             localeName[currentCulture.Length() + 6] = 0;
         }
-        std::locale::global(std::locale(localeName));
+        try
+        {
+            std::locale::global(std::locale(localeName));
+        }
+        catch (std::runtime_error const&) {}
+        catch (...) {}
     }
 #endif
 


### PR DESCRIPTION
Setting global locale might emitting runtime error and cause crash 