### PR TITLE
Missing flaxengine api tags

### DIFF
--- a/Source/Engine/Debug/Exception.h
+++ b/Source/Engine/Debug/Exception.h
@@ -13,7 +13,7 @@ namespace Log
     /// <summary>
     /// Represents errors that occur during application execution.
     /// </summary>
-    class Exception : public Object
+    class FLAXENGINE_API Exception : public Object
     {
     protected:
 

--- a/Source/Engine/Scripting/ManagedCLR/MField.h
+++ b/Source/Engine/Scripting/ManagedCLR/MField.h
@@ -8,7 +8,7 @@
 /// <summary>
 /// Encapsulates information about a single Mono (managed) fields belonging to some managed class. This object also allows you to access the field data of an object instance.
 /// </summary>
-class MField
+class FLAXENGINE_API MField
 {
     friend MClass;
 

--- a/Source/Engine/Utilities/StateMachine.h
+++ b/Source/Engine/Utilities/StateMachine.h
@@ -9,7 +9,7 @@ class StateMachine;
 /// <summary>
 /// State machine state
 /// </summary>
-class State
+class FLAXENGINE_API State
 {
     friend StateMachine;
 
@@ -71,7 +71,7 @@ protected:
 /// <summary>
 /// State machine logic pattern
 /// </summary>
-class StateMachine
+class FLAXENGINE_API StateMachine
 {
     friend State;
 


### PR DESCRIPTION
Added some missing FLAXENGINE_API tags in StateMachine.h, Exception.h, MField.h.