### PR TITLE
Organize new actor CM better

### DIFF
--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -253,7 +253,7 @@ namespace FlaxEditor.Windows.Assets
                 if (actorType.IsAbstract)
                     continue;
                 ActorContextMenuAttribute attribute = null;
-                foreach (var e in actorType.GetAttributes(true))
+                foreach (var e in actorType.GetAttributes(false))
                 {
                     if (e is ActorContextMenuAttribute actorContextMenuAttribute)
                     {

--- a/Source/Editor/Windows/ContentWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/ContentWindow.ContextMenu.cs
@@ -162,7 +162,7 @@ namespace FlaxEditor.Windows
 
                 // Get attribute
                 ContentContextMenuAttribute attribute = null;
-                foreach (var typeAttribute in type.GetAttributes(true))
+                foreach (var typeAttribute in type.GetAttributes(false))
                 {
                     if (typeAttribute is ContentContextMenuAttribute contentContextMenuAttribute)
                     {

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -152,11 +152,11 @@ namespace FlaxEditor.Windows
             // go through each actor and add it to the context menu if it has the ActorContextMenu attribute
             foreach (var actorType in Editor.CodeEditing.Actors.Get())
             {
-                if (actorType.IsAbstract || !actorType.HasAttribute(typeof(ActorContextMenuAttribute), true))
+                if (actorType.IsAbstract || !actorType.HasAttribute(typeof(ActorContextMenuAttribute), false))
                     continue;
 
                 ActorContextMenuAttribute attribute = null;
-                foreach (var actorAttribute in actorType.GetAttributes(true))
+                foreach (var actorAttribute in actorType.GetAttributes(false))
                 {
                     if (actorAttribute is ActorContextMenuAttribute actorContextMenuAttribute)
                     {

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -66,7 +66,7 @@ namespace FlaxEditor.Windows
                     if (actorType.IsAbstract)
                         continue;
                     ActorContextMenuAttribute attribute = null;
-                    foreach (var e in actorType.GetAttributes(true))
+                    foreach (var e in actorType.GetAttributes(false))
                     {
                         if (e is ActorContextMenuAttribute actorContextMenuAttribute)
                         {

--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -250,7 +250,7 @@ namespace FlaxEditor.Windows
             foreach (var actorType in Editor.CodeEditing.Actors.Get())
             {
                 ActorToolboxAttribute attribute = null;
-                foreach (var e in actorType.GetAttributes(true))
+                foreach (var e in actorType.GetAttributes(false))
                 {
                     if (e is ActorToolboxAttribute actorToolboxAttribute)
                     {

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -10,7 +10,7 @@
 /// Representation of the car vehicle that uses wheels. Built on top of the RigidBody with collider representing its chassis shape and wheels.
 /// </summary>
 /// <seealso cref="RigidBody" />
-API_CLASS() class FLAXENGINE_API WheeledVehicle : public RigidBody
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorToolbox(\"Physics\")") class FLAXENGINE_API WheeledVehicle : public RigidBody
 {
     friend class PhysicsBackend;
     DECLARE_SCENE_OBJECT(WheeledVehicle);

--- a/Source/Engine/Physics/Colliders/BoxCollider.h
+++ b/Source/Engine/Physics/Colliders/BoxCollider.h
@@ -9,7 +9,7 @@
 /// A box-shaped primitive collider.
 /// </summary>
 /// <seealso cref="Collider" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Box Collider\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Colliders/Box Collider\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API BoxCollider : public Collider
 {
     DECLARE_SCENE_OBJECT(BoxCollider);

--- a/Source/Engine/Physics/Colliders/CapsuleCollider.h
+++ b/Source/Engine/Physics/Colliders/CapsuleCollider.h
@@ -10,7 +10,7 @@
 /// </summary>
 /// <remarks>Capsules are cylinders with a half-sphere at each end centered at the origin and extending along the X axis, and two hemispherical ends.</remarks>
 /// <seealso cref="Collider" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Capsule Collider\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Colliders/Capsule Collider\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API CapsuleCollider : public Collider
 {
     DECLARE_SCENE_OBJECT(CapsuleCollider);

--- a/Source/Engine/Physics/Colliders/MeshCollider.h
+++ b/Source/Engine/Physics/Colliders/MeshCollider.h
@@ -10,7 +10,7 @@
 /// A collider represented by an arbitrary mesh.
 /// </summary>
 /// <seealso cref="Collider" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Mesh Collider\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Colliders/Mesh Collider\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API MeshCollider : public Collider
 {
     DECLARE_SCENE_OBJECT(MeshCollider);

--- a/Source/Engine/Physics/Colliders/SphereCollider.h
+++ b/Source/Engine/Physics/Colliders/SphereCollider.h
@@ -8,7 +8,7 @@
 /// A sphere-shaped primitive collider.
 /// </summary>
 /// <seealso cref="Collider" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Sphere Collider\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Colliders/Sphere Collider\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API SphereCollider : public Collider
 {
     DECLARE_SCENE_OBJECT(SphereCollider);

--- a/Source/Engine/Physics/Joints/D6Joint.h
+++ b/Source/Engine/Physics/Joints/D6Joint.h
@@ -160,7 +160,7 @@ public:
 /// It also allows you to constrain limits to only specific axes or completely lock specific axes.
 /// </summary>
 /// <seealso cref="Joint" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/D6 Joint\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/D6 Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API D6Joint : public Joint
 {
     DECLARE_SCENE_OBJECT(D6Joint);

--- a/Source/Engine/Physics/Joints/DistanceJoint.h
+++ b/Source/Engine/Physics/Joints/DistanceJoint.h
@@ -37,7 +37,7 @@ DECLARE_ENUM_OPERATORS(DistanceJointFlag);
 /// Physics joint that maintains an upper or lower (or both) bound on the distance between two bodies.
 /// </summary>
 /// <seealso cref="Joint" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Distance Joint\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/Distance Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API DistanceJoint : public Joint
 {
     DECLARE_SCENE_OBJECT(DistanceJoint);

--- a/Source/Engine/Physics/Joints/FixedJoint.h
+++ b/Source/Engine/Physics/Joints/FixedJoint.h
@@ -8,7 +8,7 @@
 /// Physics joint that maintains a fixed distance and orientation between its two attached bodies.
 /// </summary>
 /// <seealso cref="Joint" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Fixed Joint\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/Fixed Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API FixedJoint : public Joint
 {
     DECLARE_SCENE_OBJECT(FixedJoint);

--- a/Source/Engine/Physics/Joints/HingeJoint.h
+++ b/Source/Engine/Physics/Joints/HingeJoint.h
@@ -67,7 +67,7 @@ public:
 /// Physics joint that removes all but a single rotation degree of freedom from its two attached bodies (for example a door hinge).
 /// </summary>
 /// <seealso cref="Joint" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Hinge Joint\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/Hinge Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API HingeJoint : public Joint
 {
     DECLARE_SCENE_OBJECT(HingeJoint);

--- a/Source/Engine/Physics/Joints/SliderJoint.h
+++ b/Source/Engine/Physics/Joints/SliderJoint.h
@@ -27,7 +27,7 @@ DECLARE_ENUM_OPERATORS(SliderJointFlag);
 /// Physics joint that removes all but a single translational degree of freedom. Bodies are allowed to move along a single axis.
 /// </summary>
 /// <seealso cref="Joint" />
-API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Slider Joint\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/Slider Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API SliderJoint : public Joint
 {
     DECLARE_SCENE_OBJECT(SliderJoint);

--- a/Source/Engine/Physics/Joints/SphericalJoint.h
+++ b/Source/Engine/Physics/Joints/SphericalJoint.h
@@ -29,7 +29,7 @@ DECLARE_ENUM_OPERATORS(SphericalJointFlag);
 /// rotate around the anchor points, and their rotation can be limited by an elliptical cone.
 /// </summary>
 /// <seealso cref="Joint" />
-API_CLASS(Attributes = "ActorContextMenu(\"New/Physics/Spherical Joint\"), ActorToolbox(\"Physics\")")
+API_CLASS(Attributes = "ActorContextMenu(\"New/Physics/Joints/Spherical Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API SphericalJoint : public Joint
 {
     DECLARE_SCENE_OBJECT(SphericalJoint);


### PR DESCRIPTION
Hello, this PR organizes the new actor CM physics portion into better categories (Joints, colliders) and adds the wheeled vehicle to the menu .This also make it so if an actor has a parent with the `ActorContextMenuAttribute` that it wont be added to the menu automatically without especially adding the attribute to the child actor (Ran into issues with have 2 things named the same in the editor).