### PR TITLE
Added NumThreadPoolThreads to Threading.h

### DIFF
--- a/Source/Engine/Threading/ThreadPool.cpp
+++ b/Source/Engine/Threading/ThreadPool.cpp
@@ -18,6 +18,11 @@ FLAXENGINE_API bool IsInMainThread()
     return Globals::MainThreadID == Platform::GetCurrentThreadID();
 }
 
+FLAXENGINE_API int32 NumThreadPoolThreads()
+{
+    return Math::Clamp<int32>(Platform::GetCPUInfo().ProcessorCoreCount - 1, 2, PLATFORM_THREADS_LIMIT);
+}
+
 namespace ThreadPoolImpl
 {
     volatile int64 ExitFlag = 0;
@@ -51,7 +56,7 @@ ThreadPoolService ThreadPoolServiceInstance;
 bool ThreadPoolService::Init()
 {
     // Spawn threads
-    const int32 numThreads = Math::Clamp<int32>(Platform::GetCPUInfo().ProcessorCoreCount - 1, 2, PLATFORM_THREADS_LIMIT);
+    const int32 numThreads = NumThreadPoolThreads();
     LOG(Info, "Spawning {0} Thread Pool workers", numThreads);
     for (int32 i = ThreadPoolImpl::Threads.Count(); i < numThreads; i++)
     {

--- a/Source/Engine/Threading/Threading.h
+++ b/Source/Engine/Threading/Threading.h
@@ -10,6 +10,11 @@
 FLAXENGINE_API bool IsInMainThread();
 
 /// <summary>
+/// Returns the number of threads in the task thread pool.
+/// </summary>
+FLAXENGINE_API int32 NumThreadPoolThreads();
+
+/// <summary>
 /// Scope locker for critical section.
 /// </summary>
 class ScopeLock


### PR DESCRIPTION
The new function exposes to script the number of worker threads available to the thread pool.

The number of threads in the thread pool was previously set in ThreadPool.cpp on line 54, within the function ThreadPoolService::Init(). I have promoted this value to a public function in the global namespace and exposed said function to the scripting API. The declaration of the new function is in Threading.h (immediately beneath IsInMainThread()) and its definition is in ThreadPool.cpp (also immediately beneath IsInMainThread()).

I wanted to know how many worker threads I was working with and couldn't find this value publicly exposed anywhere, so I added it. If the value is already publicly exposed and I missed it, please reject and disregard this PR.

