### PR TITLE
Exposes a bool to control the expand and collapse animations for tree nodes

### DIFF
--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -156,6 +156,16 @@ namespace FlaxEditor.GUI.Tree
         /// Gets a value indicating whether this node is root.
         /// </summary>
         public bool IsRoot => !(Parent is TreeNode);
+        
+        /// <summary>
+        /// Sets whether or not the expand animation will pay when arrow is clicked
+        /// </summary>
+        public bool AnimateExpand = false;
+        
+        /// <summary>
+        /// Sets whether or not the Collapse animation will pay when arrow is clicked
+        /// </summary>
+        public bool AnimateCollapse = false;
 
         /// <summary>
         /// Gets the minimum width of the node sub-tree.
@@ -771,9 +781,9 @@ namespace FlaxEditor.GUI.Tree
                 {
                     // Toggle open state
                     if (_opened)
-                        Collapse();
+                        Collapse(!AnimateCollapse);
                     else
-                        Expand();
+                        Expand(!AnimateExpand);
                 }
 
                 // Check if mouse hits bar


### PR DESCRIPTION
This adds two bools for allowing the tree nodes expand and collapse animations or not and defaults them to not animate (as I personally dont think the tree nodes need to animate)