### PR TITLE
Fix wrong library linkage in DirectXShaderCompiler

### DIFF
--- a/Source/Engine/ShadersCompilation/DirectX/ShaderCompilerDX.Build.cs
+++ b/Source/Engine/ShadersCompilation/DirectX/ShaderCompilerDX.Build.cs
@@ -22,7 +22,7 @@ public class ShaderCompilerDX : ShaderCompiler
         options.PublicDefinitions.Add("COMPILE_WITH_DX_SHADER_COMPILER");
 
         var depsRoot = options.DepsFolder;
-        options.OutputFiles.Add("dxcompiler.lib");
+        options.OutputFiles.Add(Path.Combine(depsRoot, "dxcompiler.lib"));
         options.DependencyFiles.Add(Path.Combine(depsRoot, "dxcompiler.dll"));
         options.DependencyFiles.Add(Path.Combine(depsRoot, "dxil.dll"));
         options.DelayLoadLibraries.Add("dxcompiler.dll");

--- a/Source/Tools/Flax.Build/Platforms/Windows/WindowsPlatformBase.cs
+++ b/Source/Tools/Flax.Build/Platforms/Windows/WindowsPlatformBase.cs
@@ -371,8 +371,8 @@ namespace Flax.Build.Platforms
                 WindowsPlatformSDK.v10_0_17763_0,
                 WindowsPlatformSDK.v10_0_18362_0,
                 WindowsPlatformSDK.v10_0_19041_0,
-                //WindowsPlatformSDK.v10_0_20348_0, // Breaks on Flax Editor build
-                //WindowsPlatformSDK.v10_0_22000_0, // Breaks on Flax Editor build
+                WindowsPlatformSDK.v10_0_20348_0,
+                WindowsPlatformSDK.v10_0_22000_0,
             };
             foreach (var sdk10 in sdk10Roots)
             {


### PR DESCRIPTION
This fixes the wrong dxcompiler.lib from getting linked to the shader compiler. Without the added path, the dxcompiler included in the Windows SDK is used instead, which leads to linker errors in Windows SDK versions v10.0.20348 and v10.0.22000.

The dxcompiler must also be updated to latest version as well, because the declarations of `DxcCreateInstance` and `DxcCreateInstance2` are wrong in the current version. These lines must be removed in dxcapi.h (works with dxcompiler v1.6.2106) for these changes to fully fix the linking errors in all SDK versions:
![image](https://user-images.githubusercontent.com/4064397/159172689-a27c71aa-22b5-42f5-9b00-6ead8a7f9915.png)
