### PR TITLE
Small fix for auto save popup

### DIFF
--- a/Source/Editor/GUI/Popups/AutoSavePopup.cs
+++ b/Source/Editor/GUI/Popups/AutoSavePopup.cs
@@ -101,18 +101,6 @@ namespace FlaxEditor.GUI
             _timeRemaining = Mathf.CeilToInt(time);
             if (_timeLabel != null)
                 _timeLabel.Text = "Auto Save in: " + _timeRemaining;
-            
-            // Move on text update if the progress bar is visible - removes this call from update
-            if (Editor.Instance.UI.ProgressVisible && !_isMoved)
-            {
-                _isMoved = true;
-                LocalX -= 250;
-            }
-            else if (!Editor.Instance.UI.ProgressVisible && _isMoved)
-            {
-                LocalX += 250;
-                _isMoved = false;
-            }
         }
 
         /// <inheritdoc />
@@ -122,6 +110,18 @@ namespace FlaxEditor.GUI
             {
                 _saveNowButton.TextColor = _saveNowButton.IsMouseOver ? Style.Current.BackgroundHighlighted : _defaultTextColor;
                 _cancelSaveButton.TextColor = _cancelSaveButton.IsMouseOver ? Style.Current.BackgroundHighlighted : _defaultTextColor;
+            }
+            
+            // Move if the progress bar is visible
+            if (Editor.Instance.UI.ProgressVisible && !_isMoved)
+            {
+                _isMoved = true;
+                LocalX -= 280;
+            }
+            else if (!Editor.Instance.UI.ProgressVisible && _isMoved)
+            {
+                LocalX += 280;
+                _isMoved = false;
             }
             base.Update(deltaTime);
         }


### PR DESCRIPTION
There was an issue with the popup not moving when requested for the progress bar. There was also an issue of this popup interfering with longer progress bar label text. This fixes both of those issues.

Also I originally had this similar to how unreal has their popups. Would that be better then on the bar like this?