### PR TITLE
.NET7: Enable roll-forward to latest .NET major preview version

### DIFF
--- a/Source/Engine/Scripting/Runtime/DotNet.cpp
+++ b/Source/Engine/Scripting/Runtime/DotNet.cpp
@@ -681,6 +681,7 @@ bool MAssembly::LoadCorlib()
 
 bool MAssembly::LoadImage(const String& assemblyPath, const StringView& nativePath)
 {
+    // TODO: Use new hostfxr delegate load_assembly_bytes? (.NET 8+)
     // Open .Net assembly
     const StringAnsi assemblyPathAnsi = assemblyPath.ToStringAnsi();
     const char* name;
@@ -1567,9 +1568,9 @@ bool InitHostfxr()
         Platform::OpenUrl(TEXT("https://dotnet.microsoft.com/en-us/download/dotnet/7.0"));
 #endif
 #if USE_EDITOR
-        LOG(Fatal, "Missing .NET 7 SDK installation requried to run Flax Editor.");
+        LOG(Fatal, "Missing .NET 7 SDK installation required to run Flax Editor.");
 #else
-        LOG(Fatal, "Missing .NET 7 Runtime installation requried to run this application.");
+        LOG(Fatal, "Missing .NET 7 Runtime installation required to run this application.");
 #endif
         return true;
     }
@@ -1595,6 +1596,15 @@ bool InitHostfxr()
         LOG(Fatal, "Failed to setup hostfxr API ({0})", path);
         return true;
     }
+
+    // TODO: Implement picking different version of hostfxr, currently prefers highest available version.
+    // Allow future and preview versions of .NET
+    String dotnetRollForward;
+    String dotnetRollForwardPr;
+    if (Platform::GetEnvironmentVariable(TEXT("DOTNET_ROLL_FORWARD"), dotnetRollForward))
+        Platform::SetEnvironmentVariable(TEXT("DOTNET_ROLL_FORWARD"), TEXT("LatestMajor"));
+    if (Platform::GetEnvironmentVariable(TEXT("DOTNET_ROLL_FORWARD_TO_PRERELEASE"), dotnetRollForwardPr))
+        Platform::SetEnvironmentVariable(TEXT("DOTNET_ROLL_FORWARD_TO_PRERELEASE"), TEXT("1"));
 
     // Initialize hosting component
     const char_t* argv[1] = { libraryPath.Get() };


### PR DESCRIPTION
`get_hostfxr_path` seems to prefer returning the latest version of hostfxr, which includes major preview versions as well. So in case you have .NET 8 preview installed on your machine, the .NET 8 version of the hostfxr is returned in this case. This however causes some issues in resolving the latest runtime version, which right now ignored preview versions of .NET and uses the latest .NET 7 runtime found on the system. Mixing the major versions causes some system assemblies to be resolved into wrong version (following the hostfxr version in this case) and not the requested runtime version set in the runtime configuration.

This change effectively enables the .NET runtime to run in latest detected version on the system, which is better than not running at all in case new major (preview) version is found. The lookup for hostfxr path should be reworked to prefer using the same major version set by the build tool instead of using the default behaviour. There seems to be new tools for querying multiple versions in the .NET 8 version of hostfxr, but that doesn't seem to help in .NET 7 case.