### PR TITLE
Fix issue of game window not returning focus to parent on mouse leave.

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -346,6 +346,13 @@ namespace FlaxEditor.Windows
         }
 
         /// <inheritdoc />
+        public override void OnMouseLeave()
+        {
+            Parent?.Focus();
+            base.OnMouseLeave();
+        }
+
+        /// <inheritdoc />
         public override void OnShowContextMenu(ContextMenu menu)
         {
             base.OnShowContextMenu(menu);


### PR DESCRIPTION
Hello, this PR returns the focus to the parent of the game window when the mouse leaves it. This issue was causing the cursor not to change on the splitters if the game window was focused.