### PR TITLE
Changed location of renaming box for ActorTreeNodes to start at the label for better UX.

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -282,7 +282,7 @@ namespace FlaxEditor.SceneGraph.GUI
                 (window as PrefabWindow).ScrollingOnTreeView(false);
 
             // Start renaming the actor
-            var dialog = RenamePopup.Show(this, HeaderRect, _actorNode.Name, false);
+            var dialog = RenamePopup.Show(this, TextRect, _actorNode.Name, false);
             dialog.Renamed += OnRenamed;
             dialog.Closed += popup =>
             {


### PR DESCRIPTION
Hello, This changes the renaming box to use the text rectangle instead of the header rectangle for it's size for the ActorTreeNodes. This is really nice if there are a lot of child objects so that way the user doesn't have to scroll back to the left to rename and can just rename in the current panel view.

![ex](https://user-images.githubusercontent.com/71274967/206580136-c7943687-80cf-4832-8f6e-12f3fdd274b5.PNG)
