### PR TITLE
Fix issue with link image overlapping different lengths of text for scale properties.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -96,7 +96,8 @@ namespace FlaxEditor.CustomEditors.Editors
                     AnchorPreset = AnchorPresets.TopLeft,
                     TooltipText = "Scale values are linked together.",
                 };
-                _linkImage.LocalX += 40;
+                var x = LinkedLabel.Text.Value.Length * 7 + 5;
+                _linkImage.LocalX += x;
                 _linkImage.LocalY += 1;
 
                 LinkedLabel.SetupContextMenu += (label, menu, editor) =>


### PR DESCRIPTION
There was an issue with the text of the scale label being different lengths and caused the link image to overlap. This PR changes the image to move based on text length to allow for better placement if the text length is different.

Before:
![image](https://user-images.githubusercontent.com/71274967/218359871-a715be94-9ad4-4206-b627-7fa018eeb096.png)

After:
![image](https://user-images.githubusercontent.com/71274967/218359718-56e969d0-eed1-4f8d-b49f-8d6ff81f6631.png)
