### PR TITLE
Changed the content window so the search bars do not scroll with the content items

### DIFF
--- a/Source/Editor/Content/Tree/ContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/ContentTreeNode.cs
@@ -95,11 +95,19 @@ namespace FlaxEditor.Content
         {
             if (!_folder.CanRename)
                 return;
-
+            Editor.Instance.Windows.ContentWin.ScrollingOnTreeView(false);
             // Start renaming the folder
             var dialog = RenamePopup.Show(this, HeaderRect, _folder.ShortName, false);
             dialog.Tag = _folder;
-            dialog.Renamed += popup => Editor.Instance.Windows.ContentWin.Rename((ContentFolder)popup.Tag, popup.Text);
+            dialog.Renamed += popup =>
+            {
+                Editor.Instance.Windows.ContentWin.Rename((ContentFolder)popup.Tag, popup.Text);
+                Editor.Instance.Windows.ContentWin.ScrollingOnTreeView(true);
+            };
+            dialog.Closed += popup =>
+            {
+                Editor.Instance.Windows.ContentWin.ScrollingOnTreeView(true);
+            };
         }
 
         /// <summary>

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -27,6 +27,8 @@ namespace FlaxEditor.Windows
         private const string ProjectDataLastViewedFolder = "LastViewedFolder";
         private bool _isWorkspaceDirty;
         private SplitPanel _split;
+        private Panel _contentViewPanel;
+        private Panel _contentTreePanel;
         private ContentView _view;
 
         private readonly ToolStrip _toolStrip;
@@ -95,7 +97,7 @@ namespace FlaxEditor.Windows
             };
 
             // Split panel
-            _split = new SplitPanel(options.Options.Interface.ContentWindowOrientation, ScrollBars.Both, ScrollBars.Vertical)
+            _split = new SplitPanel(options.Options.Interface.ContentWindowOrientation, ScrollBars.None, ScrollBars.None)
             {
                 AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = new Margin(0, 0, _toolStrip.Bottom, 0),
@@ -120,11 +122,20 @@ namespace FlaxEditor.Windows
             };
             _foldersSearchBox.TextChanged += OnFoldersSearchBoxTextChanged;
 
+            // Content tree panel
+            _contentTreePanel = new Panel
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(0, 0, headerPanel.Bottom, 0),
+                IsScrollable = true,
+                ScrollBars = ScrollBars.Both,
+                Parent = _split.Panel1,
+            };
+            
             // Content structure tree
             _tree = new Tree(false)
             {
-                Y = headerPanel.Bottom,
-                Parent = _split.Panel1,
+                Parent = _contentTreePanel,
             };
             _tree.SelectedChanged += OnTreeSelectionChanged;
             headerPanel.Parent = _split.Panel1;
@@ -159,13 +170,23 @@ namespace FlaxEditor.Windows
                 _viewDropdown.Items.Add(((ContentItemSearchFilter)i).ToString());
             _viewDropdown.PopupCreate += OnViewDropdownPopupCreate;
 
+            // Content view panel
+            _contentViewPanel = new Panel
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(0, 0, contentItemsSearchPanel.Bottom + 4, 0),
+                IsScrollable = true,
+                ScrollBars = ScrollBars.Vertical,
+                Parent = _split.Panel2,
+            };
+            
             // Content View
             _view = new ContentView
             {
                 AnchorPreset = AnchorPresets.HorizontalStretchTop,
-                Offsets = new Margin(0, 0, contentItemsSearchPanel.Bottom + 4, 0),
+                Offsets = new Margin(0, 0, 0, 0),
                 IsScrollable = true,
-                Parent = _split.Panel2,
+                Parent = _contentViewPanel,
             };
             _view.OnOpen += Open;
             _view.OnNavigateBack += NavigateBackward;
@@ -285,6 +306,14 @@ namespace FlaxEditor.Windows
                 _split.Panel2.VScrollBar.ThumbEnabled = false;
             if (_split.Panel2.HScrollBar != null)
                 _split.Panel2.HScrollBar.ThumbEnabled = false;
+            if (_contentViewPanel.VScrollBar != null)
+                _contentViewPanel.VScrollBar.ThumbEnabled = false;
+            if (_contentViewPanel.HScrollBar != null)
+                _contentViewPanel.HScrollBar.ThumbEnabled = false;
+            if (_contentTreePanel.VScrollBar != null)
+                _contentTreePanel.VScrollBar.ThumbEnabled = false;
+            if (_contentTreePanel.HScrollBar != null)
+                _contentTreePanel.HScrollBar.ThumbEnabled = false;
 
             // Show rename popup
             var popup = RenamePopup.Show(item, item.TextRectangle, item.ShortName, true);
@@ -298,6 +327,14 @@ namespace FlaxEditor.Windows
                     _split.Panel2.VScrollBar.ThumbEnabled = true;
                 if (_split.Panel2.HScrollBar != null)
                     _split.Panel2.HScrollBar.ThumbEnabled = true;
+                if (_contentViewPanel.VScrollBar != null)
+                    _contentViewPanel.VScrollBar.ThumbEnabled = true;
+                if (_contentViewPanel.HScrollBar != null)
+                    _contentViewPanel.HScrollBar.ThumbEnabled = true;
+                if (_contentTreePanel.VScrollBar != null)
+                    _contentTreePanel.VScrollBar.ThumbEnabled = true;
+                if (_contentTreePanel.HScrollBar != null)
+                    _contentTreePanel.HScrollBar.ThumbEnabled = true;
 
                 // Check if was creating new element
                 if (_newElement != null)

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -293,6 +293,30 @@ namespace FlaxEditor.Windows
         }
 
         /// <summary>
+        ///  Enables or disables vertical and horizontal scrolling on the content tree panel
+        /// </summary>
+        /// <param name="enabled">The state to set scrolling to</param>
+        public void ScrollingOnTreeView(bool enabled)
+        {
+            if (_contentTreePanel.VScrollBar != null)
+                _contentTreePanel.VScrollBar.ThumbEnabled = enabled;
+            if (_contentTreePanel.HScrollBar != null)
+                _contentTreePanel.HScrollBar.ThumbEnabled = enabled;
+        }
+
+        /// <summary>
+        ///  Enables or disables vertical and horizontal scrolling on the content view panel
+        /// </summary>
+        /// <param name="enabled">The state to set scrolling to</param>
+        public void ScrollingOnContentView(bool enabled)
+        {
+            if (_contentViewPanel.VScrollBar != null)
+                _contentViewPanel.VScrollBar.ThumbEnabled = enabled;
+            if (_contentViewPanel.HScrollBar != null)
+                _contentViewPanel.HScrollBar.ThumbEnabled = enabled;
+        }
+
+        /// <summary>
         /// Shows popup dialog with UI to rename content item.
         /// </summary>
         /// <param name="item">The item to rename.</param>
@@ -306,14 +330,7 @@ namespace FlaxEditor.Windows
                 _split.Panel2.VScrollBar.ThumbEnabled = false;
             if (_split.Panel2.HScrollBar != null)
                 _split.Panel2.HScrollBar.ThumbEnabled = false;
-            if (_contentViewPanel.VScrollBar != null)
-                _contentViewPanel.VScrollBar.ThumbEnabled = false;
-            if (_contentViewPanel.HScrollBar != null)
-                _contentViewPanel.HScrollBar.ThumbEnabled = false;
-            if (_contentTreePanel.VScrollBar != null)
-                _contentTreePanel.VScrollBar.ThumbEnabled = false;
-            if (_contentTreePanel.HScrollBar != null)
-                _contentTreePanel.HScrollBar.ThumbEnabled = false;
+            ScrollingOnContentView(false);
 
             // Show rename popup
             var popup = RenamePopup.Show(item, item.TextRectangle, item.ShortName, true);
@@ -327,14 +344,7 @@ namespace FlaxEditor.Windows
                     _split.Panel2.VScrollBar.ThumbEnabled = true;
                 if (_split.Panel2.HScrollBar != null)
                     _split.Panel2.HScrollBar.ThumbEnabled = true;
-                if (_contentViewPanel.VScrollBar != null)
-                    _contentViewPanel.VScrollBar.ThumbEnabled = true;
-                if (_contentViewPanel.HScrollBar != null)
-                    _contentViewPanel.HScrollBar.ThumbEnabled = true;
-                if (_contentTreePanel.VScrollBar != null)
-                    _contentTreePanel.VScrollBar.ThumbEnabled = true;
-                if (_contentTreePanel.HScrollBar != null)
-                    _contentTreePanel.HScrollBar.ThumbEnabled = true;
+                ScrollingOnContentView(true);
 
                 // Check if was creating new element
                 if (_newElement != null)


### PR DESCRIPTION
This change to the content window allows for the same functionality as before but does not scroll the search bars in either part of the split panel. This allows for better usability of the content window when there are many content items.