### PR TITLE
Fix C++ API for Vector2/3 Normalization

### DIFF
--- a/Source/Engine/Core/Math/Vector2.h
+++ b/Source/Engine/Core/Math/Vector2.h
@@ -228,8 +228,9 @@ public:
     /// </summary>
     Vector2Base GetNormalized() const
     {
-        const T rcp = 1.0f / Length();
-        return Vector2Base(X * rcp, Y * rcp);
+		Vector2Base Result(X, Y);
+        Result.Normalize();
+        return Result;
     }
 
 public:

--- a/Source/Engine/Core/Math/Vector3.h
+++ b/Source/Engine/Core/Math/Vector3.h
@@ -254,8 +254,9 @@ public:
     /// </summary>
     Vector3Base GetNormalized() const
     {
-        const T rcp = 1.0f / Length();
-        return Vector3Base(X * rcp, Y * rcp, Z * rcp);
+		Vector3Base Result(X, Y, Z);
+        Result.Normalize();
+        return Result;
     }
 
 public:


### PR DESCRIPTION
This code fixes the issue with C++ API for normalization, that allows users to get -NaN vectors in return due to a lack of a length check