### PR TITLE
Add `ClampLength` functions to C++ Vector3

### DIFF
--- a/Source/Engine/Core/Math/Vector3.h
+++ b/Source/Engine/Core/Math/Vector3.h
@@ -566,6 +566,58 @@ public:
         result = Vector3Base(Math::Clamp(v.X, min.X, max.X), Math::Clamp(v.Y, min.Y, max.Y), Math::Clamp(v.Z, min.Z, max.Z));
     }
 
+    /// <summary>
+    /// Makes sure that Length of the output vector is always below max and above 0.
+    /// </summary>
+    /// <param name="vector">Input Vector.</param>
+    /// <param name="max">Max Length</param>
+    static Vector3Base ClampLength(const Vector3Base& v, float max)
+    {
+        return ClampLength(v, 0, max);
+    }
+
+    /// <summary>
+    /// Makes sure that Length of the output vector is always below max and above min.
+    /// </summary>
+    /// <param name="vector">Input Vector.</param>
+    /// <param name="min">Min Length</param>
+    /// <param name="max">Max Length</param>
+    static Vector3Base ClampLength(const Vector3Base& v, float min, float max)
+    {
+        Vector3Base result;
+        ClampLength(v, min, max, result);
+        return result;
+    }
+
+    /// <summary>
+    /// Makes sure that Length of the output vector is always below max and above min.
+    /// </summary>
+    /// <param name="vector">Input Vector.</param>
+    /// <param name="min">Min Length</param>
+    /// <param name="max">Max Length</param>
+    /// <param name="result">The result vector.</param>
+    static void ClampLength(const Vector3Base& v, float min, float max, Vector3Base& result)
+    {
+        result.X = v.X;
+        result.Y = v.Y;
+        result.Z = v.Z;
+        auto lenSq = result.LengthSquared();
+        if (lenSq > max * max)
+        {
+            auto scaleFactor = max / (float)Math::Sqrt(lenSq);
+            result.X *= scaleFactor;
+            result.Y *= scaleFactor;
+            result.Z *= scaleFactor;
+        }
+        if (lenSq < min * min)
+        {
+            auto scaleFactor = min / (float)Math::Sqrt(lenSq);
+            result.X *= scaleFactor;
+            result.Y *= scaleFactor;
+            result.Z *= scaleFactor;
+        }
+    }
+
     // Calculates the distance between two vectors
     // @param a The first vector
     // @param b The second vector


### PR DESCRIPTION
These functions were missing in the C++ `Vector3` class, so I just added them from the C# class.