### PR TITLE
Made it so the visuals of dragging an actor in a tree will only show between the nodes and on the node.

### DIFF
--- a/Source/Editor/GUI/Tree/Tree.cs
+++ b/Source/Editor/GUI/Tree/Tree.cs
@@ -41,6 +41,11 @@ namespace FlaxEditor.GUI.Tree
         private bool _autoSize = true;
 
         /// <summary>
+        /// The TreeNode that is being dragged over. This could have a value when not dragging.
+        /// </summary>
+        public TreeNode DraggedOverNode = null;
+
+        /// <summary>
         /// Action fired when tree nodes selection gets changed.
         /// </summary>
         public event SelectionChangedDelegate SelectedChanged;

--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -659,7 +659,7 @@ namespace FlaxEditor.GUI.Tree
             Render2D.DrawText(TextFont.GetFont(), _text, textRect, _cachedTextColor, TextAlignment.Near, TextAlignment.Center);
 
             // Draw drag and drop effect
-            if (IsDragOver)
+            if (IsDragOver && _tree.DraggedOverNode == this)
             {
                 Color dragOverColor = style.BackgroundSelected * 0.6f;
                 Rectangle rect;
@@ -669,10 +669,10 @@ namespace FlaxEditor.GUI.Tree
                     rect = textRect;
                     break;
                 case DragItemPositioning.Above:
-                    rect = new Rectangle(textRect.X, textRect.Y - DefaultDragInsertPositionMargin - DefaultNodeOffsetY, textRect.Width, DefaultDragInsertPositionMargin * 2.0f);
+                    rect = new Rectangle(textRect.X, textRect.Top - DefaultDragInsertPositionMargin - DefaultNodeOffsetY - _margin.Top, textRect.Width, DefaultDragInsertPositionMargin * 2.0f);
                     break;
                 case DragItemPositioning.Below:
-                    rect = new Rectangle(textRect.X, textRect.Bottom - DefaultDragInsertPositionMargin, textRect.Width, DefaultDragInsertPositionMargin * 2.0f);
+                    rect = new Rectangle(textRect.X, textRect.Bottom + _margin.Bottom - DefaultDragInsertPositionMargin, textRect.Width, DefaultDragInsertPositionMargin * 2.0f);
                     break;
                 default:
                     rect = Rectangle.Empty;
@@ -922,6 +922,7 @@ namespace FlaxEditor.GUI.Tree
             if (result == DragDropEffect.None)
             {
                 UpdateDrawPositioning(ref location);
+                _tree.DraggedOverNode = this;
 
                 // Check if mouse is over header
                 _isDragOverHeader = TestHeaderHit(ref location);

--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -717,6 +717,11 @@ namespace FlaxEditor.SceneGraph.GUI
                 for (var i = 0; i < tree.Selection.Count; i++)
                 {
                     var e = tree.Selection[i];
+                    
+                    // Skip if parent is already selected to keep correct parenting
+                    if (tree.Selection.Contains(e.Parent))
+                        continue;
+
                     if (e is ActorTreeNode node && node.ActorNode.CanDrag)
                         actors.Add(node.ActorNode);
                 }

--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -706,6 +706,8 @@ namespace FlaxEditor.SceneGraph.GUI
         {
             DragData data;
             var tree = ParentTree;
+            if (tree.Selection.Count == 1)
+                Select();
 
             // Check if this node is selected
             if (tree.Selection.Contains(this))


### PR DESCRIPTION
When dragging an actor in a tree, right now it will show that you can drop it on the node, or 3 (only suppose to be above and below, but there is a bug that makes it highlight both at certain mouse positions) different locations between nodes. This makes it so the visuals only show that you can drop it on the node, and in between the node making it less confusing.

This also fixes a bug of children actors getting re-parented when dragging selected children and parents.