### PR TITLE
Fix rename popup from not focusing and selecting text.

### DIFF
--- a/Source/Editor/GUI/Popups/RenamePopup.cs
+++ b/Source/Editor/GUI/Popups/RenamePopup.cs
@@ -172,6 +172,7 @@ namespace FlaxEditor.GUI
         /// <inheritdoc />
         protected override void OnShow()
         {
+            _inputField.EndEditOnClick = false; // Ending edit is handled through popup
             _inputField.Focus();
             _inputField.SelectAll();
 


### PR DESCRIPTION
Ending edit for the rename popup is handled in the popup itself, so no need to use the text box end on click. This fixes and issue with trying to rename clickable property labels.