### PR TITLE
Added value boxes hiding cursor and returning it to its position when done

### DIFF
--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -57,6 +57,7 @@ namespace FlaxEditor.GUI.Input
         private Float2 _startSlideLocation;
         private double _clickStartTime = -1;
         private bool _cursorChanged;
+        private Float2 _mouseClickedPosition;
 
         /// <summary>
         /// Occurs when value gets changed.
@@ -244,8 +245,12 @@ namespace FlaxEditor.GUI.Input
                 _startSlideLocation = location;
                 _startSlideValue = _value;
                 StartMouseCapture(true);
-                Cursor = CursorType.SizeWE;
+                
+                // Hide cursor and cache location
+                Cursor = CursorType.Hidden;
+                _mouseClickedPosition = location;
                 _cursorChanged = true;
+                
                 SlidingStart?.Invoke();
                 return true;
             }
@@ -268,7 +273,7 @@ namespace FlaxEditor.GUI.Input
             }
             
             // Update cursor type so user knows they can slide value
-            if (CanUseSliding && SlideRect.Contains(location))
+            if (CanUseSliding && SlideRect.Contains(location) && !_isSliding)
             {
                 Cursor = CursorType.SizeWE;
                 _cursorChanged = true;
@@ -287,7 +292,8 @@ namespace FlaxEditor.GUI.Input
         {
             if (button == MouseButton.Left && _isSliding)
             {
-                // End sliding
+                // End sliding and return mouse to original location
+                Root.MousePosition = ScreenPos + _mouseClickedPosition;
                 EndSliding();
                 return true;
             }


### PR DESCRIPTION
Hello, this is a QoL addition. I always found it cumbersome to have to move my mouse back to the property panel after I had slid a value in a value box. This change makes the value box more like unreal engines where it will hide the cursor and then move the cursor back to its original position when done sliding.