### PR TITLE
Removed unnecessary NULL terminator in RunBuildTool() to fix #402

### DIFF
--- a/Source/Editor/Scripting/ScriptsBuilder.cpp
+++ b/Source/Editor/Scripting/ScriptsBuilder.cpp
@@ -239,7 +239,6 @@ bool ScriptsBuilder::RunBuildTool(const StringView& args)
     cmdLine.Append(buildToolPath);
     cmdLine.Append(TEXT("\" "));
     cmdLine.Append(args.Get(), args.Length());
-    cmdLine.Append(TEXT('\0'));
     // TODO: Set env var for the mono MONO_GC_PARAMS=nursery-size64m to boost build performance -> profile it
 
     // Call build tool


### PR DESCRIPTION
Removed unnecessary NULL terminator in RunBuildTool() to fix #402: "Copying new log after clearing partially fails".
(This is now safe to merge, as fixes from PR #592 were already merged.)