### PR TITLE
Enable DXGI flip presentation mode and tearing in D3D11 mode

### DIFF
--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
@@ -265,18 +265,15 @@ bool GPUDeviceDX11::Init()
         return true;
     }
     UpdateOutputs(adapter);
+
+    ComPtr<IDXGIFactory5> factory5;
+    _factoryDXGI->QueryInterface(IID_PPV_ARGS(&factory5));
+    if (factory5)
     {
-        ComPtr<IDXGIFactory5> factory5;
-        _factoryDXGI->QueryInterface(IID_PPV_ARGS(&factory5));
-        if (factory5)
-        {
-            BOOL allowTearing;
-            if (SUCCEEDED(factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing))) && allowTearing)
-            {
-                AllowTearing = true;
-            }
-            factory5->Release();
-        }
+        BOOL allowTearing;
+        if (SUCCEEDED(factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing))) && allowTearing)
+            AllowTearing = true;
+        factory5->Release();
     }
 
 

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
@@ -265,6 +265,19 @@ bool GPUDeviceDX11::Init()
         return true;
     }
     UpdateOutputs(adapter);
+    {
+        ComPtr<IDXGIFactory5> factory5;
+        _factoryDXGI->QueryInterface(IID_PPV_ARGS(&factory5));
+        if (factory5)
+        {
+            BOOL allowTearing;
+            if (SUCCEEDED(factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing))) && allowTearing)
+            {
+                AllowTearing = true;
+            }
+        }
+    }
+
 
     // Get flags and device type base on current configuration
     uint32 flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
@@ -275,6 +275,7 @@ bool GPUDeviceDX11::Init()
             {
                 AllowTearing = true;
             }
+            factory5->Release();
         }
     }
 

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.h
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.h
@@ -52,6 +52,10 @@ public:
 
 public:
 
+    bool AllowTearing = false;
+
+public:
+
     // Gets DX11 device
     ID3D11Device* GetDevice() const
     {

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.cpp
@@ -112,6 +112,16 @@ void GPUSwapChainDX11::SetFullscreen(bool isFullscreen)
         }
 
         _isFullscreen = isFullscreen;
+
+        // Buffers must be resized in flip presentation model
+        if (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL ||
+            swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD)
+        {
+            const int32 width = _width;
+            const int32 height = _height;
+            _width = _height = 0;
+            Resize(width, height);
+        }
     }
 #else
     LOG(Info, "Cannot change fullscreen mode on this platform");
@@ -218,7 +228,7 @@ bool GPUSwapChainDX11::Resize(int32 width, int32 height)
         ASSERT(_swapChain);
 
         // Disable DXGI changes to the window
-        VALIDATE_DIRECTX_RESULT(dxgi->MakeWindowAssociation(_windowHandle, 0));
+        VALIDATE_DIRECTX_RESULT(dxgi->MakeWindowAssociation(_windowHandle, DXGI_MWA_NO_ALT_ENTER));
 #else
         auto dxgiFactory = (IDXGIFactory2*)_device->GetDXGIFactory();
         VALIDATE_DIRECTX_RESULT(dxgiFactory->CreateSwapChainForCoreWindow(_device->GetDevice(), static_cast<IUnknown*>(_windowHandle), &swapChainDesc, nullptr, &_swapChain));

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.h
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUSwapChainDX11.h
@@ -23,6 +23,7 @@ private:
 #if PLATFORM_WINDOWS
     HWND _windowHandle;
     IDXGISwapChain* _swapChain;
+    bool _allowTearing, _isFullscreen;
 #else
 	IUnknown* _windowHandle;
 	IDXGISwapChain1* _swapChain;

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.cpp
@@ -274,6 +274,7 @@ bool GPUDeviceDX12::Init()
             {
                 AllowTearing = true;
             }
+            factory5->Release();
         }
     }
 

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
@@ -51,6 +51,8 @@ GPUSwapChainDX12::GPUSwapChainDX12(GPUDeviceDX12* device, Window* window)
     , _windowHandle(static_cast<HWND>(window->GetNativePtr()))
     , _swapChain(nullptr)
     , _currentFrameIndex(0)
+    , _allowTearing(false)
+    , _isFullscreen(false)
 {
     ASSERT(_windowHandle);
     _window = window;

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUSwapChainDX12.cpp
@@ -137,6 +137,16 @@ void GPUSwapChainDX12::SetFullscreen(bool isFullscreen)
         }
 
         _isFullscreen = isFullscreen;
+
+        // Buffers must be resized in flip presentation model
+        if (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL ||
+            swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD)
+        {
+            const int32 width = _width;
+            const int32 height = _height;
+            _width = _height = 0;
+            Resize(width, height);
+        }
     }
 #else
     LOG(Info, "Cannot change fullscreen mode on this platform");
@@ -219,7 +229,7 @@ bool GPUSwapChainDX12::Resize(int32 width, int32 height)
         _backBuffers.Resize(swapChainDesc.BufferCount);
 
         // Disable DXGI changes to the window
-        dxgiFactory->MakeWindowAssociation(_windowHandle, 0);
+        VALIDATE_DIRECTX_RESULT(dxgiFactory->MakeWindowAssociation(_windowHandle, DXGI_MWA_NO_ALT_ENTER));
     }
     else
     {

--- a/Source/Engine/GraphicsDevice/DirectX/IncludeDirectXHeaders.h
+++ b/Source/Engine/GraphicsDevice/DirectX/IncludeDirectXHeaders.h
@@ -39,6 +39,7 @@ typedef IGraphicsUnknown IDXGISwapChain3;
 #include <D3D11.h>
 #include <d3d11_1.h>
 #include <dxgi1_3.h>
+#include <dxgi1_5.h>
 #endif
 #if GRAPHICS_API_DIRECTX12
 #include <dxgi1_5.h>

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -1031,6 +1031,10 @@ LRESULT WindowsWindow::WndProc(UINT msg, WPARAM wParam, LPARAM lParam)
                     // In this case, we don't resize yet -- we wait until the user stops dragging, and a WM_EXITSIZEMOVE message comes.
                     UpdateRegion();
                 }
+                else if (_isSwitchingFullScreen)
+                {
+                    // Ignored
+                }
                 else
                 {
                     // This WM_SIZE come from resizing the window via an API like SetWindowPos() so resize
@@ -1088,6 +1092,12 @@ LRESULT WindowsWindow::WndProc(UINT msg, WPARAM wParam, LPARAM lParam)
         {
             LOG(Info, "Alt+F4 pressed");
             Close(ClosingReason::User);
+            return 0;
+        }
+        if (wParam == VK_RETURN)
+        {
+            LOG(Info, "Alt+Enter pressed");
+            SetIsFullscreen(!IsFullscreen());
             return 0;
         }
         break;


### PR DESCRIPTION
Flip presentation is already used in D3D12 mode, so why not in D3D11 as well? This is only supported in Windows 10 or later systems, for older systems the non-flip modes are used instead.