### PR TITLE
Fix linking against C#-only modules

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -799,7 +799,7 @@ namespace Flax.Build
                                         moduleOptions.CompileEnv.PreprocessorDefinitions.Add(dependencyModule.BinaryModuleName.ToUpperInvariant() + "_API=" + toolchain.DllImport);
 
                                         var dependencyModuleBuild = buildData.FinReferenceBuildModule(moduleName);
-                                        if (dependencyModuleBuild != null)
+                                        if (dependencyModuleBuild != null && !string.IsNullOrEmpty(dependencyModuleBuild.NativePath))
                                         {
                                             // Link against the referenced binary module
                                             if (toolchain.UseImportLibraryWhenLinking)


### PR DESCRIPTION
Fixes an issue while building a project with FidelityFXR-plugin on Linux due to following error:
`[ 00:02:49.512 ]: [Info] ld: error: unable to find library -l-lFlaxEditor`

Empty library name gets accidentally added to the LinkEnv.InputLibraries when the plugin has no native code.