### PR TITLE
Add LookingAt to Actor

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -1425,9 +1425,23 @@ Actor* Actor::Intersects(const Ray& ray, float& distance, Vector3& normal)
 
 void Actor::LookAt(const Vector3& worldPos)
 {
+    const Quaternion orientation = LookingAt(worldPos);
+
+    SetOrientation(orientation);
+}
+
+void Actor::LookAt(const Vector3& worldPos, const Vector3& worldUp)
+{
+    const Quaternion orientation = LookingAt(worldPos, worldUp);
+
+    SetOrientation(orientation);
+}
+
+Quaternion Actor::LookingAt(const Vector3& worldPos)
+{
     const Vector3 direction = worldPos - _transform.Translation;
     if (direction.LengthSquared() < ZeroTolerance)
-        return;
+        return _parent->GetOrientation();
 
     const Vector3 newForward = Vector3::Normalize(direction);
     const Vector3 oldForward = _transform.Orientation * Vector3::Forward;
@@ -1447,26 +1461,25 @@ void Actor::LookAt(const Vector3& worldPos)
         orientation = rotQuat * _transform.Orientation;
     }
 
-    SetOrientation(orientation);
+    return orientation;
 }
 
-void Actor::LookAt(const Vector3& worldPos, const Vector3& worldUp)
+Quaternion Actor::LookingAt(const Vector3& worldPos, const Vector3& worldUp)
 {
     const Vector3 direction = worldPos - _transform.Translation;
     if (direction.LengthSquared() < ZeroTolerance)
-        return;
+        return _parent->GetOrientation();
     const Vector3 forward = Vector3::Normalize(direction);
     const Vector3 up = Vector3::Normalize(worldUp);
 
     if (Math::IsOne(Vector3::Dot(forward, up)))
     {
-        LookAt(worldPos);
-        return;
+        return LookingAt(worldPos);
     }
 
     Quaternion orientation;
     Quaternion::LookRotation(direction, up, orientation);
-    SetOrientation(orientation);
+    return orientation;
 }
 
 void WriteObjectToBytes(SceneObject* obj, rapidjson_flax::StringBuffer& buffer, MemoryWriteStream& output)

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -792,6 +792,19 @@ public:
     /// <param name="worldUp">The up direction that Constrains y axis orientation to a plane this vector lies on. This rule might be broken if forward and up direction are nearly parallel.</param>
     API_FUNCTION() void LookAt(const Vector3& worldPos, const Vector3& worldUp);
 
+    /// <summary>
+    /// Gets rotation of the actor oriented towards the specified world position.
+    /// </summary>
+    /// <param name="worldPos">The world position to orient towards.</param>
+    API_FUNCTION() Quaternion LookingAt(const Vector3& worldPos);
+
+    /// <summary>
+    /// Gets rotation of the actor oriented towards the specified world position with upwards direction.
+    /// </summary>
+    /// <param name="worldPos">The world position to orient towards.</param>
+    /// <param name="worldUp">The up direction that Constrains y axis orientation to a plane this vector lies on. This rule might be broken if forward and up direction are nearly parallel.</param>
+    API_FUNCTION() Quaternion LookingAt(const Vector3& worldPos, const Vector3& worldUp);
+
 public:
 
     /// <summary>


### PR DESCRIPTION
LookAt() modifies the Actor's rotation without returning anything and I needed a way to lerp that rotation, so LookingAt() just returns the rotation without modifying it.