### PR TITLE
Fixed some CM buttons that shouldn't close when clicked.

### DIFF
--- a/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
@@ -198,6 +198,7 @@ namespace FlaxEditor.Viewport.Previews
                 // Preview LOD
                 {
                     var previewLOD = ViewWidgetButtonMenu.AddButton("Preview LOD");
+                    previewLOD.CloseMenuOnClick = false;
                     var previewLODValue = new IntValueBox(-1, 90, 2, 70.0f, -1, 10, 0.02f)
                     {
                         Parent = previewLOD

--- a/Source/Editor/Viewport/Previews/ModelBasePreview.cs
+++ b/Source/Editor/Viewport/Previews/ModelBasePreview.cs
@@ -62,6 +62,7 @@ namespace FlaxEditor.Viewport.Previews
                 // Preview LOD
                 {
                     var previewLOD = ViewWidgetButtonMenu.AddButton("Preview LOD");
+                    previewLOD.CloseMenuOnClick = false;
                     var previewLODValue = new IntValueBox(-1, 90, 2, 70.0f, -1, 10, 0.02f)
                     {
                         Parent = previewLOD

--- a/Source/Editor/Viewport/Previews/ModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/ModelPreview.cs
@@ -201,6 +201,7 @@ namespace FlaxEditor.Viewport.Previews
                 // Preview LOD
                 {
                     var previewLOD = ViewWidgetButtonMenu.AddButton("Preview LOD");
+                    previewLOD.CloseMenuOnClick = false;
                     var previewLODValue = new IntValueBox(-1, 90, 2, 70.0f, -1, 10, 0.02f)
                     {
                         Parent = previewLOD

--- a/Source/Editor/Viewport/Previews/ParticleEmitterPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleEmitterPreview.cs
@@ -67,6 +67,7 @@ namespace FlaxEditor.Viewport.Previews
             if (useWidgets)
             {
                 var playbackDuration = ViewWidgetButtonMenu.AddButton("Duration");
+                playbackDuration.CloseMenuOnClick = false;
                 var playbackDurationValue = new FloatValueBox(_playbackDuration, 90, 2, 70.0f, 0.1f, 1000000.0f, 0.1f)
                 {
                     Parent = playbackDuration

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -205,6 +205,7 @@ namespace FlaxEditor.Windows
             showFileExtensionsButton.AutoCheck = true;
 
             var viewScale = menu.AddButton("View Scale");
+            viewScale.CloseMenuOnClick = false;
             var scaleValue = new FloatValueBox(1, 75, 2, 50.0f, 0.3f, 3.0f, 0.01f)
             {
                 Parent = viewScale


### PR DESCRIPTION
Hello, this fixes a few context menu items that were closing when clicked even though they were not acting as a button. This makes it so they dont close when clicked.