### PR TITLE
On top rendering using MinDepth and MaxDepth.

### DIFF
--- a/Source/Editor/Windows/Assets/MaterialWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialWindow.cs
@@ -128,6 +128,12 @@ namespace FlaxEditor.Windows.Assets
             [EditorOrder(440), DefaultValue(MaterialPostFxLocation.AfterPostProcessingPass), EditorDisplay("Misc"), Tooltip("The post fx material rendering location.")]
             public MaterialPostFxLocation PostFxLocation;
 
+            [EditorOrder(450), DefaultValue(0.0f), EditorDisplay("Misc"), Tooltip("Minimum depth used for rendering."), Limit(0.0f, 1.0f, 0.001f)]
+            public float MinDepth;
+
+            [EditorOrder(460), DefaultValue(1.0f), EditorDisplay("Misc"), Tooltip("Maximum depth used for rendering."), Limit(0.0f, 1.0f, 0.001f)]
+            public float MaxDepth;
+
             // Parameters
 
             [EditorOrder(1000), EditorDisplay("Parameters"), CustomEditor(typeof(ParametersEditor)), NoSerialize]
@@ -173,6 +179,8 @@ namespace FlaxEditor.Windows.Assets
                 BlendMode = info.BlendMode;
                 ShadingModel = info.ShadingModel;
                 Domain = info.Domain;
+                MinDepth = info.MinDepth;
+                MaxDepth = info.MaxDepth;
 
                 // Link
                 Window = window;
@@ -218,6 +226,8 @@ namespace FlaxEditor.Windows.Assets
                 info.BlendMode = BlendMode;
                 info.ShadingModel = ShadingModel;
                 info.Domain = Domain;
+                info.MinDepth = MinDepth;
+                info.MaxDepth = MaxDepth;
             }
 
             /// <summary>

--- a/Source/Editor/Windows/Assets/MaterialWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialWindow.cs
@@ -134,6 +134,8 @@ namespace FlaxEditor.Windows.Assets
             [EditorOrder(460), DefaultValue(1.0f), EditorDisplay("Misc"), Tooltip("Maximum depth used for rendering."), Limit(0.0f, 1.0f, 0.001f)]
             public float MaxDepth;
 
+            [EditorOrder(470), DefaultValue(0.0f), EditorDisplay("Misc"), Tooltip("Static FOV, will not change even when camara FOV change. Use 0 to disable."), Limit(0.0f, 170.0f, 0.001f)]
+            public float StaticFOV;
             // Parameters
 
             [EditorOrder(1000), EditorDisplay("Parameters"), CustomEditor(typeof(ParametersEditor)), NoSerialize]
@@ -181,6 +183,7 @@ namespace FlaxEditor.Windows.Assets
                 Domain = info.Domain;
                 MinDepth = info.MinDepth;
                 MaxDepth = info.MaxDepth;
+                StaticFOV = info.StaticFOV;
 
                 // Link
                 Window = window;
@@ -228,6 +231,7 @@ namespace FlaxEditor.Windows.Assets
                 info.Domain = Domain;
                 info.MinDepth = MinDepth;
                 info.MaxDepth = MaxDepth;
+                info.StaticFOV = StaticFOV;
             }
 
             /// <summary>

--- a/Source/Editor/Windows/Assets/MaterialWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialWindow.cs
@@ -136,6 +136,10 @@ namespace FlaxEditor.Windows.Assets
 
             [EditorOrder(470), DefaultValue(0.0f), EditorDisplay("Misc"), Tooltip("Static FOV, will not change even when camara FOV change. Use 0 to disable."), Limit(0.0f, 170.0f, 0.001f)]
             public float StaticFOV;
+
+            [EditorOrder(480), DefaultValue(0.0f), EditorDisplay("Misc"), Tooltip("Distance Bias. Allow you to control draw order."), Limit(-500000.0f, 500000.0f, 0.001f)]
+            public float DistanceBias;
+
             // Parameters
 
             [EditorOrder(1000), EditorDisplay("Parameters"), CustomEditor(typeof(ParametersEditor)), NoSerialize]
@@ -184,6 +188,7 @@ namespace FlaxEditor.Windows.Assets
                 MinDepth = info.MinDepth;
                 MaxDepth = info.MaxDepth;
                 StaticFOV = info.StaticFOV;
+                DistanceBias = info.DistanceBias;
 
                 // Link
                 Window = window;
@@ -232,6 +237,7 @@ namespace FlaxEditor.Windows.Assets
                 info.MinDepth = MinDepth;
                 info.MaxDepth = MaxDepth;
                 info.StaticFOV = StaticFOV;
+                info.DistanceBias = DistanceBias;
             }
 
             /// <summary>

--- a/Source/Engine/Content/Upgraders/ShaderAssetUpgrader.h
+++ b/Source/Engine/Content/Upgraders/ShaderAssetUpgrader.h
@@ -68,7 +68,8 @@ private:
             newHeader.Material.Info = oldHeader.Material.Info;
             newHeader.Material.Info.MinDepth = 0.0f;
             newHeader.Material.Info.MaxDepth = 1.0f;
-            for (int i = 0; i < 10; i++)
+            newHeader.Material.Info.StaticFOV = 0.0f;
+            for (int i = 0; i < 9; i++)
             {
                 newHeader.Material.Info.for_future_use[i] = -2.0f;
             }

--- a/Source/Engine/Content/Upgraders/ShaderAssetUpgrader.h
+++ b/Source/Engine/Content/Upgraders/ShaderAssetUpgrader.h
@@ -69,9 +69,11 @@ private:
             newHeader.Material.Info.MinDepth = 0.0f;
             newHeader.Material.Info.MaxDepth = 1.0f;
             newHeader.Material.Info.StaticFOV = 0.0f;
-            for (int i = 0; i < 9; i++)
+            newHeader.Material.Info.DistanceBias = 0.0f;
+
+            for (int i = 0; i < 8; i++)
             {
-                newHeader.Material.Info.for_future_use[i] = -2.0f;
+                newHeader.Material.Info.for_future_use[i] = 0.0f;
             }
         }
         else if (context.Input.Header.TypeName == TEXT("FlaxEngine.Shader"))

--- a/Source/Engine/Content/Upgraders/ShaderAssetUpgrader.h
+++ b/Source/Engine/Content/Upgraders/ShaderAssetUpgrader.h
@@ -68,6 +68,10 @@ private:
             newHeader.Material.Info = oldHeader.Material.Info;
             newHeader.Material.Info.MinDepth = 0.0f;
             newHeader.Material.Info.MaxDepth = 1.0f;
+            for (int i = 0; i < 10; i++)
+            {
+                newHeader.Material.Info.for_future_use[i] = -2.0f;
+            }
         }
         else if (context.Input.Header.TypeName == TEXT("FlaxEngine.Shader"))
         {

--- a/Source/Engine/ContentImporters/CreateMaterial.cpp
+++ b/Source/Engine/ContentImporters/CreateMaterial.cpp
@@ -103,15 +103,17 @@ CreateMaterial::Options::Options()
     Info.OpacityThreshold = 0.12f;
     Info.TessellationMode = TessellationMethod::None;
     Info.MaxTessellationFactor = 15;
+    Info.MinDepth = 0.0f;
+    Info.MaxDepth = 1.0f;
 }
 
 CreateAssetResult CreateMaterial::Create(CreateAssetContext& context)
 {
     // Base
-    IMPORT_SETUP(Material, 20);
+    IMPORT_SETUP(Material, 21);
     context.SkipMetadata = true;
 
-    ShaderStorage::Header20 shaderHeader;
+    ShaderStorage::Header21 shaderHeader;
     Platform::MemoryClear(&shaderHeader, sizeof(shaderHeader));
     if (context.CustomArg)
     {

--- a/Source/Engine/ContentImporters/CreateParticleEmitter.h
+++ b/Source/Engine/ContentImporters/CreateParticleEmitter.h
@@ -22,11 +22,11 @@ public:
     static CreateAssetResult Create(CreateAssetContext& context)
     {
         // Base
-        IMPORT_SETUP(ParticleEmitter, 20);
+        IMPORT_SETUP(ParticleEmitter, 21);
         context.SkipMetadata = true;
 
         // Set Custom Data with Header
-        ShaderStorage::Header20 shaderHeader;
+        ShaderStorage::Header21 shaderHeader;
         Platform::MemoryClear(&shaderHeader, sizeof(shaderHeader));
         context.Data.CustomData.Copy(&shaderHeader);
 

--- a/Source/Engine/ContentImporters/ImportShader.cpp
+++ b/Source/Engine/ContentImporters/ImportShader.cpp
@@ -14,7 +14,7 @@
 CreateAssetResult ImportShader::Import(CreateAssetContext& context)
 {
     // Base
-    IMPORT_SETUP(Shader, 20);
+    IMPORT_SETUP(Shader, 21);
     const int32 SourceCodeChunk = 15;
     context.SkipMetadata = true;
 
@@ -40,7 +40,7 @@ CreateAssetResult ImportShader::Import(CreateAssetContext& context)
     Encryption::EncryptBytes(sourceCode, sourceCodeSize);
 
     // Set Custom Data with Header
-    ShaderStorage::Header20 shaderHeader;
+    ShaderStorage::Header21 shaderHeader;
     Platform::MemoryClear(&shaderHeader, sizeof(shaderHeader));
     context.Data.CustomData.Copy(&shaderHeader);
 

--- a/Source/Engine/Graphics/MaterialInfo.cs
+++ b/Source/Engine/Graphics/MaterialInfo.cs
@@ -67,7 +67,9 @@ namespace FlaxEngine
                    && Mathf.NearEqual(MaskThreshold, other.MaskThreshold)
                    && Mathf.NearEqual(OpacityThreshold, other.OpacityThreshold)
                    && TessellationMode == other.TessellationMode
-                   && MaxTessellationFactor == other.MaxTessellationFactor;
+                   && MaxTessellationFactor == other.MaxTessellationFactor
+                   && MinDepth == other.MinDepth
+                   && MaxDepth == other.MaxDepth;
         }
 
         /// <inheritdoc />
@@ -93,6 +95,7 @@ namespace FlaxEngine
                 hashCode = (hashCode * 397) ^ (int)(OpacityThreshold * 1000.0f);
                 hashCode = (hashCode * 397) ^ (int)TessellationMode;
                 hashCode = (hashCode * 397) ^ MaxTessellationFactor;
+                hashCode = (hashCode * 397) ^ (int)((MinDepth + MaxDepth) * 100.0f);
                 return hashCode;
             }
         }

--- a/Source/Engine/Graphics/MaterialInfo.cs
+++ b/Source/Engine/Graphics/MaterialInfo.cs
@@ -24,6 +24,9 @@ namespace FlaxEngine
                 OpacityThreshold = 0.12f,
                 TessellationMode = TessellationMethod.None,
                 MaxTessellationFactor = 15,
+                MinDepth = 0.0f,
+                MaxDepth = 1.0f,
+                StaticFOV = 0.0f,
             };
         }
 
@@ -69,7 +72,8 @@ namespace FlaxEngine
                    && TessellationMode == other.TessellationMode
                    && MaxTessellationFactor == other.MaxTessellationFactor
                    && MinDepth == other.MinDepth
-                   && MaxDepth == other.MaxDepth;
+                   && MaxDepth == other.MaxDepth
+                   && StaticFOV == other.StaticFOV;
         }
 
         /// <inheritdoc />
@@ -95,7 +99,7 @@ namespace FlaxEngine
                 hashCode = (hashCode * 397) ^ (int)(OpacityThreshold * 1000.0f);
                 hashCode = (hashCode * 397) ^ (int)TessellationMode;
                 hashCode = (hashCode * 397) ^ MaxTessellationFactor;
-                hashCode = (hashCode * 397) ^ (int)((MinDepth + MaxDepth) * 100.0f);
+                hashCode = (hashCode * 397) ^ (int)((MinDepth + MaxDepth + StaticFOV) * 100.0f);
                 return hashCode;
             }
         }

--- a/Source/Engine/Graphics/MaterialInfo.cs
+++ b/Source/Engine/Graphics/MaterialInfo.cs
@@ -27,6 +27,7 @@ namespace FlaxEngine
                 MinDepth = 0.0f,
                 MaxDepth = 1.0f,
                 StaticFOV = 0.0f,
+                DistanceBias = 0.0f,
             };
         }
 
@@ -73,7 +74,8 @@ namespace FlaxEngine
                    && MaxTessellationFactor == other.MaxTessellationFactor
                    && MinDepth == other.MinDepth
                    && MaxDepth == other.MaxDepth
-                   && StaticFOV == other.StaticFOV;
+                   && StaticFOV == other.StaticFOV
+                   && DistanceBias == other.DistanceBias;
         }
 
         /// <inheritdoc />

--- a/Source/Engine/Graphics/Materials/DeferredMaterialShader.cpp
+++ b/Source/Engine/Graphics/Materials/DeferredMaterialShader.cpp
@@ -83,7 +83,20 @@ void DeferredMaterialShader::Bind(BindParameters& params)
 
     // Setup material constants
     {
-        Matrix::Transpose(view.Frustum.GetMatrix(), materialData->ViewProjectionMatrix);
+        if (params.CustomFrustum)
+        {
+            // Copy custom frustum matrix and transpose.
+            Matrix ViewProjection;
+            ViewProjection.SetRow1(params.CustomFrustum->GetRow1());
+            ViewProjection.SetRow2(params.CustomFrustum->GetRow2());
+            ViewProjection.SetRow3(params.CustomFrustum->GetRow3());
+            ViewProjection.SetRow4(params.CustomFrustum->GetRow4());
+            Matrix::Transpose(ViewProjection, materialData->ViewProjectionMatrix);
+        }
+        else
+        {
+            Matrix::Transpose(view.Frustum.GetMatrix(), materialData->ViewProjectionMatrix);
+        }
         Matrix::Transpose(drawCall.World, materialData->WorldMatrix);
         Matrix::Transpose(view.View, materialData->ViewMatrix);
         Matrix::Transpose(drawCall.Surface.PrevWorld, materialData->PrevWorldMatrix);

--- a/Source/Engine/Graphics/Materials/IMaterial.h
+++ b/Source/Engine/Graphics/Materials/IMaterial.h
@@ -151,6 +151,11 @@ public:
         /// </summary>
         GPUTextureView* Input = nullptr;
 
+        /// <summary>
+        /// Custom Frustum , used to change view projection matrix for static FOV.
+        /// </summary>
+        Matrix* CustomFrustum = nullptr;
+
         BindParameters(::GPUContext* context, const ::RenderContext& renderContext);
         BindParameters(::GPUContext* context, const ::RenderContext& renderContext, const DrawCall& drawCall);
         BindParameters(::GPUContext* context, const ::RenderContext& renderContext, const DrawCall* firstDrawCall, int32 drawCallsCount);

--- a/Source/Engine/Graphics/Materials/MaterialInfo.h
+++ b/Source/Engine/Graphics/Materials/MaterialInfo.h
@@ -495,6 +495,34 @@ struct MaterialInfo9
 };
 
 /// <summary>
+/// Material info structure - version 10
+/// [Deprecated on 14.11.2022, expires on 14.11.2024]
+/// </summary>
+struct MaterialInfo10
+{
+    MaterialDomain Domain;
+    MaterialBlendMode BlendMode;
+    MaterialShadingModel ShadingModel;
+    MaterialUsageFlags UsageFlags;
+    MaterialFeaturesFlags FeaturesFlags;
+    MaterialDecalBlendingMode DecalBlendingMode;
+    MaterialTransparentLightingMode TransparentLightingMode;
+    MaterialPostFxLocation PostFxLocation;
+    CullMode CullMode;
+    float MaskThreshold;
+    float OpacityThreshold;
+    TessellationMethod TessellationMode;
+    int32 MaxTessellationFactor;
+
+    MaterialInfo10()
+    {
+    }
+
+    MaterialInfo10(const MaterialInfo9& other);
+    bool operator==(const MaterialInfo10& other) const;
+};
+
+/// <summary>
 /// Structure with basic information about the material surface. It describes how material is reacting on light and which graphical features of it requires to render.
 /// </summary>
 API_STRUCT() struct FLAXENGINE_API MaterialInfo
@@ -566,14 +594,24 @@ API_STRUCT() struct FLAXENGINE_API MaterialInfo
     /// </summary>
     API_FIELD() int32 MaxTessellationFactor;
 
+    /// <summary>
+    /// The Minimum depth
+    /// </summary>
+    API_FIELD() float MinDepth;
+
+    /// <summary>
+    /// The Maximum depth
+    /// </summary>
+    API_FIELD() float MaxDepth;
+
     MaterialInfo()
     {
     }
 
-    MaterialInfo(const MaterialInfo9& other);
+    MaterialInfo(const MaterialInfo10& other);
     bool operator==(const MaterialInfo& other) const;
 };
 
 // The current material info descriptor version used by the material pipeline
-typedef MaterialInfo MaterialInfo10;
-#define MaterialInfo_Version 10
+typedef MaterialInfo MaterialInfo11;
+#define MaterialInfo_Version 11

--- a/Source/Engine/Graphics/Materials/MaterialInfo.h
+++ b/Source/Engine/Graphics/Materials/MaterialInfo.h
@@ -610,10 +610,15 @@ API_STRUCT() struct FLAXENGINE_API MaterialInfo
     API_FIELD() float StaticFOV;
 
     /// <summary>
-    /// Reserved for future use, just add a float before this line and count it down.
-    /// Will be initialised with -2.0 so can be used in most cases, also new initialising is possible if < -1.0.
+    /// Distance Bias used to control draw order.
     /// </summary>
-    float for_future_use[9];
+    API_FIELD() float DistanceBias;
+
+    /// <summary>
+    /// Reserved for future use, just add a float before this line and count it down.
+    /// Now initialised with 0.0 so can be used in most cases.
+    /// </summary>
+    float for_future_use[8];
 
     MaterialInfo()
     {

--- a/Source/Engine/Graphics/Materials/MaterialInfo.h
+++ b/Source/Engine/Graphics/Materials/MaterialInfo.h
@@ -604,6 +604,12 @@ API_STRUCT() struct FLAXENGINE_API MaterialInfo
     /// </summary>
     API_FIELD() float MaxDepth;
 
+    /// <summary>
+    /// Reserved for future use, just add a float before this line and count it down.
+    /// Will be initialised with -2.0 so can be used in most cases, also new initialising is possible if < -1.0.
+    /// </summary>
+    float for_future_use[10];
+
     MaterialInfo()
     {
     }

--- a/Source/Engine/Graphics/Materials/MaterialInfo.h
+++ b/Source/Engine/Graphics/Materials/MaterialInfo.h
@@ -605,10 +605,15 @@ API_STRUCT() struct FLAXENGINE_API MaterialInfo
     API_FIELD() float MaxDepth;
 
     /// <summary>
+    /// Static FOV material will always use this FOV no matter what the camera use.
+    /// </summary>
+    API_FIELD() float StaticFOV;
+
+    /// <summary>
     /// Reserved for future use, just add a float before this line and count it down.
     /// Will be initialised with -2.0 so can be used in most cases, also new initialising is possible if < -1.0.
     /// </summary>
-    float for_future_use[10];
+    float for_future_use[9];
 
     MaterialInfo()
     {

--- a/Source/Engine/Graphics/Materials/MaterialParams.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialParams.cpp
@@ -94,7 +94,7 @@ bool MaterialInfo9::operator==(const MaterialInfo9& other) const
             && MaxTessellationFactor == other.MaxTessellationFactor;
 }
 
-MaterialInfo::MaterialInfo(const MaterialInfo9& other)
+MaterialInfo10::MaterialInfo10(const MaterialInfo9& other)
 {
     Domain = other.Domain;
     BlendMode = other.BlendMode;
@@ -111,21 +111,59 @@ MaterialInfo::MaterialInfo(const MaterialInfo9& other)
     MaxTessellationFactor = other.MaxTessellationFactor;
 }
 
+bool MaterialInfo10::operator==(const MaterialInfo10& other) const
+{
+    return Domain == other.Domain
+        && BlendMode == other.BlendMode
+        && ShadingModel == other.ShadingModel
+        && UsageFlags == other.UsageFlags
+        && FeaturesFlags == other.FeaturesFlags
+        && DecalBlendingMode == other.DecalBlendingMode
+        && TransparentLightingMode == other.TransparentLightingMode
+        && PostFxLocation == other.PostFxLocation
+        && CullMode == other.CullMode
+        && Math::NearEqual(MaskThreshold, other.MaskThreshold)
+        && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
+        && TessellationMode == other.TessellationMode
+        && MaxTessellationFactor == other.MaxTessellationFactor;
+}
+
+MaterialInfo::MaterialInfo(const MaterialInfo10& other)
+{
+    Domain = other.Domain;
+    BlendMode = other.BlendMode;
+    ShadingModel = other.ShadingModel;
+    UsageFlags = other.UsageFlags;
+    FeaturesFlags = other.FeaturesFlags;
+    DecalBlendingMode = other.DecalBlendingMode;
+    TransparentLightingMode = other.TransparentLightingMode;
+    PostFxLocation = other.PostFxLocation;
+    CullMode = other.CullMode;
+    MaskThreshold = other.MaskThreshold;
+    OpacityThreshold = other.OpacityThreshold;
+    TessellationMode = other.TessellationMode;
+    MaxTessellationFactor = other.MaxTessellationFactor;
+    MinDepth = 0.0f;
+    MaxDepth = 1.0f;
+}
+
 bool MaterialInfo::operator==(const MaterialInfo& other) const
 {
     return Domain == other.Domain
-            && BlendMode == other.BlendMode
-            && ShadingModel == other.ShadingModel
-            && UsageFlags == other.UsageFlags
-            && FeaturesFlags == other.FeaturesFlags
-            && DecalBlendingMode == other.DecalBlendingMode
-            && TransparentLightingMode == other.TransparentLightingMode
-            && PostFxLocation == other.PostFxLocation
-            && CullMode == other.CullMode
-            && Math::NearEqual(MaskThreshold, other.MaskThreshold)
-            && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
-            && TessellationMode == other.TessellationMode
-            && MaxTessellationFactor == other.MaxTessellationFactor;
+        && BlendMode == other.BlendMode
+        && ShadingModel == other.ShadingModel
+        && UsageFlags == other.UsageFlags
+        && FeaturesFlags == other.FeaturesFlags
+        && DecalBlendingMode == other.DecalBlendingMode
+        && TransparentLightingMode == other.TransparentLightingMode
+        && PostFxLocation == other.PostFxLocation
+        && CullMode == other.CullMode
+        && Math::NearEqual(MaskThreshold, other.MaskThreshold)
+        && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
+        && TessellationMode == other.TessellationMode
+        && MaxTessellationFactor == other.MaxTessellationFactor
+        && MinDepth == other.MinDepth
+        && MaxDepth == other.MaxDepth;
 }
 
 const Char* ToString(MaterialParameterType value)

--- a/Source/Engine/Graphics/Materials/MaterialParams.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialParams.cpp
@@ -146,6 +146,7 @@ MaterialInfo::MaterialInfo(const MaterialInfo10& other)
     MinDepth = 0.0f;
     MaxDepth = 1.0f;
     StaticFOV = 0.0f;
+    DistanceBias = 0.0f;
 }
 
 bool MaterialInfo::operator==(const MaterialInfo& other) const
@@ -165,7 +166,8 @@ bool MaterialInfo::operator==(const MaterialInfo& other) const
         && MaxTessellationFactor == other.MaxTessellationFactor
         && MinDepth == other.MinDepth
         && MaxDepth == other.MaxDepth
-        && StaticFOV == other.StaticFOV;
+        && StaticFOV == other.StaticFOV
+        && DistanceBias == other.DistanceBias;
 }
 
 const Char* ToString(MaterialParameterType value)

--- a/Source/Engine/Graphics/Materials/MaterialParams.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialParams.cpp
@@ -145,6 +145,7 @@ MaterialInfo::MaterialInfo(const MaterialInfo10& other)
     MaxTessellationFactor = other.MaxTessellationFactor;
     MinDepth = 0.0f;
     MaxDepth = 1.0f;
+    StaticFOV = 0.0f;
 }
 
 bool MaterialInfo::operator==(const MaterialInfo& other) const
@@ -163,7 +164,8 @@ bool MaterialInfo::operator==(const MaterialInfo& other) const
         && TessellationMode == other.TessellationMode
         && MaxTessellationFactor == other.MaxTessellationFactor
         && MinDepth == other.MinDepth
-        && MaxDepth == other.MaxDepth;
+        && MaxDepth == other.MaxDepth
+        && StaticFOV == other.StaticFOV;
 }
 
 const Char* ToString(MaterialParameterType value)

--- a/Source/Engine/Graphics/Shaders/Cache/ShaderStorage.h
+++ b/Source/Engine/Graphics/Shaders/Cache/ShaderStorage.h
@@ -161,7 +161,52 @@ public:
     };
 
     /// <summary>
+    /// File header, version 21
+    /// </summary>
+    struct Header21
+    {
+        static const int32 Version = 21;
+
+        union
+        {
+            struct
+            {
+            } Shader;
+
+            struct
+            {
+                /// <summary>
+                /// The material graph version.
+                /// </summary>
+                int32 GraphVersion;
+
+                /// <summary>
+                /// The material additional information.
+                /// </summary>
+                MaterialInfo11 Info;
+            } Material;
+
+            struct
+            {
+                /// <summary>
+                /// The particle emitter graph version.
+                /// </summary>
+                int32 GraphVersion;
+
+                /// <summary>
+                /// The custom particles data size (in bytes).
+                /// </summary>
+                int32 CustomDataSize;
+            } ParticleEmitter;
+        };
+
+        Header21()
+        {
+        }
+    };
+
+    /// <summary>
     /// Current header type
     /// </summary>
-    typedef Header20 Header;
+    typedef Header21 Header;
 };

--- a/Source/Engine/Renderer/RenderList.cpp
+++ b/Source/Engine/Renderer/RenderList.cpp
@@ -493,7 +493,8 @@ void RenderList::SortDrawCalls(const RenderContext& renderContext, bool reverseD
     for (int32 i = 0; i < listSize; i++)
     {
         auto& drawCall = DrawCalls[list.Indices[i]];
-        const float distance = Float3::Dot(planeNormal, drawCall.ObjectPosition) - planePoint;
+        auto materialInfo = drawCall.Material->GetInfo();
+        const float distance = (Float3::Dot(planeNormal, drawCall.ObjectPosition) - planePoint) + materialInfo.DistanceBias;
         const uint32 sortKey = RenderTools::ComputeDistanceSortKey(distance) ^ sortKeyXor;
         int32 batchKey = GetHash(drawCall.Geometry.IndexBuffer);
         batchKey = (batchKey * 397) ^ GetHash(drawCall.Geometry.VertexBuffers[0]);

--- a/Source/Engine/Renderer/RenderList.cpp
+++ b/Source/Engine/Renderer/RenderList.cpp
@@ -654,6 +654,7 @@ DRAW:
 
             Viewport oldviewport;
             RenderView customView;
+            Matrix CustomFrustum;
             bool RestoreViewport = false;
             bool RestoreFov = false;
             auto info = drawCall.Material->GetInfo();
@@ -676,7 +677,8 @@ DRAW:
                 Matrix::PerspectiveFov(info.StaticFOV * DegreesToRadians, aspectRatio, renderContext.View.Near, renderContext.View.Far, proj);
                 customView = renderContext.View;
                 customView.SetUp(renderContext.Task->View.View, proj);
-                bindParams.CustomFrustum = &customView.Frustum.GetMatrix();
+                CustomFrustum = customView.Frustum.GetMatrix();
+                bindParams.CustomFrustum = &CustomFrustum;
                 RestoreFov = true;
             }
 
@@ -785,6 +787,7 @@ DRAW:
 
                 Viewport oldviewport;
                 RenderView customView;
+                Matrix CustomFrustum;
                 bool RestoreViewport = false;
                 bool RestoreFov = false;
                 auto info = drawCall.Material->GetInfo();
@@ -807,7 +810,8 @@ DRAW:
                     Matrix::PerspectiveFov(info.StaticFOV * DegreesToRadians, aspectRatio, renderContext.View.Near, renderContext.View.Far, proj);
                     customView = renderContext.View;
                     customView.SetUp(renderContext.Task->View.View, proj);
-                    bindParams.CustomFrustum = &customView.Frustum.GetMatrix();
+                    CustomFrustum = customView.Frustum.GetMatrix();
+                    bindParams.CustomFrustum = &CustomFrustum;
                     RestoreFov = true;
                 }
 


### PR DESCRIPTION
PE: csharp allow setting material minimum and max depth, for on top rendering.
PE: allow setting material minimum and max depth, for on top rendering.
PE: Also support on top SpriteRender for crosshair...
PE: Reserve some floats in materialinfo11 to allow new features in the future without changing header version and upgrading shaders.
PE: Static FOV, material will always have this static FOV even if camera change FOV.

Usage: Min Depth: 0.0 , Max Depth: 0.1
Usage: Static FOV: 60

@mafiesto4 Added Static FOV to this pull as it fit with the material/header upgrade, so it now fix both weapon clipping and weapon FOV issues.

@mafiesto4 Added distance bias to control draw order, can be used to set transparency sort priority. Added to this pull as this also require a material update :)

![distancebias](https://user-images.githubusercontent.com/18662417/209951659-64e712fa-2625-4664-ac0d-39e32ebb9254.jpg)

