### PR TITLE
Fix collision assets creation in non asset folders.

### DIFF
--- a/Source/Editor/Content/Proxy/CollisionDataProxy.cs
+++ b/Source/Editor/Content/Proxy/CollisionDataProxy.cs
@@ -141,7 +141,13 @@ namespace FlaxEditor.Content
                 });
             };
             var initialName = (modelItem?.ShortName ?? Path.GetFileNameWithoutExtension(model.Path)) + " Collision";
-            Editor.Instance.Windows.ContentWin.NewItem(this, null, create, initialName, withRenaming);
+            
+            // If folder can not have assets then move to folder with the model and create asset
+            var contentWin = Editor.Instance.Windows.ContentWin;
+            if (!contentWin.CurrentViewFolder.CanHaveAssets)
+                contentWin.Navigate(modelItem?.ParentFolder?.Node);
+            
+            contentWin.NewItem(this, null, create, initialName, withRenaming);
         }
     }
 }

--- a/Source/Editor/Content/Proxy/CollisionDataProxy.cs
+++ b/Source/Editor/Content/Proxy/CollisionDataProxy.cs
@@ -141,13 +141,7 @@ namespace FlaxEditor.Content
                 });
             };
             var initialName = (modelItem?.ShortName ?? Path.GetFileNameWithoutExtension(model.Path)) + " Collision";
-            
-            // If folder can not have assets then move to folder with the model and create asset
-            var contentWin = Editor.Instance.Windows.ContentWin;
-            if (!contentWin.CurrentViewFolder.CanHaveAssets)
-                contentWin.Navigate(modelItem?.ParentFolder?.Node);
-            
-            contentWin.NewItem(this, null, create, initialName, withRenaming);
+            Editor.Instance.Windows.ContentWin.NewItem(this, null, create, initialName, withRenaming);
         }
     }
 }

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -656,6 +656,11 @@ namespace FlaxEditor.Windows
                 throw new ArgumentNullException(nameof(proxy));
 
             string name = initialName ?? proxy.NewItemName;
+
+            // If the proxy can not be created in the current folder, then navigate to the content folder
+            if (!proxy.CanCreate(CurrentViewFolder))
+                Navigate(Editor.Instance.ContentDatabase.Game.Content);
+
             ContentFolder parentFolder = CurrentViewFolder;
             string parentFolderPath = parentFolder.Path;
 


### PR DESCRIPTION
If a collision asset is trying to be created in a folder that can not have assets, the folder will switch to the folder with the model in it.