### PR TITLE
changed `QueryFilterHelper.MinLength` to 1 to start filtering after first character is entered.

### DIFF
--- a/Source/Editor/Utilities/QueryFilterHelper.cs
+++ b/Source/Editor/Utilities/QueryFilterHelper.cs
@@ -15,7 +15,7 @@ namespace FlaxEditor.Utilities
         /// <summary>
         /// The minimum text match length.
         /// </summary>
-        public const int MinLength = 2;
+        public const int MinLength = 1;
 
         /// <summary>
         /// Matches the specified text with the filter.


### PR DESCRIPTION
In reference to #906. I think filtering off of the first character should be allowed. IDK if there was a specific reason for it being 2, but 1 is more user friendly for me at least.