### PR TITLE
Possible fix for values reverting to previous values in ValueBoxs

### DIFF
--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -181,6 +181,7 @@ namespace FlaxEditor.GUI.Input
                 _cursorChanged = false;
             }
             SlidingEnd?.Invoke();
+            Defocus();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Hello this PR is a fix for an issue that was occurring when the user tried to edit the value in a value box right after they had slid the value. The issue was that if the user tried to edit the value right after sliding the value, if they clicked enter it would revert back to the previous value. You can see an example of this happening in the video I posted for #930.