### PR TITLE
Scale linking and unlinking

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -82,6 +82,12 @@ namespace FlaxEditor.CustomEditors.Editors
             /// <inheritdoc />
             public override void Initialize(LayoutElementsContainer layout)
             {
+                var scaleLocked = Editor.Instance.Windows.PropertiesWin.ScaleLocked;
+                if (scaleLocked)
+                {
+                    ChangeValuesTogether = scaleLocked;
+                }
+                
                 base.Initialize(layout);
 
                 // Override colors
@@ -106,7 +112,7 @@ namespace FlaxEditor.CustomEditors.Editors
                             Parent = nameLabel,
                             Width = 18,
                             Height = 18,
-                            BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Link32),
+                            BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Link32), // TODO change on scale lock
                             BackgroundColor = Color.White,
                             BorderColor = Color.Transparent,
                             BorderColorSelected = Color.Transparent,
@@ -119,6 +125,7 @@ namespace FlaxEditor.CustomEditors.Editors
                         lockButton.Clicked += () =>
                         {
                             ChangeValuesTogether = !ChangeValuesTogether;
+                            Editor.Instance.Windows.PropertiesWin.ScaleLocked = ChangeValuesTogether;
                             // TODO: change image
                             Debug.Log(ChangeValuesTogether);
                         };
@@ -131,12 +138,6 @@ namespace FlaxEditor.CustomEditors.Editors
                 YElement.ValueBox.BorderSelectedColor = AxisColorY;
                 ZElement.ValueBox.BorderColor = Color.Lerp(AxisColorZ, back, grayOutFactor);
                 ZElement.ValueBox.BorderSelectedColor = AxisColorZ;
-                
-                Debug.Log(YElement.ValueBox.Parent);
-                Debug.Log(YElement.ValueBox.Parent.Parent);
-                Debug.Log(YElement.ValueBox.Parent.Parent.Parent);
-                Debug.Log(YElement.ValueBox.Parent.Parent.Parent.Parent);
-                Debug.Log(YElement.ValueBox.Parent.Parent.Parent.Parent.Parent);
             }
         }
     }

--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
+using FlaxEditor.CustomEditors.GUI;
 using FlaxEngine;
+using FlaxEngine.GUI;
 
 namespace FlaxEditor.CustomEditors.Editors
 {
@@ -87,10 +89,54 @@ namespace FlaxEditor.CustomEditors.Editors
                 var grayOutFactor = 0.6f;
                 XElement.ValueBox.BorderColor = Color.Lerp(AxisColorX, back, grayOutFactor);
                 XElement.ValueBox.BorderSelectedColor = AxisColorX;
+                
+                if (XElement.ValueBox.Parent.Parent is PropertiesList list)
+                {
+                    foreach (var child in list.Children)
+                    {
+                        if (!(child is PropertyNameLabel))
+                            continue;
+
+                        var nameLabel = child as PropertyNameLabel;
+                        if (!string.Equals(nameLabel.Text, "Scale"))
+                            continue;
+                        
+                        var lockButton = new Button
+                        {
+                            Parent = nameLabel,
+                            Width = 18,
+                            Height = 18,
+                            BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Link32),
+                            BackgroundColor = Color.White,
+                            BorderColor = Color.Transparent,
+                            BorderColorSelected = Color.Transparent,
+                            BorderColorHighlighted = Color.Transparent,
+                            AnchorPreset = AnchorPresets.TopLeft,
+                            TooltipText = "Locks/Unlocks setting the scale values.",
+                        };
+                        lockButton.LocalX += 40;
+                        lockButton.LocalY += 1;
+                        lockButton.Clicked += () =>
+                        {
+                            ChangeValuesTogether = !ChangeValuesTogether;
+                            // TODO: change image
+                            Debug.Log(ChangeValuesTogether);
+                        };
+
+                        break;
+                    }
+                }
+                
                 YElement.ValueBox.BorderColor = Color.Lerp(AxisColorY, back, grayOutFactor);
                 YElement.ValueBox.BorderSelectedColor = AxisColorY;
                 ZElement.ValueBox.BorderColor = Color.Lerp(AxisColorZ, back, grayOutFactor);
                 ZElement.ValueBox.BorderSelectedColor = AxisColorZ;
+                
+                Debug.Log(YElement.ValueBox.Parent);
+                Debug.Log(YElement.ValueBox.Parent.Parent);
+                Debug.Log(YElement.ValueBox.Parent.Parent.Parent);
+                Debug.Log(YElement.ValueBox.Parent.Parent.Parent.Parent);
+                Debug.Log(YElement.ValueBox.Parent.Parent.Parent.Parent.Parent);
             }
         }
     }

--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -79,65 +79,53 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <seealso cref="FlaxEditor.CustomEditors.Editors.Float3Editor" />
         public class ScaleEditor : Float3Editor
         {
+
+            private Image _linkImage;
+
             /// <inheritdoc />
             public override void Initialize(LayoutElementsContainer layout)
             {
-                var scaleLocked = Editor.Instance.Windows.PropertiesWin.ScaleLocked;
-                if (scaleLocked)
-                {
-                    ChangeValuesTogether = scaleLocked;
-                }
-                
                 base.Initialize(layout);
+                
+                LinkValuesTogether = Editor.Instance.Windows.PropertiesWin.ScaleLocked;
+
+                _linkImage = new Image
+                {
+                    Parent = LinkedLabel,
+                    Width = 18,
+                    Height = 18,
+                    Brush = LinkValuesTogether ? new SpriteBrush(Editor.Instance.Icons.Link32) : new SpriteBrush(),
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    TooltipText = "Scale values are linked together.",
+                };
+                _linkImage.LocalX += 40;
+                _linkImage.LocalY += 1;
+
+                LinkedLabel.SetupContextMenu += (label, menu, editor) =>
+                {
+                    menu.AddSeparator();
+                    menu.AddButton(LinkValuesTogether ? "Unlink" : "Link", ToggleLink);
+                };
 
                 // Override colors
                 var back = FlaxEngine.GUI.Style.Current.TextBoxBackground;
                 var grayOutFactor = 0.6f;
                 XElement.ValueBox.BorderColor = Color.Lerp(AxisColorX, back, grayOutFactor);
                 XElement.ValueBox.BorderSelectedColor = AxisColorX;
-                
-                if (XElement.ValueBox.Parent.Parent is PropertiesList list)
-                {
-                    foreach (var child in list.Children)
-                    {
-                        if (!(child is PropertyNameLabel))
-                            continue;
-
-                        var nameLabel = child as PropertyNameLabel;
-                        if (!string.Equals(nameLabel.Text, "Scale"))
-                            continue;
-                        
-                        var lockButton = new Button
-                        {
-                            Parent = nameLabel,
-                            Width = 18,
-                            Height = 18,
-                            BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Link32), // TODO change on scale lock
-                            BackgroundColor = Color.White,
-                            BorderColor = Color.Transparent,
-                            BorderColorSelected = Color.Transparent,
-                            BorderColorHighlighted = Color.Transparent,
-                            AnchorPreset = AnchorPresets.TopLeft,
-                            TooltipText = "Locks/Unlocks setting the scale values.",
-                        };
-                        lockButton.LocalX += 40;
-                        lockButton.LocalY += 1;
-                        lockButton.Clicked += () =>
-                        {
-                            ChangeValuesTogether = !ChangeValuesTogether;
-                            Editor.Instance.Windows.PropertiesWin.ScaleLocked = ChangeValuesTogether;
-                            // TODO: change image
-                            Debug.Log(ChangeValuesTogether);
-                        };
-
-                        break;
-                    }
-                }
-                
                 YElement.ValueBox.BorderColor = Color.Lerp(AxisColorY, back, grayOutFactor);
                 YElement.ValueBox.BorderSelectedColor = AxisColorY;
                 ZElement.ValueBox.BorderColor = Color.Lerp(AxisColorZ, back, grayOutFactor);
                 ZElement.ValueBox.BorderSelectedColor = AxisColorZ;
+            }
+
+            /// <summary>
+            /// Toggles the linking functionality.
+            /// </summary>
+            public void ToggleLink()
+            {
+                LinkValuesTogether = !LinkValuesTogether;
+                Editor.Instance.Windows.PropertiesWin.ScaleLocked = LinkValuesTogether;
+                _linkImage.Brush = LinkValuesTogether ? new SpriteBrush(Editor.Instance.Icons.Link32) : new SpriteBrush();
             }
         }
     }

--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -86,14 +86,14 @@ namespace FlaxEditor.CustomEditors.Editors
             {
                 base.Initialize(layout);
                 
-                LinkValuesTogether = Editor.Instance.Windows.PropertiesWin.ScaleLocked;
+                LinkValues = Editor.Instance.Windows.PropertiesWin.ScaleLinked;
 
                 _linkImage = new Image
                 {
                     Parent = LinkedLabel,
                     Width = 18,
                     Height = 18,
-                    Brush = LinkValuesTogether ? new SpriteBrush(Editor.Instance.Icons.Link32) : new SpriteBrush(),
+                    Brush = LinkValues ? new SpriteBrush(Editor.Instance.Icons.Link32) : new SpriteBrush(),
                     AnchorPreset = AnchorPresets.TopLeft,
                     TooltipText = "Scale values are linked together.",
                 };
@@ -103,7 +103,7 @@ namespace FlaxEditor.CustomEditors.Editors
                 LinkedLabel.SetupContextMenu += (label, menu, editor) =>
                 {
                     menu.AddSeparator();
-                    menu.AddButton(LinkValuesTogether ? "Unlink" : "Link", ToggleLink);
+                    menu.AddButton(LinkValues ? "Unlink" : "Link", ToggleLink);
                 };
 
                 // Override colors
@@ -122,9 +122,9 @@ namespace FlaxEditor.CustomEditors.Editors
             /// </summary>
             public void ToggleLink()
             {
-                LinkValuesTogether = !LinkValuesTogether;
-                Editor.Instance.Windows.PropertiesWin.ScaleLocked = LinkValuesTogether;
-                _linkImage.Brush = LinkValuesTogether ? new SpriteBrush(Editor.Instance.Icons.Link32) : new SpriteBrush();
+                LinkValues = !LinkValues;
+                Editor.Instance.Windows.PropertiesWin.ScaleLinked = LinkValues;
+                _linkImage.Brush = LinkValues ? new SpriteBrush(Editor.Instance.Icons.Link32) : new SpriteBrush();
             }
         }
     }

--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -1,6 +1,5 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
-using FlaxEditor.CustomEditors.GUI;
 using FlaxEngine;
 using FlaxEngine.GUI;
 

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -48,9 +48,15 @@ namespace FlaxEditor.CustomEditors.Editors
         /// If true, when one value is changed, the other 2 will change as well.
         /// </summary>
         protected bool ChangeValuesTogether = false;
-        private bool _xChanged;
-        private bool _yChanged;
-        private bool _zChanged;
+
+        private enum ValueChanged
+        {
+            X = 0,
+            Y = 1,
+            Z = 2
+        }
+
+        private ValueChanged _valueChanged;
 
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
@@ -90,11 +96,8 @@ namespace FlaxEditor.CustomEditors.Editors
             if (IsSetBlocked)
                 return;
             if (ChangeValuesTogether)
-            {
-                _xChanged = true;
-                _yChanged = false;
-                _zChanged = false;
-            }
+                _valueChanged = ValueChanged.X;
+
             OnValueChanged();
         }
         
@@ -103,11 +106,8 @@ namespace FlaxEditor.CustomEditors.Editors
             if (IsSetBlocked)
                 return;
             if (ChangeValuesTogether)
-            {
-                _xChanged = false;
-                _yChanged = true;
-                _zChanged = false;
-            }
+                _valueChanged = ValueChanged.Y;
+
             OnValueChanged();
         }
         
@@ -116,11 +116,8 @@ namespace FlaxEditor.CustomEditors.Editors
             if (IsSetBlocked)
                 return;
             if (ChangeValuesTogether)
-            {
-                _xChanged = false;
-                _yChanged = false;
-                _zChanged = true;
-            }
+                _valueChanged = ValueChanged.Z;
+ 
             OnValueChanged();
         }
         
@@ -136,25 +133,25 @@ namespace FlaxEditor.CustomEditors.Editors
             if (ChangeValuesTogether)
             {
                 var adder = 0.0f;
-                if (_xChanged)
+                switch (_valueChanged)
                 {
+                case ValueChanged.X:
                     adder = xValue - ((Float3)Values[0]).X;
                     yValue += adder;
                     zValue += adder;
-                }
-
-                if (_yChanged)
-                {
+                    break;
+                case ValueChanged.Y:
                     adder = yValue - ((Float3)Values[0]).Y;
                     xValue += adder;
                     zValue += adder;
-                }
-                
-                if (_zChanged)
-                {
+                    break;
+                case ValueChanged.Z:
                     adder = zValue - ((Float3)Values[0]).Z;
                     xValue += adder;
                     yValue += adder;
+                    break;
+                default: 
+                    break;
                 }
             }
 
@@ -169,13 +166,6 @@ namespace FlaxEditor.CustomEditors.Editors
             else if (v is Double3)
                 v = (Double3)value;
             SetValue(v, token);
-            
-            if (ChangeValuesTogether)
-            {
-                _xChanged = false;
-                _yChanged = false;
-                _zChanged = false;
-            }
         }
 
         /// <inheritdoc />

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -47,7 +47,7 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <summary>
         /// If true, when one value is changed, the other 2 will change as well.
         /// </summary>
-        public bool LinkValuesTogether = false;
+        public bool LinkValues = false;
 
         private enum ValueChanged
         {
@@ -95,7 +95,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (IsSetBlocked)
                 return;
-            if (LinkValuesTogether)
+            if (LinkValues)
                 _valueChanged = ValueChanged.X;
 
             OnValueChanged();
@@ -105,7 +105,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (IsSetBlocked)
                 return;
-            if (LinkValuesTogether)
+            if (LinkValues)
                 _valueChanged = ValueChanged.Y;
 
             OnValueChanged();
@@ -115,7 +115,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (IsSetBlocked)
                 return;
-            if (LinkValuesTogether)
+            if (LinkValues)
                 _valueChanged = ValueChanged.Z;
  
             OnValueChanged();
@@ -130,7 +130,7 @@ namespace FlaxEditor.CustomEditors.Editors
             var yValue = YElement.ValueBox.Value;
             var zValue = ZElement.ValueBox.Value;
 
-            if (LinkValuesTogether)
+            if (LinkValues)
             {
                 var valueChange = 0.0f;
                 switch (_valueChanged)

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -47,7 +47,7 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <summary>
         /// If true, when one value is changed, the other 2 will change as well.
         /// </summary>
-        protected bool ChangeValuesTogether = false;
+        public bool LinkValuesTogether = false;
 
         private enum ValueChanged
         {
@@ -95,7 +95,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (IsSetBlocked)
                 return;
-            if (ChangeValuesTogether)
+            if (LinkValuesTogether)
                 _valueChanged = ValueChanged.X;
 
             OnValueChanged();
@@ -105,7 +105,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (IsSetBlocked)
                 return;
-            if (ChangeValuesTogether)
+            if (LinkValuesTogether)
                 _valueChanged = ValueChanged.Y;
 
             OnValueChanged();
@@ -115,7 +115,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (IsSetBlocked)
                 return;
-            if (ChangeValuesTogether)
+            if (LinkValuesTogether)
                 _valueChanged = ValueChanged.Z;
  
             OnValueChanged();
@@ -130,25 +130,25 @@ namespace FlaxEditor.CustomEditors.Editors
             var yValue = YElement.ValueBox.Value;
             var zValue = ZElement.ValueBox.Value;
 
-            if (ChangeValuesTogether)
+            if (LinkValuesTogether)
             {
-                var adder = 0.0f;
+                var valueChange = 0.0f;
                 switch (_valueChanged)
                 {
                 case ValueChanged.X:
-                    adder = xValue - ((Float3)Values[0]).X;
-                    yValue += adder;
-                    zValue += adder;
+                    valueChange = xValue - ((Float3)Values[0]).X;
+                    yValue += valueChange;
+                    zValue += valueChange;
                     break;
                 case ValueChanged.Y:
-                    adder = yValue - ((Float3)Values[0]).Y;
-                    xValue += adder;
-                    zValue += adder;
+                    valueChange = yValue - ((Float3)Values[0]).Y;
+                    xValue += valueChange;
+                    zValue += valueChange;
                     break;
                 case ValueChanged.Z:
-                    adder = zValue - ((Float3)Values[0]).Z;
-                    xValue += adder;
-                    yValue += adder;
+                    valueChange = zValue - ((Float3)Values[0]).Z;
+                    xValue += valueChange;
+                    yValue += valueChange;
                     break;
                 default: 
                     break;

--- a/Source/Editor/Windows/PropertiesWindow.cs
+++ b/Source/Editor/Windows/PropertiesWindow.cs
@@ -28,7 +28,7 @@ namespace FlaxEditor.Windows
         /// <summary>
         /// Indication of if the scale is locked.
         /// </summary>
-        public bool ScaleLocked = false;
+        public bool ScaleLinked = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertiesWindow"/> class.
@@ -65,14 +65,14 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override void OnLayoutSerialize(XmlWriter writer)
         {
-            writer.WriteAttributeString("ScaleLocked", ScaleLocked.ToString());
+            writer.WriteAttributeString("ScaleLinked", ScaleLinked.ToString());
         }
         
         /// <inheritdoc />
         public override void OnLayoutDeserialize(XmlElement node)
         {
-            if (bool.TryParse(node.GetAttribute("ScaleLocked"), out bool value1))
-                ScaleLocked = value1;
+            if (bool.TryParse(node.GetAttribute("ScaleLinked"), out bool value1))
+                ScaleLinked = value1;
         }
     }
 }

--- a/Source/Editor/Windows/PropertiesWindow.cs
+++ b/Source/Editor/Windows/PropertiesWindow.cs
@@ -17,6 +17,9 @@ namespace FlaxEditor.Windows
     {
         private IEnumerable<object> undoRecordObjects;
 
+        /// <inheritdoc />
+        public override bool UseLayoutData => true;
+
         /// <summary>
         /// The editor.
         /// </summary>

--- a/Source/Editor/Windows/PropertiesWindow.cs
+++ b/Source/Editor/Windows/PropertiesWindow.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 using FlaxEditor.CustomEditors;
 using FlaxEngine.GUI;
 
@@ -20,6 +21,11 @@ namespace FlaxEditor.Windows
         /// The editor.
         /// </summary>
         public readonly CustomEditorPresenter Presenter;
+
+        /// <summary>
+        /// Indication of if the scale is locked.
+        /// </summary>
+        public bool ScaleLocked = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertiesWindow"/> class.
@@ -51,6 +57,19 @@ namespace FlaxEditor.Windows
             undoRecordObjects = Editor.SceneEditing.Selection.ConvertAll(x => x.UndoRecordObject).Distinct();
             var objects = Editor.SceneEditing.Selection.ConvertAll(x => x.EditableObject).Distinct();
             Presenter.Select(objects);
+        }
+
+        /// <inheritdoc />
+        public override void OnLayoutSerialize(XmlWriter writer)
+        {
+            writer.WriteAttributeString("ScaleLocked", ScaleLocked.ToString());
+        }
+        
+        /// <inheritdoc />
+        public override void OnLayoutDeserialize(XmlElement node)
+        {
+            if (bool.TryParse(node.GetAttribute("ScaleLocked"), out bool value1))
+                ScaleLocked = value1;
         }
     }
 }


### PR DESCRIPTION
Hello this PR adds the ability to link and unlink the scale vector together so if 1 value is changed then the other 2 values will change as well. This can be toggled from the right click context menu on the scale property label. A little link image will appear next to the 'Scale' text to show that the values are linked.


https://user-images.githubusercontent.com/71274967/216877130-10fa25b3-deb0-4da1-89f7-da2e47bd7d6b.mp4
