### PR TITLE
Format Content Window Tooltips Better, Including Types On Everything.

### DIFF
--- a/Source/Editor/Content/Items/AssetItem.cs
+++ b/Source/Editor/Content/Items/AssetItem.cs
@@ -80,9 +80,9 @@ namespace FlaxEditor.Content
         /// <param name="sb">The String Builder.</param>
         protected virtual void OnBuildTooltipText(StringBuilder sb)
         {
-            sb.Append("Type: ").Append(TypeName).AppendLine();
+            sb.Append("Type: ").Append(Utilities.Utils.TranslateTypeName(TypeName)).AppendLine();
             sb.Append("Size: ").Append(Utilities.Utils.FormatBytesCount((int)new FileInfo(Path).Length)).AppendLine();
-            sb.Append("Path: ").Append(FlaxEditor.Utilities.Utils.GetAssetNamePathWithExt(Path)).AppendLine();
+            sb.Append("Path: ").Append(Utilities.Utils.GetAssetNamePathWithExt(Path)).AppendLine();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Content/Items/AssetItem.cs
+++ b/Source/Editor/Content/Items/AssetItem.cs
@@ -82,7 +82,7 @@ namespace FlaxEditor.Content
         {
             sb.Append("Type: ").Append(TypeName).AppendLine();
             sb.Append("Size: ").Append(Utilities.Utils.FormatBytesCount((int)new FileInfo(Path).Length)).AppendLine();
-            sb.Append("Path: ").Append(Path).AppendLine();
+            sb.Append("Path: ").Append(FlaxEditor.Utilities.Utils.GetAssetNamePathWithExt(Path)).AppendLine();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Content/Items/ContentFolder.cs
+++ b/Source/Editor/Content/Items/ContentFolder.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using FlaxEditor.GUI.Drag;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -137,7 +138,13 @@ namespace FlaxEditor.Content
         /// <inheritdoc />
         public override void UpdateTooltipText()
         {
-            TooltipText = Path;
+            string fileDescription = "Folder";
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("Type: ").Append(fileDescription).AppendLine();
+            sb.Append("Path: ").Append(Utilities.Utils.GetAssetNamePathWithExt(Path)).AppendLine();
+
+            TooltipText = sb.ToString();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Content/Items/ContentItem.cs
+++ b/Source/Editor/Content/Items/ContentItem.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using FlaxEditor.Content.GUI;
 using FlaxEditor.GUI.Drag;
 using FlaxEngine;
@@ -353,13 +355,19 @@ namespace FlaxEditor.Content
         }
 
         /// <summary>
-        /// Updates the tooltip text text.
+        /// Updates the tooltip text.
         /// </summary>
         public virtual void UpdateTooltipText()
         {
-            Editor.Log(FlaxEditor.Utilities.Utils.GetAssetNamePath(Path));
+            string fileExtension = System.IO.Path.GetExtension(Path);
+            string fileDescription = Utilities.Utils.TranslateFileExtension(fileExtension);
+            StringBuilder sb = new StringBuilder();
 
-            TooltipText = "Path: " + Path;
+            sb.Append("Type: ").Append(fileDescription).AppendLine();
+            sb.Append("Size: ").Append(Utilities.Utils.FormatBytesCount((int)new FileInfo(Path).Length)).AppendLine();
+            sb.Append("Path: ").Append(Utilities.Utils.GetAssetNamePathWithExt(Path)).AppendLine();
+
+            TooltipText = sb.ToString();
         }
 
         /// <summary>

--- a/Source/Editor/Content/Items/ContentItem.cs
+++ b/Source/Editor/Content/Items/ContentItem.cs
@@ -357,6 +357,8 @@ namespace FlaxEditor.Content
         /// </summary>
         public virtual void UpdateTooltipText()
         {
+            Editor.Log(FlaxEditor.Utilities.Utils.GetAssetNamePath(Path));
+
             TooltipText = "Path: " + Path;
         }
 

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -135,6 +135,13 @@ namespace FlaxEditor.Options
         public FlaxEngine.GUI.Orientation ContentWindowOrientation { get; set; } = FlaxEngine.GUI.Orientation.Horizontal;
 
         /// <summary>
+        /// Gets or sets the option to use type name translations.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Interface"), EditorOrder(290), Tooltip("Attempt to translate asset type names.")]
+        public bool TranslateTypeNames { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the timestamps prefix mode for output log messages.
         /// </summary>
         [DefaultValue(TimestampsFormats.TimeSinceStartup)]

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -1018,15 +1018,28 @@ namespace FlaxEditor.Utilities
         }
 
         /// <summary>
-        /// Gets the asset name relative to the project root folder (without asset file extension)
+        /// Gets the asset name relative to the project root folder (with asset file extension)
         /// </summary>
         /// <param name="path">The asset path.</param>
         /// <returns>The processed name path.</returns>
-        public static string GetAssetNamePath(string path)
+        /// 
+        public static string GetAssetNamePathWithExt(string path)
         {
             var projectFolder = Globals.ProjectFolder;
             if (path.StartsWith(projectFolder))
                 path = path.Substring(projectFolder.Length + 1);
+            return path;
+        }
+
+        /// <summary>
+        /// Gets the asset name relative to the project root folder (without asset file extension)
+        /// </summary>
+        /// <param name="path">The asset path.</param>
+        /// <returns>The processed name path.</returns>
+        /// 
+        public static string GetAssetNamePath(string path)
+        {
+            path = GetAssetNamePathWithExt(path);
             return StringUtils.GetPathWithoutExtension(path);
         }
 

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -1046,11 +1046,41 @@ namespace FlaxEditor.Utilities
         }
 
         /// <summary>
+        /// Gets a description of a file from it's extension.
+        /// </summary>
+        /// <param name="fileExtension">The file's extension</param>
+        /// <returns>The processed description.</returns>
+        public static string TranslateFileExtension(string fileExtension)
+        {
+            string fileDescription = "";
+            switch (fileExtension)
+            {
+                case ".cs":
+                    fileDescription = "C# Source Code";
+                    break;
+                case ".cpp":
+                    fileDescription = "C++ Source Code";
+                    break;
+                case ".h":
+                    fileDescription = "C++ Header File";
+                    break;
+                case ".json":
+                    fileDescription = "JSON File";
+                    break;
+                default:
+                    fileDescription = fileExtension;
+                    break;
+            }
+
+            return fileDescription;
+        }
+
+
+        /// <summary>
         /// Gets the asset name relative to the project root folder (with asset file extension)
         /// </summary>
         /// <param name="path">The asset path.</param>
-        /// <returns>The processed name path.</returns>
-        /// 
+        /// <returns>The processed name path.</returns> 
         public static string GetAssetNamePathWithExt(string path)
         {
             var projectFolder = Globals.ProjectFolder;
@@ -1064,7 +1094,6 @@ namespace FlaxEditor.Utilities
         /// </summary>
         /// <param name="path">The asset path.</param>
         /// <returns>The processed name path.</returns>
-        /// 
         public static string GetAssetNamePath(string path)
         {
             path = GetAssetNamePathWithExt(path);

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -20,6 +20,8 @@ using FlaxEditor.SceneGraph;
 using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
+using FlaxEditor.Options;
+using System.Linq;
 
 namespace FlaxEngine
 {
@@ -1015,6 +1017,32 @@ namespace FlaxEditor.Utilities
             else
                 node.Collapse(true);
             node.Visible = isThisVisible | isAnyChildVisible;
+        }
+
+        /// <summary>
+        /// Gets the asset type, translating if possible, and if enabled in InterfaceOptions.TranslateTypes.
+        /// </summary>
+        /// <param name="typeName">The type name.</param>
+        /// <returns>The translated type name.</returns>
+        public static string TranslateTypeName(string typeName)
+        {
+            // TODO: Surely there is a better way to get this value.
+            if (!Editor.Instance.Options.Options.Interface.TranslateTypeNames)
+            {
+                return typeName;
+            }
+
+            string[] typeNamespaces = typeName.Split('.');
+            string lastNamespace = typeNamespaces.Last();
+
+            // TODO: Add better handling for unconventional type names.
+            try
+            {
+                // Adds spaces between capital letters.
+                return string.Concat(lastNamespace.Select(x => Char.IsUpper(x) ? " " + x : x.ToString())).TrimStart(' ');
+            } catch { 
+                return typeName;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR aims to make tooltips in Flax easier to read, as well as more consistent. I have added the following functionality:

- Relative paths for all tooltips.
- Basic "Type:" descriptions for several files types (Not Assets)
- "Type:" description generation for Assets. This is done by adding a space before every capital letter. Plenty of edge cases it can hit, room for improvement for sure.
- More consistent tooltips. Folders, Assets, and other Content now all have "Path:" and "Type:", and Assets and Content both have "Size:"

BTW, I forgot to make a new branch for this, hopefully this does not interfere with the PR process.