### PR TITLE
Prevent spawning abstract type

### DIFF
--- a/Source/Engine/Level/Actor.cs
+++ b/Source/Engine/Level/Actor.cs
@@ -123,6 +123,9 @@ namespace FlaxEngine
         /// <returns>The child actor.</returns>
         public Actor AddChild(Type type)
         {
+            if (type.IsAbstract)
+                return null;
+            
             var result = (Actor)New(type);
             result.SetParent(this, false, false);
             return result;
@@ -135,6 +138,9 @@ namespace FlaxEngine
         /// <returns>The child actor.</returns>
         public T AddChild<T>() where T : Actor
         {
+            if (typeof(T).IsAbstract)
+                return null;
+
             var result = New<T>();
             result.SetParent(this, false, false);
             return result;
@@ -172,6 +178,9 @@ namespace FlaxEngine
             var result = GetChild<T>();
             if (result == null)
             {
+                if (typeof(T).IsAbstract)
+                    return null;
+                
                 result = New<T>();
                 result.SetParent(this, false, false);
             }
@@ -185,6 +194,9 @@ namespace FlaxEngine
         /// <returns>The created script instance, null otherwise.</returns>
         public Script AddScript(Type type)
         {
+            if (type.IsAbstract)
+                return null;
+            
             var script = (Script)New(type);
             script.Parent = this;
             return script;
@@ -197,6 +209,9 @@ namespace FlaxEngine
         /// <returns>The created script instance, null otherwise.</returns>
         public T AddScript<T>() where T : Script
         {
+            if (typeof(T).IsAbstract)
+                return null;
+            
             var script = New<T>();
             script.Parent = this;
             return script;

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -227,8 +227,7 @@ public:
         T* result = (T*)GetChild(T::GetStaticClass());
         if (!result)
         {
-            const MClass* type = T::GetStaticClass();
-            if (type->IsAbstract())
+            if (T::GetStaticClass()->IsAbstract())
                 return nullptr;
 
             result = New<T>();

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -227,6 +227,10 @@ public:
         T* result = (T*)GetChild(T::GetStaticClass());
         if (!result)
         {
+            const MClass* type = T::GetStaticClass();
+            if (type->IsAbstract())
+                return nullptr;
+
             result = New<T>();
             result->SetParent(this, false, false);
         }

--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -177,6 +177,12 @@ bool LevelImpl::spawnActor(Actor* actor, Actor* parent)
         return true;
     }
 
+    if (actor->GetType().ManagedClass->IsAbstract())
+    {
+        Log::Exception(TEXT("Cannot spawn abstract actor type."));
+        return true;
+    }
+
     if (actor->Is<Scene>())
     {
         // Spawn scene


### PR DESCRIPTION
Hello, saw this on the roadmap under "Add prevention from spawning abstract actor type (eg. Actor.AddChild<Actor>())" for 1.5 and thought I would go ahead a take a shot at implementing it. Basically this returns null or nullptr if the user is trying to add an abstract type as an Actor child or script child. It also wont allow Level.SpawnActor() to spawn an abstract type.