### PR TITLE
Ensure prefab actors static flags match parent flags or keeps it's own.

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -625,7 +625,16 @@ namespace FlaxEditor.SceneGraph.GUI
                 {
                     var item = _dragAssets.Objects[i];
                     var actor = item.OnEditorDrop(this);
-                    actor.StaticFlags = spawnParent.StaticFlags;
+                    if (spawnParent.GetType() != typeof(Scene))
+                    {
+                        // Set all Actors static flags to match parents
+                        List<Actor> childActors = new List<Actor>();
+                        GetActorsTree(childActors, actor);
+                        foreach (var child in childActors)
+                        {
+                            child.StaticFlags = spawnParent.StaticFlags;
+                        }
+                    }
                     actor.Name = item.ShortName;
                     actor.Transform = spawnParent.Transform;
                     Editor.Instance.SceneEditing.Spawn(actor, spawnParent, false);
@@ -669,6 +678,16 @@ namespace FlaxEditor.SceneGraph.GUI
             }
 
             return result;
+        }
+        
+        private void GetActorsTree(List<Actor> list, Actor a)
+        {
+            list.Add(a);
+            int cnt = a.ChildrenCount;
+            for (int i = 0; i < cnt; i++)
+            {
+                GetActorsTree(list, a.GetChild(i));
+            }
         }
 
         private bool ValidateDragActor(ActorNode actorNode)


### PR DESCRIPTION
This makes it so if the parent is the `scene` then it keeps the prefab's static flags. This also makes it so if the prefab is placed under an actor in the scene then all of the prefab's children take the parent's static flags.