### PR TITLE
Flax.Build multiple fixes

### DIFF
--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -433,7 +433,7 @@ namespace Flax.Build
                                     else if (dependencyModule.BinaryModuleName == "FlaxEngine")
                                     {
                                         // TODO: instead of this hack find a way to reference the prebuilt target bindings binary (example: game C# project references FlaxEngine C# prebuilt dll)
-                                        project.CSharp.FileReferences.Add(Path.Combine(Globals.EngineRoot, "Binaries/Editor/Win64/Development/FlaxEngine.CSharp.dll"));
+                                        project.CSharp.FileReferences.Add(Path.Combine(Globals.EngineRoot, Platform.GetEditorBinaryDirectory(), "Development/FlaxEngine.CSharp.dll"));
                                     }
                                 }
                             }

--- a/Source/Tools/Flax.Build/Build/Platform.cs
+++ b/Source/Tools/Flax.Build/Build/Platform.cs
@@ -246,6 +246,24 @@ namespace Flax.Build
         }
 
         /// <summary>
+        /// Gets path to the current platform binary directory 
+        /// </summary>
+        public static string GetEditorBinaryDirectory()
+        {
+            var subdir = "Binaries/Editor/";
+            switch (Platform.BuildTargetPlatform)
+            {
+                case TargetPlatform.Windows:
+                    return subdir + "Win64";
+                case TargetPlatform.Linux:
+                    return subdir + "Linux";
+                case TargetPlatform.Mac:
+                    return subdir + "Mac";
+            }
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Creates the project files generator for the specified project format.
         /// </summary>
         /// <param name="targetPlatform">The target platform.</param>

--- a/Source/Tools/Flax.Build/Configuration.cs
+++ b/Source/Tools/Flax.Build/Configuration.cs
@@ -40,6 +40,12 @@ namespace Flax.Build
         public static bool Deploy = false;
 
         /// <summary>
+        /// Compresses deployed files.
+        /// </summary>
+        [CommandLine("deployDontCompress", "Skips compressing deployed files, and keeps files.")]
+        public static bool DontCompress = false;
+
+        /// <summary>
         /// Builds the targets. Builds all the targets, use <see cref="BuildTargets"/> to select a custom set of targets for the build.
         /// </summary>
         [CommandLine("build", "Builds the targets.")]

--- a/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
+++ b/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
@@ -127,6 +127,9 @@ namespace Flax.Deploy
                 DeployFile(RootPath, OutputPath, "Flax.flaxproj");
 
                 // Compress
+                if (Configuration.DontCompress)
+                    return;
+                
                 Log.Info(string.Empty);
                 Log.Info("Compressing editor files...");
                 string editorPackageZipPath;

--- a/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
+++ b/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Flax.Build;
+using Flax.Build.Platforms;
 
 namespace Flax.Deploy
 {
@@ -129,18 +130,18 @@ namespace Flax.Deploy
                 Log.Info(string.Empty);
                 Log.Info("Compressing editor files...");
                 string editorPackageZipPath;
-                if (Platform.BuildTargetPlatform == TargetPlatform.Linux)
+                var unix = Platform.BuildTargetPlatform == TargetPlatform.Linux || Platform.BuildTargetPlatform == TargetPlatform.Mac;
+                if (unix)
                 {
-                    // Use system tool (preserves executable file attributes and link files)
-                    editorPackageZipPath = Path.Combine(Deployer.PackageOutputPath, "FlaxEditorLinux.zip");
-                    Utilities.FileDelete(editorPackageZipPath);
-                    Utilities.Run("zip", "Editor.zip -r .", null, OutputPath, Utilities.RunOptions.ThrowExceptionOnError);
-                    File.Move(Path.Combine(OutputPath, "Editor.zip"), editorPackageZipPath);
+                    var zipEofPath = UnixPlatform.Which("zip");
+                    unix = File.Exists(zipEofPath);
+                    if (!unix)
+                        Log.Verbose("Using .NET compressing");
                 }
-                else if (Platform.BuildTargetPlatform == TargetPlatform.Mac)
+                if (unix)
                 {
                     // Use system tool (preserves executable file attributes and link files)
-                    editorPackageZipPath = Path.Combine(Deployer.PackageOutputPath, "FlaxEditorMac.zip");
+                    editorPackageZipPath = Path.Combine(Deployer.PackageOutputPath, $"FlaxEditor{Enum.GetName(typeof(TargetPlatform), Platform.BuildTargetPlatform)}.zip");
                     Utilities.FileDelete(editorPackageZipPath);
                     Utilities.Run("zip", "Editor.zip -r .", null, OutputPath, Utilities.RunOptions.ThrowExceptionOnError);
                     File.Move(Path.Combine(OutputPath, "Editor.zip"), editorPackageZipPath);

--- a/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
+++ b/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
@@ -193,13 +193,14 @@ namespace Flax.Deploy
 
             private static void DeployEditorBinaries(TargetConfiguration configuration)
             {
+                var binariesSubDir = Path.Combine(Platform.GetEditorBinaryDirectory(), configuration.ToString());
+                var src = Path.Combine(RootPath, binariesSubDir);
+                var dst = Path.Combine(OutputPath, binariesSubDir);
+                Directory.CreateDirectory(dst);
+
                 if (Platform.BuildTargetPlatform == TargetPlatform.Windows)
                 {
-                    var binariesSubDir = "Binaries/Editor/Win64/" + configuration;
-                    var src = Path.Combine(RootPath, binariesSubDir);
-                    var dst = Path.Combine(OutputPath, binariesSubDir);
                     var dstDebug = Path.Combine(Deployer.PackageOutputPath, "EditorDebugSymbols/Win64/" + configuration);
-                    Directory.CreateDirectory(dst);
                     Directory.CreateDirectory(dstDebug);
 
                     // Validate that build editor app has a valid version number
@@ -233,11 +234,6 @@ namespace Flax.Deploy
                 }
                 else if (Platform.BuildTargetPlatform == TargetPlatform.Linux)
                 {
-                    var binariesSubDir = "Binaries/Editor/Linux/" + configuration;
-                    var src = Path.Combine(RootPath, binariesSubDir);
-                    var dst = Path.Combine(OutputPath, binariesSubDir);
-                    Directory.CreateDirectory(dst);
-
                     // Deploy binaries
                     DeployFile(src, dst, "FlaxEditor");
                     DeployFile(src, dst, "FlaxEditor.Build.json");
@@ -257,11 +253,6 @@ namespace Flax.Deploy
                 }
                 else if (Platform.BuildTargetPlatform == TargetPlatform.Mac)
                 {
-                    var binariesSubDir = "Binaries/Editor/Mac/" + configuration;
-                    var src = Path.Combine(RootPath, binariesSubDir);
-                    var dst = Path.Combine(OutputPath, binariesSubDir);
-                    Directory.CreateDirectory(dst);
-
                     // Deploy binaries
                     DeployFile(src, dst, "FlaxEditor");
                     DeployFile(src, dst, "FlaxEditor.Build.json");
@@ -277,10 +268,6 @@ namespace Flax.Deploy
                     Utilities.Run("strip", "FlaxEditor.dylib", null, dst, Utilities.RunOptions.None);
                     Utilities.Run("strip", "libmonosgen-2.0.1.dylib", null, dst, Utilities.RunOptions.None);
                     Utilities.Run("strip", "libMoltenVK.dylib", null, dst, Utilities.RunOptions.None);
-                }
-                else
-                {
-                    throw new NotImplementedException();
                 }
             }
         }

--- a/Source/Tools/Flax.Build/Deploy/Deployment.Platforms.cs
+++ b/Source/Tools/Flax.Build/Deploy/Deployment.Platforms.cs
@@ -63,6 +63,7 @@ namespace Flax.Deploy
                 }
 
                 // Compress
+                if (!Configuration.DontCompress)
                 {
                     Log.Info("Compressing platform files...");
 
@@ -84,10 +85,10 @@ namespace Flax.Deploy
 #endif
 
                     Log.Info(string.Format("Compressed {0} package size: {1}", platformName, Utilities.GetFileSize(packageZipPath)));
-                }
 
-                // Remove files (only zip package is used)
-                Utilities.DirectoryDelete(dst);
+                    // Remove files (only zip package is used)
+                    Utilities.DirectoryDelete(dst);
+                }
 
                 Log.Info(string.Empty);
             }

--- a/Source/Tools/Flax.Build/Platforms/Linux/LinuxPlatform.cs
+++ b/Source/Tools/Flax.Build/Platforms/Linux/LinuxPlatform.cs
@@ -58,7 +58,7 @@ namespace Flax.Build.Platforms
             if (Compiler != null)
             {
                 // System compiler
-                ToolchainRoot = string.Empty;
+                ToolchainRoot = "/";
                 Log.Verbose($"Using native Linux toolchain (compiler {Compiler})");
                 HasRequiredSDKsInstalled = true;
             }

--- a/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
@@ -23,9 +23,16 @@ namespace Flax.Build.Platforms
         : base(platform, architecture, platform.ToolchainRoot, platform.Compiler)
         {
             // Setup system paths
-            SystemIncludePaths.Add(Path.Combine(ToolsetRoot, "usr", "include"));
-            SystemIncludePaths.Add(Path.Combine(ToolsetRoot, "include", "c++", "5.2.0"));
-            SystemIncludePaths.Add(Path.Combine(ToolsetRoot, "lib", "clang", ClangVersion.Major.ToString(), "include"));
+            var includePath = Path.Combine(ToolsetRoot, "usr", "include");
+            SystemIncludePaths.Add(includePath);
+            var cppIncludePath = Path.Combine(includePath, "c++", ClangVersion.ToString());
+            if (Directory.Exists(cppIncludePath))
+                SystemIncludePaths.Add(cppIncludePath);
+            var clangLibPath = Path.Combine(ToolsetRoot, "usr", "lib", "clang");
+            var clangIncludePath = Path.Combine(clangLibPath, ClangVersion.Major.ToString(), "include");
+            if (!Directory.Exists(clangIncludePath))
+                clangIncludePath = Path.Combine(clangLibPath, ClangVersion.ToString(), "include");
+            SystemIncludePaths.Add(clangIncludePath);
         }
 
         /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Projects/ProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/ProjectGenerator.cs
@@ -138,7 +138,9 @@ namespace Flax.Build.Projects
                 default: throw new ArgumentOutOfRangeException(nameof(type), type, null);
                 }
             }
-            case ProjectFormat.VisualStudioCode: return new VisualStudioCodeProjectGenerator();
+            case ProjectFormat.VisualStudioCode: return type == TargetType.DotNet 
+                ? (ProjectGenerator)new CSProjectGenerator(VisualStudioVersion.VisualStudio2015)
+                : (ProjectGenerator)new VisualStudioCodeProjectGenerator();
             case ProjectFormat.XCode: return new XCodeProjectGenerator();
             case ProjectFormat.Custom:
                 if (CustomProjectTypes.TryGetValue(Configuration.ProjectFormatCustom, out var factory))

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -547,6 +547,10 @@ namespace Flax.Build.Projects.VisualStudioCode
                 json.AddField("**/Output", true);
                 json.AddField("**/*.flax", true);
                 json.EndObject();
+                
+                // Extension settings
+                json.AddField("omnisharp.useModernNet", false);
+
 
                 json.EndRootObject();
                 json.Save(Path.Combine(vsCodeFolder, "settings.json"));


### PR DESCRIPTION
 - Fixed VS Code cpp include paths
 - Fixed compressing on Linux & Mac (when zip package is not installed)
 - Fixed FlaxEngine.CSharp referencing
 - Added FlaxEngine project file generation for VS Code
 - Added DontCompress configuration

Related issues:
 #649 #115 #666 