### PR TITLE
VisjectSurface Shortcuts

### DIFF
--- a/Source/Editor/Surface/MaterialSurface.cs
+++ b/Source/Editor/Surface/MaterialSurface.cs
@@ -110,54 +110,11 @@ namespace FlaxEditor.Surface
         }
 
         /// <inheritdoc/>
-        public override bool OnMouseDown(Float2 location, MouseButton button)
+        protected override void GetShortcutNode(KeyboardKeys key, out ushort archetype, out ushort node)
         {
-            if (button != MouseButton.Left) return base.OnMouseDown(location, button);
-
-            GetNode(_heldKey, out var archetype, out var node);
-
-            if (archetype == 0 || node == 0) return base.OnMouseDown(location, button);
-
-            var spawnedNode = Context.SpawnNode(archetype, node, _rootControl.PointFromParent(location));
-            return base.OnMouseDown(location, button);
-        }
-
-        private void GetNode(KeyboardKeys key, out ushort archetype, out ushort node)
-        {
-            archetype = 0;
-            node = 0;
+            base.GetShortcutNode(key, out archetype, out node);
             switch (key)
             {
-                // Add node
-                case KeyboardKeys.A:
-                    archetype = 3;
-                    node = 1;
-                    break;
-                // Subtract
-                case KeyboardKeys.S:
-                    archetype = 3;
-                    node = 2;
-                    break;
-                // Multiply
-                case KeyboardKeys.M:
-                    archetype = 3;
-                    node = 3;
-                    break;
-                // Divide
-                case KeyboardKeys.D:
-                    archetype = 3;
-                    node = 5;
-                    break;
-                // Lerp
-                case KeyboardKeys.L:
-                    archetype = 3;
-                    node = 25;
-                    break;
-                // Power
-                case KeyboardKeys.E:
-                    archetype = 3;
-                    node = 23;
-                    break;
                 // Texture Sample
                 case KeyboardKeys.T:
                     archetype = 5;
@@ -167,41 +124,6 @@ namespace FlaxEditor.Surface
                 case KeyboardKeys.U:
                     archetype = 5;
                     node = 2;
-                    break;
-                // Get Parameter
-                case KeyboardKeys.G:
-                    archetype = 6;
-                    node = 1;
-                    break;
-
-                // Float
-                case KeyboardKeys.Alpha1:
-                    archetype = 2;
-                    node = 3;
-                    break;
-                // Float2
-                case KeyboardKeys.Alpha2:
-                    archetype = 2;
-                    node = 4;
-                    break;
-                // Float3
-                case KeyboardKeys.Alpha3:
-                    archetype = 2;
-                    node = 5;
-                    break;
-                // Float4
-                case KeyboardKeys.Alpha4:
-                    archetype = 2;
-                    node = 6;
-                    break;
-                // Color
-                case KeyboardKeys.Alpha5:
-                    archetype = 2;
-                    node = 7;
-                    break;
-
-
-                default:
                     break;
             }
         }

--- a/Source/Editor/Surface/MaterialSurface.cs
+++ b/Source/Editor/Surface/MaterialSurface.cs
@@ -109,30 +109,24 @@ namespace FlaxEditor.Surface
             base.HandleDragDropAssets(objects, args);
         }
 
-        private KeyboardKeys _cachedKey;
-
-        /// <inheritdoc/>
-        public override bool OnKeyDown(KeyboardKeys key)
-        {
-            _cachedKey = key;
-            return base.OnKeyDown(key);
-        }
-
-        /// <inheritdoc/>
-        public override void OnKeyUp(KeyboardKeys key)
-        {
-            base.OnKeyUp(key);
-            _cachedKey = KeyboardKeys.None;
-        }
-
         /// <inheritdoc/>
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
             if (button != MouseButton.Left) return base.OnMouseDown(location, button);
-            ushort archetype = 0;
-            ushort node = 0;
 
-            switch (_cachedKey)
+            GetNode(_heldKey, out var archetype, out var node);
+
+            if (archetype == 0 || node == 0) return base.OnMouseDown(location, button);
+
+            var spawnedNode = Context.SpawnNode(archetype, node, _rootControl.PointFromParent(location));
+            return base.OnMouseDown(location, button);
+        }
+
+        private void GetNode(KeyboardKeys key, out ushort archetype, out ushort node)
+        {
+            archetype = 0;
+            node = 0;
+            switch (key)
             {
                 // Add node
                 case KeyboardKeys.A:
@@ -164,6 +158,21 @@ namespace FlaxEditor.Surface
                     archetype = 3;
                     node = 23;
                     break;
+                // Texture Sample
+                case KeyboardKeys.T:
+                    archetype = 5;
+                    node = 1;
+                    break;
+                // Texture Coordinates
+                case KeyboardKeys.U:
+                    archetype = 5;
+                    node = 2;
+                    break;
+                // Get Parameter
+                case KeyboardKeys.G:
+                    archetype = 6;
+                    node = 1;
+                    break;
 
                 // Float
                 case KeyboardKeys.Alpha1:
@@ -191,13 +200,10 @@ namespace FlaxEditor.Surface
                     node = 7;
                     break;
 
+
                 default:
                     break;
             }
-            if (archetype == 0 || node == 0) return base.OnMouseDown(location, button);
-
-            var spawnedNode = Context.SpawnNode(archetype, node, _rootControl.PointFromParent(location));
-            return base.OnMouseDown(location, button);
         }
     }
 }

--- a/Source/Editor/Surface/MaterialSurface.cs
+++ b/Source/Editor/Surface/MaterialSurface.cs
@@ -108,5 +108,96 @@ namespace FlaxEditor.Surface
 
             base.HandleDragDropAssets(objects, args);
         }
+
+        private KeyboardKeys _cachedKey;
+
+        /// <inheritdoc/>
+        public override bool OnKeyDown(KeyboardKeys key)
+        {
+            _cachedKey = key;
+            return base.OnKeyDown(key);
+        }
+
+        /// <inheritdoc/>
+        public override void OnKeyUp(KeyboardKeys key)
+        {
+            base.OnKeyUp(key);
+            _cachedKey = KeyboardKeys.None;
+        }
+
+        /// <inheritdoc/>
+        public override bool OnMouseDown(Float2 location, MouseButton button)
+        {
+            if (button != MouseButton.Left) return base.OnMouseDown(location, button);
+            ushort archetype = 0;
+            ushort node = 0;
+
+            switch (_cachedKey)
+            {
+                // Add node
+                case KeyboardKeys.A:
+                    archetype = 3;
+                    node = 1;
+                    break;
+                // Subtract
+                case KeyboardKeys.S:
+                    archetype = 3;
+                    node = 2;
+                    break;
+                // Multiply
+                case KeyboardKeys.M:
+                    archetype = 3;
+                    node = 3;
+                    break;
+                // Divide
+                case KeyboardKeys.D:
+                    archetype = 3;
+                    node = 5;
+                    break;
+                // Lerp
+                case KeyboardKeys.L:
+                    archetype = 3;
+                    node = 25;
+                    break;
+                // Power
+                case KeyboardKeys.E:
+                    archetype = 3;
+                    node = 23;
+                    break;
+
+                // Float
+                case KeyboardKeys.Alpha1:
+                    archetype = 2;
+                    node = 3;
+                    break;
+                // Float2
+                case KeyboardKeys.Alpha2:
+                    archetype = 2;
+                    node = 4;
+                    break;
+                // Float3
+                case KeyboardKeys.Alpha3:
+                    archetype = 2;
+                    node = 5;
+                    break;
+                // Float4
+                case KeyboardKeys.Alpha4:
+                    archetype = 2;
+                    node = 6;
+                    break;
+                // Color
+                case KeyboardKeys.Alpha5:
+                    archetype = 2;
+                    node = 7;
+                    break;
+
+                default:
+                    break;
+            }
+            if (archetype == 0 || node == 0) return base.OnMouseDown(location, button);
+
+            var spawnedNode = Context.SpawnNode(archetype, node, _rootControl.PointFromParent(location));
+            return base.OnMouseDown(location, button);
+        }
     }
 }

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -488,6 +488,16 @@ namespace FlaxEditor.Surface
                 else if (_connectionInstigator != null)
                 {
                 }
+                else if (_heldKey != KeyboardKeys.None)
+                {
+                    // Get shortcut based on key held down
+                    GetShortcutNode(_heldKey, out var archetype, out var node);
+
+                    if (archetype == 0 || node == 0) return true;
+
+                    // Spawn node based on the key that is held down
+                    Context.SpawnNode(archetype, node, _rootControl.PointFromParent(location));
+                }
                 // Selecting
                 else
                 {
@@ -922,6 +932,86 @@ namespace FlaxEditor.Surface
                 }
             }
             return null;
+        }
+
+        // TODO Move this to Utils.cs and make it static?
+        /// <summary>
+        /// Sets archetype and node based on the input key.
+        /// </summary>
+        /// <param name="key">The key being held down.</param>
+        /// <param name="archetype"></param>
+        /// <param name="node"></param>
+        protected virtual void GetShortcutNode(KeyboardKeys key, out ushort archetype, out ushort node)
+        {
+            archetype = 0;
+            node = 0;
+            switch (key)
+            {
+                // Add node
+                case KeyboardKeys.A:
+                    archetype = 3;
+                    node = 1;
+                    break;
+                // Subtract
+                case KeyboardKeys.S:
+                    archetype = 3;
+                    node = 2;
+                    break;
+                // Multiply
+                case KeyboardKeys.M:
+                    archetype = 3;
+                    node = 3;
+                    break;
+                // Divide
+                case KeyboardKeys.D:
+                    archetype = 3;
+                    node = 5;
+                    break;
+                // Lerp
+                case KeyboardKeys.L:
+                    archetype = 3;
+                    node = 25;
+                    break;
+                // Power
+                case KeyboardKeys.E:
+                    archetype = 3;
+                    node = 23;
+                    break;
+
+                // Get Parameter
+                case KeyboardKeys.G:
+                    archetype = 6;
+                    node = 1;
+                    break;
+
+                // Float
+                case KeyboardKeys.Alpha1:
+                    archetype = 2;
+                    node = 3;
+                    break;
+                // Float2
+                case KeyboardKeys.Alpha2:
+                    archetype = 2;
+                    node = 4;
+                    break;
+                // Float3
+                case KeyboardKeys.Alpha3:
+                    archetype = 2;
+                    node = 5;
+                    break;
+                // Float4
+                case KeyboardKeys.Alpha4:
+                    archetype = 2;
+                    node = 6;
+                    break;
+                // Color
+                case KeyboardKeys.Alpha5:
+                    archetype = 2;
+                    node = 7;
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -573,49 +573,49 @@ namespace FlaxEditor.Surface
                 var keyMoveRange = 50;
                 switch (key)
                 {
-                case KeyboardKeys.Backspace:
+                    case KeyboardKeys.Backspace:
                     if (InputText.Length > 0)
                         InputText = InputText.Substring(0, InputText.Length - 1);
                     return true;
-                case KeyboardKeys.Escape:
+                    case KeyboardKeys.Escape:
                     ClearSelection();
                     return true;
-                case KeyboardKeys.Return:
-                {
-                    Box selectedBox = GetSelectedBox(SelectedNodes, false);
-                    Box toSelect = selectedBox?.ParentNode.GetNextBox(selectedBox);
-                    if (toSelect != null)
+                    case KeyboardKeys.Return:
                     {
-                        Select(toSelect.ParentNode);
-                        toSelect.ParentNode.SelectBox(toSelect);
-                    }
-                    return true;
-                }
-                case KeyboardKeys.ArrowUp:
-                case KeyboardKeys.ArrowDown:
-                {
-                    // Selected box navigation
-                    Box selectedBox = GetSelectedBox(SelectedNodes);
-                    if (selectedBox != null)
-                    {
-                        Box toSelect = (key == KeyboardKeys.ArrowUp) ? selectedBox?.ParentNode.GetPreviousBox(selectedBox) : selectedBox?.ParentNode.GetNextBox(selectedBox);
-                        if (toSelect != null && toSelect.IsOutput == selectedBox.IsOutput)
+                        Box selectedBox = GetSelectedBox(SelectedNodes, false);
+                        Box toSelect = selectedBox?.ParentNode.GetNextBox(selectedBox);
+                        if (toSelect != null)
                         {
                             Select(toSelect.ParentNode);
                             toSelect.ParentNode.SelectBox(toSelect);
                         }
+                        return true;
                     }
-                    else if (!IsMovingSelection && CanEdit)
+                    case KeyboardKeys.ArrowUp:
+                    case KeyboardKeys.ArrowDown:
                     {
-                        // Move selected nodes
-                        var delta = new Float2(0, key == KeyboardKeys.ArrowUp ? -keyMoveRange : keyMoveRange);
-                        MoveSelectedNodes(delta);
+                        // Selected box navigation
+                        Box selectedBox = GetSelectedBox(SelectedNodes);
+                        if (selectedBox != null)
+                        {
+                            Box toSelect = (key == KeyboardKeys.ArrowUp) ? selectedBox?.ParentNode.GetPreviousBox(selectedBox) : selectedBox?.ParentNode.GetNextBox(selectedBox);
+                            if (toSelect != null && toSelect.IsOutput == selectedBox.IsOutput)
+                            {
+                                Select(toSelect.ParentNode);
+                                toSelect.ParentNode.SelectBox(toSelect);
+                            }
+                        }
+                        else if (!IsMovingSelection && CanEdit)
+                        {
+                            // Move selected nodes
+                            var delta = new Float2(0, key == KeyboardKeys.ArrowUp ? -keyMoveRange : keyMoveRange);
+                            MoveSelectedNodes(delta);
+                        }
+                        return true;
                     }
-                    return true;
-                }
-                case KeyboardKeys.ArrowRight:
-                case KeyboardKeys.ArrowLeft:
-                {
+                    case KeyboardKeys.ArrowRight:
+                    case KeyboardKeys.ArrowLeft:
+                    {
                     // Selected box navigation
                     Box selectedBox = GetSelectedBox(SelectedNodes);
                     if (selectedBox != null)
@@ -658,30 +658,48 @@ namespace FlaxEditor.Surface
                         MoveSelectedNodes(delta);
                     }
                     return true;
-                }
-                case KeyboardKeys.Tab:
-                {
-                    Box selectedBox = GetSelectedBox(SelectedNodes, false);
-                    if (selectedBox == null)
-                        return true;
-
-                    int connectionCount = selectedBox.Connections.Count;
-                    if (connectionCount == 0)
-                        return true;
-
-                    if (Root.GetKey(KeyboardKeys.Shift))
-                    {
-                        _selectedConnectionIndex = ((_selectedConnectionIndex - 1) % connectionCount + connectionCount) % connectionCount;
                     }
-                    else
+                    case KeyboardKeys.Tab:
                     {
-                        _selectedConnectionIndex = (_selectedConnectionIndex + 1) % connectionCount;
+                        Box selectedBox = GetSelectedBox(SelectedNodes, false);
+                        if (selectedBox == null)
+                            return true;
+
+                        int connectionCount = selectedBox.Connections.Count;
+                        if (connectionCount == 0)
+                            return true;
+
+                        if (Root.GetKey(KeyboardKeys.Shift))
+                        {
+                            _selectedConnectionIndex = ((_selectedConnectionIndex - 1) % connectionCount + connectionCount) % connectionCount;
+                        }
+                        else
+                        {
+                            _selectedConnectionIndex = (_selectedConnectionIndex + 1) % connectionCount;
+                        }
+                        return true;
                     }
-                    return true;
-                }
+                    case KeyboardKeys.Spacebar:
+                    {
+                        Box selectedBox = GetSelectedBox(SelectedNodes, true);
+                        if (selectedBox == null) selectedBox = GetUnconnectedElement(SelectedNodes[0]);
+                        // Add a new node
+                        ConnectingStart(selectedBox);
+                        Cursor = CursorType.Default; // Do I need this?
+                        EndMouseCapture();
+                        ShowPrimaryMenu(_rootControl.PointToParent(FindEmptySpace(selectedBox)), true);
+                        return true;
+                    }
                 }
             }
-
+            else
+            {
+                if (key == KeyboardKeys.Spacebar)
+                {
+                    ShowPrimaryMenu(_mousePos);
+                    return true;
+                }
+            }
             return false;
         }
 
@@ -704,17 +722,17 @@ namespace FlaxEditor.Surface
             var selection = SelectedNodes;
             if (selection.Count == 0)
             {
-                if (_inputBrackets.Count == 0)
-                {
-                    ResetInput();
-                    ShowPrimaryMenu(_mousePos, false, currentInputText);
-                }
-                else
-                {
-                    InputText = "";
-                    ShowPrimaryMenu(_rootControl.PointToParent(_inputBrackets.Peek().Area.Location), true, currentInputText);
-                }
-                return;
+                //if (_inputBrackets.Count == 0)
+                //{
+                //    ResetInput();
+                //    ShowPrimaryMenu(_mousePos, false, currentInputText);
+                //}
+                //else
+                //{
+                //    InputText = "";
+                //    ShowPrimaryMenu(_rootControl.PointToParent(_inputBrackets.Peek().Area.Location), true, currentInputText);
+                //}
+                //return;
             }
 
             // Multi-Node Editing
@@ -771,16 +789,16 @@ namespace FlaxEditor.Surface
                     }
                 }
             }
-            else
-            {
-                InputText = "";
+            //else
+            //{
+            //    InputText = "";
 
-                // Add a new node
-                ConnectingStart(selectedBox);
-                Cursor = CursorType.Default; // Do I need this?
-                EndMouseCapture();
-                ShowPrimaryMenu(_rootControl.PointToParent(FindEmptySpace(selectedBox)), true, currentInputText);
-            }
+            //    // Add a new node
+            //    ConnectingStart(selectedBox);
+            //    Cursor = CursorType.Default; // Do I need this?
+            //    EndMouseCapture();
+            //    ShowPrimaryMenu(_rootControl.PointToParent(FindEmptySpace(selectedBox)), true, currentInputText);
+            //}
         }
 
         private Box GetSelectedBox(List<SurfaceNode> selection, bool onlyIfSelected = true)
@@ -895,6 +913,29 @@ namespace FlaxEditor.Surface
             outputBox = null;
             inputBox = null;
             return false;
+        }
+
+        private Box GetUnconnectedElement(SurfaceNode node)
+        {
+            
+            for (int i = 0; i < node.Elements.Count; i++)
+            {
+                if (node.Elements[i] is InputBox ib)
+                {
+                    if (ib.Connections.Count == 0)
+                    {
+                        return ib as Box;
+                    }
+                }
+                else if(node.Elements[i] is OutputBox ob)
+                {
+                    if (ob.Connections.Count == 0)
+                    {
+                        return ob as Box;
+                    }
+                }
+            }
+            return null;
         }
     }
 }

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -568,6 +568,8 @@ namespace FlaxEditor.Surface
             if (InputActions.Process(Editor.Instance, this, key))
                 return true;
 
+            _heldKey = key;
+
             if (HasNodesSelection)
             {
                 var keyMoveRange = 50;
@@ -682,7 +684,8 @@ namespace FlaxEditor.Surface
                     case KeyboardKeys.Spacebar:
                     {
                         Box selectedBox = GetSelectedBox(SelectedNodes, true);
-                        if (selectedBox == null) selectedBox = GetUnconnectedElement(SelectedNodes[0]);
+                        // If we don't have a input/output selected, find one.
+                        if (selectedBox == null) selectedBox = GetFirstEmptyPort(SelectedNodes[0]);
                         // Add a new node
                         ConnectingStart(selectedBox);
                         Cursor = CursorType.Default; // Do I need this?
@@ -703,6 +706,13 @@ namespace FlaxEditor.Surface
             return false;
         }
 
+        /// <inheritdoc/>
+        public override void OnKeyUp(KeyboardKeys key)
+        {
+            base.OnKeyUp(key);
+            _heldKey = KeyboardKeys.None;
+        }
+
         private void ResetInput()
         {
             InputText = "";
@@ -720,20 +730,6 @@ namespace FlaxEditor.Surface
             }
 
             var selection = SelectedNodes;
-            if (selection.Count == 0)
-            {
-                //if (_inputBrackets.Count == 0)
-                //{
-                //    ResetInput();
-                //    ShowPrimaryMenu(_mousePos, false, currentInputText);
-                //}
-                //else
-                //{
-                //    InputText = "";
-                //    ShowPrimaryMenu(_rootControl.PointToParent(_inputBrackets.Peek().Area.Location), true, currentInputText);
-                //}
-                //return;
-            }
 
             // Multi-Node Editing
             const string Comment = "//";
@@ -789,16 +785,6 @@ namespace FlaxEditor.Surface
                     }
                 }
             }
-            //else
-            //{
-            //    InputText = "";
-
-            //    // Add a new node
-            //    ConnectingStart(selectedBox);
-            //    Cursor = CursorType.Default; // Do I need this?
-            //    EndMouseCapture();
-            //    ShowPrimaryMenu(_rootControl.PointToParent(FindEmptySpace(selectedBox)), true, currentInputText);
-            //}
         }
 
         private Box GetSelectedBox(List<SurfaceNode> selection, bool onlyIfSelected = true)
@@ -915,7 +901,7 @@ namespace FlaxEditor.Surface
             return false;
         }
 
-        private Box GetUnconnectedElement(SurfaceNode node)
+        private Box GetFirstEmptyPort(SurfaceNode node)
         {
             
             for (int i = 0; i < node.Elements.Count; i++)

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -585,49 +585,49 @@ namespace FlaxEditor.Surface
                 var keyMoveRange = 50;
                 switch (key)
                 {
-                    case KeyboardKeys.Backspace:
+                case KeyboardKeys.Backspace:
                     if (InputText.Length > 0)
                         InputText = InputText.Substring(0, InputText.Length - 1);
                     return true;
-                    case KeyboardKeys.Escape:
+                case KeyboardKeys.Escape:
                     ClearSelection();
                     return true;
-                    case KeyboardKeys.Return:
+                case KeyboardKeys.Return:
+                {
+                    Box selectedBox = GetSelectedBox(SelectedNodes, false);
+                    Box toSelect = selectedBox?.ParentNode.GetNextBox(selectedBox);
+                    if (toSelect != null)
                     {
-                        Box selectedBox = GetSelectedBox(SelectedNodes, false);
-                        Box toSelect = selectedBox?.ParentNode.GetNextBox(selectedBox);
-                        if (toSelect != null)
+                        Select(toSelect.ParentNode);
+                        toSelect.ParentNode.SelectBox(toSelect);
+                    }
+                    return true;
+                }
+                case KeyboardKeys.ArrowUp:
+                case KeyboardKeys.ArrowDown:
+                {
+                    // Selected box navigation
+                    Box selectedBox = GetSelectedBox(SelectedNodes);
+                    if (selectedBox != null)
+                    {
+                        Box toSelect = (key == KeyboardKeys.ArrowUp) ? selectedBox?.ParentNode.GetPreviousBox(selectedBox) : selectedBox?.ParentNode.GetNextBox(selectedBox);
+                        if (toSelect != null && toSelect.IsOutput == selectedBox.IsOutput)
                         {
                             Select(toSelect.ParentNode);
                             toSelect.ParentNode.SelectBox(toSelect);
                         }
-                        return true;
                     }
-                    case KeyboardKeys.ArrowUp:
-                    case KeyboardKeys.ArrowDown:
+                    else if (!IsMovingSelection && CanEdit)
                     {
-                        // Selected box navigation
-                        Box selectedBox = GetSelectedBox(SelectedNodes);
-                        if (selectedBox != null)
-                        {
-                            Box toSelect = (key == KeyboardKeys.ArrowUp) ? selectedBox?.ParentNode.GetPreviousBox(selectedBox) : selectedBox?.ParentNode.GetNextBox(selectedBox);
-                            if (toSelect != null && toSelect.IsOutput == selectedBox.IsOutput)
-                            {
-                                Select(toSelect.ParentNode);
-                                toSelect.ParentNode.SelectBox(toSelect);
-                            }
-                        }
-                        else if (!IsMovingSelection && CanEdit)
-                        {
-                            // Move selected nodes
-                            var delta = new Float2(0, key == KeyboardKeys.ArrowUp ? -keyMoveRange : keyMoveRange);
-                            MoveSelectedNodes(delta);
-                        }
-                        return true;
+                        // Move selected nodes
+                        var delta = new Float2(0, key == KeyboardKeys.ArrowUp ? -keyMoveRange : keyMoveRange);
+                        MoveSelectedNodes(delta);
                     }
-                    case KeyboardKeys.ArrowRight:
-                    case KeyboardKeys.ArrowLeft:
-                    {
+                    return true;
+                }
+                case KeyboardKeys.ArrowRight:
+                case KeyboardKeys.ArrowLeft:
+                {
                     // Selected box navigation
                     Box selectedBox = GetSelectedBox(SelectedNodes);
                     if (selectedBox != null)
@@ -670,39 +670,39 @@ namespace FlaxEditor.Surface
                         MoveSelectedNodes(delta);
                     }
                     return true;
-                    }
-                    case KeyboardKeys.Tab:
-                    {
-                        Box selectedBox = GetSelectedBox(SelectedNodes, false);
-                        if (selectedBox == null)
-                            return true;
-
-                        int connectionCount = selectedBox.Connections.Count;
-                        if (connectionCount == 0)
-                            return true;
-
-                        if (Root.GetKey(KeyboardKeys.Shift))
-                        {
-                            _selectedConnectionIndex = ((_selectedConnectionIndex - 1) % connectionCount + connectionCount) % connectionCount;
-                        }
-                        else
-                        {
-                            _selectedConnectionIndex = (_selectedConnectionIndex + 1) % connectionCount;
-                        }
+                }
+                case KeyboardKeys.Tab:
+                {
+                    Box selectedBox = GetSelectedBox(SelectedNodes, false);
+                    if (selectedBox == null)
                         return true;
-                    }
-                    case KeyboardKeys.Spacebar:
-                    {
-                        Box selectedBox = GetSelectedBox(SelectedNodes, true);
-                        // If we don't have a input/output selected, find one.
-                        if (selectedBox == null) selectedBox = GetFirstEmptyPort(SelectedNodes[0]);
-                        // Add a new node
-                        ConnectingStart(selectedBox);
-                        Cursor = CursorType.Default; // Do I need this?
-                        EndMouseCapture();
-                        ShowPrimaryMenu(_rootControl.PointToParent(FindEmptySpace(selectedBox)), true);
+
+                    int connectionCount = selectedBox.Connections.Count;
+                    if (connectionCount == 0)
                         return true;
+
+                    if (Root.GetKey(KeyboardKeys.Shift))
+                    {
+                        _selectedConnectionIndex = ((_selectedConnectionIndex - 1) % connectionCount + connectionCount) % connectionCount;
                     }
+                    else
+                    {
+                        _selectedConnectionIndex = (_selectedConnectionIndex + 1) % connectionCount;
+                    }
+                    return true;
+                }
+                case KeyboardKeys.Spacebar:
+                {
+                    Box selectedBox = GetSelectedBox(SelectedNodes, true);
+                    // If we don't have a input/output selected, find one.
+                    if (selectedBox == null) selectedBox = GetFirstEmptyPort(SelectedNodes[0]);
+                    // Add a new node
+                    ConnectingStart(selectedBox);
+                    Cursor = CursorType.Default; // Do I need this?
+                    EndMouseCapture();
+                    ShowPrimaryMenu(_rootControl.PointToParent(FindEmptySpace(selectedBox)), true);
+                    return true;
+                }
                 }
             }
             else

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -75,6 +75,11 @@ namespace FlaxEditor.Surface
         protected Float2 _mousePos = Float2.Minimum;
 
         /// <summary>
+        /// The key currently being held down.
+        /// </summary>
+        protected KeyboardKeys _heldKey = KeyboardKeys.None;
+
+        /// <summary>
         /// The mouse movement amount.
         /// </summary>
         protected float _mouseMoveAmount;


### PR DESCRIPTION
Adds the ability to have shortcuts for any VisjectSurfaces, with special attention to the Material surface. Functions very similarly to other material graphs in similar software, you can hold down a keyboard key and on mouse up, it will spawn the relevant node. To get this functionality it unfortunately meant removing the functionality of simply typing to bring up the primary menu, but instead you can simply press the spacebar to bring the menu up. With a node selected and pressing spacebar you can also automatically spawn a node that will try and connect to the selected node.

While this does remove functionality I do believe it will bring a more comfortable experience for users while also providing them with a familiar one if they are used to other similar graph systems.

1-5 will spawn a float1-4 and then color node
A = Add
S = Subtract
D = Divide
L = Lerp
E = Power
G = Get Parameter

On the material graph you can use
T for a Texture Sampler
U for a TexCoord node

To add similar functionality to other VisjectSurfaces you can simply override the GetShortcutNode() function and add the shortcuts as demonstrated in MaterialSurface.cs