### PR TITLE
Add new (experimental) update mode

### DIFF
--- a/Source/Engine/Core/Config/TimeSettings.cs
+++ b/Source/Engine/Core/Config/TimeSettings.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
+
+namespace FlaxEditor.Content.Settings
+{
+    public partial class TimeSettings
+    {
+#if FLAX_EDITOR
+        // ReSharper disable once UnusedMember.Local
+        internal bool IsDrawFPSUsed => UpdateMode == TimeUpdateMode.UpdateAndDrawSeparated;
+#endif
+    }
+}

--- a/Source/Engine/Core/Config/TimeSettings.h
+++ b/Source/Engine/Core/Config/TimeSettings.h
@@ -5,12 +5,36 @@
 #include "Engine/Core/Config/Settings.h"
 
 /// <summary>
+/// Contains available time update modes for update and draw calls.
+/// </summary>
+API_ENUM(Namespace="FlaxEditor.Content.Settings") enum class FLAXENGINE_API TimeUpdateMode
+{
+    /// <summary>
+    /// Update and draw run separately - i.e. can run at different FPS, might get called at the same frame but this is not guaranteed.
+    /// Not recommended, might cause visible stutter and other graphical glitches when update is running less often than draw.
+    /// </summary>
+    UpdateAndDrawSeparated,
+    
+    /// <summary>
+    /// Update and draw run together. Update is called every time draw is also going to be called.
+    /// </summary>
+    UpdateAndDrawPaired
+};
+
+/// <summary>
 /// Time and game simulation settings container.
 /// </summary>
 API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API TimeSettings : public SettingsBase
 {
 DECLARE_SCRIPTING_TYPE_MINIMAL(TimeSettings);
 public:
+
+    /// <summary>
+    /// The mode at which update and draw is called. Does not affect fixed update/physics fps.
+    /// When set to UpdateAndDrawPaired, only UpdateFPS and PhysicsFPS properties are in use, DrawFPS does not affect timing.
+    /// </summary>
+    API_FIELD(Attributes="EditorOrder(0), EditorDisplay(\"General\", \"Update mode\")")
+    TimeUpdateMode UpdateMode = TimeUpdateMode::UpdateAndDrawPaired;
 
     /// <summary>
     /// The target amount of the game logic updates per second (script updates frequency).
@@ -27,7 +51,7 @@ public:
     /// <summary>
     /// The target amount of the frames rendered per second (actual game FPS).
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(3), Limit(0, 1000), EditorDisplay(\"General\", \"Draw FPS\")")
+    API_FIELD(Attributes="EditorOrder(3), Limit(0, 1000), EditorDisplay(\"General\", \"Draw FPS\"), VisibleIf(\"IsDrawFPSUsed\")")
     float DrawFPS = 60.0f;
 
     /// <summary>

--- a/Source/Engine/Engine/Time.cpp
+++ b/Source/Engine/Engine/Time.cpp
@@ -15,8 +15,10 @@ namespace
 }
 
 bool Time::_gamePaused = false;
+bool Time::_forceDraw = false;
 float Time::_physicsMaxDeltaTime = 0.1f;
 DateTime Time::StartupTime;
+bool Time::IsDrawSyncedWithUpdate = false;
 float Time::UpdateFPS = 60.0f;
 float Time::PhysicsFPS = 60.0f;
 float Time::DrawFPS = 60.0f;
@@ -47,6 +49,7 @@ TimeService TimeServiceInstance;
 
 void TimeSettings::Apply()
 {
+    Time::IsDrawSyncedWithUpdate = UpdateMode == TimeUpdateMode::UpdateAndDrawPaired;
     Time::UpdateFPS = UpdateFPS;
     Time::PhysicsFPS = PhysicsFPS;
     Time::DrawFPS = DrawFPS;
@@ -56,6 +59,7 @@ void TimeSettings::Apply()
 
 void TimeSettings::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
 {
+    DESERIALIZE(UpdateMode);
     DESERIALIZE(UpdateFPS);
     DESERIALIZE(PhysicsFPS);
     DESERIALIZE(DrawFPS);
@@ -81,7 +85,7 @@ void Time::TickData::OnReset(float targetFps, double currentTime)
     LastEnd = currentTime;
 }
 
-bool Time::TickData::OnTickBegin(float targetFps, float maxDeltaTime)
+bool Time::TickData::OnTickBegin(float targetFps, float maxDeltaTime, bool forceTick)
 {
     // Check if can perform a tick
     const double time = Platform::GetTimeSeconds();
@@ -92,7 +96,7 @@ bool Time::TickData::OnTickBegin(float targetFps, float maxDeltaTime)
     }
     else
     {
-        if (time < NextBegin)
+        if (!forceTick && time < NextBegin) // TODO: Make sure that we don't mess up draw DT when forcing the tick 
             return false;
 
         deltaTime = Math::Max((time - LastBegin), 0.0);
@@ -132,7 +136,7 @@ void Time::TickData::Advance(double time, double deltaTime)
     TicksCount++;
 }
 
-bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime)
+bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime, bool forceTick)
 {
     // Check if can perform a tick
     double time = Platform::GetTimeSeconds();
@@ -274,8 +278,9 @@ bool Time::OnBeginPhysics()
 
 bool Time::OnBeginDraw()
 {
-    if (Draw.OnTickBegin(DrawFPS, 1.0f))
+    if (Draw.OnTickBegin(DrawFPS, 1.0f, _forceDraw))
     {
+        _forceDraw = false;
         Current = &Draw;
         return true;
     }
@@ -286,6 +291,9 @@ void Time::OnEndUpdate()
 {
     Update.OnTickEnd();
     Current = nullptr;
+    
+    // Force to draw when draw is running in sync-with-update mode.
+    _forceDraw = IsDrawSyncedWithUpdate;
 }
 
 void Time::OnEndPhysics()

--- a/Source/Engine/Engine/Time.h
+++ b/Source/Engine/Engine/Time.h
@@ -78,7 +78,7 @@ public:
 
         virtual void OnBeforeRun(float targetFps, double currentTime);
         virtual void OnReset(float targetFps, double currentTime);
-        virtual bool OnTickBegin(float targetFps, float maxDeltaTime);
+        virtual bool OnTickBegin(float targetFps, float maxDeltaTime, bool forceTick = false);
         virtual void OnTickEnd();
 
     protected:
@@ -101,12 +101,13 @@ public:
     public:
 
         // [TickData]
-        bool OnTickBegin(float targetFps, float maxDeltaTime) override;
+        bool OnTickBegin(float targetFps, float maxDeltaTime, bool forceTick = false) override;
     };
 
 private:
 
     static bool _gamePaused;
+    static bool _forceDraw;
     static float _physicsMaxDeltaTime;
 
 public:
@@ -115,6 +116,11 @@ public:
     /// The time at which the game started (UTC local).
     /// </summary>
     API_FIELD(ReadOnly) static DateTime StartupTime;
+
+    /// <summary>
+    /// When true, draw and update calls are invoked at the same exact frames.
+    /// </summary>
+    API_FIELD() static bool IsDrawSyncedWithUpdate;
 
     /// <summary>
     /// The target amount of the game logic updates per second (script updates frequency).


### PR DESCRIPTION
This PR adds a totally new option for TimeSettings, where you can choose to force the draw to be perfectly synced with update.

Thanks to this mode, we can limit the FPS at which update and draw operates (without VSync) and make sure that we get draw called always at the same frame as update.

Two things:
* We can mark this feature as experimental, as it changes pretty much a lot (?).
* Also, we need to discuss wheter we want the paired mode as default - or not (?). 
I'd suggest to go for it, and make it default, so the update/draw is no longer confusing for new developers.

Draft until fully tested (draw DT/time/frames need some manual checks).