### PR TITLE
Added scene panel to separate the tree from the search bar and made it not scroll when renaming

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -273,15 +273,26 @@ namespace FlaxEditor.SceneGraph.GUI
 
             Select();
 
+            // disable scrolling of scene view
+            Editor.Instance.Windows.SceneWin.ScrollingOnSceneTreeView(false);
+            
             // Start renaming the actor
             var dialog = RenamePopup.Show(this, HeaderRect, _actorNode.Name, false);
             dialog.Renamed += OnRenamed;
+            dialog.Closed += popup =>
+            {
+                // enable scrolling of scene view
+                Editor.Instance.Windows.SceneWin.ScrollingOnSceneTreeView(true);
+            };
         }
 
         private void OnRenamed(RenamePopup renamePopup)
         {
             using (new UndoBlock(ActorNode.Root.Undo, Actor, "Rename"))
                 Actor.Name = renamePopup.Text;
+            
+            // enable scrolling of scene view
+            Editor.Instance.Windows.SceneWin.ScrollingOnSceneTreeView(true);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -131,6 +131,7 @@ namespace FlaxEditor.Windows
 
         private TextBox _searchBox;
         private Tree _tree;
+        private Panel _sceneTreePanel;
         private bool _isUpdatingSelection;
         private bool _isMouseDown;
 
@@ -143,10 +144,9 @@ namespace FlaxEditor.Windows
         /// </summary>
         /// <param name="editor">The editor.</param>
         public SceneTreeWindow(Editor editor)
-        : base(editor, true, ScrollBars.Both)
+        : base(editor, true, ScrollBars.None)
         {
             Title = "Scene";
-            ScrollMargin = new Margin(0, 0, 0, 100.0f);
 
             // Scene searching query input box
             var headerPanel = new ContainerControl
@@ -165,19 +165,29 @@ namespace FlaxEditor.Windows
             };
             _searchBox.TextChanged += OnSearchBoxTextChanged;
 
+            // Scene tree panel
+            _sceneTreePanel = new Panel
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(0, 0, headerPanel.Bottom, 0),
+                IsScrollable = true,
+                ScrollBars = ScrollBars.Both,
+                Parent = this,
+            };
+            
             // Create scene structure tree
             var root = editor.Scene.Root;
             root.TreeNode.ChildrenIndent = 0;
             root.TreeNode.Expand();
             _tree = new Tree(true)
             {
-                Y = headerPanel.Bottom,
                 Margin = new Margin(0.0f, 0.0f, -16.0f, 0.0f), // Hide root node
+                IsScrollable = true,
             };
             _tree.AddChild(root.TreeNode);
             _tree.SelectedChanged += Tree_OnSelectedChanged;
             _tree.RightClick += OnTreeRightClick;
-            _tree.Parent = this;
+            _tree.Parent = _sceneTreePanel;
             headerPanel.Parent = this;
 
             // Setup input actions
@@ -186,6 +196,18 @@ namespace FlaxEditor.Windows
             InputActions.Add(options => options.ScaleMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale);
             InputActions.Add(options => options.FocusSelection, () => Editor.Windows.EditWin.Viewport.FocusSelection());
             InputActions.Add(options => options.Rename, Rename);
+        }
+        
+        /// <summary>
+        ///  Enables or disables vertical and horizontal scrolling on the scene tree panel
+        /// </summary>
+        /// <param name="enabled">The state to set scrolling to</param>
+        public void ScrollingOnSceneTreeView(bool enabled)
+        {
+            if (_sceneTreePanel.VScrollBar != null)
+                _sceneTreePanel.VScrollBar.ThumbEnabled = enabled;
+            if (_sceneTreePanel.HScrollBar != null)
+                _sceneTreePanel.HScrollBar.ThumbEnabled = enabled;
         }
 
         private void OnSearchBoxTextChanged()


### PR DESCRIPTION
This fixes a small bug in being able to scroll while renaming in the scene view. This also separates the search bar from the scene tree and looks cleaner.