### PR TITLE
GPUResource property glue generation fix for `Name` 

### DIFF
--- a/Source/Editor/Windows/Profiler/MemoryGPU.cs
+++ b/Source/Editor/Windows/Profiler/MemoryGPU.cs
@@ -133,7 +133,9 @@ namespace FlaxEditor.Windows.Profiler
                 {
                     resource = new Resource
                     {
+#if !BUILD_RELEASE
                         Name = gpuResource.Name,
+#endif
                         Type = gpuResource.ResourceType,
                     };
 


### PR DESCRIPTION
This fixes the issue when compiling the editor in the `Release`
 
`
D:\Development\FlaxEngine\Source\Editor\Windows\Profiler\MemoryGPU.cs(136,44,136,48): error CS1061: 'GPUResource' does not contain a definition for 'Name' and no accessible extension method 'Name' accepting a first argument of type 'GPUResource' could be found (are you missing a using directive or an assembly reference?)
ModelTool.cpp
`
 
`
Task C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\Roslyn\csc.exe /noconfig /shared @"D:\Development\FlaxEngine\Cache/Intermediate\FlaxEditor\Windows\x64\Release\FlaxEngine.CSharp.response" failed with exit code 1
`