### PR TITLE
Various fixes to prefab tree view

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -9,6 +9,8 @@ using FlaxEditor.GUI.Drag;
 using FlaxEditor.GUI.Tree;
 using FlaxEditor.Scripting;
 using FlaxEditor.Utilities;
+using FlaxEditor.Windows;
+using FlaxEditor.Windows.Assets;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using Object = FlaxEngine.Object;
@@ -265,7 +267,7 @@ namespace FlaxEditor.SceneGraph.GUI
         /// <summary>
         /// Starts the actor renaming action.
         /// </summary>
-        public void StartRenaming()
+        public void StartRenaming(EditorWindow window)
         {
             // Block renaming during scripts reload
             if (Editor.Instance.ProgressReporting.CompileScripts.IsActive)
@@ -273,16 +275,22 @@ namespace FlaxEditor.SceneGraph.GUI
 
             Select();
 
-            // Disable scrolling of scene view
-            Editor.Instance.Windows.SceneWin.ScrollingOnSceneTreeView(false);
+            // Disable scrolling of view
+            if (window is SceneTreeWindow)
+                (window as SceneTreeWindow).ScrollingOnSceneTreeView(false);
+            else if (window is PrefabWindow)
+                (window as PrefabWindow).ScrollingOnTreeView(false);
 
             // Start renaming the actor
             var dialog = RenamePopup.Show(this, HeaderRect, _actorNode.Name, false);
             dialog.Renamed += OnRenamed;
             dialog.Closed += popup =>
             {
-                // Enable scrolling of scene view
-                Editor.Instance.Windows.SceneWin.ScrollingOnSceneTreeView(true);
+                // Enable scrolling of view
+                if (window is SceneTreeWindow)
+                    (window as SceneTreeWindow).ScrollingOnSceneTreeView(true);
+                else if (window is PrefabWindow)
+                    (window as PrefabWindow).ScrollingOnTreeView(true);
             };
         }
 
@@ -290,9 +298,6 @@ namespace FlaxEditor.SceneGraph.GUI
         {
             using (new UndoBlock(ActorNode.Root.Undo, Actor, "Rename"))
                 Actor.Name = renamePopup.Text;
-
-            // Enable scrolling of scene view
-            Editor.Instance.Windows.SceneWin.ScrollingOnSceneTreeView(true);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/Assets/PrefabWindow.Actions.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Actions.cs
@@ -153,6 +153,9 @@ namespace FlaxEditor.Windows.Assets
             {
                 OnPasteAction(pasteAction);
             }
+            
+            // Scroll to new selected node
+            ScrollToSelectedNode();
         }
 
         /// <summary>
@@ -180,6 +183,9 @@ namespace FlaxEditor.Windows.Assets
             {
                 OnPasteAction(pasteAction);
             }
+            
+            // Scroll to new selected node
+            ScrollToSelectedNode();
         }
 
         private void OnPasteAction(PasteActorsAction pasteAction)
@@ -328,6 +334,9 @@ namespace FlaxEditor.Windows.Assets
             }, action2.ActionString);
             action.Do();
             Undo.AddAction(action);
+            
+            _treePanel.PerformLayout();
+            _treePanel.PerformLayout();
         }
     }
 }

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -67,7 +67,7 @@ namespace FlaxEditor.Windows.Assets
             private DragHandlers _dragHandlers;
 
             public SceneTreePanel(PrefabWindow window)
-            : base(ScrollBars.Vertical)
+            : base(ScrollBars.None)
             {
                 _window = window;
                 Offsets = Margin.Zero;
@@ -310,7 +310,7 @@ namespace FlaxEditor.Windows.Assets
             {
                 if (selection.Count != 0)
                     Select(actor);
-                actor.TreeNode.StartRenaming();
+                actor.TreeNode.StartRenaming(this);
             }
         }
 

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -260,6 +260,12 @@ namespace FlaxEditor.Windows.Assets
                 ShowContextMenu(Parent, ref locationCM);
                 return true;
             }
+
+            if (button == MouseButton.Left && _treePanel.ContainsPoint(ref location))
+            {
+                _tree.Deselect();
+                return true;
+            }
             return false;
         }
 

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -442,6 +442,15 @@ namespace FlaxEditor.Windows
                 return true;
             }
 
+            if (buttons == MouseButton.Left)
+            {
+                if (Editor.StateMachine.CurrentState.CanEditScene)
+                {
+                    Editor.SceneEditing.Deselect();
+                }
+                return true;
+            }
+
             return false;
         }
 

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -249,7 +249,7 @@ namespace FlaxEditor.Windows
             {
                 if (selection.Count != 0)
                     Editor.SceneEditing.Select(actor);
-                actor.TreeNode.StartRenaming();
+                actor.TreeNode.StartRenaming(this);
             }
         }
 


### PR DESCRIPTION
Hello, this fixes several issues with the tree view in the prefab window to make it like the scene view tree.

- Now scrolls like the scene view tree when duplicating, pasting, or deleting actors.
- You can right click anywhere in the panel to open up the context menu to add a new actor.
- stops scrolling on the prefab tree when renaming.
- separates the search bar from the tree panel so the scroll bar doesn't hit the search bar.
- Deselects nodes if left click in empty space in the scene tree view and the prefab scene tree view.