### PR TITLE
added to not close the child context menu on click

### DIFF
--- a/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
@@ -26,6 +26,7 @@ namespace FlaxEditor.GUI.ContextMenu
         : base(parent, text)
         {
             Text = text;
+            CloseMenuOnClick = false;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Even though I know that I can just hover over the child context menu to show its children, I always end up clicking it and the whole context menu closes even if I am 2 layers deep which is frustrating to me. This makes it so the whole context menu doesn't close if you click on a child CM.