### PR TITLE
Add `Unload all but this scene` 

### DIFF
--- a/Source/Editor/Modules/SceneModule.cs
+++ b/Source/Editor/Modules/SceneModule.cs
@@ -316,6 +316,42 @@ namespace FlaxEditor.Modules
         }
 
         /// <summary>
+        /// Closes all of the scenes except for the specified scene (async).
+        /// </summary>
+        /// <param name="scene">The scene to not close.</param>
+        public void CloseAllScenesExcept(Scene scene)
+        {
+            // Check if cannot change scene now
+            if (!Editor.StateMachine.CurrentState.CanChangeScene)
+                return;
+
+            var scenes = new List<Scene>();
+            foreach (var s in Level.Scenes)
+            {
+                if (s == scene)
+                    continue;
+                scenes.Add(s);
+            }
+            
+            // In play-mode Editor mocks the level streaming script
+            if (Editor.IsPlayMode)
+            {
+                foreach (var s in scenes)
+                {
+                    Level.UnloadSceneAsync(s);
+                }
+                return;
+            }
+
+            // Ensure to save all pending changes
+            if (CheckSaveBeforeClose())
+                return;
+
+            // Unload scenes
+            Editor.StateMachine.ChangingScenesState.UnloadScene(scenes);
+        }
+
+        /// <summary>
         /// Show save before scene load/unload action.
         /// </summary>
         /// <param name="scene">The scene that will be closed.</param>

--- a/Source/Editor/SceneGraph/Actors/SceneNode.cs
+++ b/Source/Editor/SceneGraph/Actors/SceneNode.cs
@@ -77,6 +77,8 @@ namespace FlaxEditor.SceneGraph.Actors
             }
             contextMenu.AddButton("Save scene", OnSave).LinkTooltip("Saves this scene.").Enabled = IsEdited && !Editor.IsPlayMode;
             contextMenu.AddButton("Unload scene", OnUnload).LinkTooltip("Unloads this scene.").Enabled = Editor.Instance.StateMachine.CurrentState.CanChangeScene;
+            if (Level.ScenesCount > 1)
+                contextMenu.AddButton("Unload all but this scene", OnUnloadAllButSelectedScene).LinkTooltip("Unloads all of the active scenes except for the selected scene.").Enabled = Editor.Instance.StateMachine.CurrentState.CanChangeScene;
 
             base.OnContextMenu(contextMenu);
         }
@@ -94,6 +96,11 @@ namespace FlaxEditor.SceneGraph.Actors
         private void OnUnload()
         {
             Editor.Instance.Scene.CloseScene(Scene);
+        }
+
+        private void OnUnloadAllButSelectedScene()
+        {
+            Editor.Instance.Scene.CloseAllScenesExcept(Scene);
         }
     }
 }


### PR DESCRIPTION
This adds the option to the scene context menu to unload all of the active scenes except for the selected one. It is a nice utility to have when a user has multiple scenes active in the editor and wants to unload all of them but one scene without they trying to find the scene asset.