### PR TITLE
Fixed editor not saving added tags

### DIFF
--- a/Source/Editor/CustomEditors/Editors/TagEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/TagEditor.cs
@@ -260,6 +260,8 @@ namespace FlaxEditor.CustomEditors.Editors
 
                     // Reload editor window to reflect new tag
                     assetWindow?.RefreshAsset();
+                    assetWindow?.MarkAsEdited();
+                    assetWindow?.Save();
                 }
             };
             dialog.Closed += popup =>

--- a/Source/Editor/CustomEditors/Editors/TagEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/TagEditor.cs
@@ -260,8 +260,6 @@ namespace FlaxEditor.CustomEditors.Editors
 
                     // Reload editor window to reflect new tag
                     assetWindow?.RefreshAsset();
-                    assetWindow?.MarkAsEdited();
-                    assetWindow?.Save();
                 }
             };
             dialog.Closed += popup =>

--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -313,7 +313,14 @@ namespace FlaxEditor.Windows.Assets
         /// </summary>
         public void RefreshAsset()
         {
-            _isWaitingForLoaded = true;
+            if (_asset == null)
+                return;
+            if (!_asset.IsLoaded)
+                return;
+
+            OnAssetLoaded();
+            MarkAsEdited();
+            Save();
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes the saving issue in #885. Seems like refreshing the asset removes that it is dirty and then doesnt let you save. this marks it as dirty and allows it to save properly. Maybe it would be better to change how this is done, but this is a fix for the issue.