### PR TITLE
Add cursor clipping

### DIFF
--- a/Source/Engine/Engine/Screen.cpp
+++ b/Source/Engine/Engine/Screen.cpp
@@ -116,6 +116,19 @@ CursorLockMode Screen::GetCursorLock()
 
 void Screen::SetCursorLock(CursorLockMode mode)
 {
+#if USE_EDITOR
+    const auto win = Editor::Managed->GetGameWindow();
+#else
+    const auto win = Engine::MainWindow;
+#endif
+    if (win && mode == CursorLockMode::Clipped)
+    {
+        win->StartClippingCursor(win->GetClientBounds());
+    }
+    else if (win && CursorLock == CursorLockMode::Clipped)
+    {
+        win->EndClippingCursor();
+    }
     CursorLock = mode;
 }
 

--- a/Source/Engine/Input/Enums.h
+++ b/Source/Engine/Input/Enums.h
@@ -21,6 +21,11 @@ API_ENUM() enum class CursorLockMode
     /// Cursor position is locked to the center of the game window.
     /// </summary>
     Locked = 1,
+
+    /// <summary>
+    /// Cursor position is confined to the bounds of the game window.
+    /// </summary>
+    Clipped = 2,
 };
 
 /// <summary>

--- a/Source/Engine/Platform/Base/WindowBase.cpp
+++ b/Source/Engine/Platform/Base/WindowBase.cpp
@@ -104,6 +104,7 @@ WindowBase::WindowBase(const CreateWindowSettings& settings)
     , _trackingMouseOffset(Vector2::Zero)
     , _isUsingMouseOffset(false)
     , _isTrackingMouse(false)
+    , _isClippingCursor(false)
     , RenderTask(nullptr)
 {
     // Update window location based on start location

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -288,6 +288,7 @@ protected:
     bool _isUsingMouseOffset;
     Rectangle _mouseOffsetScreenSize;
     bool _isTrackingMouse;
+    bool _isClippingCursor;
 
     explicit WindowBase(const CreateWindowSettings& settings);
     virtual ~WindowBase();
@@ -691,6 +692,29 @@ public:
     /// Ends the mouse tracking.
     /// </summary>
     API_FUNCTION() virtual void EndTrackingMouse()
+    {
+    }
+
+    /// <summary>
+    /// Starts the cursor clipping.
+    /// </summary>
+    /// <param name="bounds">The bounds that the cursor will be confined to.</param>
+    API_FUNCTION() virtual void StartClippingCursor(const Rectangle& bounds)
+    {
+    }
+
+    /// <summary>
+    /// Gets the value indicating whenever the cursor is being clipped.
+    /// </summary>
+    API_PROPERTY bool IsCursorClipping() const
+    {
+        return _isClippingCursor;
+    }
+
+    /// <summary>
+    /// Ends the cursor clipping.
+    /// </summary>
+    API_FUNCTION() virtual void EndClippingCursor()
     {
     }
 

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -706,7 +706,7 @@ public:
     /// <summary>
     /// Gets the value indicating whenever the cursor is being clipped.
     /// </summary>
-    API_PROPERTY bool IsCursorClipping() const
+    API_PROPERTY() bool IsCursorClipping() const
     {
         return _isClippingCursor;
     }

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -564,6 +564,34 @@ void WindowsWindow::EndTrackingMouse()
     }
 }
 
+void WindowsWindow::StartClippingCursor(const Rectangle& bounds)
+{
+    ASSERT(HasHWND());
+
+    if (!_isClippingCursor)
+    {
+        _isClippingCursor = true;
+    }
+
+    const RECT lpRect = { 
+        bounds.GetUpperLeft().X,
+        bounds.GetUpperLeft().Y,
+        bounds.GetBottomRight().X,
+        bounds.GetBottomRight().Y
+    };
+    ClipCursor(&lpRect);
+}
+
+void WindowsWindow::EndClippingMouse()
+{
+    if (_isClippingCursor)
+    {
+        _isClippingCursor = false;
+
+        ClipCursor(NULL);
+    }
+}
+
 void WindowsWindow::SetCursor(CursorType type)
 {
     // Base

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -582,7 +582,7 @@ void WindowsWindow::StartClippingCursor(const Rectangle& bounds)
     ClipCursor(&lpRect);
 }
 
-void WindowsWindow::EndClippingMouse()
+void WindowsWindow::EndClippingCursor()
 {
     if (_isClippingCursor)
     {

--- a/Source/Engine/Platform/Windows/WindowsWindow.h
+++ b/Source/Engine/Platform/Windows/WindowsWindow.h
@@ -120,6 +120,8 @@ public:
     DragDropEffect DoDragDrop(const StringView& data) override;
     void StartTrackingMouse(bool useMouseScreenOffset) override;
     void EndTrackingMouse() override;
+    void StartClippingCursor(const Rectangle& bounds) override;
+    void EndClippingCursor() override;
     void SetCursor(CursorType type) override;
 
 #if USE_EDITOR


### PR DESCRIPTION
Cursor clipping confines the cursor within a specified rectangle, which is necessary for games that use edge-scrolling (RTS, MOBA, etc.)

I'm submitting this as a draft as the code is for Windows only. If you'd like to make use of this, feel free to compile this branch and set CursorLock to CursorLockMode.Clipped.