### PR TITLE
use a fixed font if the requested cannot be found for message boxes

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxPlatform.cpp
+++ b/Source/Engine/Platform/Linux/LinuxPlatform.cpp
@@ -212,7 +212,9 @@ static int X11_MessageBoxInit(MessageBoxData* data)
 	if (data->font_set == nullptr)
 	{
 		LINUX_DIALOG_PRINT("Couldn't load font %s", MessageBoxFont);
-		return 1;
+		data->font_set = X11::XCreateFontSet(data->display, "fixed", &missing, &num_missing, NULL);
+		if (missing != nullptr) X11::XFreeStringList(missing);
+		//return 1;
 	}
 
 	return 0;


### PR DESCRIPTION
Message boxes may cause a segfault if the requested font cannot be found. It's better to fall back to a simple default so that the message box can be rendered.