### PR TITLE
`Actor::GetEditorBox()` virtual `API_PROPERTY()` fix

### DIFF
--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -651,7 +651,7 @@ public:
     /// <summary>
     /// Gets actor bounding box (single actor, no children included) for editor tools.
     /// </summary>
-    API_PROPERTY() virtual BoundingBox GetEditorBox() const;
+    API_FUNCTION() virtual BoundingBox GetEditorBox() const;
 
     /// <summary>
     /// Gets actor bounding box of the actor including all child actors for editor tools.


### PR DESCRIPTION
Currently, you can easily override `Actor::GetEditorBox()` from a C++ script to get a selectable actor/script in the viewport, but for some reason for the C# API it was marked as `API_PROPERTY`, even though it was explicitly marked as virtual in the source.