### PR TITLE
Various Xaudio2 backend fixes

### DIFF
--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -168,11 +168,10 @@ namespace FlaxEditor.Windows.Assets
             }
             if (!_previewSource)
             {
-                _previewSource = new AudioSource
-                {
-                    Parent = _previewScene,
-                    Clip = _asset,
-                };
+                // HACK: AudioClip must be assigned before Parent, needed for XAudio2 backend
+                _previewSource = new AudioSource();
+                _previewSource.Clip = _asset;
+                _previewSource.Parent = _previewScene;
             }
             if (_previewSource.State == AudioSource.States.Playing)
                 _previewSource.Stop();

--- a/Source/Engine/Audio/XAudio2/AudioBackendXAudio2.cpp
+++ b/Source/Engine/Audio/XAudio2/AudioBackendXAudio2.cpp
@@ -816,8 +816,8 @@ void AudioBackendXAudio2::Base_Update()
             // TODO: implement proper matrix setup to convert input channels into output mastering voice
             // hardcoded case for mono audio -> stereo speakers
             Platform::MemoryClear(dsp.pMatrixCoefficients, sizeof(XAudio2::MatrixCoefficients));
-            dsp.pMatrixCoefficients[0] = 0.5f;
-            dsp.pMatrixCoefficients[1] = 0.5f;
+            dsp.pMatrixCoefficients[0] = 1.0f;
+            dsp.pMatrixCoefficients[1] = 1.0f;
         }
 
         const float frequencyRatio = dopplerFactor * source.Pitch * dsp.DopplerFactor;


### PR DESCRIPTION
Fixes a crash in audio clip editor when Play-button is pressed. This probably should be fixed elsewhere later, but for some reason the XAudio2 backend creates the audio source when the parent is assigned and not when the clip is assigned. The initializer assigns the parent before clip which skips the audio source creation and leads to crash when the audio source is expected to be loaded when it's being played.

Also fixes the audio clips volume levels to correct levels, before the fix the volume of the audio clips were more quieter than expected.