### PR TITLE
Allow word wrapping to wrap on capital letters and underscores.

### DIFF
--- a/Source/Engine/Render2D/Font.cpp
+++ b/Source/Engine/Render2D/Font.cpp
@@ -122,6 +122,12 @@ void Font::ProcessText(const StringView& text, Array<FontLineCache>& outputLines
     float lastWhitespaceX = 0;
     bool lastMoveLine = false;
 
+    int32 lastUpperIndex = INVALID_INDEX;
+    float lastUpperX = 0;
+    
+    int32 lastUnderscoreIndex = INVALID_INDEX;
+    float lastUnderscoreX = 0;
+
     // Process each character to split text into single lines
     for (int32 currentIndex = 0; currentIndex < textLength;)
     {
@@ -139,6 +145,21 @@ void Font::ProcessText(const StringView& text, Array<FontLineCache>& outputLines
             // Cache line break point
             lastWhitespaceIndex = currentIndex;
             lastWhitespaceX = cursorX;
+        }
+
+        // Check if character is an upper case letter
+        const bool isUpper = StringUtils::IsUpper(currentChar);
+        if (isUpper && currentIndex != 0)
+        {
+            lastUpperIndex = currentIndex;
+            lastUpperX = cursorX;
+        }
+
+        const bool isUnderscore = currentChar == '_';
+        if (isUnderscore)
+        {
+            lastUnderscoreIndex = currentIndex;
+            lastUnderscoreX = cursorX;
         }
 
         // Check if it's a newline character
@@ -185,6 +206,20 @@ void Font::ProcessText(const StringView& text, Array<FontLineCache>& outputLines
                     currentIndex = lastWhitespaceIndex + 1;
                     nextCharIndex = currentIndex;
                 }
+                else if (lastUpperIndex != INVALID_INDEX)
+                {
+                    cursorX = lastUpperX;
+                    tmpLine.LastCharIndex = lastUpperIndex - 1;
+                    currentIndex = lastUpperIndex;
+                    nextCharIndex = currentIndex;
+                }
+                else if (lastUnderscoreIndex != INVALID_INDEX)
+                {
+                    cursorX = lastUnderscoreX;
+                    tmpLine.LastCharIndex = lastUnderscoreIndex;
+                    currentIndex = lastUnderscoreIndex + 1;
+                    nextCharIndex = currentIndex;
+                }
                 else
                 {
                     nextCharIndex = currentIndex;
@@ -223,6 +258,12 @@ void Font::ProcessText(const StringView& text, Array<FontLineCache>& outputLines
 
             lastWhitespaceIndex = INVALID_INDEX;
             lastWhitespaceX = 0;
+
+            lastUpperIndex = INVALID_INDEX;
+            lastUpperX = 0;
+
+            lastUnderscoreIndex = INVALID_INDEX;
+            lastUnderscoreX = 0;
 
             previous.IsValid = false;
         }

--- a/Source/Engine/Render2D/Font.cpp
+++ b/Source/Engine/Render2D/Font.cpp
@@ -124,7 +124,7 @@ void Font::ProcessText(const StringView& text, Array<FontLineCache>& outputLines
 
     int32 lastUpperIndex = INVALID_INDEX;
     float lastUpperX = 0;
-    
+
     int32 lastUnderscoreIndex = INVALID_INDEX;
     float lastUnderscoreX = 0;
 
@@ -155,6 +155,7 @@ void Font::ProcessText(const StringView& text, Array<FontLineCache>& outputLines
             lastUpperX = cursorX;
         }
 
+        // Check if character is an underscore
         const bool isUnderscore = currentChar == '_';
         if (isUnderscore)
         {


### PR DESCRIPTION
This makes the editor asset's names look good if they dont have any spaces and instead use capital letters or underscores. Good for scripts and other naming conventions.

Examples (no spaces):
![image](https://user-images.githubusercontent.com/71274967/232144048-dde2fad8-bdc6-45e5-8017-fd98e3b27b19.png)
![image](https://user-images.githubusercontent.com/71274967/232144140-9b347e78-2eed-4d3f-9a89-f841d2a399a0.png)
