### PR TITLE
Changed using screen coords to using window points in value box.

### DIFF
--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -248,7 +248,7 @@ namespace FlaxEditor.GUI.Input
 
                 // Hide cursor and cache location
                 Cursor = CursorType.Hidden;
-                _mouseClickedPosition = location;
+                _mouseClickedPosition = PointToWindow(location);
                 _cursorChanged = true;
 
                 SlidingStart?.Invoke();
@@ -293,7 +293,7 @@ namespace FlaxEditor.GUI.Input
             if (button == MouseButton.Left && _isSliding)
             {
                 // End sliding and return mouse to original location
-                Root.MousePosition = ScreenPos + _mouseClickedPosition;
+                RootWindow.MousePosition = _mouseClickedPosition;
                 EndSliding();
                 return true;
             }


### PR DESCRIPTION
Hello, there was an issue with restoring the mouse position using the screen position in the value box to its original location if the application was not maximized. This has been changed to use the point to window function and works with all window sizes from my testing. Fix for issue in #783 