### PR TITLE
Fix issue with filters being ignored for two controllers colliding

### DIFF
--- a/Source/Engine/Physics/Colliders/CharacterController.cpp
+++ b/Source/Engine/Physics/Colliders/CharacterController.cpp
@@ -173,6 +173,7 @@ CharacterController::CollisionFlags CharacterController::Move(const Vector3& dis
         filters.mFilterData = (PxFilterData*)&_filterData;
         filters.mFilterCallback = Physics::GetCharacterQueryFilterCallback();
         filters.mFilterFlags = PxQueryFlag::eDYNAMIC | PxQueryFlag::eSTATIC | PxQueryFlag::ePREFILTER;
+        filters.mCCTFilterCallback = Physics::GetCharacterControllerFilterCallback();
 
         result = (CollisionFlags)(byte)_controller->move(C2P(displacement), _minMoveDistance, deltaTime, filters);
         _lastFlags = result;

--- a/Source/Engine/Physics/Physics.h
+++ b/Source/Engine/Physics/Physics.h
@@ -113,6 +113,11 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(Physics);
     static PxQueryFilterCallback* GetCharacterQueryFilterCallback();
 
     /// <summary>
+    /// Gets the default controller filter callback used for the character controller collisions detection.
+    /// </summary>
+    static PxControllerFilterCallback* GetCharacterControllerFilterCallback();
+
+    /// <summary>
     /// Gets the default physical material.
     /// </summary>
     static PxMaterial* GetDefaultMaterial();

--- a/Source/Engine/Physics/Types.h
+++ b/Source/Engine/Physics/Types.h
@@ -39,6 +39,7 @@ namespace physx
     class PxController;
     class PxCapsuleController;
     class PxQueryFilterCallback;
+    class PxControllerFilterCallback;
     class PxHeightField;
     struct PxFilterData;
     struct PxRaycastHit;


### PR DESCRIPTION
Adds CCT Callbacks to physics queries so that layer collision settings are respected.  Tried to follow the existing code as much as possible, let me know if anything should be removed, added, or edited.