### PR TITLE
Fix visuals of the `Blend with Mask` node

### DIFF
--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -484,7 +484,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Blend with Mask",
                 Description = "Blend animation poses using skeleton mask",
                 Flags = NodeFlags.AnimGraph,
-                Size = new Float2(180, 100),
+                Size = new Float2(180, 140),
                 DefaultValues = new object[]
                 {
                     0.0f,
@@ -496,7 +496,7 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, "Pose A", true, typeof(void), 1),
                     NodeElementArchetype.Factory.Input(1, "Pose B", true, typeof(void), 2),
                     NodeElementArchetype.Factory.Input(2, "Alpha", true, typeof(float), 3, 0),
-                    NodeElementArchetype.Factory.Asset(100, 20, 1, typeof(SkeletonMask)),
+                    NodeElementArchetype.Factory.Asset(0, 70, 1, typeof(SkeletonMask)),
                 }
             },
             new NodeArchetype


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/71274967/222846577-96d4fee6-3dcf-4581-b611-74c57f0a3776.png)

After:
![image](https://user-images.githubusercontent.com/71274967/222846388-6a5aca23-fa86-4674-b56b-4e01e9ee8dad.png)
