### PR TITLE
Prefer LLVM linker over other linkers on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Flax Visual Studio extension provides better programming workflow, C# scripts de
 * Install Windows 8.1 SDK or newer (via Visual Studio Installer)
 * Install Microsoft Visual C++ 2015 v140 toolset or newer (via Visual Studio Installer)
 * Install .Net Framework 4.5.2 SDK/Targeting Pack (via Visual Studio Installer)
+* Install Git with LFS
 * Clone repo (with LFS)
 * Run **GenerateProjectFiles.bat**
 * Open `Flax.sln` and set solution configuration to **Editor.Development** and solution platform to **Win64**
@@ -48,12 +49,23 @@ Flax Visual Studio extension provides better programming workflow, C# scripts de
 ## Linux
 
 * Install Visual Studio Code
-* Install Mono ([https://www.mono-project.com/download/stable](https://www.mono-project.com/download/stable))
-* Install Vulkan SDK ([https://vulkan.lunarg.com/](https://vulkan.lunarg.com/))
+* Install Mono
+  * Ubuntu: see the instructions here: ([https://www.mono-project.com/download/stable](https://www.mono-project.com/download/stable))
+  * Arch: `sudo pacman -S mono`
+* Install Vulkan SDK
+  * Ubuntu: see the instructions here: ([https://vulkan.lunarg.com/](https://vulkan.lunarg.com/))
+  * Arch: `sudo pacman -S spirv-tools vulkan-headers vulkan-tools vulkan-validation-layers`
 * Install Git with LFS
-* Install requried packages: `sudo apt-get install libx11-dev libxcursor-dev libxinerama-dev nuget autoconf libogg-dev automake build-essential gettext cmake python libtool libtool-bin libpulse-dev libasound2-dev libjack-dev portaudio19-dev`
-* Install compiler `sudo apt-get install clang lldb lld` (Clang 6 or newer)
-* Clone repo (with LFS)
+  * Ubuntu: `sudo apt-get install git git-lfs`
+  * Arch: `sudo pacman -S git git-lfs`
+  * `git-lfs install`
+* Install the required packages:
+  * Ubuntu: `sudo apt-get install libx11-dev libxcursor-dev libxinerama-dev zlib1g-dev`
+  * Arch: `sudo pacman -S base-devel libx11 libxcursor libxinerama zlib`
+* Install Clang compiler (version 6 or later):
+  * Ubuntu: `sudo apt-get install clang lldb lld`
+  * Arch: `sudo pacman -S clang lldb lld`
+* Clone the repository (with LFS)
 * Run `./GenerateProjectFiles.sh`
 * Open workspace with Visual Code
 * Build and run (configuration and task named `Flax|Editor.Linux.Development|x64`)

--- a/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
@@ -96,6 +96,7 @@ namespace Flax.Build.Platforms
             args.Add("-pthread");
             args.Add("-ldl");
             args.Add("-lrt");
+            args.Add("-lz");
 
             // Link X11
             args.Add("-L/usr/X11R6/lib");

--- a/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
@@ -75,7 +75,8 @@ namespace Flax.Build.Platforms
 
             args.Add("-Wl,-rpath,\"\\$ORIGIN\"");
             //args.Add("-Wl,--as-needed");
-            args.Add("-Wl,--copy-dt-needed-entries");
+            if (LdKind == "bfd")
+                args.Add("-Wl,--copy-dt-needed-entries");
             args.Add("-Wl,--hash-style=gnu");
             //args.Add("-Wl,--build-id");
 

--- a/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
@@ -62,6 +62,11 @@ namespace Flax.Build.Platforms
         protected string LdPath;
 
         /// <summary>
+        /// The type of the linker.
+        /// </summary>
+        protected string LdKind;
+
+        /// <summary>
         /// The clang tool version.
         /// </summary>
         protected Version ClangVersion;
@@ -91,7 +96,19 @@ namespace Flax.Build.Platforms
                 RanlibPath = UnixPlatform.Which("ranlib");
                 StripPath = UnixPlatform.Which("strip");
                 ObjcopyPath = UnixPlatform.Which("objcopy");
-                LdPath = UnixPlatform.Which("ld");
+
+                LdPath = UnixPlatform.Which("ld.lld");
+                LdKind = "lld";
+                if (LdPath == null)
+                {
+                    LdPath = UnixPlatform.Which("ld.gold");
+                    LdKind = "gold";
+                }
+                if (LdPath == null)
+                {
+                    LdPath = UnixPlatform.Which("ld");
+                    LdKind = null;
+                }
             }
             else
             {
@@ -478,6 +495,9 @@ namespace Flax.Build.Platforms
                 // TODO: linkEnvironment.LinkTimeCodeGeneration
                 // TODO: linkEnvironment.Optimization
                 // TODO: linkEnvironment.UseIncrementalLinking
+
+                if (!string.IsNullOrEmpty(LdKind))
+                    args.Add(string.Format("-fuse-ld={0}", LdKind));
             }
             SetupLinkFilesArgs(graph, options, args, outputFilePath);
 

--- a/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
@@ -107,8 +107,8 @@ namespace Flax.Build.Platforms
                 }
                 if (LdPath == null)
                 {
-                    LdPath = UnixPlatform.Which("ld");
-                    LdKind = null;
+                    LdPath = UnixPlatform.Which("ld"); // ld.bfd
+                    LdKind = "bfd";
                 }
             }
             else

--- a/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Flax.Build.Graph;
 using Flax.Build.NativeCpp;
@@ -556,9 +557,10 @@ namespace Flax.Build.Platforms
                 }
             }
 
-            // Input files
+            // Input files (link static libraries last)
             task.PrerequisiteFiles.AddRange(linkEnvironment.InputFiles);
-            foreach (var file in linkEnvironment.InputFiles)
+            foreach (var file in linkEnvironment.InputFiles.Where(x => !x.EndsWith(".a"))
+                                                .Concat(linkEnvironment.InputFiles.Where(x => x.EndsWith(".a"))))
             {
                 args.Add(string.Format("\"{0}\"", file.Replace('\\', '/')));
             }


### PR DESCRIPTION
LLVM's linker performed much faster than the default linker clang is using (LD?), so why not use it instead when it's detected in the environment.