### PR TITLE
Skeleton mask editor also changes children bones if Shift key is being pressed

### DIFF
--- a/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
+++ b/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
@@ -7,6 +7,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.CustomEditors.Elements;
 using FlaxEditor.GUI;
+using FlaxEditor.GUI.Tree;
 using FlaxEditor.Viewport.Cameras;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
@@ -166,7 +167,24 @@ namespace FlaxEditor.Windows.Assets
                     var proxy = (PropertiesProxy)Values[0];
                     int nodeIndex = (int)checkBox.Tag;
                     proxy.NodesMask[nodeIndex] = checkBox.Checked;
+                    if(Input.GetKey(KeyboardKeys.Shift))
+                        SetTreeChecked(checkBox.Parent as TreeNode, checkBox.Checked);
                     proxy.Window.MarkAsEdited();
+                }
+
+                private void SetTreeChecked(TreeNode tree, bool state)
+                {
+                    foreach(var node in tree.Children)
+                    {
+                        if(node is TreeNode)
+                        {
+                            SetTreeChecked(node as TreeNode, state);
+                        }
+                        if(node is CheckBox)
+                        {
+                            (node as CheckBox).Checked = state;
+                        }
+                    }
                 }
             }
         }

--- a/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
+++ b/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
@@ -180,7 +180,7 @@ namespace FlaxEditor.Windows.Assets
                         {
                             SetTreeChecked(node as TreeNode, state);
                         }
-                        if(node is CheckBox)
+                        else if(node is CheckBox)
                         {
                             (node as CheckBox).Checked = state;
                         }

--- a/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
+++ b/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
@@ -180,7 +180,7 @@ namespace FlaxEditor.Windows.Assets
                         {
                             SetTreeChecked(node as TreeNode, state);
                         }
-                        else if(node is CheckBox)
+                        if(node is CheckBox)
                         {
                             (node as CheckBox).Checked = state;
                         }


### PR DESCRIPTION
An UX feature, selecting the bones one by one can be so frustrating, so what it does is when pressing shift key and change some bone checkbox, it will change the whole hierarchy of this bone too.


https://user-images.githubusercontent.com/65502434/195143159-1cb431bf-e192-45b8-ab10-dcd4ea0162f6.mp4



