### PR TITLE
hide tooltip while dragging

### DIFF
--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -950,11 +950,8 @@ namespace FlaxEngine.GUI
             _isDragOver = true;
             
             // Hide tooltip
-            if (_tooltipUpdate != null)
-            {
-                Tooltip.Hide();
-            }
-            
+            Tooltip?.Hide();
+
             return DragDropEffect.None;
         }
 

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -948,6 +948,11 @@ namespace FlaxEngine.GUI
         {
             // Set flag
             _isDragOver = true;
+            // Update tooltip
+            if (_tooltipUpdate != null)
+            {
+                Tooltip.Hide();
+            }
             return DragDropEffect.None;
         }
 
@@ -960,12 +965,6 @@ namespace FlaxEngine.GUI
         [NoAnimate]
         public virtual DragDropEffect OnDragMove(ref Float2 location, DragData data)
         {
-            // Update tooltip
-            if (_tooltipUpdate != null)
-            {
-                SetUpdate(ref _tooltipUpdate, null);
-                Tooltip.Hide();
-            }
             return DragDropEffect.None;
         }
 

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -948,11 +948,13 @@ namespace FlaxEngine.GUI
         {
             // Set flag
             _isDragOver = true;
-            // Update tooltip
+            
+            // Hide tooltip
             if (_tooltipUpdate != null)
             {
                 Tooltip.Hide();
             }
+            
             return DragDropEffect.None;
         }
 

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -960,6 +960,12 @@ namespace FlaxEngine.GUI
         [NoAnimate]
         public virtual DragDropEffect OnDragMove(ref Float2 location, DragData data)
         {
+            // Update tooltip
+            if (_tooltipUpdate != null)
+            {
+                SetUpdate(ref _tooltipUpdate, null);
+                Tooltip.Hide();
+            }
             return DragDropEffect.None;
         }
 


### PR DESCRIPTION
Hello, I noticed several people have had issues while dragging their actors in the scene view and running into the tooltip and it not allowing them to drag the actor into that area that is covered by the box. This hides the tooltip when the user is dragging and solves the issue people are having. I do not think that the tool tip needs to be shown while the control is being dragged at all.