### PR TITLE
Fix process creation on Linux

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxPlatform.cpp
+++ b/Source/Engine/Platform/Linux/LinuxPlatform.cpp
@@ -2802,6 +2802,7 @@ int32 LinuxProcess(const StringView& cmdLine, const StringView& workingDir, cons
         {
 			close(fildes[0]); // close the reading end of the pipe
 			dup2(fildes[1], STDOUT_FILENO); // redirect stdout to pipe
+			close(fildes[1]);
 			dup2(STDOUT_FILENO, STDERR_FILENO); // redirect stderr to stdout
 		}
 
@@ -2810,6 +2811,8 @@ int32 LinuxProcess(const StringView& cmdLine, const StringView& workingDir, cons
         {
 			LOG(Warning, " failed, errno={}", errno);
 		}
+		fflush(stdout);
+		_exit(1);
 	}
     else
     {
@@ -2822,7 +2825,7 @@ int32 LinuxProcess(const StringView& cmdLine, const StringView& workingDir, cons
             {
 				char lineBuffer[1024];
 				close(fildes[1]); // close the writing end of the pipe
-				FILE *stdPipe = fdopen(fildes[0], "r");
+				FILE* stdPipe = fdopen(fildes[0], "r");
 				while (fgets(lineBuffer, sizeof(lineBuffer), stdPipe) != NULL)
                 {
 					char *p = lineBuffer + strlen(lineBuffer)-1;
@@ -2857,6 +2860,7 @@ int32 LinuxProcess(const StringView& cmdLine, const StringView& workingDir, cons
 					returnCode = EPIPE;
 				}
 			}
+			close(fildes[0]);
 		}
 	}
 


### PR DESCRIPTION
Forked child process did not exit properly, sometimes causing scripting compilation to get stuck and never finish.