### PR TITLE
changed the default for script members order.

### DIFF
--- a/Source/Editor/Options/GeneralOptions.cs
+++ b/Source/Editor/Options/GeneralOptions.cs
@@ -137,9 +137,9 @@ namespace FlaxEditor.Options
         /// <summary>
         /// Gets or sets an order of script properties/fields in properties panel.
         /// </summary>
-        [DefaultValue(MembersOrder.Alphabetical)]
+        [DefaultValue(MembersOrder.Declaration)]
         [EditorDisplay("Scripting", "Script Members Order"), EditorOrder(503), Tooltip("Order of script properties/fields in properties panel")]
-        public MembersOrder ScriptMembersOrder { get; set; } = MembersOrder.Alphabetical;
+        public MembersOrder ScriptMembersOrder { get; set; } = MembersOrder.Declaration;
 
         /// <summary>
         /// Gets or sets a value indicating whether automatically save the Visual Script asset editors when starting the play mode in editor.


### PR DESCRIPTION
Hello, this is often something asked in the Discord and often the first thing people change when they start with the engine. It may as well be set to Declaration by default as that is what people are used to coming from different engines