### PR TITLE
Input phases

### DIFF
--- a/Source/Engine/Input/Enums.h
+++ b/Source/Engine/Input/Enums.h
@@ -264,6 +264,31 @@ API_ENUM() enum class InputActionMode
 };
 
 /// <summary>
+/// The input action event trigger modes.
+/// </summary>
+API_ENUM() enum class InputActionPhase
+{
+    /// <summary>
+    /// User is pressing the key/button.
+    /// </summary>
+    Pressing = 0,
+
+    /// <summary>
+    /// User pressed the key/button (but wasn't pressing it in the previous frame).
+    /// </summary>
+    Press = 1,
+
+    /// <summary>
+    /// User released the key/button (was pressing it in the previous frame).
+    /// </summary>
+    Release = 2,
+
+    Waiting = 3,
+
+    None = 4,
+};
+
+/// <summary>
 /// The input gamepad index.
 /// </summary>
 API_ENUM() enum class InputGamepadIndex

--- a/Source/Engine/Input/Enums.h
+++ b/Source/Engine/Input/Enums.h
@@ -264,28 +264,34 @@ API_ENUM() enum class InputActionMode
 };
 
 /// <summary>
-/// The input action event trigger modes.
+/// The input action event phases.
 /// </summary>
 API_ENUM() enum class InputActionPhase
 {
     /// <summary>
+    /// The key/button is not assigned.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The key/button is waiting for input.
+    /// </summary>
+    Waiting = 1,
+
+    /// <summary>
     /// User is pressing the key/button.
     /// </summary>
-    Pressing = 0,
+    Pressing = 2,
 
     /// <summary>
     /// User pressed the key/button (but wasn't pressing it in the previous frame).
     /// </summary>
-    Press = 1,
+    Press = 3,
 
     /// <summary>
     /// User released the key/button (was pressing it in the previous frame).
     /// </summary>
-    Release = 2,
-
-    Waiting = 3,
-
-    None = 4,
+    Release = 4,
 };
 
 /// <summary>

--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -25,7 +25,7 @@ struct AxisEvaluation
     bool Used;
 };
 
-struct ActionData
+struct  ActionData
 {
     bool Active;
     uint64 FrameIndex;
@@ -35,7 +35,7 @@ struct ActionData
     {
         Active = false;
         FrameIndex = 0;
-        Phase = InputActionPhase::None;
+        Phase = InputActionPhase::Waiting;
     }
 };
 
@@ -844,11 +844,17 @@ void InputService::Update()
         }
 
         if (Input::GetKeyDown(config.Key) || Input::GetMouseButtonDown(config.MouseButton) || Input::GetGamepadButtonDown(config.Gamepad, config.GamepadButton))
+        {
             data.Phase = InputActionPhase::Press;
+        }
         else if (Input::GetKey(config.Key) || Input::GetMouseButton(config.MouseButton) || Input::GetGamepadButton(config.Gamepad, config.GamepadButton))
+        {
             data.Phase = InputActionPhase::Pressing;
+        }
         else if (Input::GetKeyUp(config.Key) || Input::GetMouseButtonUp(config.MouseButton) || Input::GetGamepadButtonUp(config.Gamepad, config.GamepadButton))
+        {
             data.Phase = InputActionPhase::Release;
+        }
 
         data.Active |= isActive;
     }

--- a/Source/Engine/Input/Input.h
+++ b/Source/Engine/Input/Input.h
@@ -310,6 +310,14 @@ public:
     API_FUNCTION() static bool GetAction(const StringView& name);
 
     /// <summary>
+    /// Gets the value of the virtual action identified by name. Use <see cref="ActionMappings"/> to get the current config.
+    /// </summary>
+    /// <param name="name">The action name.</param>
+    /// <returns>True if action has been triggered in the current frame (e.g. button pressed), otherwise false.</returns>
+    /// <seealso cref="ActionMappings"/>
+    API_FUNCTION() static InputActionPhase GetActionPhase(const StringView& name);
+
+    /// <summary>
     /// Gets the value of the virtual axis identified by name. Use <see cref="AxisMappings"/> to get the current config.
     /// </summary>
     /// <param name="name">The action name.</param>

--- a/Source/Engine/Input/Input.h
+++ b/Source/Engine/Input/Input.h
@@ -313,7 +313,7 @@ public:
     /// Gets the value of the virtual action identified by name. Use <see cref="ActionMappings"/> to get the current config.
     /// </summary>
     /// <param name="name">The action name.</param>
-    /// <returns>True if action has been triggered in the current frame (e.g. button pressed), otherwise false.</returns>
+    /// <returns>A InputActionPhase determining the current phase of the Action (e.g If it was just pressed, is being held or just released).</returns>
     /// <seealso cref="ActionMappings"/>
     API_FUNCTION() static InputActionPhase GetActionPhase(const StringView& name);
 

--- a/Source/Engine/Input/VirtualInput.h
+++ b/Source/Engine/Input/VirtualInput.h
@@ -48,6 +48,9 @@ API_STRUCT() struct ActionConfig
     /// </summary>
     API_FIELD(Attributes="EditorOrder(40)")
     InputGamepadIndex Gamepad;
+
+    API_FIELD(Attributes = "EditorOrder(50)")
+    InputActionMode Phase;
 };
 
 /// <summary>

--- a/Source/Engine/Input/VirtualInput.h
+++ b/Source/Engine/Input/VirtualInput.h
@@ -48,9 +48,6 @@ API_STRUCT() struct ActionConfig
     /// </summary>
     API_FIELD(Attributes="EditorOrder(40)")
     InputGamepadIndex Gamepad;
-
-    API_FIELD(Attributes = "EditorOrder(50)")
-    InputActionMode Phase;
 };
 
 /// <summary>


### PR DESCRIPTION
This PR allows you to poll specific input phases (Waiting, Pressed, Held, Released) rather than having to create many different actions that might share the same Input. This also doesn't take into account what "Mode" the Action uses so you can create significantly less actions. This doesn't change how input currently works and can seamlessly be used with any current project.

An example of how this may be used is if I want to create multiple actions on the same key but I don't want to have to create multiple Actions for them since it gets tedious to maintain. So instead of, for example, creating `JumpPressed`, `JumpHeld`, `JumpReleased`, I could just sample the phase of the Jump Action like so:
![devenv_2023-05-11_21-16-43](https://github.com/FlaxEngine/FlaxEngine/assets/38583668/cbba95a6-6f16-4f52-a930-3a418054e29a)
This would give me the following output
![FlaxEditor_2023-05-11_21-16-32](https://github.com/FlaxEngine/FlaxEngine/assets/38583668/06d659c4-f819-436e-bf12-89ade28128ff)

