### PR TITLE
All Actor and Custom Actor Tabs in ToolBox

### DIFF
--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -2,10 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using FlaxEditor.CustomEditors.Editors;
-using FlaxEditor.GUI.Drag;
 using FlaxEditor.GUI.Tabs;
 using FlaxEditor.GUI.Tree;
 using FlaxEditor.Scripting;

--- a/Source/Engine/Scripting/Attributes/Editor/ShowInCustomToolBoxTabAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/ShowInCustomToolBoxTabAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace FlaxEngine
+{
+    /// <summary>
+    /// Allows to add an actor class to the Custom tab in the tool box. This will only will show Actors.
+    /// </summary>
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ShowInCustomToolBoxTabAttribute: Attribute
+    {
+        
+    }
+}


### PR DESCRIPTION
This adds an all actor tab that shows all of the actors. This is useful because it lets the user browse all of the actors if they are searching for one but don't remember its name. I also added an exclude list, I think I got the ones the crash the editor or cause problems with workflows, but I wasn't sure if there were any others that should be excluded.

This also adds an attribute that can be put ahead of an actor class and will add it to the custom actors tab in the toolbox, this is useful because it lets users add their own actors to the toolbox if they often use them and don't want to search for them.