### PR TITLE
Fix bug with path name preventing the item to be renamed when duplicated

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -536,7 +536,7 @@ namespace FlaxEditor.Windows
                 destinationName = StringUtils.IncrementNameNumber(item.ShortName, x => !File.Exists(StringUtils.CombinePaths(sourceFolder, x + extension))) + extension;
             }
 
-            return StringUtils.CombinePaths(sourceFolder, destinationName);
+            return StringUtils.NormalizePath(StringUtils.CombinePaths(sourceFolder, destinationName));
         }
 
         /// <summary>
@@ -563,6 +563,7 @@ namespace FlaxEditor.Windows
             // Start renaming it
             if (targetItem != null)
             {
+                Select(targetItem);
                 Rename(targetItem);
             }
         }


### PR DESCRIPTION
This fixes a bug that prevents a duplicated content item to be selected and begin renaming when it is duplicated.