### PR TITLE
More fixes to ensuring static flags are correct for actors and prefabs.

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -287,6 +287,15 @@ void Actor::SetParent(Actor* value, bool worldPositionsStays, bool canBreakPrefa
     if (_parent)
     {
         _parent->Children.Add(this);
+        if (_parent != this->GetScene())
+        {
+            // Set static flags to same as parent
+            Array<Actor*> childActors = GetActorsTree();
+            for(auto& child : childActors)
+            {
+                child->SetStaticFlags(_parent->GetStaticFlags());
+            }
+        }
     }
 
     // Sync scene change if need to
@@ -352,6 +361,23 @@ void Actor::SetParent(Actor* value, bool worldPositionsStays, bool canBreakPrefa
 void Actor::SetParent(Actor* value, bool canBreakPrefabLink)
 {
     SetParent(value, false, canBreakPrefabLink);
+}
+
+void Actor::GetActorsTree(Array<Actor*> &list, Actor* a)
+{
+    list.Add(a);
+    const int cnt = a->Children.Count();
+    for (int i = 0; i < cnt; i++)
+    {
+        GetActorsTree(list, a->GetChild(i));
+    }
+}
+
+Array<Actor*> Actor::GetActorsTree()
+{
+    Array<Actor*> actors;
+    GetActorsTree(actors, this);
+    return actors;
 }
 
 int32 Actor::GetOrderInParent() const

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -821,6 +821,11 @@ public:
 
 public:
     /// <summary>
+    /// Gets all of the actor tree of this actor.
+    /// </summary>
+    API_FUNCTION() Array<Actor*> GetActorsTree();
+
+    /// <summary>
     /// Execute custom action on actors tree.
     /// Action should returns false to stop calling deeper.
     /// First action argument is current actor object.
@@ -997,6 +1002,8 @@ private:
     // Helper methods used by templates GetChildren/GetScripts to prevent including MClass/Script here
     static bool IsSubClassOf(const Actor* object, const MClass* klass);
     static bool IsSubClassOf(const Script* object, const MClass* klass);
+
+    void GetActorsTree(Array<Actor*>& list, Actor* a);
 
 public:
     // [ScriptingObject]

--- a/Source/Engine/Level/Prefabs/PrefabManager.cpp
+++ b/Source/Engine/Level/Prefabs/PrefabManager.cpp
@@ -263,6 +263,16 @@ Actor* PrefabManager::SpawnPrefab(Prefab* prefab, Actor* parent, Dictionary<Guid
         obj->LinkPrefab(prefabId, prefabObjectId);
     }
 
+    // Set static flags to match parent
+    if (parent && parent != root->GetScene())
+    {
+        Array<Actor*> childActors = root->GetActorsTree();
+        for(auto& child : childActors)
+        {
+            child->SetStaticFlags(parent->GetStaticFlags());
+        }
+    }
+
     // Update transformations
     root->OnTransformChanged();
 


### PR DESCRIPTION
This makes sure the static flags of children being added through code by either `SetParent` or `SpawnPrefab` get the correct static flags from their parent actor (unless it is a scene root). Also exposes a useful function for getting the whole actor tree.