### PR TITLE
Rename on left click

### DIFF
--- a/Source/Editor/GUI/Popups/RenamePopup.cs
+++ b/Source/Editor/GUI/Popups/RenamePopup.cs
@@ -88,7 +88,7 @@ namespace FlaxEditor.GUI
             if (!ContainsPoint(ref mouseLocation) && RootWindow.ContainsFocus && Text != _startValue)
             {
                 // rename item before closing if left mouse button in clicked
-                if (FlaxEngine.Input.GetMouseButton(MouseButton.Left))
+                if (FlaxEngine.Input.GetMouseButtonDown(MouseButton.Left))
                     OnEnd();
             }
 

--- a/Source/Editor/GUI/Popups/RenamePopup.cs
+++ b/Source/Editor/GUI/Popups/RenamePopup.cs
@@ -81,6 +81,20 @@ namespace FlaxEditor.GUI
 
         private bool IsInputValid => !string.IsNullOrWhiteSpace(_inputField.Text) && (_inputField.Text == _startValue || Validate == null || Validate(this, _inputField.Text));
 
+        /// <inheritdoc />
+        public override void Update(float deltaTime)
+        {
+            var mouseLocation = Root.MousePosition;
+            if (!ContainsPoint(ref mouseLocation) && RootWindow.ContainsFocus && Text != _startValue)
+            {
+                // rename item before closing if left mouse button in clicked
+                if (FlaxEngine.Input.GetMouseButton(MouseButton.Left))
+                    OnEnd();
+            }
+
+            base.Update(deltaTime);
+        }
+
         private void OnTextChanged()
         {
             if (Validate == null)


### PR DESCRIPTION
Hello, this PR allows for the item to be renamed when the user left clicks outside of the rename popup instead of having to only press enter to rename.