### PR TITLE
Improve C++ standard library version detection

### DIFF
--- a/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
@@ -28,7 +28,7 @@ namespace Flax.Build.Platforms
                 SystemIncludePaths.Add(includePath);
             else
                 Log.Error($"Missing toolset header files location {includePath}");
-            var cppIncludePath = Path.Combine(includePath, "c++", ClangVersion.ToString());
+            var cppIncludePath = Path.Combine(includePath, "c++", LibStdCppVersion);
             if (Directory.Exists(cppIncludePath))
                 SystemIncludePaths.Add(cppIncludePath);
             else


### PR DESCRIPTION
Clang seems to default to the same version of the stdlibc++ which is shipped with the installed GCC. The verbose output of Clang shows the detected version of the library, so we can parse the version from there.