### PR TITLE
Remove double click to rename content item

### DIFF
--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -537,15 +537,6 @@ namespace FlaxEditor.Content.GUI
         }
 
         /// <summary>
-        /// Called when user wants to rename item.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        public void OnItemDoubleClickName(ContentItem item)
-        {
-            OnRename?.Invoke(item);
-        }
-
-        /// <summary>
         /// Called when user wants to open item.
         /// </summary>
         /// <param name="item">The item.</param>

--- a/Source/Editor/Content/Items/ContentItem.cs
+++ b/Source/Editor/Content/Items/ContentItem.cs
@@ -690,18 +690,9 @@ namespace FlaxEditor.Content
         public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
         {
             Focus();
-
-            // Check if clicked on name area (and can be renamed)
-            if (CanRename && TextRectangle.Contains(ref location))
-            {
-                // Rename
-                (Parent as ContentView).OnItemDoubleClickName(this);
-            }
-            else
-            {
-                // Open
-                (Parent as ContentView).OnItemDoubleClick(this);
-            }
+            
+            // Open
+            (Parent as ContentView).OnItemDoubleClick(this);
 
             return true;
         }


### PR DESCRIPTION
I am used to clicking anywhere on the content item to open it in other game engines. I found that the double click to rename functionality was cumbersome and decreased my workflow. I have read in the discord that others have mentioned this as well. This request is to remove the double click to rename.