### PR TITLE
Add World Triplanar Texture node to shader editor

### DIFF
--- a/Source/Editor/Surface/Archetypes/Textures.cs
+++ b/Source/Editor/Surface/Archetypes/Textures.cs
@@ -385,6 +385,24 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, "World Position", true, typeof(Float3), 1),
                 }
             },
+            new NodeArchetype
+            {
+                TypeID = 16,
+                Title = "World Triplanar Texture",
+                Description = "Projects a texture using world-space coordinates instead of UVs.",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Float2(240, 60),
+                DefaultValues = new object[]
+                {
+                    1.0f
+                },
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Texture", true, typeof(FlaxEngine.Object), 0),
+                    NodeElementArchetype.Factory.Input(1, "Scale", true, typeof(float), 1, 0),
+                    NodeElementArchetype.Factory.Output(0, "Color", typeof(Float3), 2)
+                }
+            },
         };
     }
 }


### PR DESCRIPTION
Adds the World Triplanar Texture node to the Material editor. The node projects a texture using world-space coordinates instead of using object UVs. This is very useful in cases where a texture should not move with an object, such as with prototype materials.
![image](https://user-images.githubusercontent.com/89754713/186447213-15abdafb-77a6-49df-ada0-c2b1ecfdd5fb.png)

Before:

https://user-images.githubusercontent.com/89754713/186447931-0aff1e49-d2c5-425f-ab01-7d460a8685ac.mp4

After:

https://user-images.githubusercontent.com/89754713/186447963-836f1935-ca2b-4652-a04c-be2074b44a61.mp4

Test project: [MaterialTest.zip](https://github.com/FlaxEngine/FlaxEngine/files/9417120/MaterialTest.zip)
 