### PR TITLE
Moved Material Instance override options into a settings icon with context menu

### DIFF
--- a/Content/Editor/IconsAtlas.flax
+++ b/Content/Editor/IconsAtlas.flax
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff5774c1073e5d4e5de362f7f8a0a74822cacb0b074272d4bba341be0c92d4ed
-size 5611572
+oid sha256:a8a0d257d4252e329997949687274a0888698c0ad2c786df8c303483fde4743c
+size 5608349

--- a/Source/Editor/EditorIcons.cs
+++ b/Source/Editor/EditorIcons.cs
@@ -96,6 +96,7 @@ namespace FlaxEditor
         public SpriteHandle Link64;
         public SpriteHandle Build64;
         public SpriteHandle Add64;
+        public SpriteHandle Settings64;
 
         // 96px
         public SpriteHandle Toolbox96;

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -401,8 +401,8 @@ namespace FlaxEditor.Windows.Assets
             }
             if (undoActions.Count == 0)
                 return;
-            _properties.Window._undo.AddAction(new MultiUndoAction(undoActions));
-            _properties.Window.MarkAsEdited();
+            _undo.AddAction(new MultiUndoAction(undoActions));
+            MarkAsEdited();
             _editor.BuildLayoutOnUpdate();
         }
 

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -336,14 +336,13 @@ namespace FlaxEditor.Windows.Assets
             _undoButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo (Ctrl+Z)");
             _redoButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo (Ctrl+Y)");
             _toolstrip.AddSeparator();
-            _toolstrip.AddButton(Editor.Icons.Rotate64, OnRevertAllParameters).LinkTooltip("Revert all the parameters to the default values");
-            _toolstrip.AddSeparator();
             var optionsButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Settings64).LinkTooltip("Options");
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/graphics/materials/instanced-materials/index.html")).LinkTooltip("See documentation to learn more");
             
             // context menu for options button
             var optionsCM = new ContextMenu();
+            optionsCM.AddButton("Revert All Parameters", OnRevertAllParameters).TooltipText = "Revert all the parameters to the default values";
             optionsCM.AddButton("Override All Parameters", OnOverrideAll).TooltipText = "Checks all parameter overrides.";
             optionsCM.AddButton("Remove Parameter Overrides", OnRemoveOverrides).TooltipText = "Unchecks all parameter overrides.";
             optionsButton.Clicked += () => optionsCM.Show(Root, Root.MousePosition);

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -342,7 +342,7 @@ namespace FlaxEditor.Windows.Assets
             
             // context menu for options button
             var optionsCM = new ContextMenu();
-            optionsCM.AddButton("Revert All Parameters", OnRevertAllParameters).TooltipText = "Reverts all the overriden parameters to the default values.";
+            optionsCM.AddButton("Revert All Parameters", OnRevertAllParameters).TooltipText = "Reverts all the overridden parameters to the default values.";
             optionsCM.AddButton("Override All Parameters", OnOverrideAll).TooltipText = "Checks all parameter overrides.";
             optionsCM.AddButton("Remove Parameter Overrides", OnRemoveOverrides).TooltipText = "Unchecks all parameter overrides.";
             optionsButton.Clicked += () => optionsCM.Show(Root, Root.MousePosition);

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -344,8 +344,8 @@ namespace FlaxEditor.Windows.Assets
             
             // context menu for options button
             var optionsCM = new ContextMenu();
-            optionsCM.AddButton("Override All Parameters").Clicked += OnOverrideAll;
-            optionsCM.AddButton("Remove Parameter Overrides").Clicked += OnRemoveOverrides;
+            optionsCM.AddButton("Override All Parameters", OnOverrideAll).TooltipText = "Checks all parameter's overrides.";
+            optionsCM.AddButton("Remove Parameter Overrides", OnRemoveOverrides).TooltipText = "Unchecks all overrides for parameters.";
             optionsButton.Clicked += () => optionsCM.Show(Root, Root.MousePosition);
 
             // Split Panel
@@ -386,25 +386,23 @@ namespace FlaxEditor.Windows.Assets
 
         private void OnSetOverrides(bool isOverride)
         {
-            var proxy = _properties;
             var undoActions = new List<IUndoAction>();
-            foreach (var graphParameter in Asset.Parameters)
+            foreach (var parameter in Asset.Parameters)
             {
-                var p = graphParameter;
-                if (!p.IsPublic || p.IsOverride == isOverride)
+                if (!parameter.IsPublic || parameter.IsOverride == isOverride)
                     continue;
-                p.IsOverride = isOverride;
+                parameter.IsOverride = isOverride;
                 undoActions.Add(new EditParamOverrideAction
                 {
-                    Window = proxy.Window,
-                    Name = p.Name,
+                    Window = _properties.Window,
+                    Name = parameter.Name,
                     Before = !isOverride,
                 });
             }
             if (undoActions.Count == 0)
                 return;
-            proxy.Window._undo.AddAction(new MultiUndoAction(undoActions));
-            proxy.Window.MarkAsEdited();
+            _properties.Window._undo.AddAction(new MultiUndoAction(undoActions));
+            _properties.Window.MarkAsEdited();
             _editor.BuildLayoutOnUpdate();
         }
 

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -342,7 +342,7 @@ namespace FlaxEditor.Windows.Assets
             
             // context menu for options button
             var optionsCM = new ContextMenu();
-            optionsCM.AddButton("Revert All Parameters", OnRevertAllParameters).TooltipText = "Revert all the parameters to the default values";
+            optionsCM.AddButton("Revert All Parameters", OnRevertAllParameters).TooltipText = "Reverts all the overriden parameters to the default values.";
             optionsCM.AddButton("Override All Parameters", OnOverrideAll).TooltipText = "Checks all parameter overrides.";
             optionsCM.AddButton("Remove Parameter Overrides", OnRemoveOverrides).TooltipText = "Unchecks all parameter overrides.";
             optionsButton.Clicked += () => optionsCM.Show(Root, Root.MousePosition);

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -344,8 +344,8 @@ namespace FlaxEditor.Windows.Assets
             
             // context menu for options button
             var optionsCM = new ContextMenu();
-            optionsCM.AddButton("Override All Parameters", OnOverrideAll).TooltipText = "Checks all parameter's overrides.";
-            optionsCM.AddButton("Remove Parameter Overrides", OnRemoveOverrides).TooltipText = "Unchecks all overrides for parameters.";
+            optionsCM.AddButton("Override All Parameters", OnOverrideAll).TooltipText = "Checks all parameter overrides.";
+            optionsCM.AddButton("Remove Parameter Overrides", OnRemoveOverrides).TooltipText = "Unchecks all parameter overrides.";
             optionsButton.Clicked += () => optionsCM.Show(Root, Root.MousePosition);
 
             // Split Panel


### PR DESCRIPTION
Hello, I felt that the place of the parameter override all and remove override buttons are in a weird spot. This PR moves those buttons into a context menu that is accessible through a new settings icon on the toolstrip. 

New Button:

![new toolstrip button](https://user-images.githubusercontent.com/71274967/198452613-4cfbf91c-10be-4ddd-9b3a-a1a7c8265b35.png)

New CM:

![newcm](https://user-images.githubusercontent.com/71274967/198453027-809e2f1f-934b-42f2-9c30-b9ff67b1969f.png)
