### PR TITLE
Add saving and re-opening all active scenes between editor sessions.

### DIFF
--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -691,7 +691,6 @@ namespace FlaxEditor
                 {
                     lastSceneIds.Add(Guid.Empty);
                 }
-                //var lastSceneId = Level.ScenesCount > 0 ? Level.Scenes[0].ID : Guid.Empty;
                 var lastSceneSpawn = Windows.EditWin.Viewport.ViewRay;
                 ProjectCache.SetCustomData(ProjectDataLastScene, JsonSerializer.Serialize(lastSceneIds));
                 ProjectCache.SetCustomData(ProjectDataLastSceneSpawn, JsonSerializer.Serialize(lastSceneSpawn));

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -690,7 +690,7 @@ namespace FlaxEditor
                     lastSceneIds.Add(Guid.Empty);
                 }
                 var lastSceneSpawn = Windows.EditWin.Viewport.ViewRay;
-                ProjectCache.SetCustomData(ProjectDataLastScene, JsonSerializer.Serialize(lastSceneIds));
+                ProjectCache.SetCustomData(ProjectDataLastScene, JsonSerializer.Serialize(lastSceneIds.ToArray()));
                 ProjectCache.SetCustomData(ProjectDataLastSceneSpawn, JsonSerializer.Serialize(lastSceneSpawn));
             }
 

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -325,8 +325,7 @@ namespace FlaxEditor
                 {
                     if (ProjectCache.TryGetCustomData(ProjectDataLastScene, out var lastSceneIdName))
                     {
-                        var lastSceneList = JsonSerializer.Deserialize<List<Guid>>(lastSceneIdName);
-
+                        var lastSceneList = JsonSerializer.Deserialize<Guid[]>(lastSceneIdName);
                         foreach (var scene in lastSceneList)
                         {
                             var lastScene = scene;
@@ -448,8 +447,7 @@ namespace FlaxEditor
             {
                 if (ProjectCache.TryGetCustomData(ProjectDataLastScene, out var lastSceneIdName))
                 {
-                    var lastSceneList = JsonSerializer.Deserialize<List<Guid>>(lastSceneIdName);
-
+                    var lastSceneList = JsonSerializer.Deserialize<Guid[]>(lastSceneIdName);
                     foreach (var sceneId in lastSceneList)
                     {
                         var lastScene = ContentDatabase.Find(sceneId);
@@ -677,7 +675,7 @@ namespace FlaxEditor
             // Start exit
             StateMachine.GoToState<ClosingState>();
 
-            // Cache last opened scene
+            // Cache last opened scenes
             {
                 List<Guid> lastSceneIds = new List<Guid>();
                 if (Level.ScenesCount > 0)


### PR DESCRIPTION
This allows the editor to save all of the open scenes on editor close and allows the editor to re-open all of the scenes on init.