### PR TITLE
First property name letter to upper case fix

### DIFF
--- a/Source/Editor/CustomEditors/GUI/PropertyNameLabel.cs
+++ b/Source/Editor/CustomEditors/GUI/PropertyNameLabel.cs
@@ -51,6 +51,9 @@ namespace FlaxEditor.CustomEditors.GUI
         /// <param name="name">The name.</param>
         public PropertyNameLabel(string name)
         {
+            // Format name with capital first letter
+            name = name[0].ToString().ToUpper() + name.Substring(1);
+            
             Text = name;
             HorizontalAlignment = TextAlignment.Near;
             VerticalAlignment = TextAlignment.Center;

--- a/Source/Editor/CustomEditors/GUI/PropertyNameLabel.cs
+++ b/Source/Editor/CustomEditors/GUI/PropertyNameLabel.cs
@@ -51,9 +51,6 @@ namespace FlaxEditor.CustomEditors.GUI
         /// <param name="name">The name.</param>
         public PropertyNameLabel(string name)
         {
-            // Format name with capital first letter
-            name = name[0].ToString().ToUpper() + name.Substring(1);
-            
             Text = name;
             HorizontalAlignment = TextAlignment.Near;
             VerticalAlignment = TextAlignment.Center;

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -906,13 +906,16 @@ namespace FlaxEditor.Utilities
             if (name.StartsWith("g_") || name.StartsWith("m_"))
                 startIndex = 2;
 
+            if (name.StartsWith("_"))
+                startIndex = 1;
+
             // Filter text
             var lastChar = '\0';
             for (int i = startIndex; i < length; i++)
             {
                 var c = name[i];
 
-                if (i == 0)
+                if (i == startIndex)
                 {
                     sb.Append(char.ToUpper(c));
                     continue;

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -912,6 +912,12 @@ namespace FlaxEditor.Utilities
             {
                 var c = name[i];
 
+                if (i == 0)
+                {
+                    sb.Append(char.ToUpper(c));
+                    continue;
+                }
+
                 // Space before word starting with uppercase letter
                 if (char.IsUpper(c) && i > 0)
                 {

--- a/Source/Tools/FlaxEngine.Tests/TestPropertyNameUI.cs
+++ b/Source/Tools/FlaxEngine.Tests/TestPropertyNameUI.cs
@@ -11,10 +11,10 @@ namespace FlaxEditor.Tests
         [Test]
         public void TestFormatting()
         {
-            Assert.AreEqual("property", Utils.GetPropertyNameUI("property"));
-            Assert.AreEqual("property", Utils.GetPropertyNameUI("_property"));
-            Assert.AreEqual("property", Utils.GetPropertyNameUI("m_property"));
-            Assert.AreEqual("property", Utils.GetPropertyNameUI("g_property"));
+            Assert.AreEqual("Property", Utils.GetPropertyNameUI("property"));
+            Assert.AreEqual("Property", Utils.GetPropertyNameUI("_property"));
+            Assert.AreEqual("Property", Utils.GetPropertyNameUI("m_property"));
+            Assert.AreEqual("Property", Utils.GetPropertyNameUI("g_property"));
             Assert.AreEqual("Property", Utils.GetPropertyNameUI("Property"));
             Assert.AreEqual("Property 1", Utils.GetPropertyNameUI("Property1"));
             Assert.AreEqual("Property Name", Utils.GetPropertyNameUI("PropertyName"));


### PR DESCRIPTION
Hello, this makes the first letter to always be capitalized in the UI for properties.
