### PR TITLE
fixed position of child CMs when having to open left

### DIFF
--- a/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
@@ -155,11 +155,19 @@ namespace FlaxEditor.GUI.ContextMenu
                     if (parent is ContextMenu menu && menu._childCM != null)
                         locationSS.Y += 30.0f * dpiScale;
                 }
-                if (monitorBounds.Right < rightBottomLocationSS.X)
+                if (monitorBounds.Right < rightBottomLocationSS.X || _parentCM?.Direction == ContextMenuDirection.LeftDown || _parentCM?.Direction == ContextMenuDirection.LeftUp)
                 {
                     // Direction: left
                     isLeft = true;
-                    locationSS.X -= dpiSize.X;
+                    
+                    if (IsSubMenu && _parentCM != null)
+                    {
+                        locationSS.X -= _parentCM.Width + dpiSize.X;
+                    }
+                    else
+                    {
+                        locationSS.X -= dpiSize.X;
+                    }
                 }
             }
 


### PR DESCRIPTION
This fixes the positioning of the child context menus when having to open to the left side of the parent context menu. This reduces overlap in the CMs and increased QoL.