### PR TITLE
Mouse sliding fixes

### DIFF
--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -259,7 +259,7 @@ namespace FlaxEditor.GUI.Input
         /// <inheritdoc />
         public override void OnMouseMove(Float2 location)
         {
-            if (_isSliding && !RootWindow.Window.IsHorizontalFlippingMouse)
+            if (_isSliding && !RootWindow.Window.IsMouseFlippingHorizontally)
             {
                 // Update sliding
                 var slideLocation = location + Root.TrackingMouseOffset;

--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -259,7 +259,7 @@ namespace FlaxEditor.GUI.Input
         /// <inheritdoc />
         public override void OnMouseMove(Float2 location)
         {
-            if (_isSliding)
+            if (_isSliding && !RootWindow.Window.IsHorizontalFlippingMouse)
             {
                 // Update sliding
                 var slideLocation = location + Root.TrackingMouseOffset;

--- a/Source/Editor/GUI/Timeline/GUI/TimelineEdge.cs
+++ b/Source/Editor/GUI/Timeline/GUI/TimelineEdge.cs
@@ -71,27 +71,10 @@ namespace FlaxEditor.GUI.Timeline.GUI
         /// <inheritdoc />
         public override void OnMouseMove(Float2 location)
         {
-            if (_isMoving)
+            if (_isMoving && !_timeline.RootWindow.Window.IsHorizontalFlippingMouse)
             {
-                Float2 currWndCenter = _timeline.RootWindow.Window.ClientBounds.Center;
-                Float2 currMonitorSize = Platform.GetMonitorBounds(currWndCenter).Size;
                 var moveLocation = Root.MousePosition;
-                var diffFromLastMoveLocation = Mathf.Max(_lastMouseLocation.X, moveLocation.X) - Mathf.Min(_lastMouseLocation.X, moveLocation.X);
-                var movePorcentOfXMonitorSize = diffFromLastMoveLocation * 100f / currMonitorSize.X;
-
-                if (movePorcentOfXMonitorSize >= 90f)
-                {
-                    if (_lastMouseLocation.X > moveLocation.X)
-                    {
-                        _flipScreenMoveDelta += currMonitorSize.X;
-                    }
-                    else
-                    {
-                        _flipScreenMoveDelta -= currMonitorSize.X;
-                    }
-                }
-
-                var moveLocationDelta = moveLocation - _startMoveLocation + _flipScreenMoveDelta;
+                var moveLocationDelta = moveLocation - _startMoveLocation + _timeline.Root.TrackingMouseOffset.X;
                 var moveDelta = (int)(moveLocationDelta.X / (Timeline.UnitsPerSecond * _timeline.Zoom) * _timeline.FramesPerSecond);
                 var durationFrames = _timeline.DurationFrames;
 

--- a/Source/Editor/GUI/Timeline/GUI/TimelineEdge.cs
+++ b/Source/Editor/GUI/Timeline/GUI/TimelineEdge.cs
@@ -15,8 +15,6 @@ namespace FlaxEditor.GUI.Timeline.GUI
         private Timeline _timeline;
         private bool _isMoving;
         private Float2 _startMoveLocation;
-        private Float2 _lastMouseLocation;
-        private float _flipScreenMoveDelta;
         private int _startMoveDuration;
         private bool _isStart;
         private bool _canEdit;
@@ -71,14 +69,12 @@ namespace FlaxEditor.GUI.Timeline.GUI
         /// <inheritdoc />
         public override void OnMouseMove(Float2 location)
         {
-            if (_isMoving && !_timeline.RootWindow.Window.IsHorizontalFlippingMouse)
+            if (_isMoving && !_timeline.RootWindow.Window.IsMouseFlippingHorizontally)
             {
                 var moveLocation = Root.MousePosition;
                 var moveLocationDelta = moveLocation - _startMoveLocation + _timeline.Root.TrackingMouseOffset.X;
                 var moveDelta = (int)(moveLocationDelta.X / (Timeline.UnitsPerSecond * _timeline.Zoom) * _timeline.FramesPerSecond);
                 var durationFrames = _timeline.DurationFrames;
-
-
 
                 if (_isStart)
                 {
@@ -94,9 +90,6 @@ namespace FlaxEditor.GUI.Timeline.GUI
                 {
                     _timeline.MarkAsEdited();
                 }
-
-                _lastMouseLocation = moveLocation;
-
             }
             else
             {
@@ -148,7 +141,6 @@ namespace FlaxEditor.GUI.Timeline.GUI
                     _timeline.DurationFrames = duration;
             }
             _isMoving = false;
-            _flipScreenMoveDelta = 0;
             _timeline.MediaBackground.HScrollBar.Value = _timeline.MediaBackground.HScrollBar.Maximum;
 
             EndMouseCapture();

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -683,17 +683,17 @@ public:
     }
 
     /// <summary>
-    /// todo : add doc
+    /// Gets the value indicating if the mouse flipped to the other screen edge horizontally
     /// </summary>
-    API_PROPERTY() bool IsHorizontalFlippingMouse() const
+    API_PROPERTY() bool IsMouseFlippingHorizontally() const
     {
         return _isHorizontalFlippingMouse;
     }
 
     /// <summary>
-    /// todo : add doc
+    /// Gets the value indicating if the mouse flipped to the other screen edge vertically
     /// </summary>
-    API_PROPERTY() bool IsVerticalFlippingMouse() const
+    API_PROPERTY() bool IsMouseFlippingVertically() const
     {
         return _isVerticalFlippingMouse;
     }

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -287,6 +287,8 @@ protected:
     bool _isUsingMouseOffset;
     Rectangle _mouseOffsetScreenSize;
     bool _isTrackingMouse;
+    bool _isHorizontalFlippingMouse;
+    bool _isVerticalFlippingMouse;
     bool _isClippingCursor;
 
     explicit WindowBase(const CreateWindowSettings& settings);
@@ -678,6 +680,22 @@ public:
     API_PROPERTY() bool IsMouseTracking() const
     {
         return _isTrackingMouse;
+    }
+
+    /// <summary>
+    /// todo : add doc
+    /// </summary>
+    API_PROPERTY() bool IsHorizontalFlippingMouse() const
+    {
+        return _isHorizontalFlippingMouse;
+    }
+
+    /// <summary>
+    /// todo : add doc
+    /// </summary>
+    API_PROPERTY() bool IsVerticalFlippingMouse() const
+    {
+        return _isVerticalFlippingMouse;
     }
 
     /// <summary>

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -544,6 +544,8 @@ void WindowsWindow::StartTrackingMouse(bool useMouseScreenOffset)
         _isTrackingMouse = true;
         _trackingMouseOffset = Float2::Zero;
         _isUsingMouseOffset = useMouseScreenOffset;
+        _isHorizontalFlippingMouse = false;
+        _isVerticalFlippingMouse = false;
 
         int32 x = 0, y = 0, width = 0, height = 0;
         GetScreenInfo(x, y, width, height);
@@ -558,6 +560,8 @@ void WindowsWindow::EndTrackingMouse()
     if (_isTrackingMouse)
     {
         _isTrackingMouse = false;
+        _isHorizontalFlippingMouse = false;
+        _isVerticalFlippingMouse = false;
 
         ReleaseCapture();
     }

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -824,14 +824,14 @@ LRESULT WindowsWindow::WndProc(UINT msg, WPARAM wParam, LPARAM lParam)
             const Float2 mousePos(static_cast<float>(WINDOWS_GET_X_LPARAM(lParam)), static_cast<float>(WINDOWS_GET_Y_LPARAM(lParam)));
             Float2 mousePosition = ClientToScreen(mousePos);
             Float2 newMousePosition = mousePosition;
-            if (mousePosition.X <= desktopLocation.X + 2)
-                newMousePosition.X = desktopSize.X - 2;
-            else if (mousePosition.X >= desktopSize.X - 1)
-                newMousePosition.X = desktopLocation.X + 2;
-            if (mousePosition.Y <= desktopLocation.Y + 2)
-                newMousePosition.Y = desktopSize.Y - 2;
-            else if (mousePosition.Y >= desktopSize.Y - 1)
-                newMousePosition.Y = desktopLocation.Y + 2;
+            if (_isHorizontalFlippingMouse = mousePosition.X <= desktopLocation.X + 2)
+                newMousePosition.X = desktopSize.X - 3;
+            else if (_isHorizontalFlippingMouse = mousePosition.X >= desktopSize.X - 1)
+                newMousePosition.X = desktopLocation.X + 3;
+            if (_isVerticalFlippingMouse = mousePosition.Y <= desktopLocation.Y + 2)
+                newMousePosition.Y = desktopSize.Y - 3;
+            else if (_isVerticalFlippingMouse = mousePosition.Y >= desktopSize.Y - 1)
+                newMousePosition.Y = desktopLocation.Y + 3;
             if (!Float2::NearEqual(mousePosition, newMousePosition))
             {
                 _trackingMouseOffset -= newMousePosition - mousePosition;


### PR DESCRIPTION
- Fixed when sliding the cursor slowly to a screen edge, mouse get flipped to the other screen edge and come back again. (only fixed on Windows)

- Fixed when mouse get flipped. Some sliders that use mouse tracking also update the frame of mouse flip, causing a wrong slide delta. (only fixed on Windows)

I fixed it on timeline edge, but it also happens on value box and sliders that support screen flipping, so the way I found to fix this is to provide info if the mouse is being flipped on desktops. It is per platform implementation, and I just fixed on Windows.


https://user-images.githubusercontent.com/65502434/195600480-6a0fd7ba-10ec-4f66-91d9-6fa38bc6d42b.mp4
