### PR TITLE
Move the child menu arrow image to accommodate for the scroll bar showing when the amount of items exceeds the maximum.

### DIFF
--- a/Source/Editor/GUI/ContextMenu/ContextMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenu.cs
@@ -365,6 +365,7 @@ namespace FlaxEditor.GUI.ContextMenu
             float maxWidth = 0;
             float height = _itemsAreaMargin.Height;
             int itemsLeft = MaximumItemsInViewCount;
+            int overflowItemCount = 0;
             for (int i = 0; i < _panel.Children.Count; i++)
             {
                 if (_panel.Children[i] is ContextMenuItem item && item.Visible)
@@ -374,10 +375,26 @@ namespace FlaxEditor.GUI.ContextMenu
                         height += item.Height + _itemsMargin.Height;
                         itemsLeft--;
                     }
+                    else
+                    {
+                        overflowItemCount++;
+                    }
                     maxWidth = Mathf.Max(maxWidth, item.MinimumWidth);
                 }
             }
             maxWidth = Mathf.Max(maxWidth + 20, MinimumWidth);
+
+            // Move child arrows to accommodate scroll bar showing 
+            if (overflowItemCount > 0)
+            {
+                foreach (var child in _panel.Children)
+                {
+                    if (child is ContextMenuChildMenu item && item.Visible)
+                    {
+                        item.AdjustArrowAmount = -_panel.VScrollBar.Width;
+                    }
+                }
+            }
 
             // Resize container
             Size = new Float2(Mathf.Ceil(maxWidth), Mathf.Ceil(height));

--- a/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
@@ -18,6 +18,11 @@ namespace FlaxEditor.GUI.ContextMenu
         public readonly ContextMenu ContextMenu = new ContextMenu();
 
         /// <summary>
+        /// The amount to adjust the arrow image by in x coordinates.
+        /// </summary>
+        public float AdjustArrowAmount = 0;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ContextMenuChildMenu"/> class.
         /// </summary>
         /// <param name="parent">The parent context menu.</param>
@@ -44,7 +49,7 @@ namespace FlaxEditor.GUI.ContextMenu
 
             // Draw arrow
             if (ContextMenu.HasChildren)
-                Render2D.DrawSprite(style.ArrowRight, new Rectangle(Width - 15, (Height - 12) / 2, 12, 12), Enabled ? isCMopened ? style.BackgroundSelected : style.Foreground : style.ForegroundDisabled);
+                Render2D.DrawSprite(style.ArrowRight, new Rectangle(Width - 15 + AdjustArrowAmount, (Height - 12) / 2, 12, 12), Enabled ? isCMopened ? style.BackgroundSelected : style.Foreground : style.ForegroundDisabled);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This makes it easier to see the arrow if the scroll bar is visible.

Before:
![image](https://user-images.githubusercontent.com/71274967/218364102-724133c8-c189-43ba-b756-50c75a73378e.png)

After:
![image](https://user-images.githubusercontent.com/71274967/218364117-de3991d3-5e3e-46a1-a862-ea17adc3b539.png)
