### PR TITLE
Always run fixed update ticks at fixed deltatime

### DIFF
--- a/Source/Engine/Engine/Time.cpp
+++ b/Source/Engine/Engine/Time.cpp
@@ -104,7 +104,7 @@ bool Time::TickData::OnTickBegin(float targetFps, float maxDeltaTime)
 
         if (targetFps > ZeroTolerance)
         {
-            int skip = (int)(1 + (time - NextBegin) / (1.0 / targetFps));
+            const int skip = (int)(1 + (time - NextBegin) / (1.0 / targetFps));
             NextBegin += (1.0 / targetFps) * skip;
         }
     }
@@ -139,18 +139,16 @@ bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime)
 {
     // Check if can perform a tick
     double time = Platform::GetTimeSeconds();
-    double deltaTime, minDeltaTime;
+    double deltaTime;
     if (FixedDeltaTimeEnable)
     {
         deltaTime = (double)FixedDeltaTimeValue;
-        minDeltaTime = deltaTime;
     }
     else
     {
         if (time < NextBegin)
             return false;
 
-        minDeltaTime = targetFps > ZeroTolerance ? 1.0 / targetFps : 0.0;
         deltaTime = Math::Max((time - LastBegin), 0.0);
         if (deltaTime > maxDeltaTime)
         {
@@ -160,20 +158,9 @@ bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime)
 
         if (targetFps > ZeroTolerance)
         {
-            int skip = (int)(1 + (time - NextBegin) / (1.0 / targetFps));
-            NextBegin += (1.0 / targetFps) * skip;
+            deltaTime = 1.0 / targetFps;
+            NextBegin += 1.0 / targetFps;
         }
-    }
-    Samples.Add(deltaTime);
-
-    // Check if last few ticks were not taking too long so it's running slowly
-    const bool isRunningSlowly = Samples.Average() > 1.5 * minDeltaTime;
-    if (!isRunningSlowly)
-    {
-        // Make steps fixed size
-        const double diff = deltaTime - minDeltaTime;
-        time -= diff;
-        deltaTime = minDeltaTime;
     }
 
     // Update data

--- a/Source/Engine/Engine/Time.h
+++ b/Source/Engine/Engine/Time.h
@@ -5,7 +5,6 @@
 #include "Engine/Core/Types/TimeSpan.h"
 #include "Engine/Core/Types/DateTime.h"
 #include "Engine/Scripting/ScriptingType.h"
-#include "Engine/Core/Collections/SamplesBuffer.h"
 
 /// <summary>
 /// Game ticking and timing system.
@@ -91,13 +90,6 @@ public:
     /// </summary>
     class FixedStepTickData : public TickData
     {
-    public:
-
-        /// <summary>
-        /// The last few ticks delta times. Used to check if can use fixed steps or whenever is running slowly so should use normal stepping.
-        /// </summary>
-        SamplesBuffer<double, 4> Samples;
-
     public:
 
         // [TickData]


### PR DESCRIPTION
The random variance in fixed updates makes it impossible to do anything deterministic during physics ticks.