### PR TITLE
Custom editor game viewport sizing

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -238,12 +238,51 @@ namespace FlaxEditor.Windows
             // Setup viewport
             _viewport = new RenderOutputControl(task)
             {
-                AnchorPreset = AnchorPresets.StretchAll,
+                AnchorPreset = AnchorPresets.TopLeft,
                 Offsets = Margin.Zero,
                 AutoFocus = false,
                 Parent = this
             };
             task.PostRender += OnPostRender;
+            
+            // TODO move external and let user define. Maybe also just let them define a ratio as well
+            Float2 viewPortSize = new Float2(1920, 1080);
+            bool useCustomAspect = true;
+            bool freeAspect = false;
+            Float2 customAspect = new Float2(9, 16);
+            
+            SizeChanged += control =>
+            {
+                float viewportAspectRatio = 1;
+                float windowAspectRatio = 1;
+                if (!freeAspect)
+                {
+                    if (!useCustomAspect)
+                        viewportAspectRatio = viewPortSize.X / viewPortSize.Y;
+                    else
+                        viewportAspectRatio = customAspect.X / customAspect.Y;
+                    
+                    windowAspectRatio = Size.X / Size.Y;
+                }
+                
+                var scaleWidth = viewportAspectRatio / windowAspectRatio;
+                var scaleHeight = windowAspectRatio / viewportAspectRatio;
+
+                if (scaleHeight < 1)
+                {
+                    _viewport.Width = Size.X;
+                    _viewport.Height = Size.Y * scaleHeight;
+                    _viewport.X = 0;
+                    _viewport.Y = Size.Y * (1-scaleHeight)/2;
+                }
+                else
+                {
+                    _viewport.Width = Size.X * scaleWidth;
+                    _viewport.Height = Size.Y;
+                    _viewport.X = Size.X * (1-scaleWidth)/2;
+                    _viewport.Y = 0;
+                }
+            };
 
             // Override the game GUI root
             _guiRoot = new GameRoot

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -34,8 +34,8 @@ namespace FlaxEditor.Windows
         private List<ViewportScaling> _customViewportScaling = new List<ViewportScaling>();
         private float _viewportAspectRatio = 1;
         private float _windowAspectRatio = 1;
-        bool _useAspect = false;
-        bool _freeAspect = true;
+        private bool _useAspect = false;
+        private bool _freeAspect = true;
 
         /// <summary>
         /// Gets the viewport.

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -247,7 +247,7 @@ namespace FlaxEditor.Windows
             
             // TODO move external and let user define. Maybe also just let them define a ratio as well
             Float2 viewPortSize = new Float2(1920, 1080);
-            bool useCustomAspect = true;
+            bool useCustomAspect = false;
             bool freeAspect = false;
             Float2 customAspect = new Float2(9, 16);
             

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -238,51 +238,12 @@ namespace FlaxEditor.Windows
             // Setup viewport
             _viewport = new RenderOutputControl(task)
             {
-                AnchorPreset = AnchorPresets.TopLeft,
+                AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = Margin.Zero,
                 AutoFocus = false,
                 Parent = this
             };
             task.PostRender += OnPostRender;
-            
-            // TODO move external and let user define. Maybe also just let them define a ratio as well
-            Float2 viewPortSize = new Float2(1920, 1080);
-            bool useCustomAspect = false;
-            bool freeAspect = false;
-            Float2 customAspect = new Float2(9, 16);
-            
-            SizeChanged += control =>
-            {
-                float viewportAspectRatio = 1;
-                float windowAspectRatio = 1;
-                if (!freeAspect)
-                {
-                    if (!useCustomAspect)
-                        viewportAspectRatio = viewPortSize.X / viewPortSize.Y;
-                    else
-                        viewportAspectRatio = customAspect.X / customAspect.Y;
-                    
-                    windowAspectRatio = Size.X / Size.Y;
-                }
-                
-                var scaleWidth = viewportAspectRatio / windowAspectRatio;
-                var scaleHeight = windowAspectRatio / viewportAspectRatio;
-
-                if (scaleHeight < 1)
-                {
-                    _viewport.Width = Size.X;
-                    _viewport.Height = Size.Y * scaleHeight;
-                    _viewport.X = 0;
-                    _viewport.Y = Size.Y * (1-scaleHeight)/2;
-                }
-                else
-                {
-                    _viewport.Width = Size.X * scaleWidth;
-                    _viewport.Height = Size.Y;
-                    _viewport.X = Size.X * (1-scaleWidth)/2;
-                    _viewport.Y = 0;
-                }
-            };
 
             // Override the game GUI root
             _guiRoot = new GameRoot
@@ -294,6 +255,62 @@ namespace FlaxEditor.Windows
                 Parent = _viewport
             };
             RootControl.GameRoot = _guiRoot;
+
+            // TODO move external and let user define. Maybe also just let them define a ratio as well
+            Float2 viewPortSize = new Float2(2560, 1440);
+            //Float2 viewPortSize = new Float2(1280, 720);
+            //Float2 viewPortSize = new Float2(848, 480);
+            bool useCustomAspect = false;
+            bool freeAspect = false;
+            Float2 customAspect = new Float2(9, 16);
+
+            SizeChanged += control =>
+            {
+                float viewportAspectRatio = 1;
+                float windowAspectRatio = 1;
+                
+                if (!freeAspect)
+                {
+                    if (!useCustomAspect)
+                    {
+                        viewportAspectRatio = viewPortSize.X / viewPortSize.Y;
+                        _viewport.KeepAspectRatio = true;
+                        _viewport.CustomResolution = new Int2((int)viewPortSize.X, (int)viewPortSize.Y);
+                    }
+                    else
+                    {
+                        viewportAspectRatio = customAspect.X / customAspect.Y;
+                        _viewport.CustomResolution = new Int2?();
+                        _viewport.KeepAspectRatio = false;
+                    }
+                    
+                    windowAspectRatio = Width / Height;
+                }
+                else
+                {
+                    _viewport.CustomResolution = new Int2?();
+                    _viewport.KeepAspectRatio = false;
+                }
+                
+                var scaleWidth = viewportAspectRatio / windowAspectRatio;
+                var scaleHeight = windowAspectRatio / viewportAspectRatio;
+
+                if (scaleHeight < 1)
+                {
+                    _viewport.Width = Width;
+                    _viewport.Height = Height * scaleHeight;
+                    _viewport.X = 0;
+                    _viewport.Y = Height * (1 - scaleHeight) / 2;
+                }
+                else
+                {
+                    _viewport.Width = Width * scaleWidth;
+                    _viewport.Height = Height;
+                    _viewport.X = Width * (1 - scaleWidth) / 2;
+                    _viewport.Y = 0;
+                }
+            };
+            
             Editor.StateMachine.PlayingState.SceneDuplicating += PlayingStateOnSceneDuplicating;
             Editor.StateMachine.PlayingState.SceneRestored += PlayingStateOnSceneRestored;
 

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -297,17 +297,11 @@ namespace FlaxEditor.Windows
 
                 if (scaleHeight < 1)
                 {
-                    _viewport.Width = Width;
-                    _viewport.Height = Height * scaleHeight;
-                    _viewport.X = 0;
-                    _viewport.Y = Height * (1 - scaleHeight) / 2;
+                    _viewport.Bounds = new Rectangle(0, Height * (1 - scaleHeight) / 2, Width, Height * scaleHeight);
                 }
                 else
                 {
-                    _viewport.Width = Width * scaleWidth;
-                    _viewport.Height = Height;
-                    _viewport.X = Width * (1 - scaleWidth) / 2;
-                    _viewport.Y = 0;
+                    _viewport.Bounds = new Rectangle(Width * (1 - scaleWidth) / 2, 0, Width * scaleWidth, Height);
                 }
             };
             

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -28,6 +28,14 @@ namespace FlaxEditor.Windows
         private GUI.Docking.DockState _maximizeRestoreDockState;
         private GUI.Docking.DockPanel _maximizeRestoreDockTo;
         private CursorLockMode _cursorLockMode = CursorLockMode.None;
+        
+        // Viewport scaling variables
+        private List<ViewportScaling> _defaultViewportScaling = new List<ViewportScaling>();
+        private List<ViewportScaling> _customViewportScaling = new List<ViewportScaling>();
+        private float _viewportAspectRatio = 1;
+        private float _windowAspectRatio = 1;
+        bool _useAspect = false;
+        bool _freeAspect = true;
 
         /// <summary>
         /// Gets the viewport.
@@ -106,14 +114,6 @@ namespace FlaxEditor.Windows
         /// Gets or sets a value indicating whether auto-focus game window on play mode start.
         /// </summary>
         public bool FocusOnPlay { get; set; }
-
-        // TODO move by other privates
-        private List<ViewportScaling> _defaultViewportScaling = new List<ViewportScaling>();
-        private List<ViewportScaling> _customViewportScaling = new List<ViewportScaling>();
-        private float _viewportAspectRatio = 1;
-        private float _windowAspectRatio = 1;
-        bool _useAspect = false;
-        bool _freeAspect = true;
 
         private enum ViewportScalingType
         {
@@ -294,14 +294,6 @@ namespace FlaxEditor.Windows
             };
             RootControl.GameRoot = _guiRoot;
 
-            // TODO move external and let user define. Maybe also just let them define a ratio as well
-            Float2 viewPortSize = new Float2(2560, 1440);
-            //Float2 viewPortSize = new Float2(1280, 720);
-            //Float2 viewPortSize = new Float2(848, 480);
-            bool useCustomAspect = false;
-            bool freeAspect = false;
-            Float2 customAspect = new Float2(9, 16);
-
             SizeChanged += control =>
             {
                 ResizeViewport();
@@ -324,7 +316,6 @@ namespace FlaxEditor.Windows
             if (v == null)
                 return;
             
-            // TODO make it so user can not enter values of 0 or lower
             if (v.Size.Y <= 0 || v.Size.X <= 0)
             {
                 return;

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -500,7 +500,6 @@ namespace FlaxEditor.Windows
                 // Create default scaling options if they dont exist from deserialization.
                 if (_defaultViewportScaling.Count == 0)
                 {
-                    Debug.Log("Had to create scalings.");
                     _defaultViewportScaling.Add(new ViewportScaling
                     {
                         Label = "Free Aspect",

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -30,8 +30,8 @@ namespace FlaxEditor.Windows
         private CursorLockMode _cursorLockMode = CursorLockMode.None;
         
         // Viewport scaling variables
-        private List<ViewportScaling> _defaultViewportScaling = new List<ViewportScaling>();
-        private List<ViewportScaling> _customViewportScaling = new List<ViewportScaling>();
+        private List<ViewportScaleOptions> _defaultViewportScaling = new List<ViewportScaleOptions>();
+        private List<ViewportScaleOptions> _customViewportScaling = new List<ViewportScaleOptions>();
         private float _viewportAspectRatio = 1;
         private float _windowAspectRatio = 1;
         private bool _useAspect = false;
@@ -115,13 +115,13 @@ namespace FlaxEditor.Windows
         /// </summary>
         public bool FocusOnPlay { get; set; }
 
-        private enum ViewportScalingType
+        private enum ViewportScaleType
         {
             Resolution = 0,
             Aspect = 1,
         }
         
-        private class ViewportScaling
+        private class ViewportScaleOptions
         {
             /// <summary>
             /// The name.
@@ -131,7 +131,7 @@ namespace FlaxEditor.Windows
             /// <summary>
             /// The Type of scaling to do.
             /// </summary>
-            public ViewportScalingType ScalingType;
+            public ViewportScaleType ScaleType;
             
             /// <summary>
             /// The width and height to scale by.
@@ -311,7 +311,7 @@ namespace FlaxEditor.Windows
             InputActions.Add(options => options.StepFrame, Editor.Simulation.RequestPlayOneFrame);
         }
 
-        private void ChangeViewportRatio(ViewportScaling v)
+        private void ChangeViewportRatio(ViewportScaleOptions v)
         {
             if (v == null)
                 return;
@@ -328,13 +328,13 @@ namespace FlaxEditor.Windows
             }
             else
             {
-                switch (v.ScalingType)
+                switch (v.ScaleType)
                 {
-                    case ViewportScalingType.Aspect:
+                    case ViewportScaleType.Aspect:
                         _useAspect = true;
                         _freeAspect = false;
                         break;
-                    case ViewportScalingType.Resolution:
+                    case ViewportScaleType.Resolution:
                         _useAspect = false;
                         _freeAspect = false;
                         break;
@@ -500,38 +500,38 @@ namespace FlaxEditor.Windows
                 // Create default scaling options if they dont exist from deserialization.
                 if (_defaultViewportScaling.Count == 0)
                 {
-                    _defaultViewportScaling.Add(new ViewportScaling
+                    _defaultViewportScaling.Add(new ViewportScaleOptions
                     {
                         Label = "Free Aspect",
-                        ScalingType = ViewportScalingType.Aspect,
+                        ScaleType = ViewportScaleType.Aspect,
                         Size = new Int2(1,1),
                         Active = true,
                     });
-                    _defaultViewportScaling.Add(new ViewportScaling
+                    _defaultViewportScaling.Add(new ViewportScaleOptions
                     {
                         Label = "16:9 Aspect",
-                        ScalingType = ViewportScalingType.Aspect,
+                        ScaleType = ViewportScaleType.Aspect,
                         Size = new Int2(16,9),
                         Active = false,
                     });
-                    _defaultViewportScaling.Add(new ViewportScaling
+                    _defaultViewportScaling.Add(new ViewportScaleOptions
                     {
                         Label = "16:10 Aspect",
-                        ScalingType = ViewportScalingType.Aspect,
+                        ScaleType = ViewportScaleType.Aspect,
                         Size = new Int2(16,10),
                         Active = false,
                     });
-                    _defaultViewportScaling.Add(new ViewportScaling
+                    _defaultViewportScaling.Add(new ViewportScaleOptions
                     {
                         Label = "1920x1080 Resolution",
-                        ScalingType = ViewportScalingType.Resolution,
+                        ScaleType = ViewportScaleType.Resolution,
                         Size = new Int2(1920,1080),
                         Active = false,
                     });
-                    _defaultViewportScaling.Add(new ViewportScaling
+                    _defaultViewportScaling.Add(new ViewportScaleOptions
                     {
                         Label = "2560x1440 Resolution",
-                        ScalingType = ViewportScalingType.Resolution,
+                        ScaleType = ViewportScaleType.Resolution,
                         Size = new Int2(2560,1440),
                         Active = false,
                     });
@@ -592,7 +592,7 @@ namespace FlaxEditor.Windows
                     {
                         if (child is ContextMenuButton cmb)
                         {
-                            var v = (ViewportScaling)cmb.Tag;
+                            var v = (ViewportScaleOptions)cmb.Tag;
                             if (cmb == button)
                             {
                                 v.Active = true;
@@ -632,7 +632,7 @@ namespace FlaxEditor.Windows
                     {
                         if (child is ContextMenuButton cmb)
                         {
-                            var v = (ViewportScaling)child.Tag;
+                            var v = (ViewportScaleOptions)child.Tag;
                             if (child == childCM)
                             {
                                 v.Active = true;
@@ -655,7 +655,7 @@ namespace FlaxEditor.Windows
                     if (childCM.Tag == null)
                         return;
 
-                    var v = (ViewportScaling)childCM.Tag;
+                    var v = (ViewportScaleOptions)childCM.Tag;
                     if (v.Active)
                     {
                         v.Active = false;
@@ -766,14 +766,14 @@ namespace FlaxEditor.Windows
 
                 submitButton.Clicked += () =>
                 {
-                    Enum.TryParse(typeDropdown.SelectedItem, out ViewportScalingType type);
+                    Enum.TryParse(typeDropdown.SelectedItem, out ViewportScaleType type);
 
-                    var combineString = type == ViewportScalingType.Aspect ? ":" : "x";
+                    var combineString = type == ViewportScaleType.Aspect ? ":" : "x";
                     var name = nameTextBox.Text + " (" + wValue.Value + combineString + hValue.Value + ") " + typeDropdown.SelectedItem;
 
-                    var newViewportOption = new ViewportScaling
+                    var newViewportOption = new ViewportScaleOptions
                     {
-                        ScalingType = type,
+                        ScaleType = type,
                         Label = name,
                         Size = new Int2(wValue.Value, hValue.Value),
                     };
@@ -1041,7 +1041,7 @@ namespace FlaxEditor.Windows
             if (bool.TryParse(node.GetAttribute("ShowDebugDraw"), out value1))
                 ShowDebugDraw = value1;
             if (node.HasAttribute("CustomViewportScaling"))
-                _customViewportScaling = JsonSerializer.Deserialize<List<ViewportScaling>>(node.GetAttribute("CustomViewportScaling"));
+                _customViewportScaling = JsonSerializer.Deserialize<List<ViewportScaleOptions>>(node.GetAttribute("CustomViewportScaling"));
             
             for (int i = 0; i < _customViewportScaling.Count; i++)
             {
@@ -1050,7 +1050,7 @@ namespace FlaxEditor.Windows
             }
             
             if (node.HasAttribute("DefaultViewportScaling"))
-                _defaultViewportScaling = JsonSerializer.Deserialize<List<ViewportScaling>>(node.GetAttribute("DefaultViewportScaling"));
+                _defaultViewportScaling = JsonSerializer.Deserialize<List<ViewportScaleOptions>>(node.GetAttribute("DefaultViewportScaling"));
             
             for (int i = 0; i < _defaultViewportScaling.Count; i++)
             {


### PR DESCRIPTION
Hello, this PR allows for the user to customize the aspect and resolution of the game window viewport. There are some pre built ones for the user to choose from or they can create their own and apply them. The new context menu is accessed by right clicking on the game window tab. This is very useful for seeing how the game looks at different resolutions or aspect ratios.

*** The UI does not scale with the viewport. I haven't figured out a good way to do that but thought I would submit this anyways. The UI highlighting also doesnt work when at a custom aspect.

9:16 Aspect:
![image](https://user-images.githubusercontent.com/71274967/209913420-1c02ff9a-d4cc-4a08-8dba-651aa1fccb1d.png)

16:9 Aspect:
![image](https://user-images.githubusercontent.com/71274967/209913450-b2a79e46-2ac9-4ddb-9d63-4ac6ed43c1c2.png)

Free Aspect:
![image](https://user-images.githubusercontent.com/71274967/209913504-90b21796-84c0-4b15-876b-fe0025a297b9.png)

Menu:
![viewportscalemenu](https://user-images.githubusercontent.com/71274967/209913629-c7be57ef-5a89-44da-a572-f0c4206d8ca4.png)

Menu with Add menu:
![viewportscalemenu](https://user-images.githubusercontent.com/71274967/209914111-1b0da76f-9114-435b-ba98-a86ec652277f.png)
