### PR TITLE
Context menu and tooltip fixes

### DIFF
--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -700,6 +700,8 @@ namespace FlaxEditor.GUI.Tree
         /// <inheritdoc />
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
+            UpdateMouseOverFlags(location);
+
             // Check if mouse hits bar and node isn't a root
             if (_mouseOverHeader)
             {
@@ -728,6 +730,8 @@ namespace FlaxEditor.GUI.Tree
         /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
+            UpdateMouseOverFlags(location);
+
             // Clear flag for left button
             if (button == MouseButton.Left)
             {
@@ -815,21 +819,7 @@ namespace FlaxEditor.GUI.Tree
         /// <inheritdoc />
         public override void OnMouseMove(Float2 location)
         {
-            // Cache flags
-            _mouseOverArrow = HasAnyVisibleChild && ArrowRect.Contains(location);
-            _mouseOverHeader = new Rectangle(0, 0, Width, _headerHeight - 1).Contains(location);
-            if (_mouseOverHeader)
-            {
-                // Allow non-scrollable controls to stay on top of the header and override the mouse behaviour
-                for (int i = 0; i < Children.Count; i++)
-                {
-                    if (!Children[i].IsScrollable && IntersectsChildContent(Children[i], location, out _))
-                    {
-                        _mouseOverHeader = false;
-                        break;
-                    }
-                }
-            }
+            UpdateMouseOverFlags(location);
 
             // Check if start drag and drop
             if (_isMouseDown && Float2.Distance(_mouseDownPos, location) > 10.0f)
@@ -849,6 +839,25 @@ namespace FlaxEditor.GUI.Tree
                 // Base
                 if (_opened)
                     base.OnMouseMove(location);
+            }
+        }
+
+        private void UpdateMouseOverFlags(Vector2 location)
+        {
+            // Cache flags
+            _mouseOverArrow = HasAnyVisibleChild && ArrowRect.Contains(location);
+            _mouseOverHeader = new Rectangle(0, 0, Width, _headerHeight - 1).Contains(location);
+            if (_mouseOverHeader)
+            {
+                // Allow non-scrollable controls to stay on top of the header and override the mouse behaviour
+                for (int i = 0; i < Children.Count; i++)
+                {
+                    if (!Children[i].IsScrollable && IntersectsChildContent(Children[i], location, out _))
+                    {
+                        _mouseOverHeader = false;
+                        break;
+                    }
+                }
             }
         }
 

--- a/Source/Engine/UI/GUI/Tooltip.cs
+++ b/Source/Engine/UI/GUI/Tooltip.cs
@@ -179,6 +179,8 @@ namespace FlaxEngine.GUI
         /// <param name="target">The target.</param>
         public void OnMouseLeaveControl(Control target)
         {
+            if (Visible)
+                Hide();
             _lastTarget = null;
         }
 


### PR DESCRIPTION
Tracking the window focus with `IsForegroundWindow` is somewhat inconsistent on Linux, so instead of relying on it, use the input focus to track when mouse is clicked outside the context menus. 

Fixes #668