### PR TITLE
Fix managed scripting object handles created in managed side

### DIFF
--- a/Source/Engine/Scripting/ScriptingObject.cpp
+++ b/Source/Engine/Scripting/ScriptingObject.cpp
@@ -634,14 +634,14 @@ DEFINE_INTERNAL_CALL(void) ObjectInternal_ManagedInstanceCreated(MObject* manage
         return;
     }
 
+    // Link created managed instance to the unmanaged object
+    obj->SetManagedInstance(managedInstance);
+
     // Set default name for actors
     if (auto* actor = dynamic_cast<Actor*>(obj))
     {
         actor->SetName(String(typeClass->GetName()));
     }
-
-    // Link created managed instance to the unmanaged object
-    obj->SetManagedInstance(managedInstance);
 
     MClass* monoClass = obj->GetClass();
 


### PR DESCRIPTION
Setting the `Actor` name causes the managed handle to get initialized in native side when the handle was created earlier in the managed side. Linking the handle first before setting the name seems to fix this.

Issue was triggered by playing any audio clip in the audio editor.