### PR TITLE
Adjusted only the bounds for content items to be floored in the content view

### DIFF
--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -720,14 +720,14 @@ namespace FlaxEditor.Content.GUI
                 if (itemsToFit < 1)
                     itemsToFit = 1;
                 float itemsWidth = width / Mathf.Max(itemsToFit, 1);
-                itemsWidth = Mathf.Floor(itemsWidth);
+                var flooredItemsWidth = Mathf.Floor(itemsWidth);
                 float itemsHeight = itemsWidth / defaultItemsWidth * (ContentItem.DefaultHeight * viewScale);
-                itemsHeight = Mathf.Floor(itemsHeight);
+                var flooredItemsHeight = Mathf.Floor(itemsHeight);
                 x = itemsToFit == 1 ? 0 : itemsWidth / itemsToFit;
                 for (int i = 0; i < _children.Count; i++)
                 {
                     var c = _children[i];
-                    c.Bounds = new Rectangle(x, y, itemsWidth, itemsHeight);
+                    c.Bounds = new Rectangle(x, y, flooredItemsWidth, flooredItemsHeight);
 
                     x += itemsWidth + itemsWidth / itemsToFit;
                     if (x + itemsWidth > width)


### PR DESCRIPTION
Hello, the spacing was affected by the items width and height floor being floored to help with the pixels. This PR changes that floor to only effect the bounds of the content item so that the spacing between them is not effected causing dead space in the panel. 