### PR TITLE
Add Orientation option to ContentWindow

### DIFF
--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -128,6 +128,13 @@ namespace FlaxEditor.Options
         public float IconsScale { get; set; } = 1.0f;
 
         /// <summary>
+        /// Gets or sets the editor content window orientation.
+        /// </summary>
+        [DefaultValue(FlaxEngine.GUI.Orientation.Horizontal)]
+        [EditorDisplay("Interface"), EditorOrder(280), Tooltip("Editor content window orientation.")]
+        public FlaxEngine.GUI.Orientation ContentWindowOrientation { get; set; } = FlaxEngine.GUI.Orientation.Horizontal;
+
+        /// <summary>
         /// Gets or sets the timestamps prefix mode for output log messages.
         /// </summary>
         [DefaultValue(TimestampsFormats.TimeSinceStartup)]

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -10,6 +10,7 @@ using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Input;
 using FlaxEditor.GUI.Tree;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.Assertions;
 using FlaxEngine.GUI;
@@ -73,6 +74,9 @@ namespace FlaxEditor.Windows
             editor.ContentDatabase.WorkspaceModified += () => _isWorkspaceDirty = true;
             editor.ContentDatabase.ItemRemoved += ContentDatabaseOnItemRemoved;
 
+            var options = Editor.Options;
+            options.OptionsChanged += OnOptionsChanged;
+
             // Toolstrip
             _toolStrip = new ToolStrip(34.0f)
             {
@@ -91,7 +95,7 @@ namespace FlaxEditor.Windows
             };
 
             // Split panel
-            _split = new SplitPanel(Orientation.Horizontal, ScrollBars.Both, ScrollBars.Vertical)
+            _split = new SplitPanel(options.Options.Interface.ContentWindowOrientation, ScrollBars.Both, ScrollBars.Vertical)
             {
                 AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = new Margin(0, 0, _toolStrip.Bottom, 0),
@@ -232,6 +236,13 @@ namespace FlaxEditor.Windows
             };
 
             return menu;
+        }
+
+        private void OnOptionsChanged(EditorOptions options)
+        {
+            _split.Orientation = options.Interface.ContentWindowOrientation;
+
+            RefreshView();
         }
 
         private void OnViewTypeButtonClicked(ContextMenuButton button)
@@ -916,6 +927,8 @@ namespace FlaxEditor.Windows
             _foldersSearchBox = null;
             _itemsSearchBox = null;
             _viewDropdown = null;
+
+            Editor.Options.OptionsChanged -= OnOptionsChanged;
 
             base.OnDestroy();
         }


### PR DESCRIPTION
This adds the ability to change the ContentWindow's Orientation from the Editor options panel. Useful for users like myself that keep the content window docked on the side and want to use it a vertical orientation.