### PR TITLE
Update CSProjectGenerator to support .NET Framework 4.8 Targeting Pack

### DIFF
--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
@@ -77,7 +77,7 @@ namespace Flax.Build.Projects.VisualStudio
 
             csProjectFileContent.AppendLine(string.Format("    <RootNamespace>{0}</RootNamespace>", project.Name));
             csProjectFileContent.AppendLine(string.Format("    <AssemblyName>{0}.CSharp</AssemblyName>", project.Name));
-            csProjectFileContent.AppendLine(string.Format("    <TargetFrameworkVersion>{0}</TargetFrameworkVersion>", "v4.5"));
+            csProjectFileContent.AppendLine(string.Format("    <TargetFrameworkVersion>{0}</TargetFrameworkVersion>", "v4.8"));
             csProjectFileContent.AppendLine("    <LangVersion>7.3</LangVersion>");
             csProjectFileContent.AppendLine("    <FileAlignment>512</FileAlignment>");
             csProjectFileContent.AppendLine("    <TargetFrameworkProfile />");


### PR DESCRIPTION
Right now, every time we create a new C# script, Flax Engine defaults to setting up the C# project file to use the .NET Framework 4.5 Targeting Pack, meaning we need to retarget the project file each time to work with the 4.8 Framework Targeting Pack, which is the newest version. In Visual Studio, this is rather simple, as we just need to press 2 buttons, but in Visual Studio Code, it requires going into the `.csproj` file and changing it ourselves, which is less than ideal.

This PR just changes the generated `.csproj` file to use the 4.8 Framework Targeting Pack by default.

(This is my very first PR on any source-available project. I hope that I'm doing it properly. 🙂)