### PR TITLE
Fix error when joining exited threads

### DIFF
--- a/Source/Engine/Content/Loading/ContentLoadingManager.cpp
+++ b/Source/Engine/Content/Loading/ContentLoadingManager.cpp
@@ -55,8 +55,7 @@ LoadingThread::~LoadingThread()
     // Check if has thread attached
     if (_thread != nullptr)
     {
-        if (_thread->IsRunning())
-            _thread->Kill(true);
+        _thread->Kill(true);
         Delete(_thread);
     }
 }

--- a/Source/Engine/Platform/Base/ThreadBase.cpp
+++ b/Source/Engine/Platform/Base/ThreadBase.cpp
@@ -43,7 +43,10 @@ void ThreadBase::SetPriority(ThreadPriority priority)
 void ThreadBase::Kill(bool waitForJoin)
 {
     if (!_isRunning)
+    {
+        ClearHandleInternal();
         return;
+    }
     ASSERT(GetID());
     const auto thread = static_cast<Thread*>(this);
 
@@ -105,7 +108,6 @@ int32 ThreadBase::Run()
         _callAfterWork = false;
         _runnable->AfterWork(false);
     }
-    ClearHandleInternal();
     _isRunning = false;
     ThreadExiting(thread, exitCode);
     ThreadRegistry::Remove(thread);

--- a/Source/Engine/Platform/Unix/UnixThread.cpp
+++ b/Source/Engine/Platform/Unix/UnixThread.cpp
@@ -53,6 +53,7 @@ UnixThread* UnixThread::Setup(UnixThread* thread, uint32 stackSize)
 void UnixThread::Join()
 {
     pthread_join(_thread, nullptr);
+    ClearHandleInternal();
 }
 
 void UnixThread::ClearHandleInternal()

--- a/Source/Engine/Platform/Win32/Win32Thread.cpp
+++ b/Source/Engine/Platform/Win32/Win32Thread.cpp
@@ -113,6 +113,7 @@ unsigned long Win32Thread::ThreadProc(void* pThis)
 void Win32Thread::Join()
 {
     WaitForSingleObject((HANDLE)_thread, INFINITE);
+    ClearHandleInternal();
 }
 
 void Win32Thread::ClearHandleInternal()

--- a/Source/Engine/Threading/JobSystem.cpp
+++ b/Source/Engine/Threading/JobSystem.cpp
@@ -149,8 +149,7 @@ void JobSystemService::Dispose()
     {
         if (Threads[i])
         {
-            if (Threads[i]->IsRunning())
-                Threads[i]->Kill(true);
+            Threads[i]->Kill(true);
             Delete(Threads[i]);
             Threads[i] = nullptr;
         }

--- a/Source/Engine/Threading/ThreadPool.cpp
+++ b/Source/Engine/Threading/ThreadPool.cpp
@@ -98,10 +98,7 @@ void ThreadPoolService::Dispose()
     // Delete threads
     for (int32 i = 0; i < ThreadPoolImpl::Threads.Count(); i++)
     {
-        if (ThreadPoolImpl::Threads[i]->IsRunning())
-        {
-            ThreadPoolImpl::Threads[i]->Kill(true);
-        }
+        ThreadPoolImpl::Threads[i]->Kill(true);
     }
     ThreadPoolImpl::Threads.ClearDelete();
 }


### PR DESCRIPTION
The internal thread handles were cleared prematurely when attempting to join them (this happens when closing the engine). The handles should be also cleared when trying to kill already exited threads.

The documentation should be updated to mention that the thread must be either joined or killed before destroying the thread.