### PR TITLE
fixes focus issues in json asset editor and prefab editor

### DIFF
--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -190,7 +190,7 @@ namespace FlaxEditor.Windows.Assets
             {
                 // Set flag
                 _isEdited = true;
-
+                Focus();
                 // Call events
                 OnEditedState();
                 OnEdited?.Invoke();

--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -185,12 +185,13 @@ namespace FlaxEditor.Windows.Assets
         /// <inheritdoc />
         public void MarkAsEdited()
         {
+            Focus();
             // Check if state will change
             if (_isEdited == false)
             {
                 // Set flag
                 _isEdited = true;
-                Focus();
+
                 // Call events
                 OnEditedState();
                 OnEdited?.Invoke();


### PR DESCRIPTION
Hello, adding  a focus call once the scene is marked as edited fixes the issue with the text box returning focus to the window for different input actions like saving. Fix for #789.