### PR TITLE
Include thirdparty files in the includes cache

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/IncludesCache.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/IncludesCache.cs
@@ -342,6 +342,16 @@ namespace Flax.Build.NativeCpp
                             }
                         }
 
+                        // Relative to ThirdParty includes for library includes
+                        if (!isValid && isLibraryInclude)
+                        {
+                            includedFilePath = Path.Combine(Globals.Root, "Source", "ThirdParty", includedFile);
+                            if (FileExists(includedFilePath))
+                            {
+                                isValid = true;
+                            }
+                        }
+
                         if (!isValid)
                         {
                             // Invalid include


### PR DESCRIPTION
Allows the build tool to detect and issue a rebuild when file changes in third-party files are detected.