### PR TITLE
Miscellaneous improvements

### DIFF
--- a/Source/Engine/Core/Collections/Dictionary.h
+++ b/Source/Engine/Core/Collections/Dictionary.h
@@ -530,7 +530,7 @@ public:
             for (int32 i = 0; i < oldSize; i++)
             {
                 if (oldData[i].IsOccupied())
-                    Add(oldData[i].Key, oldData[i].Value);
+                    Add(oldData[i].Key, MoveTemp(oldData[i].Value));
             }
         }
         if (oldElementsCount != 0)

--- a/Source/Engine/Core/Delegate.h
+++ b/Source/Engine/Core/Delegate.h
@@ -89,6 +89,20 @@ public:
         _lambda = nullptr;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Function"/> class.
+    /// </summary>
+    template<typename T>
+    Function(const T& lambda)
+    {
+        _lambda = (Lambda*)Allocator::Allocate(sizeof(Lambda) + sizeof(T));
+        _lambda->Refs = 1;
+        _lambda->Dtor = [](void* callee) -> void { static_cast<T*>(callee)->~T(); };
+        _function = [](void* callee, Params ... params) -> ReturnType { return (*static_cast<T*>(callee))(Forward<Params>(params)...); };
+        _callee = (byte*)_lambda + sizeof(Lambda);
+        new(_callee) T(lambda);
+    }
+
     Function(const Function& other)
         : _callee(other._callee)
         , _function(other._function)

--- a/Source/Engine/Core/Math/Math.cpp
+++ b/Source/Engine/Core/Math/Math.cpp
@@ -1,9 +1,16 @@
 // Copyright (c) 2012-2021 Wojciech Figat. All rights reserved.
 
 #include "Math.h"
+#include "Mathd.h"
 #include "Vector3.h"
 
 void Math::SinCos(float angle, float& sine, float& cosine)
+{
+    sine = Math::Sin(angle);
+    cosine = Math::Cos(angle);
+}
+
+void Math::SinCos(double angle, double& sine, double& cosine)
 {
     sine = Math::Sin(angle);
     cosine = Math::Cos(angle);

--- a/Source/Engine/Threading/Task.h
+++ b/Source/Engine/Threading/Task.h
@@ -251,6 +251,19 @@ public:
     /// <summary>
     /// Starts the new task.
     /// </summary>
+    /// <param name="callee">The callee object.</param>
+    /// <returns>Task</returns>
+    template<class T, void(T::* Method)()>
+    static Task* StartNew(T* callee)
+    {
+        Function<void()> action;
+        action.Bind<T, Method>(callee);
+        return StartNew(action, dynamic_cast<Object*>(callee));
+    }
+
+    /// <summary>
+    /// Starts the new task.
+    /// </summary>
     /// <param name="action">The action.</param>
     /// <param name="target">The action target object.</param>
     /// <returns>Task</returns>


### PR DESCRIPTION
Pushing some of my local commits that I thought would be useful for other people.

**Implemented Math::SinCos(double) in Math.cpp.** The double version of this function was declared in Mathd.h but not implemented anywhere.

**Tweaked Dictionary.h to support movable value types with no copy constructors.** Dictionary::SetCapacity() was preventing proper support here because the old data was being copied instead of moved.

**Added a constructor to Function class in Delegate.h to support constructing directly from reference-captured lambdas.** Mafiesto graciously added support for reference captured lambda's, but I was too dumb to notice because they had to be initialized via the Bind() method. So I copy-pasted (most of) the body of the appropriate Bind() method into a new constructor and now I can initialize Function objects like this:

    Function<void()> funkytown01 = [&]() {};
    Function<void()> funkytown02([&]() {});

... which makes me very happy!