### PR TITLE
Center the context menu that is created from clicking the add scripts button on an actor

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -72,7 +72,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
             }
             cm.ItemClicked += item => AddScript((ScriptType)item.Tag);
             cm.SortItems();
-            cm.Show(this, button.BottomLeft);
+            cm.Show(this, button.BottomLeft - new Float2((cm.Width - button.Width) / 2, 0));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Very simple UX change of centering the menu that is spawned when a user clicks the add script button. To me it feels more natural to have it centered.

![script center](https://user-images.githubusercontent.com/71274967/209205011-4c9960ed-75c8-4776-839b-25f6a3813098.png)
