### PR TITLE
Added KeyDown and KeyUp event to TextBoxBase

### DIFF
--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -135,6 +135,11 @@ namespace FlaxEngine.GUI
         public event Action<KeyboardKeys> KeyDown;
 
         /// <summary>
+        /// Event fired when a key is up.
+        /// </summary>
+        public event Action<KeyboardKeys> KeyUp; 
+
+        /// <summary>
         /// Gets or sets a value indicating whether this is a multiline text box control.
         /// </summary>
         [EditorOrder(40), Tooltip("If checked, the textbox will support multiline text input.")]
@@ -1171,6 +1176,13 @@ namespace FlaxEngine.GUI
                 return false;
             Insert(c);
             return true;
+        }
+
+        /// <inheritdoc />
+        public override void OnKeyUp(KeyboardKeys key)
+        {
+            base.OnKeyUp(key);
+            KeyUp?.Invoke(key);
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -130,6 +130,11 @@ namespace FlaxEngine.GUI
         public event Action<TextBoxBase> TextBoxEditEnd;
 
         /// <summary>
+        /// Event fired when a key is down.
+        /// </summary>
+        public event Action<KeyboardKeys> KeyDown;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this is a multiline text box control.
         /// </summary>
         [EditorOrder(40), Tooltip("If checked, the textbox will support multiline text input.")]
@@ -1174,6 +1179,7 @@ namespace FlaxEngine.GUI
             var window = Root;
             bool shiftDown = window.GetKey(KeyboardKeys.Shift);
             bool ctrDown = window.GetKey(KeyboardKeys.Control);
+            KeyDown?.Invoke(key);
 
             switch (key)
             {


### PR DESCRIPTION
Hello, this PR adds new events to the TextBoxBase. One is fired whenever a key is down and another when key is up. This allows developers to easily extend what to do when the user enters certain keys via lambda functions, etc. without having to extend the TextBox Control.