### PR TITLE
Cache transform snapping enables and values

### DIFF
--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -229,6 +229,21 @@ namespace FlaxEditor.Viewport
             TransformGizmo.RotationSnapEnabled = _editor.ProjectCache.TryGetCustomData("RotationSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
             TransformGizmo.ScaleSnapEnabled = _editor.ProjectCache.TryGetCustomData("ScaleSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
             
+            // initialize snap value if there is one cached
+            string cachedSnapValue;
+            if (_editor.ProjectCache.TryGetCustomData("TranslateSnapValue", out cachedSnapValue))
+            {
+                TransformGizmo.TranslationSnapValue = float.Parse(cachedSnapValue);
+            }
+            if (_editor.ProjectCache.TryGetCustomData("RotationSnapValue", out cachedSnapValue))
+            {
+                TransformGizmo.RotationSnapValue = float.Parse(cachedSnapValue);
+            }
+            if (_editor.ProjectCache.TryGetCustomData("ScaleSnapValue", out cachedSnapValue))
+            {
+                TransformGizmo.ScaleSnapValue = float.Parse(cachedSnapValue);
+            }
+            
             // Transform space widget
             var transformSpaceWidget = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
             var transformSpaceToggle = new ViewportWidgetButton(string.Empty, editor.Icons.Globe32, null, true)
@@ -579,6 +594,7 @@ namespace FlaxEditor.Viewport
             var v = (float)button.Tag;
             TransformGizmo.ScaleSnapValue = v;
             _scaleSnapping.Text = v.ToString();
+            _editor.ProjectCache.SetCustomData("ScaleSnapValue", TransformGizmo.ScaleSnapValue.ToString("N"));
         }
 
         private void OnWidgetScaleSnapShowHide(Control control)
@@ -616,6 +632,7 @@ namespace FlaxEditor.Viewport
             var v = (float)button.Tag;
             TransformGizmo.RotationSnapValue = v;
             _rotateSnapping.Text = v.ToString();
+            _editor.ProjectCache.SetCustomData("RotationSnapValue", TransformGizmo.RotationSnapValue.ToString("N"));
         }
 
         private void OnWidgetRotateSnapShowHide(Control control)
@@ -652,6 +669,7 @@ namespace FlaxEditor.Viewport
             var v = (float)button.Tag;
             TransformGizmo.TranslationSnapValue = v;
             _translateSnapping.Text = v.ToString();
+            _editor.ProjectCache.SetCustomData("TranslateSnapValue", TransformGizmo.TranslationSnapValue.ToString("N"));
         }
 
         private void OnWidgetTranslateSnapShowHide(Control control)

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -243,7 +243,16 @@ namespace FlaxEditor.Viewport
             {
                 TransformGizmo.ScaleSnapValue = float.Parse(cachedSnapValue);
             }
-            
+
+            // initialize transform space if one is cached
+            string cachedTransformSpace;
+            if (_editor.ProjectCache.TryGetCustomData("TransformSpaceState", out cachedTransformSpace))
+            {
+                TransformGizmoBase.TransformSpace space;
+                Enum.TryParse(cachedTransformSpace, out space);
+                TransformGizmo.ActiveTransformSpace = space;
+            }
+
             // Transform space widget
             var transformSpaceWidget = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
             var transformSpaceToggle = new ViewportWidgetButton(string.Empty, editor.Icons.Globe32, null, true)
@@ -565,6 +574,7 @@ namespace FlaxEditor.Viewport
         private void OnTransformSpaceToggle(ViewportWidgetButton button)
         {
             TransformGizmo.ToggleTransformSpace();
+            _editor.ProjectCache.SetCustomData("TransformSpaceState", TransformGizmo.ActiveTransformSpace.ToString());
         }
 
         private void OnGizmoModeChanged()

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -6,6 +6,7 @@ using FlaxEditor.Content;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Drag;
+using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.SceneGraph.Actors;
 using FlaxEditor.Scripting;
@@ -223,6 +224,12 @@ namespace FlaxEditor.Viewport
 
             editor.SceneEditing.SelectionChanged += OnSelectionChanged;
 
+            // initialize snapping enabled from cached values
+            string cachedSnapState;
+            TransformGizmo.TranslationSnapEnable = _editor.ProjectCache.TryGetCustomData("TranslateSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
+            TransformGizmo.RotationSnapEnabled = _editor.ProjectCache.TryGetCustomData("RotationSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
+            TransformGizmo.ScaleSnapEnabled = _editor.ProjectCache.TryGetCustomData("ScaleSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
+            
             // Transform space widget
             var transformSpaceWidget = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
             var transformSpaceToggle = new ViewportWidgetButton(string.Empty, editor.Icons.Globe32, null, true)
@@ -523,16 +530,22 @@ namespace FlaxEditor.Viewport
         private void OnTranslateSnappingToggle(ViewportWidgetButton button)
         {
             TransformGizmo.TranslationSnapEnable = !TransformGizmo.TranslationSnapEnable;
+            // cache value on next save
+            _editor.ProjectCache.SetCustomData("TranslateSnapState", TransformGizmo.TranslationSnapEnable.ToString());
         }
 
         private void OnRotateSnappingToggle(ViewportWidgetButton button)
         {
             TransformGizmo.RotationSnapEnabled = !TransformGizmo.RotationSnapEnabled;
+            // cache value on next save
+            _editor.ProjectCache.SetCustomData("RotationSnapState", TransformGizmo.RotationSnapEnabled.ToString());
         }
 
         private void OnScaleSnappingToggle(ViewportWidgetButton button)
         {
             TransformGizmo.ScaleSnapEnabled = !TransformGizmo.ScaleSnapEnabled;
+            // cache value on next save
+            _editor.ProjectCache.SetCustomData("ScaleSnapState", TransformGizmo.ScaleSnapEnabled.ToString());
         }
 
         private void OnTransformSpaceToggle(ViewportWidgetButton button)

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -257,9 +257,10 @@ namespace FlaxEditor.Viewport
             string cachedTransformSpace;
             if (_editor.ProjectCache.TryGetCustomData("TransformSpaceState", out cachedTransformSpace))
             {
-                TransformGizmoBase.TransformSpace space;
-                Enum.TryParse(cachedTransformSpace, out space);
-                TransformGizmo.ActiveTransformSpace = space;
+                if (Enum.TryParse(cachedTransformSpace, out TransformGizmoBase.TransformSpace space))
+                {
+                    TransformGizmo.ActiveTransformSpace = space;
+                }
             }
 
             // Transform space widget

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -553,27 +553,28 @@ namespace FlaxEditor.Viewport
         private void OnTranslateSnappingToggle(ViewportWidgetButton button)
         {
             TransformGizmo.TranslationSnapEnable = !TransformGizmo.TranslationSnapEnable;
-            // cache value on next save
+            // cache value
             _editor.ProjectCache.SetCustomData("TranslateSnapState", TransformGizmo.TranslationSnapEnable.ToString());
         }
 
         private void OnRotateSnappingToggle(ViewportWidgetButton button)
         {
             TransformGizmo.RotationSnapEnabled = !TransformGizmo.RotationSnapEnabled;
-            // cache value on next save
+            // cache value
             _editor.ProjectCache.SetCustomData("RotationSnapState", TransformGizmo.RotationSnapEnabled.ToString());
         }
 
         private void OnScaleSnappingToggle(ViewportWidgetButton button)
         {
             TransformGizmo.ScaleSnapEnabled = !TransformGizmo.ScaleSnapEnabled;
-            // cache value on next save
+            // cache value
             _editor.ProjectCache.SetCustomData("ScaleSnapState", TransformGizmo.ScaleSnapEnabled.ToString());
         }
 
         private void OnTransformSpaceToggle(ViewportWidgetButton button)
         {
             TransformGizmo.ToggleTransformSpace();
+            // cache value
             _editor.ProjectCache.SetCustomData("TransformSpaceState", TransformGizmo.ActiveTransformSpace.ToString());
         }
 
@@ -604,6 +605,7 @@ namespace FlaxEditor.Viewport
             var v = (float)button.Tag;
             TransformGizmo.ScaleSnapValue = v;
             _scaleSnapping.Text = v.ToString();
+            // cache value
             _editor.ProjectCache.SetCustomData("ScaleSnapValue", TransformGizmo.ScaleSnapValue.ToString("N"));
         }
 
@@ -642,6 +644,7 @@ namespace FlaxEditor.Viewport
             var v = (float)button.Tag;
             TransformGizmo.RotationSnapValue = v;
             _rotateSnapping.Text = v.ToString();
+            // cache value
             _editor.ProjectCache.SetCustomData("RotationSnapValue", TransformGizmo.RotationSnapValue.ToString("N"));
         }
 
@@ -679,6 +682,7 @@ namespace FlaxEditor.Viewport
             var v = (float)button.Tag;
             TransformGizmo.TranslationSnapValue = v;
             _translateSnapping.Text = v.ToString();
+            // cache value
             _editor.ProjectCache.SetCustomData("TranslateSnapValue", TransformGizmo.TranslationSnapValue.ToString("N"));
         }
 

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -225,9 +225,18 @@ namespace FlaxEditor.Viewport
 
             // initialize snapping enabled from cached values
             string cachedSnapState;
-            TransformGizmo.TranslationSnapEnable = _editor.ProjectCache.TryGetCustomData("TranslateSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
-            TransformGizmo.RotationSnapEnabled = _editor.ProjectCache.TryGetCustomData("RotationSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
-            TransformGizmo.ScaleSnapEnabled = _editor.ProjectCache.TryGetCustomData("ScaleSnapState", out cachedSnapState) && Boolean.Parse(cachedSnapState);
+            if (_editor.ProjectCache.TryGetCustomData("TranslateSnapState", out cachedSnapState))
+            {
+                TransformGizmo.TranslationSnapEnable = Boolean.Parse(cachedSnapState);
+            }
+            if (_editor.ProjectCache.TryGetCustomData("RotationSnapState", out cachedSnapState))
+            {
+                TransformGizmo.RotationSnapEnabled = Boolean.Parse(cachedSnapState);
+            }
+            if (_editor.ProjectCache.TryGetCustomData("ScaleSnapState", out cachedSnapState))
+            {
+                TransformGizmo.ScaleSnapEnabled = Boolean.Parse(cachedSnapState);
+            }
             
             // initialize snap value if there is one cached
             string cachedSnapValue;

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -6,7 +6,6 @@ using FlaxEditor.Content;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Drag;
-using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.SceneGraph.Actors;
 using FlaxEditor.Scripting;


### PR DESCRIPTION
The last state of the translate, rotate, and scale snapping enabled, value, and transform space are cached so when the viewport is opened again, you can continue right where you left off.