### PR TITLE
PE: Fixes/changes and additions.

### DIFF
--- a/Source/Editor/Windows/Assets/MaterialWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialWindow.cs
@@ -128,6 +128,12 @@ namespace FlaxEditor.Windows.Assets
             [EditorOrder(440), DefaultValue(MaterialPostFxLocation.AfterPostProcessingPass), EditorDisplay("Misc"), Tooltip("The post fx material rendering location.")]
             public MaterialPostFxLocation PostFxLocation;
 
+            [EditorOrder(450), DefaultValue(0.0f), EditorDisplay("Misc"), Tooltip("Minimum depth used for rendering."), Limit(0.0f, 1.0f, 0.001f)]
+            public float MinDepth;
+
+            [EditorOrder(460), DefaultValue(1.0f), EditorDisplay("Misc"), Tooltip("Maximum depth used for rendering."), Limit(0.0f, 1.0f, 0.001f)]
+            public float MaxDepth;
+
             // Parameters
 
             [EditorOrder(1000), EditorDisplay("Parameters"), CustomEditor(typeof(ParametersEditor)), NoSerialize]
@@ -173,6 +179,8 @@ namespace FlaxEditor.Windows.Assets
                 BlendMode = info.BlendMode;
                 ShadingModel = info.ShadingModel;
                 Domain = info.Domain;
+                MinDepth = info.MinDepth;
+                MaxDepth = info.MaxDepth;
 
                 // Link
                 Window = window;
@@ -218,6 +226,8 @@ namespace FlaxEditor.Windows.Assets
                 info.BlendMode = BlendMode;
                 info.ShadingModel = ShadingModel;
                 info.Domain = Domain;
+                info.MinDepth = MinDepth;
+                info.MaxDepth = MaxDepth;
             }
 
             /// <summary>

--- a/Source/Engine/Audio/AudioSource.cpp
+++ b/Source/Engine/Audio/AudioSource.cpp
@@ -132,7 +132,7 @@ void AudioSource::Play()
             Clip->RequestStreamingUpdate();
 
             // If we are looping and streaming also update streaming buffers
-            if (_loop)
+            if (_loop || state == States::Stopped)
                 RequestStreamingBuffersUpdate();
         }
     }

--- a/Source/Engine/ContentImporters/CreateMaterial.cpp
+++ b/Source/Engine/ContentImporters/CreateMaterial.cpp
@@ -103,15 +103,17 @@ CreateMaterial::Options::Options()
     Info.OpacityThreshold = 0.12f;
     Info.TessellationMode = TessellationMethod::None;
     Info.MaxTessellationFactor = 15;
+    Info.MinDepth = 0.0f;
+    Info.MaxDepth = 1.0f;
 }
 
 CreateAssetResult CreateMaterial::Create(CreateAssetContext& context)
 {
     // Base
-    IMPORT_SETUP(Material, 20);
+    IMPORT_SETUP(Material, 21);
     context.SkipMetadata = true;
 
-    ShaderStorage::Header20 shaderHeader;
+    ShaderStorage::Header21 shaderHeader;
     Platform::MemoryClear(&shaderHeader, sizeof(shaderHeader));
     if (context.CustomArg)
     {

--- a/Source/Engine/ContentImporters/CreateParticleEmitter.h
+++ b/Source/Engine/ContentImporters/CreateParticleEmitter.h
@@ -22,11 +22,11 @@ public:
     static CreateAssetResult Create(CreateAssetContext& context)
     {
         // Base
-        IMPORT_SETUP(ParticleEmitter, 20);
+        IMPORT_SETUP(ParticleEmitter, 21);
         context.SkipMetadata = true;
 
         // Set Custom Data with Header
-        ShaderStorage::Header20 shaderHeader;
+        ShaderStorage::Header21 shaderHeader;
         Platform::MemoryClear(&shaderHeader, sizeof(shaderHeader));
         context.Data.CustomData.Copy(&shaderHeader);
 

--- a/Source/Engine/ContentImporters/ImportShader.cpp
+++ b/Source/Engine/ContentImporters/ImportShader.cpp
@@ -14,7 +14,7 @@
 CreateAssetResult ImportShader::Import(CreateAssetContext& context)
 {
     // Base
-    IMPORT_SETUP(Shader, 20);
+    IMPORT_SETUP(Shader, 21);
     const int32 SourceCodeChunk = 15;
     context.SkipMetadata = true;
 
@@ -40,7 +40,7 @@ CreateAssetResult ImportShader::Import(CreateAssetContext& context)
     Encryption::EncryptBytes(sourceCode, sourceCodeSize);
 
     // Set Custom Data with Header
-    ShaderStorage::Header20 shaderHeader;
+    ShaderStorage::Header21 shaderHeader;
     Platform::MemoryClear(&shaderHeader, sizeof(shaderHeader));
     context.Data.CustomData.Copy(&shaderHeader);
 

--- a/Source/Engine/Graphics/MaterialInfo.cs
+++ b/Source/Engine/Graphics/MaterialInfo.cs
@@ -67,7 +67,9 @@ namespace FlaxEngine
                    && Mathf.NearEqual(MaskThreshold, other.MaskThreshold)
                    && Mathf.NearEqual(OpacityThreshold, other.OpacityThreshold)
                    && TessellationMode == other.TessellationMode
-                   && MaxTessellationFactor == other.MaxTessellationFactor;
+                   && MaxTessellationFactor == other.MaxTessellationFactor
+                   && MinDepth == other.MinDepth
+                   && MaxDepth == other.MaxDepth;
         }
 
         /// <inheritdoc />
@@ -93,6 +95,7 @@ namespace FlaxEngine
                 hashCode = (hashCode * 397) ^ (int)(OpacityThreshold * 1000.0f);
                 hashCode = (hashCode * 397) ^ (int)TessellationMode;
                 hashCode = (hashCode * 397) ^ MaxTessellationFactor;
+                hashCode = (hashCode * 397) ^ (int)((MinDepth + MaxDepth) * 100.0f);
                 return hashCode;
             }
         }

--- a/Source/Engine/Graphics/Materials/MaterialInfo.h
+++ b/Source/Engine/Graphics/Materials/MaterialInfo.h
@@ -490,6 +490,34 @@ struct MaterialInfo9
 };
 
 /// <summary>
+/// Material info structure - version 10
+/// [Deprecated on 14.11.2022, expires on 14.11.2024]
+/// </summary>
+struct MaterialInfo10
+{
+    MaterialDomain Domain;
+    MaterialBlendMode BlendMode;
+    MaterialShadingModel ShadingModel;
+    MaterialUsageFlags UsageFlags;
+    MaterialFeaturesFlags FeaturesFlags;
+    MaterialDecalBlendingMode DecalBlendingMode;
+    MaterialTransparentLightingMode TransparentLightingMode;
+    MaterialPostFxLocation PostFxLocation;
+    CullMode CullMode;
+    float MaskThreshold;
+    float OpacityThreshold;
+    TessellationMethod TessellationMode;
+    int32 MaxTessellationFactor;
+
+    MaterialInfo10()
+    {
+    }
+
+    MaterialInfo10(const MaterialInfo9& other);
+    bool operator==(const MaterialInfo10& other) const;
+};
+
+/// <summary>
 /// Structure with basic information about the material surface. It describes how material is reacting on light and which graphical features of it requires to render.
 /// </summary>
 API_STRUCT() struct FLAXENGINE_API MaterialInfo
@@ -561,14 +589,24 @@ API_STRUCT() struct FLAXENGINE_API MaterialInfo
     /// </summary>
     API_FIELD() int32 MaxTessellationFactor;
 
+    /// <summary>
+    /// The Minimum depth
+    /// </summary>
+    API_FIELD() float MinDepth;
+
+    /// <summary>
+    /// The Maximum depth
+    /// </summary>
+    API_FIELD() float MaxDepth;
+
     MaterialInfo()
     {
     }
 
-    MaterialInfo(const MaterialInfo9& other);
+    MaterialInfo(const MaterialInfo10& other);
     bool operator==(const MaterialInfo& other) const;
 };
 
 // The current material info descriptor version used by the material pipeline
-typedef MaterialInfo MaterialInfo10;
-#define MaterialInfo_Version 10
+typedef MaterialInfo MaterialInfo11;
+#define MaterialInfo_Version 11

--- a/Source/Engine/Graphics/Materials/MaterialParams.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialParams.cpp
@@ -94,7 +94,7 @@ bool MaterialInfo9::operator==(const MaterialInfo9& other) const
             && MaxTessellationFactor == other.MaxTessellationFactor;
 }
 
-MaterialInfo::MaterialInfo(const MaterialInfo9& other)
+MaterialInfo10::MaterialInfo10(const MaterialInfo9& other)
 {
     Domain = other.Domain;
     BlendMode = other.BlendMode;
@@ -111,21 +111,59 @@ MaterialInfo::MaterialInfo(const MaterialInfo9& other)
     MaxTessellationFactor = other.MaxTessellationFactor;
 }
 
+bool MaterialInfo10::operator==(const MaterialInfo10& other) const
+{
+    return Domain == other.Domain
+        && BlendMode == other.BlendMode
+        && ShadingModel == other.ShadingModel
+        && UsageFlags == other.UsageFlags
+        && FeaturesFlags == other.FeaturesFlags
+        && DecalBlendingMode == other.DecalBlendingMode
+        && TransparentLightingMode == other.TransparentLightingMode
+        && PostFxLocation == other.PostFxLocation
+        && CullMode == other.CullMode
+        && Math::NearEqual(MaskThreshold, other.MaskThreshold)
+        && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
+        && TessellationMode == other.TessellationMode
+        && MaxTessellationFactor == other.MaxTessellationFactor;
+}
+
+MaterialInfo::MaterialInfo(const MaterialInfo10& other)
+{
+    Domain = other.Domain;
+    BlendMode = other.BlendMode;
+    ShadingModel = other.ShadingModel;
+    UsageFlags = other.UsageFlags;
+    FeaturesFlags = other.FeaturesFlags;
+    DecalBlendingMode = other.DecalBlendingMode;
+    TransparentLightingMode = other.TransparentLightingMode;
+    PostFxLocation = other.PostFxLocation;
+    CullMode = other.CullMode;
+    MaskThreshold = other.MaskThreshold;
+    OpacityThreshold = other.OpacityThreshold;
+    TessellationMode = other.TessellationMode;
+    MaxTessellationFactor = other.MaxTessellationFactor;
+    MinDepth = 0.0f;
+    MaxDepth = 1.0f;
+}
+
 bool MaterialInfo::operator==(const MaterialInfo& other) const
 {
     return Domain == other.Domain
-            && BlendMode == other.BlendMode
-            && ShadingModel == other.ShadingModel
-            && UsageFlags == other.UsageFlags
-            && FeaturesFlags == other.FeaturesFlags
-            && DecalBlendingMode == other.DecalBlendingMode
-            && TransparentLightingMode == other.TransparentLightingMode
-            && PostFxLocation == other.PostFxLocation
-            && CullMode == other.CullMode
-            && Math::NearEqual(MaskThreshold, other.MaskThreshold)
-            && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
-            && TessellationMode == other.TessellationMode
-            && MaxTessellationFactor == other.MaxTessellationFactor;
+        && BlendMode == other.BlendMode
+        && ShadingModel == other.ShadingModel
+        && UsageFlags == other.UsageFlags
+        && FeaturesFlags == other.FeaturesFlags
+        && DecalBlendingMode == other.DecalBlendingMode
+        && TransparentLightingMode == other.TransparentLightingMode
+        && PostFxLocation == other.PostFxLocation
+        && CullMode == other.CullMode
+        && Math::NearEqual(MaskThreshold, other.MaskThreshold)
+        && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
+        && TessellationMode == other.TessellationMode
+        && MaxTessellationFactor == other.MaxTessellationFactor
+        && MinDepth == other.MinDepth
+        && MaxDepth == other.MaxDepth;
 }
 
 const Char* ToString(MaterialParameterType value)

--- a/Source/Engine/Graphics/Shaders/Cache/ShaderStorage.h
+++ b/Source/Engine/Graphics/Shaders/Cache/ShaderStorage.h
@@ -161,7 +161,52 @@ public:
     };
 
     /// <summary>
+    /// File header, version 21
+    /// </summary>
+    struct Header21
+    {
+        static const int32 Version = 21;
+
+        union
+        {
+            struct
+            {
+            } Shader;
+
+            struct
+            {
+                /// <summary>
+                /// The material graph version.
+                /// </summary>
+                int32 GraphVersion;
+
+                /// <summary>
+                /// The material additional information.
+                /// </summary>
+                MaterialInfo11 Info;
+            } Material;
+
+            struct
+            {
+                /// <summary>
+                /// The particle emitter graph version.
+                /// </summary>
+                int32 GraphVersion;
+
+                /// <summary>
+                /// The custom particles data size (in bytes).
+                /// </summary>
+                int32 CustomDataSize;
+            } ParticleEmitter;
+        };
+
+        Header21()
+        {
+        }
+    };
+
+    /// <summary>
     /// Current header type
     /// </summary>
-    typedef Header20 Header;
+    typedef Header21 Header;
 };

--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -1275,8 +1275,16 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
         // Trim the animation keyframes range if need to
         if (options.Duration == AnimationDuration::Custom)
         {
-            const float start = (float)(options.FramesRange.X / data.Animation.FramesPerSecond);
-            const float end = (float)(options.FramesRange.Y / data.Animation.FramesPerSecond);
+            // PE: This is wrong, FramesRange is Frame Index start end, not the frame time.
+            // PE: To extract Frame Index you has to enter Frame*FramesPerSecond or it will not work.
+            // PE: This also makes another problem as the "length" get wrong and your not able to loop animatons.
+            // const float start = (float)(options.FramesRange.X / data.Animation.FramesPerSecond);
+            // const float end = (float)(options.FramesRange.Y / data.Animation.FramesPerSecond);
+            // data.Animation.Duration = (end - start); // *data.Animation.FramesPerSecond;
+
+            // PE: Custom animation import , frame index start and end, is now correct and the real index.
+            const float start = (float)(options.FramesRange.X);
+            const float end = (float)(options.FramesRange.Y);
             for (int32 i = 0; i < data.Animation.Channels.Count(); i++)
             {
                 auto& anim = data.Animation.Channels[i];
@@ -1285,7 +1293,7 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
                 anim.Rotation.Trim(start, end);
                 anim.Scale.Trim(start, end);
             }
-            data.Animation.Duration = (end - start) * data.Animation.FramesPerSecond;
+            data.Animation.Duration = (end - start);
         }
 
         // Change the sampling rate if need to


### PR DESCRIPTION
PE: csharp allow setting material minimum and max depth, for on top rendering.
PE: allow setting material minimum and max depth, for on top rendering.
PE: Also support on top SpriteRender for crosshair...
PE: AudioSource - Stop() followed by Play() now act like a restart.
PE: Support importing WAV files that contain "extra format bytes" in "fmt" header.
PE: Fixed - Custom animation import, frame index start and end was not the actual index but depended on frames per second. Made it impossible to use, now use the real frame index.
PE: FBX Import - Improved normal map detection using diffuse name, if normap map was not setup inside object.
PE: DDS - Improve import time if source already has mipmaps and are compressed.
