### PR TITLE
.NET7: Improve Linux dotnet runtime identifier detection

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -103,9 +103,7 @@ namespace Flax.Build
                 // TODO: Support /etc/dotnet/install_location
 
                 // Detect custom RID in some distros
-                string osId = File.ReadAllLines("/etc/os-release").FirstOrDefault(x => x.StartsWith("ID="), "ID=linux").Substring("ID=".Length);
-
-                rid = $"{osId}-{arch}";
+                rid = Utilities.ReadProcessOutput("dotnet", "--info").Split('\n').FirstOrDefault(x => x.StartsWith(" RID:"), "").Replace("RID:", "").Trim();
                 ridFallback = $"linux-{arch}";
                 if (rid == ridFallback)
                     ridFallback = "";


### PR DESCRIPTION
The RID detection should work in all possible distros now (including Ubuntu 22.x using the Microsoft package feed)