### PR TITLE
Fix RunProcess not working in development builds

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -1079,7 +1079,6 @@ int32 WindowsPlatform::RunProcess(const StringView& cmdLine, const StringView& w
 
     HANDLE stdOutRead = nullptr;
     HANDLE stdErrRead = nullptr;
-    Array<byte> attributeList;
 
     if (captureStdOut)
     {
@@ -1101,8 +1100,7 @@ int32 WindowsPlatform::RunProcess(const StringView& cmdLine, const StringView& w
         SIZE_T bufferSize = 0;
         if (!InitializeProcThreadAttributeList(nullptr, 1, 0, &bufferSize) && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
         {
-            attributeList.Resize((int32)bufferSize);
-            startupInfoEx.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)attributeList.Get();
+            startupInfoEx.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)Allocate(sizeof(byte) * bufferSize, 16);
             if (!InitializeProcThreadAttributeList(startupInfoEx.lpAttributeList, 1, 0, &bufferSize))
             {
                 LOG(Warning, "InitializeProcThreadAttributeList failed");
@@ -1176,6 +1174,7 @@ ERROR_EXIT:
     if (startupInfoEx.lpAttributeList != nullptr)
     {
         DeleteProcThreadAttributeList(startupInfoEx.lpAttributeList);
+        Allocator::Free(startupInfoEx.lpAttributeList);
     }
 
     return result;


### PR DESCRIPTION
Works around a possible compiler bug caused by db6aab1cf6142be4bcfc872a99f381af9986508a