### PR TITLE
Add LateFixedUpdate event for scripts

### DIFF
--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -65,6 +65,7 @@ Action Engine::FixedUpdate;
 Action Engine::Update;
 TaskGraph* Engine::UpdateGraph = nullptr;
 Action Engine::LateUpdate;
+Action Engine::LateFixedUpdate;
 Action Engine::Draw;
 Action Engine::Pause;
 Action Engine::Unpause;
@@ -198,6 +199,7 @@ int32 Engine::Main(const Char* cmdLine)
         if (Time::OnBeginPhysics())
         {
             OnFixedUpdate();
+            OnLateFixedUpdate();
             Time::OnEndPhysics();
         }
 
@@ -271,6 +273,17 @@ void Engine::OnFixedUpdate()
         // After this point we should not modify physic objects state (rendering operations is mostly readonly)
         // That's because auto-simulation mode is performing rendering during physics simulation
     }
+}
+
+void Engine::OnLateFixedUpdate()
+{
+    PROFILE_CPU_NAMED("Late Fixed Update");
+
+    // Call event
+    LateFixedUpdate();
+
+    // Update services
+    EngineService::OnLateFixedUpdate();
 }
 
 void Engine::OnUpdate()

--- a/Source/Engine/Engine/Engine.h
+++ b/Source/Engine/Engine/Engine.h
@@ -55,6 +55,11 @@ public:
     static Action LateUpdate;
 
     /// <summary>
+    /// Event called after engine update.
+    /// </summary>
+    static Action LateFixedUpdate;
+
+    /// <summary>
     /// Event called during frame rendering and can be used to invoke custom rendering with GPUDevice.
     /// </summary>
     static Action Draw;
@@ -106,6 +111,11 @@ public:
     /// Late update callback.
     /// </summary>
     static void OnLateUpdate();
+
+    /// <summary>
+    /// Late fixed update callback.
+    /// </summary>
+    static void OnLateFixedUpdate();
 
     /// <summary>
     /// Draw callback.

--- a/Source/Engine/Engine/EngineService.cpp
+++ b/Source/Engine/Engine/EngineService.cpp
@@ -33,6 +33,7 @@ static bool CompareEngineServices(EngineService* const& a, EngineService* const&
 DEFINE_ENGINE_SERVICE_EVENT(FixedUpdate);
 DEFINE_ENGINE_SERVICE_EVENT(Update);
 DEFINE_ENGINE_SERVICE_EVENT(LateUpdate);
+DEFINE_ENGINE_SERVICE_EVENT(LateFixedUpdate);
 DEFINE_ENGINE_SERVICE_EVENT(Draw);
 DEFINE_ENGINE_SERVICE_EVENT_INVERTED(BeforeExit);
 

--- a/Source/Engine/Engine/EngineService.h
+++ b/Source/Engine/Engine/EngineService.h
@@ -44,6 +44,7 @@ public:
     DECLARE_ENGINE_SERVICE_EVENT(void, FixedUpdate);
     DECLARE_ENGINE_SERVICE_EVENT(void, Update);
     DECLARE_ENGINE_SERVICE_EVENT(void, LateUpdate);
+    DECLARE_ENGINE_SERVICE_EVENT(void, LateFixedUpdate);
     DECLARE_ENGINE_SERVICE_EVENT(void, Draw);
     DECLARE_ENGINE_SERVICE_EVENT(void, BeforeExit);
     DECLARE_ENGINE_SERVICE_EVENT(void, Dispose);

--- a/Source/Engine/Level/Scene/SceneTicking.cpp
+++ b/Source/Engine/Level/Scene/SceneTicking.cpp
@@ -121,6 +121,19 @@ void SceneTicking::LateUpdateTickData::TickScripts(const Array<Script*>& scripts
     }
 }
 
+SceneTicking::LateFixedUpdateTickData::LateFixedUpdateTickData()
+    : TickData(64)
+{
+}
+
+void SceneTicking::LateFixedUpdateTickData::TickScripts(const Array<Script*>& scripts)
+{
+    for (auto* script : scripts)
+    {
+        script->OnLateFixedUpdate();
+    }
+}
+
 void SceneTicking::AddScript(Script* obj)
 {
     ASSERT_LOW_LAYER(obj && obj->GetParent() && obj->GetParent()->GetScene());
@@ -130,6 +143,9 @@ void SceneTicking::AddScript(Script* obj)
         Update.AddScript(obj);
     if (obj->_tickLateUpdate)
         LateUpdate.AddScript(obj);
+    if (obj->_tickLateFixedUpdate)
+        LateFixedUpdate.AddScript(obj);
+    
 }
 
 void SceneTicking::RemoveScript(Script* obj)
@@ -141,6 +157,8 @@ void SceneTicking::RemoveScript(Script* obj)
         Update.RemoveScript(obj);
     if (obj->_tickLateUpdate)
         LateUpdate.RemoveScript(obj);
+    if (obj->_tickLateFixedUpdate)
+        LateFixedUpdate.RemoveScript(obj);
 }
 
 void SceneTicking::Clear()
@@ -148,4 +166,5 @@ void SceneTicking::Clear()
     FixedUpdate.Clear();
     Update.Clear();
     LateUpdate.Clear();
+    LateFixedUpdate.Clear();
 }

--- a/Source/Engine/Level/Scene/SceneTicking.h
+++ b/Source/Engine/Level/Scene/SceneTicking.h
@@ -109,6 +109,13 @@ public:
         void TickScripts(const Array<Script*>& scripts) override;
     };
 
+    class FLAXENGINE_API LateFixedUpdateTickData : public TickData
+    {
+    public:
+        LateFixedUpdateTickData();
+        void TickScripts(const Array<Script*>& scripts) override;
+    };
+
 public:
     /// <summary>
     /// Adds the script to scene ticking system.
@@ -142,4 +149,9 @@ public:
     /// The late update tick function.
     /// </summary>
     LateUpdateTickData LateUpdate;
+
+    /// <summary>
+    /// The late fixed update tick function.
+    /// </summary>
+    LateFixedUpdateTickData LateFixedUpdate;
 };

--- a/Source/Engine/Scripting/Script.cpp
+++ b/Source/Engine/Scripting/Script.cpp
@@ -26,6 +26,7 @@ Script::Script(const SpawnParams& params)
     , _tickFixedUpdate(false)
     , _tickUpdate(false)
     , _tickLateUpdate(false)
+    , _tickLateFixedUpdate(false)
     , _wasStartCalled(false)
     , _wasEnableCalled(false)
 {
@@ -181,6 +182,7 @@ void Script::SetupType()
             _tickUpdate |= type.Script.ScriptVTable[8] != nullptr;
             _tickLateUpdate |= type.Script.ScriptVTable[9] != nullptr;
             _tickFixedUpdate |= type.Script.ScriptVTable[10] != nullptr;
+            _tickLateFixedUpdate |= type.Script.ScriptVTable[11] != nullptr;
         }
         typeHandle = type.GetBaseType();
     }

--- a/Source/Engine/Scripting/Script.h
+++ b/Source/Engine/Scripting/Script.h
@@ -109,6 +109,13 @@ public:
     }
 
     /// <summary>
+    /// Called every fixed framerate frame (after FixedUpdate) if object is enabled.
+    /// </summary>
+    API_FUNCTION(Attributes = "NoAnimate") virtual void OnLateFixedUpdate()
+    {
+    }
+
+    /// <summary>
     /// Called during drawing debug shapes in editor. Use <see cref="DebugDraw"/> to draw debug shapes and other visualization.
     /// </summary>
     API_FUNCTION(Attributes="NoAnimate") virtual void OnDebugDraw()

--- a/Source/Engine/Scripting/Script.h
+++ b/Source/Engine/Scripting/Script.h
@@ -19,6 +19,7 @@ protected:
     int32 _tickFixedUpdate : 1;
     int32 _tickUpdate : 1;
     int32 _tickLateUpdate : 1;
+    int32 _tickLateFixedUpdate : 1;
     int32 _wasStartCalled : 1;
     int32 _wasEnableCalled : 1;
 #if USE_EDITOR

--- a/Source/Engine/Scripting/Scripting.cpp
+++ b/Source/Engine/Scripting/Scripting.cpp
@@ -46,6 +46,7 @@ public:
     void Update() override;
     void LateUpdate() override;
     void FixedUpdate() override;
+    void LateFixedUpdate() override;
     void Draw() override;
     void BeforeExit() override;
     void Dispose() override;
@@ -100,6 +101,7 @@ namespace
     MMethod* _method_Update = nullptr;
     MMethod* _method_LateUpdate = nullptr;
     MMethod* _method_FixedUpdate = nullptr;
+    MMethod* _method_LateFixedUpdate = nullptr;
     MMethod* _method_Draw = nullptr;
     MMethod* _method_Exit = nullptr;
     Array<BinaryModule*, InlinedAllocation<64>> _nonNativeModules;
@@ -208,6 +210,12 @@ void ScriptingService::FixedUpdate()
 {
     PROFILE_CPU_NAMED("Scripting::FixedUpdate");
     INVOKE_EVENT(FixedUpdate);
+}
+
+void ScriptingService::LateFixedUpdate()
+{
+    PROFILE_CPU_NAMED("Scripting::LateFixedUpdate");
+    INVOKE_EVENT(LateFixedUpdate);
 }
 
 void ScriptingService::Draw()

--- a/Source/Engine/Scripting/Scripting.cs
+++ b/Source/Engine/Scripting/Scripting.cs
@@ -80,17 +80,22 @@ namespace FlaxEngine
         public static event Action Update;
 
         /// <summary>
-        /// Occurs on scripting 'late' update.
+        /// Occurs on scripting late update.
         /// </summary>
         public static event Action LateUpdate;
 
         /// <summary>
-        /// Occurs on scripting `fixed` update.
+        /// Occurs on scripting fixed update.
         /// </summary>
         public static event Action FixedUpdate;
 
         /// <summary>
-        /// Occurs on scripting `draw` update. Called during frame rendering and can be used to invoke custom rendering with GPUDevice.
+        /// Occurs on scripting late fixed update.
+        /// </summary>
+        public static event Action LateFixedUpdate;
+
+        /// <summary>
+        /// Occurs on scripting draw update. Called during frame rendering and can be used to invoke custom rendering with GPUDevice.
         /// </summary>
         public static event Action Draw;
 
@@ -300,6 +305,11 @@ namespace FlaxEngine
         internal static void Internal_FixedUpdate()
         {
             FixedUpdate?.Invoke();
+        }
+
+        internal static void Internal_LateFixedUpdate()
+        {
+            LateFixedUpdate?.Invoke();
         }
 
         internal static void Internal_Draw()


### PR DESCRIPTION
Since we don't have configurable script event system or Unity's customizable script execution order system to achieve something similar, I'll propose adding `LateFixedUpdate` event for scripts which is called after all `FixedUpdate` events and physics simulation is finished.

I need to run fixed updates for game objects first and at the end of the fixed update frame, gather the results of the physics simulation and send them over network to clients. I can't do this after individual `FixedUpdate` events because objects might interact with each other in unexpected order and change the state after scripts respective `FixedUpdate` event.