### PR TITLE
Fixed crash on startup when 2 Rider installations are detected

### DIFF
--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -142,7 +142,7 @@ bool sortInstallations(RiderInstallation* const& i1, RiderInstallation* const& i
     StringUtils::Parse(values2[0].Get(), &version2[0]);
     StringUtils::Parse(values2[1].Get(), &version2[1]);
     
-    if(values1.Count() > 2)
+    if(values2.Count() > 2)
         StringUtils::Parse(values2[2].Get(), &version2[2]);
 
     // Compare by MAJOR.MINOR.BUILD


### PR DESCRIPTION
Flax Engine was crashing on startup on my system when trying to sort Rider installations. 

2 Rider installations are detected, and crash occurs while comparing them.