### PR TITLE
Fix engine ticking to catch up faster when falling behind

### DIFF
--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -146,7 +146,7 @@ int32 Engine::Main(const Char* cmdLine)
     while (!ShouldExit())
     {
         // Reduce CPU usage by introducing idle time if the engine is running very fast and has enough time to spend
-        if ((useSleep && Time::UpdateFPS > 0) || !Platform::GetHasFocus())
+        if ((useSleep && Time::UpdateFPS > ZeroTolerance) || !Platform::GetHasFocus())
         {
             double nextTick = Time::GetNextTick();
             double timeToTick = nextTick - Platform::GetTimeSeconds();

--- a/Source/Engine/Engine/Time.cpp
+++ b/Source/Engine/Engine/Time.cpp
@@ -189,11 +189,11 @@ double Time::GetNextTick()
     const double nextDraw = Time::Draw.NextBegin;
 
     double nextTick = MAX_double;
-    if (UpdateFPS > 0 && nextUpdate < nextTick)
+    if (UpdateFPS > ZeroTolerance && nextUpdate < nextTick)
         nextTick = nextUpdate;
-    if (PhysicsFPS > 0 && nextPhysics < nextTick)
+    if (PhysicsFPS > ZeroTolerance && nextPhysics < nextTick)
         nextTick = nextPhysics;
-    if (DrawFPS > 0 && nextDraw < nextTick)
+    if (DrawFPS > ZeroTolerance && nextDraw < nextTick)
         nextTick = nextDraw;
 
     if (nextTick == MAX_double)

--- a/Source/Engine/Engine/Time.cpp
+++ b/Source/Engine/Engine/Time.cpp
@@ -103,7 +103,10 @@ bool Time::TickData::OnTickBegin(float targetFps, float maxDeltaTime)
         }
 
         if (targetFps > ZeroTolerance)
-            NextBegin += (1.0 / targetFps);
+        {
+            int skip = (int)(1 + (time - NextBegin) / (1.0 / targetFps));
+            NextBegin += (1.0 / targetFps) * skip;
+        }
     }
 
     // Update data
@@ -156,7 +159,10 @@ bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime)
         }
 
         if (targetFps > ZeroTolerance)
-            NextBegin += (1.0 / targetFps);
+        {
+            int skip = (int)(1 + (time - NextBegin) / (1.0 / targetFps));
+            NextBegin += (1.0 / targetFps) * skip;
+        }
     }
     Samples.Add(deltaTime);
 


### PR DESCRIPTION
This addresses an issue when the engine is running slowly for a while, the framerate does not immediately get capped to the current effective framerate cap. For example, when the Flax Editor is not focused, the framerate is capped to 15fps, but when focus gets restored, framerate remains unlocked for a while before it gets capped again.