### PR TITLE
Fix Intellisense issues with Visual Studio Code

### DIFF
--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -621,6 +621,22 @@ namespace Flax.Build.Projects.VisualStudioCode
                 json.EndRootObject();
                 json.Save(Path.Combine(vsCodeFolder, "extensions.json"));
             }
+
+            // Create OmniSharp configuration file
+            using (var json = new JsonWriter())
+            {
+                json.BeginRootObject();
+
+                json.BeginObject("msbuild");
+                {
+                    json.AddField("enabled", true);
+                    json.AddField("Configuration", "Editor.Debug");
+                }
+                json.EndObject();
+
+                json.EndRootObject();
+                json.Save(Path.Combine(solution.WorkspaceRootPath, "omnisharp.json"));
+            }
         }
     }
 }


### PR DESCRIPTION
The C#-plugin in VSCode does not use any of the intended build configurations by default, which causes errors about missing generated bindings code. The solution to this is to generated `omnisharp.json`-file with default build configuration set to `Editor.Debug` so the Intellisense can find the correct definitions in the generated bindings files.

Includes a minor fix to not overwrite generated VSCode files, as these can contain project specific configuration settings or other custom tasks user can define for the project.