### PR TITLE
Improve font rendering and alignment with custom DPI

### DIFF
--- a/Source/Engine/Render2D/Render2D.cpp
+++ b/Source/Engine/Render2D/Render2D.cpp
@@ -1331,7 +1331,7 @@ void Render2D::DrawText(Font* font, const StringView& text, const Color& color, 
                 {
                     // Calculate character size and atlas coordinates
                     const float x = pointer.X + entry.OffsetX * scale;
-                    const float y = pointer.Y + (font->GetHeight() + font->GetDescender() - entry.OffsetY) * scale;
+                    const float y = pointer.Y - entry.OffsetY * scale + Math::Ceil((font->GetHeight() + font->GetDescender()) * scale);
 
                     Rectangle charRect(x, y, entry.UVSize.X * scale, entry.UVSize.Y * scale);
                     charRect.Offset(layout.Bounds.Location);


### PR DESCRIPTION
Some screen DPI scaling settings (notably the 125% DPI in Windows) caused some characters to not align properly with rest of the characters in the same line:
![before](https://user-images.githubusercontent.com/4064397/160260863-ee4f7c37-554e-4bcd-9b4e-689f7e740b75.png)

After the fix:
![after](https://user-images.githubusercontent.com/4064397/160260867-87bc817e-baa4-4536-8dbb-64efe46dac22.png)

