### PR TITLE
Fixed issue with ParticleEffect's properties editor when no asset is selected

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ParticleEffectEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ParticleEffectEditor.cs
@@ -96,7 +96,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
             var parameters = effect.Parameters;
             if (parameters.Length == 0)
             {
-                base.Refresh();
+                base.RefreshRootChild();
                 return;
             }
             

--- a/Source/Editor/CustomEditors/Dedicated/ParticleEffectEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ParticleEffectEditor.cs
@@ -94,6 +94,12 @@ namespace FlaxEditor.CustomEditors.Dedicated
             }
             Refresh();
             var parameters = effect.Parameters;
+            if (parameters.Length == 0)
+            {
+                base.Refresh();
+                return;
+            }
+            
             for (int i = 0; i < ChildrenEditors.Count; i++)
             {
                 if (_isActive != effect.IsActive || _parametersVersion != effect.ParametersVersion)


### PR DESCRIPTION
Hello, if no asset is selected in the particle effects' properties editor then the properties editor breaks. This fixes that issue by checking if there are existing parameters before running the custom refresh.