### PR TITLE
Added performing layout when deleting actors and scrolling to duplicated/ pasted actor when action is performed

### DIFF
--- a/Source/Editor/Modules/SceneEditingModule.cs
+++ b/Source/Editor/Modules/SceneEditingModule.cs
@@ -452,9 +452,11 @@ namespace FlaxEditor.Modules
             if (isSceneTreeFocus)
             {
                 Editor.Windows.SceneWin.Focus();
-                Editor.Windows.SceneWin.PerformLayout();
-                Editor.Windows.SceneWin.PerformLayout();
             }
+            
+            // fix scene window layout
+            Editor.Windows.SceneWin.PerformLayout();
+            Editor.Windows.SceneWin.PerformLayout();
         }
 
         /// <summary>

--- a/Source/Editor/Modules/SceneEditingModule.cs
+++ b/Source/Editor/Modules/SceneEditingModule.cs
@@ -450,7 +450,11 @@ namespace FlaxEditor.Modules
             SelectionDeleteEnd?.Invoke();
 
             if (isSceneTreeFocus)
+            {
                 Editor.Windows.SceneWin.Focus();
+                Editor.Windows.SceneWin.PerformLayout();
+                Editor.Windows.SceneWin.PerformLayout();
+            }
         }
 
         /// <summary>
@@ -514,6 +518,9 @@ namespace FlaxEditor.Modules
                 Undo.AddAction(new MultiUndoAction(pasteAction, selectAction));
                 OnSelectionChanged();
             }
+            
+            // Scroll to new selected node while pasting
+            Editor.Windows.SceneWin.ScrollToSelectedNode();
         }
 
         /// <summary>
@@ -611,6 +618,9 @@ namespace FlaxEditor.Modules
                 Undo.AddAction(new MultiUndoAction(undoActions));
                 OnSelectionChanged();
             }
+            
+            // Scroll to new selected node while duplicating
+            Editor.Windows.SceneWin.ScrollToSelectedNode();
         }
 
         /// <summary>

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -209,6 +209,17 @@ namespace FlaxEditor.Windows
             if (_sceneTreePanel.HScrollBar != null)
                 _sceneTreePanel.HScrollBar.ThumbEnabled = enabled;
         }
+        
+        /// <summary>
+        /// Scroll to selected node in the scene tree
+        /// </summary>
+        public void ScrollToSelectedNode()
+        {
+            // Scroll to node 
+            var nodeSelection = _tree.Selection;
+            var scrollPosition = nodeSelection[nodeSelection.Count - 1];
+            _sceneTreePanel.ScrollViewTo(scrollPosition);
+        }
 
         private void OnSearchBoxTextChanged()
         {

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -217,8 +217,8 @@ namespace FlaxEditor.Windows
         {
             // Scroll to node 
             var nodeSelection = _tree.Selection;
-            var scrollPosition = nodeSelection[nodeSelection.Count - 1];
-            _sceneTreePanel.ScrollViewTo(scrollPosition);
+            var scrollControl = nodeSelection[nodeSelection.Count - 1];
+            _sceneTreePanel.ScrollViewTo(scrollControl);
         }
 
         private void OnSearchBoxTextChanged()


### PR DESCRIPTION
Hello, this PR is to add a nice QoL feature to the scene view. 

This adds the ability for the scene window to perform its layout when an actor is deleted to make sure it gets rid of unwanted empty space (not sure why I had to run the function 2 times, but it doesn't work with just 1). 

This also adds the ability for the scene window to move to the new selected actor after a duplicate or paste is performed, this is nice especially when needing to duplicate an actor many times.