### PR TITLE
Fix in visject cm sometimes not populating all options once search box is cleared.

### DIFF
--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -397,6 +397,13 @@ namespace FlaxEditor.Surface.ContextMenu
                 return;
 
             Profiler.BeginEvent("VisjectCM.OnSearchFilterChanged");
+            
+            if (string.IsNullOrEmpty(_searchBox.Text))
+            {
+                ResetView();
+                Profiler.EndEvent();
+                return;
+            }
 
             // Update groups
             LockChildrenRecursive();


### PR DESCRIPTION
Sometimes the visject CM when clearing the text in the search box either by erasing the text or using the new cancel search button doesnt populate the whole list of options and leaves the list blank. Most likely a regression from the new search box class. This fixes that issue.