### PR TITLE
.NET7: Skip cached rules assembly after changing project references

### DIFF
--- a/Source/Engine/Engine/NativeInterop.cs
+++ b/Source/Engine/Engine/NativeInterop.cs
@@ -1311,16 +1311,14 @@ namespace FlaxEngine
 
                 internal static void ToManagedFieldArray(FieldInfo field, ref T fieldOwner, IntPtr fieldPtr, out int fieldOffset)
                 {
-                    fieldOffset = Unsafe.SizeOf<TField>();
-                    if (fieldAlignment > 1)
-                    {
-                        IntPtr fieldStartPtr = fieldPtr;
-                        fieldPtr = EnsureAlignment(fieldPtr, fieldAlignment);
-                        fieldOffset += (fieldPtr - fieldStartPtr).ToInt32();
-                    }
+                    // Follows the same marshalling semantics with reference types
+                    fieldOffset = Unsafe.SizeOf<IntPtr>();
+                    IntPtr fieldStartPtr = fieldPtr;
+                    fieldPtr = EnsureAlignment(fieldPtr, IntPtr.Size);
+                    fieldOffset += (fieldPtr - fieldStartPtr).ToInt32();
 
                     ref TField[] fieldValueRef = ref GetFieldReference<TField[]>(field, ref fieldOwner);
-                    MarshalHelperValueType<TField>.ToManagedArray(ref fieldValueRef, fieldPtr, false);
+                    MarshalHelperValueType<TField>.ToManagedArray(ref fieldValueRef, Unsafe.Read<IntPtr>(fieldPtr.ToPointer()), false);
                 }
 
                 internal static void ToNativeField(FieldInfo field, ref T fieldOwner, IntPtr fieldPtr, out int fieldOffset)
@@ -1342,16 +1340,24 @@ namespace FlaxEngine
             {
                 internal static void ToManagedField(FieldInfo field, ref T fieldOwner, IntPtr fieldPtr, out int fieldOffset)
                 {
+                    fieldOffset = Unsafe.SizeOf<IntPtr>();
+                    IntPtr fieldStartPtr = fieldPtr;
+                    fieldPtr = EnsureAlignment(fieldPtr, IntPtr.Size);
+                    fieldOffset += (fieldPtr - fieldStartPtr).ToInt32();
+
                     ref TField fieldValueRef = ref GetFieldReference<TField>(field, ref fieldOwner);
-                    MarshalHelperReferenceType<TField>.ToManaged(ref fieldValueRef, Marshal.ReadIntPtr(fieldPtr), false);
-                    fieldOffset = IntPtr.Size;
+                    MarshalHelperReferenceType<TField>.ToManaged(ref fieldValueRef, Unsafe.Read<IntPtr>(fieldPtr.ToPointer()), false);
                 }
 
                 internal static void ToNativeField(FieldInfo field, ref T fieldOwner, IntPtr fieldPtr, out int fieldOffset)
                 {
+                    fieldOffset = Unsafe.SizeOf<IntPtr>();
+                    IntPtr fieldStartPtr = fieldPtr;
+                    fieldPtr = EnsureAlignment(fieldPtr, IntPtr.Size);
+                    fieldOffset += (fieldPtr - fieldStartPtr).ToInt32();
+
                     ref TField fieldValueRef = ref GetFieldReference<TField>(field, ref fieldOwner);
                     MarshalHelperReferenceType<TField>.ToNative(ref fieldValueRef, fieldPtr);
-                    fieldOffset = IntPtr.Size;
                 }
             }
         }

--- a/Source/Tools/Flax.Build/Build/Assembler.cs
+++ b/Source/Tools/Flax.Build/Build/Assembler.cs
@@ -81,6 +81,13 @@ namespace Flax.Build
                     if (lastWriteTime > recentWriteTime)
                         recentWriteTime = lastWriteTime;
                 }
+                
+                // Skip when project references were changed
+                {
+                    DateTime lastWriteTime = File.GetLastWriteTime(Globals.Project.ProjectPath);
+                    if (lastWriteTime > recentWriteTime)
+                        recentWriteTime = lastWriteTime;
+                }
 
                 DateTime cacheTime = File.Exists(_cachePath)
                     ? DateTime.FromBinary(long.Parse(File.ReadAllText(_cachePath)))


### PR DESCRIPTION
Adding or removing plugin references in project should invalidate the cache, otherwise the build tool throws errors about missing targets.