### PR TITLE
`NetworkManager::RPCInvoker` implementation

### DIFF
--- a/Source/Engine/Networking/NetworkManager.cpp
+++ b/Source/Engine/Networking/NetworkManager.cpp
@@ -25,6 +25,7 @@ uint32 NetworkManager::Frame = 0;
 uint32 NetworkManager::LocalClientId = 0;
 NetworkClient* NetworkManager::LocalClient = nullptr;
 Array<NetworkClient*> NetworkManager::Clients;
+uint32 NetworkManager::RPCInvoker = 0;
 Action NetworkManager::StateChanged;
 Delegate<NetworkClientConnectionData&> NetworkManager::ClientConnecting;
 Delegate<NetworkClient*> NetworkManager::ClientConnected;

--- a/Source/Engine/Networking/NetworkManager.h
+++ b/Source/Engine/Networking/NetworkManager.h
@@ -94,6 +94,11 @@ public:
     /// </summary>
     API_FIELD(ReadOnly) static Array<NetworkClient*, HeapAllocation> Clients;
 
+    /// <summary>
+    /// Returns remote invoker of the current RPC call (returns LocalClientId on local call).
+    /// </summary>
+    API_FIELD(ReadOnly) static uint32 RPCInvoker;
+
 public:
     /// <summary>
     /// Event called when network manager state gets changed (eg. client connected to the server, or server shutdown started).

--- a/Source/Engine/Networking/NetworkReplicator.cpp
+++ b/Source/Engine/Networking/NetworkReplicator.cpp
@@ -1735,6 +1735,8 @@ void NetworkInternal::OnNetworkMessageObjectRpc(NetworkEvent& event, NetworkClie
         stream->SenderId = client ? client->ClientId : NetworkManager::ServerClientId;
         stream->Initialize(event.Message.Buffer + event.Message.Position, msgData.ArgsSize);
 
+        NetworkManager::RPCInvoker = stream->SenderId;
+
         // Execute RPC
         info->Execute(obj, stream, info->Tag);
     }

--- a/Source/Engine/Networking/NetworkRpc.h
+++ b/Source/Engine/Networking/NetworkRpc.h
@@ -88,6 +88,7 @@ FORCE_INLINE void NetworkRpcInitArg(Array<void*, FixedAllocation<16>>& args, con
             return; \
         if (rpcInfo.Client && networkMode == NetworkManagerMode::Server) \
             return; \
+        NetworkManager::RPCInvoker = NetworkManager::LocalClientId; \
     } \
     }
 
@@ -102,5 +103,6 @@ FORCE_INLINE void NetworkRpcInitArg(Array<void*, FixedAllocation<16>>& args, con
             return; \
         if (rpcInfo.Client && networkMode == NetworkManagerMode::Server) \
             return; \
+        NetworkManager::RPCInvoker = NetworkManager::LocalClientId; \
     } \
     }


### PR DESCRIPTION
This implements an ability to monitor who the latest RPC invoker was inside of the RPC method body and write a logic accordingly, like this:
```
API_FUNCTION(NetworkRpc = "Server, Reliable") void SendMessage(const String& text)
{
    NETWORK_RPC_IMPL(Chat, SendMessage, text);
    RecieveMessage(NetworkManager::RPCInvoker, text);
}

API_FUNCTION(NetworkRpc = "Client, Reliable") void RecieveMessage(uint32 sender, const String& text)
{
    NETWORK_RPC_IMPL(Chat, RecieveMessage, sender, text);
    
    if (sender == NetworkManager::LocalClientId)
    {
        LOG(Info, "Called RecieveMessage locally with text : {0}", text);
    }
    else
    {
        LOG(Info, "Got RecieveMessage remote call with text: {0}", text);
    }
}
```
This snippet of code demonstrates potential chat implementation, which allows for the server to refire the incoming chat RPC with the id of the person that sent this message for other clients, so that they could run custom formatting, like `%username%: %chat message%` for example.