### PR TITLE
Scene tree drag fixes

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -611,22 +611,26 @@ namespace FlaxEditor.SceneGraph.GUI
                         script.SetParent(newParent, true);
                     }
                 }
-
+                Select();
                 result = DragDropEffect.Move;
             }
             // Drag assets
             else if (_dragAssets != null && _dragAssets.HasValidDrag)
             {
+                var spawnParent = myActor;
+                if (DragOverMode == DragItemPositioning.Above || DragOverMode == DragItemPositioning.Below)
+                    spawnParent = newParent;
+                
                 for (int i = 0; i < _dragAssets.Objects.Count; i++)
                 {
                     var item = _dragAssets.Objects[i];
                     var actor = item.OnEditorDrop(this);
-                    actor.StaticFlags = Actor.StaticFlags;
+                    actor.StaticFlags = spawnParent.StaticFlags;
                     actor.Name = item.ShortName;
-                    actor.Transform = Actor.Transform;
-                    ActorNode.Root.Spawn(actor, Actor);
+                    actor.Transform = spawnParent.Transform;
+                    Editor.Instance.SceneEditing.Spawn(actor, spawnParent, false);
+                    actor.OrderInParent = newOrder;
                 }
-
                 result = DragDropEffect.Move;
             }
             // Drag actor type


### PR DESCRIPTION
Fix #908 to now select the actor that you drop the script on. Fix dragging asset between nodes to properly assign it's parent instead of always making it a child.