### PR TITLE
Moved where tooltip is hidden when starting drag drop

### DIFF
--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -948,10 +948,6 @@ namespace FlaxEngine.GUI
         {
             // Set flag
             _isDragOver = true;
-            
-            // Hide tooltip
-            Tooltip?.Hide();
-
             return DragDropEffect.None;
         }
 
@@ -998,6 +994,8 @@ namespace FlaxEngine.GUI
         [NoAnimate]
         public virtual void DoDragDrop(DragData data)
         {
+            // Hide tooltip
+            Tooltip?.Hide();
             Root.DoDragDrop(data);
         }
 


### PR DESCRIPTION
Hello, this function call move makes hiding the tool tip much snappier when starting the drag drop operation.