### PR TITLE
Various UI improvements around drop panels in the editor

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -94,7 +94,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 {
                     if (actor != null)
                         group.Panel.TooltipText = Surface.SurfaceUtils.GetVisualScriptTypeDescription(TypeUtils.GetObjectType(actor));
-                    const float settingsButtonSize = 14;
+                    const float settingsButtonSize = 20;
                     var settingsButton = new Image
                     {
                         TooltipText = "Settings",

--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -641,16 +641,16 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     IsScrollable = false,
                     Checked = script.Enabled,
                     Parent = group.Panel,
-                    Size = new Float2(14, 14),
-                    Bounds = new Rectangle(16, 0, 14, 14),
-                    BoxSize = 12.0f,
+                    Size = new Float2(20, 20),
+                    Bounds = new Rectangle(20, 0, 20, 20),
+                    BoxSize = 16.0f,
                     Tag = script,
                 };
                 scriptToggle.StateChanged += OnScriptToggleCheckChanged;
                 _scriptToggles[i] = scriptToggle;
 
                 // Add drag button to the group
-                const float dragIconSize = 14;
+                const float dragIconSize = 20;
                 var scriptDrag = new ScriptDragIcon(this, script)
                 {
                     TooltipText = "Script reference",
@@ -665,7 +665,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 };
 
                 // Add settings button to the group
-                const float settingsButtonSize = 14;
+                const float settingsButtonSize = 20;
                 var settingsButton = new Image
                 {
                     TooltipText = "Settings",

--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -681,7 +681,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 };
                 settingsButton.Clicked += OnSettingsButtonClicked;
 
-                group.Panel.HeaderTextMargin = new Margin(scriptDrag.Right, 15, 2, 2);
+                group.Panel.HeaderTextMargin = new Margin(scriptDrag.Right - 12, 15, 2, 2);
                 group.Object(values, editor);
 
                 // Scripts arrange bar

--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -642,7 +642,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     Checked = script.Enabled,
                     Parent = group.Panel,
                     Size = new Float2(14, 14),
-                    Bounds = new Rectangle(2, 0, 14, 14),
+                    Bounds = new Rectangle(16, 0, 14, 14),
                     BoxSize = 12.0f,
                     Tag = script,
                 };

--- a/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
@@ -13,7 +13,12 @@ namespace FlaxEditor.CustomEditors.Elements
         /// <summary>
         /// The drop panel.
         /// </summary>
-        public readonly DropPanel Panel = new DropPanel();
+        public readonly DropPanel Panel = new DropPanel
+        {
+            ArrowImageClosed = new SpriteBrush(Style.Current.ArrowRight),
+            ArrowImageOpened = new SpriteBrush(Style.Current.ArrowDown),
+            EnableDropDownIcon = true,
+        };
 
         /// <inheritdoc />
         public override ContainerControl ContainerControl => Panel;

--- a/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
@@ -18,6 +18,9 @@ namespace FlaxEditor.CustomEditors.Elements
             ArrowImageClosed = new SpriteBrush(Style.Current.ArrowRight),
             ArrowImageOpened = new SpriteBrush(Style.Current.ArrowDown),
             EnableDropDownIcon = true,
+            ItemsMargin = new Margin(7, 7, 3, 3),
+            HeaderHeight = 20,
+            EnableContainmentLines = true,
         };
 
         /// <inheritdoc />

--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -96,6 +96,7 @@ namespace FlaxEditor.CustomEditors
             if (useTransparentHeader)
             {
                 element.Panel.EnableDropDownIcon = true;
+                element.Panel.EnableContainmentLines = false;
                 element.Panel.HeaderColor = element.Panel.HeaderColorMouseOver = Color.Transparent;
             }
             OnAddElement(element);

--- a/Source/Engine/UI/GUI/Panels/DropPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/DropPanel.cs
@@ -132,6 +132,12 @@ namespace FlaxEngine.GUI
         public bool EnableDropDownIcon { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to enable containment line drawing,
+        /// </summary>
+        [EditorDisplay("Style"), EditorOrder(2000)]
+        public bool EnableContainmentLines { get; set; } = false;
+
+        /// <summary>
         /// Occurs when mouse right-clicks over the header.
         /// </summary>
         public event Action<DropPanel, Float2> MouseButtonRightClicked;
@@ -370,6 +376,16 @@ namespace FlaxEngine.GUI
 
             Render2D.DrawText(HeaderTextFont.GetFont(), HeaderTextMaterial, HeaderText, textRect, textColor, TextAlignment.Near, TextAlignment.Center);
 
+            
+            if (!_isClosed && EnableContainmentLines)
+            {
+                Color lineColor = Style.Current.ForegroundGrey - new Color(0, 0, 0, 100);
+                float lineThickness = 0.05f;
+                Render2D.DrawLine(new Float2(1, HeaderHeight), new Float2(1, Height), lineColor, lineThickness);
+                Render2D.DrawLine(new Float2(1, Height), new Float2(Width, Height), lineColor, lineThickness);
+                Render2D.DrawLine(new Float2(Width, HeaderHeight), new Float2(Width, Height), lineColor, lineThickness);
+            }
+            
             // Children
             DrawChildren();
         }


### PR DESCRIPTION
Hello this adds some improvements to drop panels in the editor to make them for user friendly. Increase header size, add containment area, and adding arrows. This allows for the user to more clearly see which drop panel they are working under. This stemmed from #805.

![properties window](https://user-images.githubusercontent.com/71274967/213884220-04cd06a2-6e62-4185-ab86-9e3101e20911.png)

![graphics window](https://user-images.githubusercontent.com/71274967/213884225-a0aaa1b8-0cdd-4947-b4ea-0ea39e413bd3.png)
