### PR TITLE
Set timer resolution to lowest possible value in all Windows systems

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -626,10 +626,17 @@ bool WindowsPlatform::Init()
         return true;
     }
 
-    // Set lowest possible timer resolution for previous Windows versions
-    if (VersionMajor < 10 || (VersionMajor == 10 && VersionBuild < 17134))
+    // Set the lowest possible timer resolution
+    const HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
+    if (ntdll)
     {
-        timeBeginPeriod(1);
+        typedef LONG (WIN_API_CALLCONV *NtSetTimerResolution)(ULONG DesiredResolution, unsigned char SetResolution, ULONG* CurrentResolution);
+        const NtSetTimerResolution ntSetTimerResolution = (NtSetTimerResolution)GetProcAddress(ntdll, "NtSetTimerResolution");
+
+        ULONG currentResolution;
+        ntSetTimerResolution(1, TRUE, &currentResolution);
+
+        ::FreeLibrary(ntdll);
     }
 
     DWORD tmp;


### PR DESCRIPTION
This change should reduce random hitching / frametime spikes when threads are sleeping and are suddenly waked up for work. ``SleepConditionVariableCS`` and other Windows functions which sleeps are affected by the system timer resolution, so setting this to as low as possible should also increase throughput in Job/Load threads as well as reduce hitching.