### PR TITLE
Fix `NetworkManager::ClientConnected` dispatch regression

### DIFF
--- a/Source/Engine/Networking/NetworkManager.cpp
+++ b/Source/Engine/Networking/NetworkManager.cpp
@@ -318,10 +318,10 @@ bool NetworkManager::StartHost()
 
     // Auto-connect host
     LocalClient->State = NetworkConnectionState::Connected;
-    ClientConnected(LocalClient);
-
     State = NetworkConnectionState::Connected;
     StateChanged();
+
+    ClientConnected(LocalClient);
     return false;
 }
 


### PR DESCRIPTION
https://github.com/FlaxEngine/FlaxEngine/commit/953ae3e9bbbfd9d353bd7d2b0b390edbf784b308 has fixed an issue, but also added an initialization problem on its own. Here is a breakdown of the regression:

Currently, if you were spawning any networked actor/component on `NetworkManager::ClientConnected` action (lets say a host player) then checking for ownership would always yield `None`. This is due to the introduction of `NetworkManager::IsConnected()` check in `NetworkReplicator::GetObjectRole` since https://github.com/FlaxEngine/FlaxEngine/commit/953ae3e9bbbfd9d353bd7d2b0b390edbf784b308. It is no longer be possible to request object's role because at that moment `State = NetworkConnectionState::Connected;` was not yet executed, and so `NetworkReplicator::GetObjectRole` would return `None` as a fallback. This PR simply shifts `State` assignment to be executed prior to dispatching `NetworkManager::ClientConnected` in order to eliminate this problem.