### PR TITLE
Fix Audio Settings not applying doppler factor

### DIFF
--- a/Source/Engine/Audio/Audio.cpp
+++ b/Source/Engine/Audio/Audio.cpp
@@ -91,6 +91,10 @@ namespace
 void AudioSettings::Apply()
 {
     ::MuteOnFocusLoss = MuteOnFocusLoss;
+    if (AudioBackend::Instance != nullptr)
+    {
+        Audio::SetDopplerFactor(DopplerFactor);
+    }
 }
 
 AudioDevice* Audio::GetActiveDevice()


### PR DESCRIPTION
Fixes an issue where the editor has to be restarted for the doppler factor in the Audio Settings to be applied. May help https://github.com/FlaxEngine/FlaxEngine/issues/815.