### PR TITLE
optimize file copy on Linux

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
+++ b/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
@@ -343,7 +343,6 @@ bool LinuxFileSystem::CopyFile(const StringView& dst, const StringView& src)
     char buffer[4096];
     ssize_t readSize;
     int cachedError;
-    off_t offset = 0;
 
     srcFile = open(srcANSI.Get(), O_RDONLY);
     if (srcFile < 0)


### PR DESCRIPTION
In Linux there is a syscall for copying files that typically takes half the time compared to a read/write loop in user space.