### PR TITLE
Fix `NetworkReplicator::SetObjectOwnership` not considering spawn queue for hierarchical assignment

### DIFF
--- a/Source/Engine/Networking/NetworkReplicator.cpp
+++ b/Source/Engine/Networking/NetworkReplicator.cpp
@@ -1026,6 +1026,12 @@ void NetworkReplicator::SetObjectOwnership(ScriptingObject* obj, uint32 ownerCli
             if (e.Item.ParentId == objectId)
                 SetObjectOwnership(e.Item.Object.Get(), ownerClientId, localRole, hierarchical);
         }
+
+        for (const SpawnItem& spawnItem : SpawnQueue)
+        {
+            if (IsParentOf(spawnItem.Object, obj))
+                SetObjectOwnership(spawnItem.Object, ownerClientId, localRole, hierarchical);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes final issue with https://github.com/FlaxEngine/FlaxEngine/issues/1066