### PR TITLE
Procedural Texture Sampling Material Node

### DIFF
--- a/Source/Editor/Surface/Archetypes/Textures.cs
+++ b/Source/Editor/Surface/Archetypes/Textures.cs
@@ -408,8 +408,8 @@ namespace FlaxEditor.Surface.Archetypes
             new NodeArchetype
             {
                 TypeID = 17,
-                Title = "Stochastic Sample Texture",
-                Description = "Projects a texture using world-space coordinates instead of UVs.",
+                Title = "Procedural Sample Texture",
+                Description = "Samples a texture to create a more natural look with less obvious tiling.",
                 Flags = NodeFlags.MaterialGraph,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]

--- a/Source/Editor/Surface/Archetypes/Textures.cs
+++ b/Source/Editor/Surface/Archetypes/Textures.cs
@@ -405,6 +405,24 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Output(0, "Color", typeof(Float3), 3)
                 }
             },
+            new NodeArchetype
+            {
+                TypeID = 17,
+                Title = "Stochastic Sample Texture",
+                Description = "Projects a texture using world-space coordinates instead of UVs.",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Float2(240, 60),
+                DefaultValues = new object[]
+                {
+                    new Float2(1.0f, 1.0f),
+                },
+                Elements = new[]
+                {
+                    NodeElementArchetype.Factory.Input(0, "Texture", true, typeof(FlaxEngine.Object), 0),
+                    NodeElementArchetype.Factory.Input(1, "UV", true, typeof(Float2), 1, 0),
+                    NodeElementArchetype.Factory.Output(0, "Color", typeof(Float4), 2),
+                }
+            },
         };
     }
 }

--- a/Source/Editor/Surface/Archetypes/Textures.cs
+++ b/Source/Editor/Surface/Archetypes/Textures.cs
@@ -86,6 +86,71 @@ namespace FlaxEditor.Surface.Archetypes
             }
         }
 
+        // TODO merge the above and below function into one?
+        internal class ProceduralSampleNode : SurfaceNode
+        {
+            private ComboBox _textureGroupPicker;
+
+            public ProceduralSampleNode(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
+            : base(id, context, nodeArch, groupArch)
+            {
+            }
+
+            public override void OnValuesChanged()
+            {
+                base.OnValuesChanged();
+
+                UpdateUI();
+            }
+
+            public override void OnLoaded()
+            {
+                base.OnLoaded();
+
+                UpdateUI();
+            }
+
+            private void UpdateUI()
+            {
+                if ((int)Values[1] == (int)CommonSamplerType.TextureGroup)
+                {
+                    if (_textureGroupPicker == null)
+                    {
+                        _textureGroupPicker = new ComboBox
+                        {
+                            Location = new Float2(FlaxEditor.Surface.Constants.NodeMarginX + 50, FlaxEditor.Surface.Constants.NodeMarginY + FlaxEditor.Surface.Constants.NodeHeaderSize + FlaxEditor.Surface.Constants.LayoutOffsetY * 3),
+                            Width = 100,
+                            Parent = this,
+                        };
+                        _textureGroupPicker.SelectedIndexChanged += OnSelectedTextureGroupChanged;
+                        var groups = GameSettings.Load<StreamingSettings>();
+                        if (groups?.TextureGroups != null)
+                        {
+                            for (int i = 0; i < groups.TextureGroups.Length; i++)
+                                _textureGroupPicker.AddItem(groups.TextureGroups[i].Name);
+                        }
+                    }
+                    else
+                    {
+                        _textureGroupPicker.Visible = true;
+                    }
+                    _textureGroupPicker.SelectedIndexChanged -= OnSelectedTextureGroupChanged;
+                    _textureGroupPicker.SelectedIndex = (int)Values[2];
+                    _textureGroupPicker.SelectedIndexChanged += OnSelectedTextureGroupChanged;
+                }
+                else if (_textureGroupPicker != null)
+                {
+                    _textureGroupPicker.Visible = false;
+                }
+                ResizeAuto();
+            }
+
+            private void OnSelectedTextureGroupChanged(ComboBox comboBox)
+            {
+                SetValue(2, _textureGroupPicker.SelectedIndex);
+            }
+        }
+
         /// <summary>
         /// The nodes for that group.
         /// </summary>
@@ -408,19 +473,24 @@ namespace FlaxEditor.Surface.Archetypes
             new NodeArchetype
             {
                 TypeID = 17,
+                Create = (id, context, arch, groupArch) => new ProceduralSampleNode(id, context, arch, groupArch),
                 Title = "Procedural Sample Texture",
                 Description = "Samples a texture to create a more natural look with less obvious tiling.",
                 Flags = NodeFlags.MaterialGraph,
-                Size = new Float2(240, 60),
+                Size = new Float2(240, 100),
                 DefaultValues = new object[]
                 {
                     new Float2(1.0f, 1.0f),
+                    2,
+                    0,
                 },
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Input(0, "Texture", true, typeof(FlaxEngine.Object), 0),
                     NodeElementArchetype.Factory.Input(1, "UV", true, typeof(Float2), 1, 0),
                     NodeElementArchetype.Factory.Output(0, "Color", typeof(Float4), 2),
+                    NodeElementArchetype.Factory.Text(0, Surface.Constants.LayoutOffsetY * 2, "Sampler"),
+                    NodeElementArchetype.Factory.ComboBox(50, Surface.Constants.LayoutOffsetY * 2, 100, 1, typeof(CommonSamplerType))
                 }
             },
         };

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
@@ -669,6 +669,7 @@ void MaterialGenerator::ProcessGroupTextures(Box* box, Node* node, Value& value)
         _writer.Write(*triplanarTexture);
         value = result;
     }
+    // Stochastic Texture Sample
     case 17:
     {
         auto textureBox = node->GetBox(0);

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
@@ -669,7 +669,7 @@ void MaterialGenerator::ProcessGroupTextures(Box* box, Node* node, Value& value)
         _writer.Write(*triplanarTexture);
         value = result;
     }
-    // Stochastic Texture Sample
+    // Procedural Texture Sample
     case 17:
     {
         auto textureBox = node->GetBox(0);


### PR DESCRIPTION
Hi!

This PR adds a node for the material editor that adds procedural stochastic texture sampling. This makes it so that you can sample a texture over a large area (such as terrain) and have no noticeable tiling.

![FlaxEditor_2022-12-23_17-12-22](https://user-images.githubusercontent.com/38583668/209533118-9c7a1b09-63d5-4cf3-a1f4-3c004ebe2af4.png)

The node supports regular texture mapping as well as normal mapping. Includes a UV input so you can tile the sample in any way that you might want.
