### PR TITLE
Fixed invalid uses of StringView::GetText(), where a null-terminated string was expected.

### DIFF
--- a/Source/Editor/Utilities/EditorUtilities.cpp
+++ b/Source/Editor/Utilities/EditorUtilities.cpp
@@ -816,6 +816,6 @@ bool EditorUtilities::ReplaceInFile(const StringView& file, const StringView& fi
     String text;
     if (File::ReadAllText(file, text))
         return true;
-    text.Replace(findWhat.GetText(), replaceWith.GetText());
+    text.Replace(findWhat.Get(), findWhat.Length(), replaceWith.Get(), replaceWith.Length());
     return File::WriteAllText(file, text, Encoding::ANSI);
 }

--- a/Source/Engine/Content/Content.cpp
+++ b/Source/Engine/Content/Content.cpp
@@ -384,12 +384,12 @@ Asset* Content::LoadAsyncInternal(const StringView& internalPath, MClass* type)
     CHECK_RETURN(type, nullptr);
     const auto scriptingType = Scripting::FindScriptingType(type->GetFullName());
     if (scriptingType)
-        return LoadAsyncInternal(internalPath.GetText(), scriptingType);
+        return LoadAsyncInternal(internalPath, scriptingType);
     LOG(Error, "Failed to find asset type '{0}'.", String(type->GetFullName()));
     return nullptr;
 }
 
-Asset* Content::LoadAsyncInternal(const Char* internalPath, const ScriptingTypeHandle& type)
+Asset* Content::LoadAsyncInternal(const StringView& internalPath, const ScriptingTypeHandle& type)
 {
 #if USE_EDITOR
     const String path = Globals::EngineContentFolder / internalPath + ASSET_FILES_EXTENSION_WITH_DOT;
@@ -409,6 +409,11 @@ Asset* Content::LoadAsyncInternal(const Char* internalPath, const ScriptingTypeH
     }
 
     return asset;
+}
+
+Asset* Content::LoadAsyncInternal(const Char* internalPath, const ScriptingTypeHandle& type)
+{
+    return LoadAsyncInternal(StringView(internalPath), type);
 }
 
 FLAXENGINE_API Asset* LoadAsset(const Guid& id, const ScriptingTypeHandle& type)

--- a/Source/Engine/Content/Content.h
+++ b/Source/Engine/Content/Content.h
@@ -193,6 +193,14 @@ public:
     /// <param name="internalPath">The path of the asset relative to the engine internal content (excluding the extension).</param>
     /// <param name="type">The asset type. If loaded object has different type (excluding types derived from the given) the loading fails.</param>
     /// <returns>The loaded asset or null if failed.</returns>
+    static Asset* LoadAsyncInternal(const StringView& internalPath, const ScriptingTypeHandle& type);
+
+    /// <summary>
+    /// Loads internal engine asset and holds it until it won't be referenced by any object. Returns null if asset is missing. Actual asset data loading is performed on a other thread in async.
+    /// </summary>
+    /// <param name="internalPath">The path of the asset relative to the engine internal content (excluding the extension).</param>
+    /// <param name="type">The asset type. If loaded object has different type (excluding types derived from the given) the loading fails.</param>
+    /// <returns>The loaded asset or null if failed.</returns>
     static Asset* LoadAsyncInternal(const Char* internalPath, const ScriptingTypeHandle& type);
 
     /// <summary>

--- a/Source/Engine/Core/Types/StringView.cpp
+++ b/Source/Engine/Core/Types/StringView.cpp
@@ -18,12 +18,12 @@ StringView::StringView(const String& str)
 
 bool StringView::operator==(const String& other) const
 {
-    return StringUtils::Compare(this->GetText(), *other) == 0;
+    return this->Compare(StringView(other)) == 0;
 }
 
 bool StringView::operator!=(const String& other) const
 {
-    return StringUtils::Compare(this->GetText(), *other) != 0;
+    return this->Compare(StringView(other)) != 0;
 }
 
 StringView StringView::Left(int32 count) const
@@ -62,12 +62,12 @@ StringAnsi StringView::ToStringAnsi() const
 
 bool operator==(const String& a, const StringView& b)
 {
-    return a.Length() == b.Length() && StringUtils::Compare(a.GetText(), b.GetText(), b.Length()) == 0;
+    return a.Length() == b.Length() && StringUtils::Compare(a.GetText(), b.GetNonTerminatedText(), b.Length()) == 0;
 }
 
 bool operator!=(const String& a, const StringView& b)
 {
-    return a.Length() != b.Length() || StringUtils::Compare(a.GetText(), b.GetText(), b.Length()) != 0;
+    return a.Length() != b.Length() || StringUtils::Compare(a.GetText(), b.GetNonTerminatedText(), b.Length()) != 0;
 }
 
 StringAnsiView StringAnsiView::Empty;
@@ -79,12 +79,12 @@ StringAnsiView::StringAnsiView(const StringAnsi& str)
 
 bool StringAnsiView::operator==(const StringAnsi& other) const
 {
-    return StringUtils::Compare(this->GetText(), *other) == 0;
+    return this->Compare(StringAnsiView(other)) == 0;
 }
 
 bool StringAnsiView::operator!=(const StringAnsi& other) const
 {
-    return StringUtils::Compare(this->GetText(), *other) != 0;
+    return this->Compare(StringAnsiView(other)) != 0;
 }
 
 StringAnsi StringAnsiView::Substring(int32 startIndex) const
@@ -111,10 +111,10 @@ StringAnsi StringAnsiView::ToStringAnsi() const
 
 bool operator==(const StringAnsi& a, const StringAnsiView& b)
 {
-    return a.Length() == b.Length() && StringUtils::Compare(a.GetText(), b.GetText(), b.Length()) == 0;
+    return a.Length() == b.Length() && StringUtils::Compare(a.GetText(), b.GetNonTerminatedText(), b.Length()) == 0;
 }
 
 bool operator!=(const StringAnsi& a, const StringAnsiView& b)
 {
-    return a.Length() != b.Length() || StringUtils::Compare(a.GetText(), b.GetText(), b.Length()) != 0;
+    return a.Length() != b.Length() || StringUtils::Compare(a.GetText(), b.GetNonTerminatedText(), b.Length()) != 0;
 }

--- a/Source/Engine/Core/Types/Variant.h
+++ b/Source/Engine/Core/Types/Variant.h
@@ -270,8 +270,8 @@ public:
     explicit operator float() const;
     explicit operator double() const;
     explicit operator void*() const;
-    explicit operator StringView() const;
-    explicit operator StringAnsiView() const;
+    explicit operator StringView() const;       // Returned StringView, if not empty, is guaranteed to point to a null terminated buffer.
+    explicit operator StringAnsiView() const;   // Returned StringView, if not empty, is guaranteed to point to a null terminated buffer.
     explicit operator ScriptingObject*() const;
     explicit operator struct _MonoObject*() const;
     explicit operator Asset*() const;

--- a/Source/Engine/Localization/Localization.cpp
+++ b/Source/Engine/Localization/Localization.cpp
@@ -278,18 +278,18 @@ String Localization::GetPluralString(const String& id, int32 n, const String& fa
 {
     CHECK_RETURN(n >= 1, fallback);
     n--;
-    StringView result;
+    const String* result = nullptr;
     for (auto& e : Instance.LocalizedStringTables)
     {
         const auto table = e.Get();
         const auto messages = table ? table->Entries.TryGet(id) : nullptr;
         if (messages && messages->Count() > n)
         {
-            result = messages->At(n);
+            result = &messages->At(n);
             break;
         }
     }
-    if (result.IsEmpty())
-        result = fallback;
-    return String::Format(result.GetText(), n);
+    if (!result)
+        result = &fallback;
+    return String::Format(result->GetText(), n);
 }

--- a/Source/Engine/Platform/Base/PlatformBase.h
+++ b/Source/Engine/Platform/Base/PlatformBase.h
@@ -169,8 +169,8 @@ public:
     /// <summary>
     /// Copy memory region
     /// </summary>
-    /// <param name="dst">Destination memory address</param>
-    /// <param name="src">Source memory address</param>
+    /// <param name="dst">Destination memory address. Must not be null, even if size is zero.</param>
+    /// <param name="src">Source memory address. Must not be null, even if size is zero.</param>
     /// <param name="size">Size of the memory to copy in bytes</param>
     FORCE_INLINE static void MemoryCopy(void* dst, const void* src, uint64 size)
     {
@@ -180,7 +180,7 @@ public:
     /// <summary>
     /// Set memory region with given value
     /// </summary>
-    /// <param name="dst">Destination memory address</param>
+    /// <param name="dst">Destination memory address. Must not be null, even if size is zero.</param>
     /// <param name="size">Size of the memory to set in bytes</param>
     /// <param name="value">Value to set</param>
     FORCE_INLINE static void MemorySet(void* dst, uint64 size, int32 value)
@@ -191,7 +191,7 @@ public:
     /// <summary>
     /// Clear memory region with zeros
     /// </summary>
-    /// <param name="dst">Destination memory address</param>
+    /// <param name="dst">Destination memory address. Must not be null, even if size is zero.</param>
     /// <param name="size">Size of the memory to clear in bytes</param>
     FORCE_INLINE static void MemoryClear(void* dst, uint64 size)
     {
@@ -201,8 +201,8 @@ public:
     /// <summary>
     /// Compare two blocks of the memory.
     /// </summary>
-    /// <param name="buf1">The first buffer address.</param>
-    /// <param name="buf2">The second buffer address.</param>
+    /// <param name="buf1">The first buffer address. Must not be null, even if size is zero.</param>
+    /// <param name="buf2">The second buffer address. Must not be null, even if size is zero.</param>
     /// <param name="size">Size of the memory to compare in bytes.</param>
     FORCE_INLINE static int32 MemoryCompare(const void* buf1, const void* buf2, uint64 size)
     {

--- a/Source/Engine/Platform/Linux/LinuxPlatform.cpp
+++ b/Source/Engine/Platform/Linux/LinuxPlatform.cpp
@@ -1659,7 +1659,7 @@ void LinuxClipboard::SetText(const StringView& text)
         return;
     X11::Window window = (X11::Window)mainWindow->GetNativePtr();
 
-    Impl::ClipboardText.Set(text.GetText(), text.Length());
+    Impl::ClipboardText.Set(text.Get(), text.Length());
     X11::XSetSelectionOwner(xDisplay, xAtomClipboard, window, CurrentTime); // CLIPBOARD
     X11::XSetSelectionOwner(xDisplay, (X11::Atom)1, window, CurrentTime); // XA_PRIMARY
 }

--- a/Source/Engine/Platform/StringUtils.h
+++ b/Source/Engine/Platform/StringUtils.h
@@ -120,36 +120,36 @@ public:
 
 public:
 
-    // Compare two strings with case sensitive
+    // Compare two strings with case sensitive. Strings must not be null.
     static int32 Compare(const Char* str1, const Char* str2);
 
-    // Compare two strings without case sensitive
+    // Compare two strings without case sensitive. Strings must not be null.
     static int32 Compare(const Char* str1, const Char* str2, int32 maxCount);
 
-    // Compare two strings without case sensitive
+    // Compare two strings without case sensitive. Strings must not be null.
     static int32 CompareIgnoreCase(const Char* str1, const Char* str2);
 
-    // Compare two strings without case sensitive
+    // Compare two strings without case sensitive. Strings must not be null.
     static int32 CompareIgnoreCase(const Char* str1, const Char* str2, int32 maxCount);
 
-    // Compare two strings with case sensitive
+    // Compare two strings with case sensitive. Strings must not be null.
     static int32 Compare(const char* str1, const char* str2);
 
-    // Compare two strings without case sensitive
+    // Compare two strings without case sensitive. Strings must not be null.
     static int32 Compare(const char* str1, const char* str2, int32 maxCount);
 
-    // Compare two strings without case sensitive
+    // Compare two strings without case sensitive. Strings must not be null.
     static int32 CompareIgnoreCase(const char* str1, const char* str2);
 
-    // Compare two strings without case sensitive
+    // Compare two strings without case sensitive. Strings must not be null.
     static int32 CompareIgnoreCase(const char* str1, const char* str2, int32 maxCount);
 
 public:
 
-    // Get string length
+    // Get string length. Returns 0 if str is null.
     static int32 Length(const Char* str);
 
-    // Get string length
+    // Get string length. Returns 0 if str is null.
     static int32 Length(const char* str);
 
     // Copy string

--- a/Source/Engine/Platform/UWP/UWPPlatform.cpp
+++ b/Source/Engine/Platform/UWP/UWPPlatform.cpp
@@ -35,7 +35,7 @@ void RunUWP()
 
 DialogResult MessageBox::Show(Window* parent, const StringView& text, const StringView& caption, MessageBoxButtons buttons, MessageBoxIcon icon)
 {
-    return (DialogResult)CUWPPlatform->ShowMessageDialog(parent ? parent->GetImpl() : nullptr, text.GetText(), caption.GetText(), (UWPPlatformImpl::MessageBoxButtons)buttons, (UWPPlatformImpl::MessageBoxIcon)icon);
+    return (DialogResult)CUWPPlatform->ShowMessageDialog(parent ? parent->GetImpl() : nullptr, String(text).GetText(), String(caption).GetText(), (UWPPlatformImpl::MessageBoxButtons)buttons, (UWPPlatformImpl::MessageBoxIcon)icon);
 }
 
 bool UWPPlatform::Init()

--- a/Source/Engine/Platform/Windows/WindowsClipboard.cpp
+++ b/Source/Engine/Platform/Windows/WindowsClipboard.cpp
@@ -25,7 +25,7 @@ void WindowsClipboard::SetText(const StringView& text)
 {
     const int32 size = (text.Length() + 1) * sizeof(Char);
     const HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, size);
-    Platform::MemoryCopy(GlobalLock(hMem), text.GetText(), size);
+    Platform::MemoryCopy(GlobalLock(hMem), String(text).GetText(), size);
     GlobalUnlock(hMem);
 
     OpenClipboard(nullptr);

--- a/Source/Engine/Platform/Windows/WindowsClipboard.cpp
+++ b/Source/Engine/Platform/Windows/WindowsClipboard.cpp
@@ -23,9 +23,12 @@ void WindowsClipboard::Clear()
 
 void WindowsClipboard::SetText(const StringView& text)
 {
-    const int32 size = (text.Length() + 1) * sizeof(Char);
-    const HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, size);
-    Platform::MemoryCopy(GlobalLock(hMem), String(text).GetText(), size);
+    const int32 sizeWithoutNull = text.Length() * sizeof(Char);
+    const HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, sizeWithoutNull + sizeof(Char));
+
+    Char* pMem = static_cast<Char*>(GlobalLock(hMem));
+    Platform::MemoryCopy(pMem, text.GetNonTerminatedText(), sizeWithoutNull);
+    Platform::MemorySet(pMem + text.Length(), sizeof(Char), 0);
     GlobalUnlock(hMem);
 
     OpenClipboard(nullptr);

--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -435,7 +435,7 @@ DialogResult MessageBox::Show(Window* parent, const StringView& text, const Stri
     }
 
     // Show dialog
-    int result = MessageBoxW(parent ? static_cast<HWND>(parent->GetNativePtr()) : nullptr, text.GetText(), caption.GetText(), flags);
+    int result = MessageBoxW(parent ? static_cast<HWND>(parent->GetNativePtr()) : nullptr, String(text).GetText(), String(caption).GetText(), flags);
 
     // Translate result to dialog result
     DialogResult dialogResult;
@@ -948,10 +948,12 @@ int32 WindowsPlatform::StartProcess(const StringView& filename, const StringView
         LOG(Info, "Working directory: {0}", workingDir);
     }
 
+    String filenameString(filename);
+
     SHELLEXECUTEINFOW shExecInfo = { 0 };
     shExecInfo.cbSize = sizeof(SHELLEXECUTEINFOW);
     shExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
-    shExecInfo.lpFile = filename.GetText();
+    shExecInfo.lpFile = filenameString.GetText();
     shExecInfo.lpParameters = args.HasChars() ? args.Get() : nullptr;
     shExecInfo.lpDirectory = workingDir.HasChars() ? workingDir.Get() : nullptr;
     shExecInfo.nShow = hiddenWindow ? SW_HIDE : SW_SHOW;
@@ -1109,7 +1111,7 @@ int32 WindowsPlatform::RunProcess(const StringView& cmdLine, const StringView& w
 
     // Create the process
     PROCESS_INFORMATION procInfo;
-    if (!CreateProcessW(nullptr, const_cast<LPWSTR>(cmdLine.GetText()), nullptr, nullptr, TRUE, dwCreationFlags, (LPVOID)environmentStr, workingDir.HasChars() ? workingDir.Get() : nullptr, &startupInfoEx.StartupInfo, &procInfo))
+    if (!CreateProcessW(nullptr, const_cast<LPWSTR>(String(cmdLine).GetText()), nullptr, nullptr, TRUE, dwCreationFlags, (LPVOID)environmentStr, String(workingDir).GetText(), &startupInfoEx.StartupInfo, &procInfo))
     {
         LOG(Warning, "Cannot start process '{0}'. Error code: 0x{1:x}", cmdLine, static_cast<int64>(GetLastError()));
         goto ERROR_EXIT;

--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -1111,7 +1111,7 @@ int32 WindowsPlatform::RunProcess(const StringView& cmdLine, const StringView& w
 
     // Create the process
     PROCESS_INFORMATION procInfo;
-    if (!CreateProcessW(nullptr, const_cast<LPWSTR>(String(cmdLine).GetText()), nullptr, nullptr, TRUE, dwCreationFlags, (LPVOID)environmentStr, String(workingDir).GetText(), &startupInfoEx.StartupInfo, &procInfo))
+    if (!CreateProcessW(nullptr, const_cast<LPWSTR>(String(cmdLine).GetText()), nullptr, nullptr, TRUE, dwCreationFlags, (LPVOID)environmentStr, workingDir.HasChars() ? workingDir.Get() : nullptr, &startupInfoEx.StartupInfo, &procInfo))
     {
         LOG(Warning, "Cannot start process '{0}'. Error code: 0x{1:x}", cmdLine, static_cast<int64>(GetLastError()));
         goto ERROR_EXIT;

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -166,7 +166,7 @@ namespace Flax.Build.Bindings
             if (typeInfo.Type == "String")
                 return $"(StringView){value}";
             if (typeInfo.IsPtr && typeInfo.IsConst && typeInfo.Type == "Char")
-                return $"((StringView){value}).GetNonTerminatedText()"; // This is a bug, as we need a null-terminated strig here. Any idea how to fix it?
+                return $"((StringView){value}).GetNonTerminatedText()"; // (StringView)Variant, if not empty, is guaranteed to point to a null-terminated buffer.
             if (typeInfo.Type == "AssetReference" || typeInfo.Type == "WeakAssetReference")
                 return $"ScriptingObject::Cast<{typeInfo.GenericArgs[0].Type}>((Asset*){value})";
             if (typeInfo.Type == "ScriptingObjectReference" || typeInfo.Type == "SoftObjectReference")

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -166,7 +166,7 @@ namespace Flax.Build.Bindings
             if (typeInfo.Type == "String")
                 return $"(StringView){value}";
             if (typeInfo.IsPtr && typeInfo.IsConst && typeInfo.Type == "Char")
-                return $"((StringView){value}).GetText()";
+                return $"((StringView){value}).GetNonTerminatedText()"; // This is a bug, as we need a null-terminated strig here. Any idea how to fix it?
             if (typeInfo.Type == "AssetReference" || typeInfo.Type == "WeakAssetReference")
                 return $"ScriptingObject::Cast<{typeInfo.GenericArgs[0].Type}>((Asset*){value})";
             if (typeInfo.Type == "ScriptingObjectReference" || typeInfo.Type == "SoftObjectReference")


### PR DESCRIPTION
Changes:
- Fixed many invalid uses of `StringView::GetText()`, where a null-terminated string was expected.  
  This should fix some hard to track bugs and random crashes.
- Renamed `GetText()` to `GetNonTerminatedText()` to reduce chance of identical bugs appearing in the future.
- Clarified some function comments to say where `nullptr`s are allowed, and where they are not.  
  This is important, as various functions have different conventions, and it's easy to make invalid assumptions.

Things to consider:
- I am was able to build the code for Windows and Linux platforms.  
  I might have missed some StringView::GetText() uses in other platforms. This would break compilation of those platforms. Help with that would be welcome.
- There are still quite a few places where `nullptr` is passed to function that explicitly defines it as an undefined behavior.  
  I have not touched those yet..