### PR TITLE
Added de-selecting items in content view by clicking empty space

### DIFF
--- a/Source/Editor/Windows/ContentWindow.Navigation.cs
+++ b/Source/Editor/Windows/ContentWindow.Navigation.cs
@@ -69,7 +69,6 @@ namespace FlaxEditor.Windows
 
                 // Update UI
                 UpdateUI();
-                _view.SelectFirstItem();
             }
         }
 

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -941,6 +941,17 @@ namespace FlaxEditor.Windows
                 return true;
             }
 
+            if (button == MouseButton.Left)
+            {
+                // Find control that is under the mouse
+                var c = GetChildAtRecursive(location);
+                if (c is ContentView)
+                {
+                    _view.ClearSelection();
+                    return true;
+                }
+            }
+
             return base.OnMouseUp(location, button);
         }
 


### PR DESCRIPTION
This allows the user to click in empty space in the content view and it will deselect items. This also removes selecting the first item when navigating in the content tree since I dont think it does anything (because the tree is still focused) besides look like a bug.