### PR TITLE
Add scripts compilation failed status to status bar

### DIFF
--- a/Source/Editor/GUI/StatusBar.cs
+++ b/Source/Editor/GUI/StatusBar.cs
@@ -31,6 +31,11 @@ namespace FlaxEditor.GUI
         public string Text { get; set; }
 
         /// <summary>
+        /// Gets or sets the status text color
+        /// </summary>
+        public Color TextColor { get; set; } = Style.Current.Foreground;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="StatusBar"/> class.
         /// </summary>
         public StatusBar()
@@ -51,7 +56,7 @@ namespace FlaxEditor.GUI
                 Render2D.DrawSprite(style.StatusBarSizeGrip, new Rectangle(Width - 12, 10, 12, 12), style.Foreground);
 
             // Draw status text
-            Render2D.DrawText(style.FontSmall, Text, new Rectangle(4, 0, Width - 20, Height), style.Foreground, TextAlignment.Near, TextAlignment.Center);
+            Render2D.DrawText(style.FontSmall, Text, new Rectangle(4, 0, Width - 20, Height), TextColor, TextAlignment.Near, TextAlignment.Center);
         }
     }
 }

--- a/Source/Editor/Modules/ProgressReportingModule.cs
+++ b/Source/Editor/Modules/ProgressReportingModule.cs
@@ -153,9 +153,10 @@ namespace FlaxEditor.Modules
             }
         }
 
-        private void HandlerOnProgressFail(ProgressHandler handler)
+        private void HandlerOnProgressFail(ProgressHandler handler, string message)
         {
-            Editor.UI.ProgressFailed();
+            UpdateProgress();
+            Editor.UI.ProgressFailed(message);
         }
     }
 }

--- a/Source/Editor/Modules/ProgressReportingModule.cs
+++ b/Source/Editor/Modules/ProgressReportingModule.cs
@@ -96,6 +96,7 @@ namespace FlaxEditor.Modules
             handler.ProgressStart += HandlerOnProgressStart;
             handler.ProgressChanged += HandlerOnProgressChanged;
             handler.ProgressEnd += HandlerOnProgressEnd;
+            handler.ProgressFailed += HandlerOnProgressFail;
         }
 
         /// <summary>
@@ -113,6 +114,7 @@ namespace FlaxEditor.Modules
             handler.ProgressStart -= HandlerOnProgressStart;
             handler.ProgressChanged -= HandlerOnProgressChanged;
             handler.ProgressEnd -= HandlerOnProgressEnd;
+            handler.ProgressFailed -= HandlerOnProgressFail;
         }
 
         private void UpdateProgress()
@@ -149,6 +151,11 @@ namespace FlaxEditor.Modules
             {
                 Editor.Windows.FlashMainWindow();
             }
+        }
+
+        private void HandlerOnProgressFail(ProgressHandler handler)
+        {
+            Editor.UI.ProgressFailed();
         }
     }
 }

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -640,10 +640,10 @@ namespace FlaxEditor.Modules
             _outputLogButton.Clicked += () =>
             {
                 Editor.Windows.OutputLogWin.FocusOrShow();
-                //_progressBar.BarColor = Style.Current.ProgressNormal;
-                //_progressBar.Value = 0;
-                //ProgressVisible = false;
-                //_outputLogButton.Visible = false;
+                _progressBar.BarColor = Style.Current.ProgressNormal;
+                _progressBar.Value = 0;
+                ProgressVisible = false;
+                _outputLogButton.Visible = false;
             };
             _progressLabel = new Label
             {

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -31,6 +31,7 @@ namespace FlaxEditor.Modules
     {
         private Label _progressLabel;
         private ProgressBar _progressBar;
+        private Button _outputLogButton;
         private List<KeyValuePair<string, DateTime>> _statusMessages;
         private ContentStats _contentStats;
 
@@ -303,7 +304,25 @@ namespace FlaxEditor.Modules
             if (_progressLabel != null)
                 _progressLabel.Text = text;
             if (_progressBar != null)
+            {
+                if (_outputLogButton.Visible)
+                {
+                    _progressBar.BarColor = Style.Current.ProgressNormal;
+                    var scale = _progressBar.SmoothingScale;
+                    _progressBar.SmoothingScale = 0;
+                    _progressBar.Value = 0;
+                    _progressBar.SmoothingScale = scale;
+                    _outputLogButton.Visible = false;
+                }
                 _progressBar.Value = progress * 100.0f;
+            }
+        }
+
+        internal void ProgressFailed()
+        {
+            _progressBar.BarColor = Color.Red;
+            _progressLabel.Text = "Failed";
+            _outputLogButton.Visible = true;
         }
 
         /// <inheritdoc />
@@ -599,6 +618,32 @@ namespace FlaxEditor.Modules
                 AnchorPreset = AnchorPresets.MiddleRight,
                 Parent = progressPanel,
                 Offsets = new Margin(-progressBarWidth - progressBarRightMargin, progressBarWidth, progressBarHeight * -0.5f, progressBarHeight),
+            };
+            _outputLogButton = new Button()
+            {
+                AnchorPreset = AnchorPresets.TopLeft,
+                Parent = _progressBar,
+                Visible = false,
+                Text = "Output Log",
+                TooltipText = "Opens or shows the output log window.",
+                BackgroundColor = Color.Transparent,
+                BorderColor = Color.Transparent,
+                BackgroundColorHighlighted = Color.Transparent,
+                BackgroundColorSelected = Color.Transparent,
+                BorderColorHighlighted = Color.Transparent,
+                BorderColorSelected = Color.Transparent,
+            };
+            _outputLogButton.LocalY -= 2;
+            var defaultTextColor = _outputLogButton.TextColor;
+            _outputLogButton.HoverBegin += () => _outputLogButton.TextColor = Style.Current.BackgroundSelected;
+            _outputLogButton.HoverEnd += () => _outputLogButton.TextColor = defaultTextColor;
+            _outputLogButton.Clicked += () =>
+            {
+                Editor.Windows.OutputLogWin.FocusOrShow();
+                //_progressBar.BarColor = Style.Current.ProgressNormal;
+                //_progressBar.Value = 0;
+                //ProgressVisible = false;
+                //_outputLogButton.Visible = false;
             };
             _progressLabel = new Label
             {

--- a/Source/Editor/Progress/Handlers/BuildingGameProgress.cs
+++ b/Source/Editor/Progress/Handlers/BuildingGameProgress.cs
@@ -39,7 +39,7 @@ namespace FlaxEditor.Progress.Handlers
                 OnUpdate(0, "Starting building game..");
                 break;
             case GameCooker.EventType.BuildFailed:
-                OnEnd();
+                OnFail();
                 break;
             case GameCooker.EventType.BuildDone:
                 OnEnd();

--- a/Source/Editor/Progress/Handlers/BuildingGameProgress.cs
+++ b/Source/Editor/Progress/Handlers/BuildingGameProgress.cs
@@ -39,7 +39,7 @@ namespace FlaxEditor.Progress.Handlers
                 OnUpdate(0, "Starting building game..");
                 break;
             case GameCooker.EventType.BuildFailed:
-                OnFail();
+                OnEnd();
                 break;
             case GameCooker.EventType.BuildDone:
                 OnEnd();

--- a/Source/Editor/Progress/Handlers/CompileScriptsProgress.cs
+++ b/Source/Editor/Progress/Handlers/CompileScriptsProgress.cs
@@ -21,7 +21,7 @@ namespace FlaxEditor.Progress.Handlers
             // Link for events
             ScriptsBuilder.CompilationBegin += OnStart;
             ScriptsBuilder.CompilationSuccess += OnEnd;
-            ScriptsBuilder.CompilationFailed += OnEnd;
+            ScriptsBuilder.CompilationFailed += OnFail;
             ScriptsBuilder.CompilationStarted += () => OnUpdate(0.2f, "Compiling scripts...");
             ScriptsBuilder.ScriptsReloadCalled += () => OnUpdate(0.8f, "Reloading scripts...");
             ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;

--- a/Source/Editor/Progress/Handlers/CompileScriptsProgress.cs
+++ b/Source/Editor/Progress/Handlers/CompileScriptsProgress.cs
@@ -21,7 +21,7 @@ namespace FlaxEditor.Progress.Handlers
             // Link for events
             ScriptsBuilder.CompilationBegin += OnStart;
             ScriptsBuilder.CompilationSuccess += OnEnd;
-            ScriptsBuilder.CompilationFailed += OnFail;
+            ScriptsBuilder.CompilationFailed += OnCompilationFail;
             ScriptsBuilder.CompilationStarted += () => OnUpdate(0.2f, "Compiling scripts...");
             ScriptsBuilder.ScriptsReloadCalled += () => OnUpdate(0.8f, "Reloading scripts...");
             ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
@@ -56,6 +56,14 @@ namespace FlaxEditor.Progress.Handlers
             base.OnStart();
 
             OnUpdate(0, "Starting scripts compilation...");
+        }
+
+        /// <summary>
+        /// Called when scripts compilation fails
+        /// </summary>
+        private void OnCompilationFail()
+        {
+            OnFail("Scripts Compilation Failed");
         }
     }
 }

--- a/Source/Editor/Progress/ProgressHandler.cs
+++ b/Source/Editor/Progress/ProgressHandler.cs
@@ -16,6 +16,11 @@ namespace FlaxEditor.Progress
         /// </summary>
         /// <param name="handler">The calling handler.</param>
         public delegate void ProgressDelegate(ProgressHandler handler);
+        
+        /// <summary>
+        /// Progress failed handler event delegate
+        /// </summary>
+        public delegate void ProgressFailedDelegate(ProgressHandler handler, string message);
 
         private float _progress;
         private bool _isActive;
@@ -54,7 +59,7 @@ namespace FlaxEditor.Progress
         /// <summary>
         /// Occurs when the progress fails
         /// </summary>
-        public event ProgressDelegate ProgressFailed;
+        public event ProgressFailedDelegate ProgressFailed;
 
         /// <summary>
         /// Gets a value indicating whether this handler action can be cancelled.
@@ -118,7 +123,7 @@ namespace FlaxEditor.Progress
         /// <summary>
         /// Called when progress action fails
         /// </summary>
-        protected virtual void OnFail()
+        protected virtual void OnFail(string message)
         {
             if (!_isActive)
                 throw new InvalidOperationException("Already ended.");
@@ -126,7 +131,7 @@ namespace FlaxEditor.Progress
             _isActive = false;
             _progress = 0;
             _infoText = string.Empty;
-            ProgressFailed?.Invoke(this);
+            ProgressFailed?.Invoke(this, message);
         }
     }
 }

--- a/Source/Editor/Progress/ProgressHandler.cs
+++ b/Source/Editor/Progress/ProgressHandler.cs
@@ -52,6 +52,11 @@ namespace FlaxEditor.Progress
         public event ProgressDelegate ProgressEnd;
 
         /// <summary>
+        /// Occurs when the progress fails
+        /// </summary>
+        public event ProgressDelegate ProgressFailed;
+
+        /// <summary>
         /// Gets a value indicating whether this handler action can be cancelled.
         /// </summary>
         public virtual bool CanBeCanceled => false;
@@ -108,6 +113,20 @@ namespace FlaxEditor.Progress
             _infoText = string.Empty;
             ProgressChanged?.Invoke(this);
             ProgressEnd?.Invoke(this);
+        }
+
+        /// <summary>
+        /// Called when progress action fails
+        /// </summary>
+        protected virtual void OnFail()
+        {
+            if (!_isActive)
+                throw new InvalidOperationException("Already ended.");
+            
+            _isActive = false;
+            _progress = 0;
+            _infoText = string.Empty;
+            ProgressFailed?.Invoke(this);
         }
     }
 }


### PR DESCRIPTION
Hello this adds to the status bar that if the scripts compilation fails it turns red and displays text letting the user know that the scripts compilation failed. The text also acts like a button to allow the user to navigate to the output log if it isnt showing or open.

![image](https://user-images.githubusercontent.com/71274967/212449167-e4b59e5e-3158-4fde-a909-6c387dc44007.png)
