### PR TITLE
`ViewportIconsRenderer::AddActorWithTexture` addition

### DIFF
--- a/Source/Editor/Utilities/ViewportIconsRenderer.h
+++ b/Source/Editor/Utilities/ViewportIconsRenderer.h
@@ -38,6 +38,13 @@ public:
     API_FUNCTION() static void AddActor(Actor* actor);
 
     /// <summary>
+    /// Adds actor to the viewport icon rendering.
+    /// </summary>
+    /// <param name="actor">The actor to register for icon drawing.</param>
+    /// <param name="iconTexture">The icon texture to draw.</param>
+    API_FUNCTION() static void AddActorWithTexture(Actor* actor, Texture* iconTexture);
+
+    /// <summary>
     /// Removes actor from the viewport icon rendering.
     /// </summary>
     /// <param name="actor">The actor to unregister for icon drawing.</param>


### PR DESCRIPTION
This adds an ability to register actors for display with viewport icons without being bound by types.