### PR TITLE
Change triplanar texture scaling to `Float3`

### DIFF
--- a/Source/Editor/Surface/Archetypes/Textures.cs
+++ b/Source/Editor/Surface/Archetypes/Textures.cs
@@ -400,7 +400,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Input(0, "Texture", true, typeof(FlaxEngine.Object), 0),
-                    NodeElementArchetype.Factory.Input(1, "Scale", true, typeof(float), 1, 0),
+                    NodeElementArchetype.Factory.Input(1, "Scale", true, typeof(Float3), 1, 0),
                     NodeElementArchetype.Factory.Input(2, "Blend", true, typeof(float), 2, 1),
                     NodeElementArchetype.Factory.Output(0, "Color", typeof(Float3), 3)
                 }

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
@@ -467,7 +467,7 @@ void MaterialGenerator::ProcessGroupTextures(Box* box, Node* node, Value& value)
         }
 
         const auto texture = eatBox(textureBox->GetParent<Node>(), textureBox->FirstConnection());
-        const auto scale = tryGetValue(scaleBox, node->Values[0]).AsFloat();
+        const auto scale = tryGetValue(scaleBox, node->Values[0]).AsFloat3();
         const auto blend = tryGetValue(blendBox, node->Values[1]).AsFloat();
 
         auto result = writeLocal(Value::InitForZero(ValueType::Float4), node);


### PR DESCRIPTION
This allows the user to customize the scaling of the triplanar texture on all 3 axes.