### PR TITLE
Adding visual cursor changes when sliding value box or resizing docked window

### DIFF
--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -174,6 +174,7 @@ namespace FlaxEditor.GUI.Input
             _isSliding = false;
             EndMouseCapture();
             Cursor = CursorType.Default;
+            _cursorChanged = false;
             SlidingEnd?.Invoke();
         }
 
@@ -224,6 +225,8 @@ namespace FlaxEditor.GUI.Input
                 // Update
                 UpdateText();
             }
+            
+            Cursor = CursorType.Default;
 
             ResetViewOffset();
         }
@@ -239,6 +242,7 @@ namespace FlaxEditor.GUI.Input
                 _startSlideValue = _value;
                 StartMouseCapture(true);
                 Cursor = CursorType.SizeWE;
+                _cursorChanged = true;
                 SlidingStart?.Invoke();
                 return true;
             }
@@ -269,6 +273,7 @@ namespace FlaxEditor.GUI.Input
             else if (_cursorChanged && !_isSliding)
             {
                 Cursor = CursorType.Default;
+                _cursorChanged = false;
             }
 
             base.OnMouseMove(location);

--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -172,6 +172,7 @@ namespace FlaxEditor.GUI.Input
         {
             _isSliding = false;
             EndMouseCapture();
+            Cursor = CursorType.Default;
             SlidingEnd?.Invoke();
         }
 
@@ -236,6 +237,7 @@ namespace FlaxEditor.GUI.Input
                 _startSlideLocation = location;
                 _startSlideValue = _value;
                 StartMouseCapture(true);
+                Cursor = CursorType.SizeWE;
                 SlidingStart?.Invoke();
                 return true;
             }
@@ -255,6 +257,16 @@ namespace FlaxEditor.GUI.Input
                 var slideLocation = location + Root.TrackingMouseOffset;
                 ApplySliding(Mathf.RoundToInt(slideLocation.X - _startSlideLocation.X) * _slideSpeed);
                 return;
+            }
+            
+            // Update cursor type so user knows they can slide value
+            if (CanUseSliding && SlideRect.Contains(location))
+            {
+                Cursor = CursorType.SizeWE;
+            }
+            else if (!_isSliding)
+            {
+                Cursor = CursorType.Default;
             }
 
             base.OnMouseMove(location);

--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -56,6 +56,7 @@ namespace FlaxEditor.GUI.Input
 
         private Float2 _startSlideLocation;
         private double _clickStartTime = -1;
+        private bool _cursorChanged;
 
         /// <summary>
         /// Occurs when value gets changed.
@@ -263,8 +264,9 @@ namespace FlaxEditor.GUI.Input
             if (CanUseSliding && SlideRect.Contains(location))
             {
                 Cursor = CursorType.SizeWE;
+                _cursorChanged = true;
             }
-            else if (!_isSliding)
+            else if (_cursorChanged && !_isSliding)
             {
                 Cursor = CursorType.Default;
             }

--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -161,6 +161,15 @@ namespace FlaxEngine.GUI
             if (_splitterClicked)
             {
                 SplitterValue = _orientation == Orientation.Horizontal ? location.X / Width : location.Y / Height;
+                Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
+            }
+            else if (_mouseOverSplitter)
+            {
+                Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
+            }
+            else
+            {
+                Cursor = CursorType.Default;
             }
 
             base.OnMouseMove(location);

--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -23,8 +23,7 @@ namespace FlaxEngine.GUI
         private float _splitterValue;
         private Rectangle _splitterRect;
         private bool _splitterClicked, _mouseOverSplitter;
-        private bool _leftMouseButtonDown;
-        private bool _rightMouseButtonDown;
+        private bool _cursorChanged;
 
         /// <summary>
         /// The first panel (left or upper based on Orientation).
@@ -168,10 +167,12 @@ namespace FlaxEngine.GUI
             else if (_mouseOverSplitter)
             {
                 Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
+                _cursorChanged = true;
             }
-            else if (!_leftMouseButtonDown && !_rightMouseButtonDown)
+            else if (_cursorChanged)
             {
                 Cursor = CursorType.Default;
+                _cursorChanged = false;
             }
 
             base.OnMouseMove(location);
@@ -180,16 +181,6 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
-            if (button == MouseButton.Left)
-            {
-                _leftMouseButtonDown = true;
-            }
-            
-            if (button == MouseButton.Right)
-            {
-                _rightMouseButtonDown = true;
-            }
-
             if (button == MouseButton.Left && _splitterRect.Contains(location))
             {
                 // Start moving splitter
@@ -204,16 +195,6 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
-            if (button == MouseButton.Left)
-            {
-                _leftMouseButtonDown = false;
-            }
-            
-            if (button == MouseButton.Right)
-            {
-                _rightMouseButtonDown = false;
-            }
-            
             if (_splitterClicked)
             {
                 EndTracking();

--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -24,7 +24,6 @@ namespace FlaxEngine.GUI
         private Rectangle _splitterRect;
         private bool _splitterClicked, _mouseOverSplitter;
         private bool _cursorChanged;
-        private bool _anyMouseButtonDown;
 
         /// <summary>
         /// The first panel (left or upper based on Orientation).
@@ -166,7 +165,7 @@ namespace FlaxEngine.GUI
                 Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
                 _cursorChanged = true;
             }
-            else if (_mouseOverSplitter && !_anyMouseButtonDown)
+            else if (_mouseOverSplitter)
             {
                 Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
                 _cursorChanged = true;
@@ -183,7 +182,6 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
-            _anyMouseButtonDown = true;
             if (button == MouseButton.Left && _splitterRect.Contains(location))
             {
                 // Start moving splitter
@@ -198,7 +196,6 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
-            _anyMouseButtonDown = false;
             if (_splitterClicked)
             {
                 EndTracking();

--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -23,6 +23,8 @@ namespace FlaxEngine.GUI
         private float _splitterValue;
         private Rectangle _splitterRect;
         private bool _splitterClicked, _mouseOverSplitter;
+        private bool _leftMouseButtonDown;
+        private bool _rightMouseButtonDown;
 
         /// <summary>
         /// The first panel (left or upper based on Orientation).
@@ -167,7 +169,7 @@ namespace FlaxEngine.GUI
             {
                 Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
             }
-            else
+            else if (!_leftMouseButtonDown && !_rightMouseButtonDown)
             {
                 Cursor = CursorType.Default;
             }
@@ -178,6 +180,16 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
+            if (button == MouseButton.Left)
+            {
+                _leftMouseButtonDown = true;
+            }
+            
+            if (button == MouseButton.Right)
+            {
+                _rightMouseButtonDown = true;
+            }
+
             if (button == MouseButton.Left && _splitterRect.Contains(location))
             {
                 // Start moving splitter
@@ -192,6 +204,16 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
+            if (button == MouseButton.Left)
+            {
+                _leftMouseButtonDown = false;
+            }
+            
+            if (button == MouseButton.Right)
+            {
+                _rightMouseButtonDown = false;
+            }
+            
             if (_splitterClicked)
             {
                 EndTracking();

--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -24,6 +24,7 @@ namespace FlaxEngine.GUI
         private Rectangle _splitterRect;
         private bool _splitterClicked, _mouseOverSplitter;
         private bool _cursorChanged;
+        private bool _anyMouseButtonDown;
 
         /// <summary>
         /// The first panel (left or upper based on Orientation).
@@ -163,8 +164,9 @@ namespace FlaxEngine.GUI
             {
                 SplitterValue = _orientation == Orientation.Horizontal ? location.X / Width : location.Y / Height;
                 Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
+                _cursorChanged = true;
             }
-            else if (_mouseOverSplitter)
+            else if (_mouseOverSplitter && !_anyMouseButtonDown)
             {
                 Cursor = _orientation == Orientation.Horizontal ? CursorType.SizeWE : CursorType.SizeNS;
                 _cursorChanged = true;
@@ -181,6 +183,7 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
+            _anyMouseButtonDown = true;
             if (button == MouseButton.Left && _splitterRect.Contains(location))
             {
                 // Start moving splitter
@@ -195,6 +198,7 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
+            _anyMouseButtonDown = false;
             if (_splitterClicked)
             {
                 EndTracking();


### PR DESCRIPTION
This change is a UX change. Having the cursor change when hovering over the "begin sliding" icon and while sliding the value allows the user to better understand what action they should take and allows for a better visual experience. Having the cursor change when hovering over or when sliding to resize a docked window allows for a much better experience for the user because they will have a visual cue of what can happen when being over the "re-size" rectangle. Other game engine use a similar functionality and it would be nice for Flax to follow suit.