### PR TITLE
Content view tree re-organization for better UX.

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -841,6 +841,7 @@ namespace FlaxEditor.Windows
             _root.AddChild(Editor.ContentDatabase.Game);
             foreach (var project in Editor.ContentDatabase.Projects)
             {
+                project.SortChildrenRecursive();
                 if (project == Editor.ContentDatabase.Game || project == Editor.ContentDatabase.Engine)
                     continue;
                 _root.AddChild(project);

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -837,13 +837,19 @@ namespace FlaxEditor.Windows
             };
             _root.Expand(true);
 
+            // Add game project on top, plugins in the middle and engine at bottom
+            _root.AddChild(Editor.ContentDatabase.Game);
             foreach (var project in Editor.ContentDatabase.Projects)
+            {
+                if (project == Editor.ContentDatabase.Game || project == Editor.ContentDatabase.Engine)
+                    continue;
                 _root.AddChild(project);
+            }
+            _root.AddChild(Editor.ContentDatabase.Engine);
 
             Editor.ContentDatabase.Game?.Expand(true);
             _tree.Margin = new Margin(0.0f, 0.0f, -16.0f, 2.0f); // Hide root node
             _tree.AddChild(_root);
-            _root.SortChildrenRecursive();
 
             // Setup navigation
             _navigationUnlocked = true;


### PR DESCRIPTION
Remove auto sorting the projects in content view tree and make it so the game project is always on top, plugins in the middle, and engine at the bottom of the tree. This is for better UX.

Current sorting:
![image](https://user-images.githubusercontent.com/71274967/207620694-eb4c94d0-3b0b-4737-adca-a666a3128730.png)

New Sorting:
![image](https://user-images.githubusercontent.com/71274967/207620849-a136949d-e73c-45fd-adf4-0882507e44fe.png)
