### PR TITLE
Update scroll speed to feel less sluggish

### DIFF
--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -23,7 +23,7 @@ namespace FlaxEngine.GUI
 
         // Scrolling
 
-        private float _clickChange = 20, _scrollChange = 30;
+        private float _clickChange = 20, _scrollChange = 75;
         private float _minimum, _maximum = 100;
         private float _value, _targetValue;
         private readonly Orientation _orientation;


### PR DESCRIPTION
Flax's current scroll speed is incredibly slow, often making it more time consuming to use the mouse wheel than dragging the scroll bar. This pull request increases the mouse wheel scroll speed to make it feel much better.