### PR TITLE
Fixes/changes and additions.

### DIFF
--- a/Source/Engine/Audio/AudioSource.cpp
+++ b/Source/Engine/Audio/AudioSource.cpp
@@ -132,7 +132,7 @@ void AudioSource::Play()
             Clip->RequestStreamingUpdate();
 
             // If we are looping and streaming also update streaming buffers
-            if (_loop)
+            if (_loop || state == States::Stopped)
                 RequestStreamingBuffersUpdate();
         }
     }

--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -1275,8 +1275,16 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
         // Trim the animation keyframes range if need to
         if (options.Duration == AnimationDuration::Custom)
         {
-            const float start = (float)(options.FramesRange.X / data.Animation.FramesPerSecond);
-            const float end = (float)(options.FramesRange.Y / data.Animation.FramesPerSecond);
+            // PE: This is wrong, FramesRange is Frame Index start end, not the frame time.
+            // PE: To extract Frame Index you has to enter Frame*FramesPerSecond or it will not work.
+            // PE: This also makes another problem as the "length" get wrong and your not able to loop animatons.
+            // const float start = (float)(options.FramesRange.X / data.Animation.FramesPerSecond);
+            // const float end = (float)(options.FramesRange.Y / data.Animation.FramesPerSecond);
+            // data.Animation.Duration = (end - start); // *data.Animation.FramesPerSecond;
+
+            // PE: Custom animation import , frame index start and end, is now correct and the real index.
+            const float start = (float)(options.FramesRange.X);
+            const float end = (float)(options.FramesRange.Y);
             for (int32 i = 0; i < data.Animation.Channels.Count(); i++)
             {
                 auto& anim = data.Animation.Channels[i];
@@ -1285,7 +1293,7 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
                 anim.Rotation.Trim(start, end);
                 anim.Scale.Trim(start, end);
             }
-            data.Animation.Duration = (end - start) * data.Animation.FramesPerSecond;
+            data.Animation.Duration = (end - start);
         }
 
         // Change the sampling rate if need to


### PR DESCRIPTION
PE: AudioSource - Stop() followed by Play() now act like a restart.
PE: Support importing WAV files that contain "extra format bytes" in "fmt" header.
PE: Fixed - Custom animation import, frame index start and end was not the actual index but depended on frames per second. Made it impossible to use, now use the real frame index.
PE: FBX Import - Improved normal map detection using diffuse name, if normap map was not setup inside object.
PE: DDS - Improve import time if source already has mipmaps and are compressed.
