### PR TITLE
Some small editor fixes

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/LayersMatrixEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/LayersMatrixEditor.cs
@@ -24,7 +24,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
         public override void Initialize(LayoutElementsContainer layout)
         {
             string[] layerNames = LayersAndTagsSettings.GetCurrentLayers();
-            int layersCount = Math.Max(4, layerNames.Length);
+            int layersCount = layerNames.Length;
             _checkBoxes = new List<CheckBox>();
             _layersCount = layersCount;
 

--- a/Source/Engine/Core/Config/GraphicsSettings.h
+++ b/Source/Engine/Core/Config/GraphicsSettings.h
@@ -73,7 +73,7 @@ public:
     /// If checked, Environment Probes will use HDR texture format. Improves quality in very bright scenes at cost of higher memory usage.
     /// </summary>
     API_FIELD(Attributes = "EditorOrder(1502), EditorDisplay(\"Quality\")")
-    bool UeeHDRProbes = false;
+    bool UseHDRProbes = false;
 
     /// <summary>
     /// If checked, enables Global SDF rendering. This can be used in materials, shaders, and particles.

--- a/Source/Engine/Renderer/ProbesRenderer.cpp
+++ b/Source/Engine/Renderer/ProbesRenderer.cpp
@@ -204,7 +204,7 @@ int32 ProbesRenderer::Entry::GetResolution() const
 
 PixelFormat ProbesRenderer::Entry::GetFormat() const
 {
-    return GraphicsSettings::Get()->UeeHDRProbes ? PixelFormat::R11G11B10_Float : PixelFormat::R8G8B8A8_UNorm;
+    return GraphicsSettings::Get()->UseHDRProbes ? PixelFormat::R11G11B10_Float : PixelFormat::R8G8B8A8_UNorm;
 }
 
 int32 ProbesRenderer::GetBakeQueueSize()


### PR DESCRIPTION
- Fix the additional layers in the matrix when there is less than 4 layers in the layers and tags settings.
 Bug:
![image_2022-10-11_134211594](https://user-images.githubusercontent.com/65502434/195150761-788ce9e1-d616-4910-b2d3-8f08e3d61feb.png)
 Fixed:
![image](https://user-images.githubusercontent.com/65502434/195151694-1f831b54-6b45-44bd-9812-1ce3a30fbc93.png)


- Typo fix in graphics settings, from 'Uee HDR Probes' to 'Use HDR Probes'
