### PR TITLE
Fix scale link to use ratio.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -97,6 +97,7 @@ namespace FlaxEditor.CustomEditors.Editors
                     AnchorPreset = AnchorPresets.TopLeft,
                 };
                 _linkButton.Clicked += ToggleLink;
+                ToggleEnabled();
                 SetLinkStyle();
                 var x = LinkedLabel.Text.Value.Length * 7 + 5;
                 _linkButton.LocalX += x;

--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -128,7 +128,36 @@ namespace FlaxEditor.CustomEditors.Editors
             {
                 LinkValues = !LinkValues;
                 Editor.Instance.Windows.PropertiesWin.ScaleLinked = LinkValues;
+                ToggleEnabled();
                 SetLinkStyle();
+            }
+
+            /// <summary>
+            /// Toggles enables on value boxes.
+            /// </summary>
+            public void ToggleEnabled()
+            {
+                if (LinkValues)
+                {
+                    if (Mathf.NearEqual(((Float3)Values[0]).X, 0))
+                    {
+                        XElement.ValueBox.Enabled = false;
+                    }
+                    if (Mathf.NearEqual(((Float3)Values[0]).Y, 0))
+                    {
+                        YElement.ValueBox.Enabled = false;
+                    }
+                    if (Mathf.NearEqual(((Float3)Values[0]).Z, 0))
+                    {
+                        ZElement.ValueBox.Enabled = false;
+                    }
+                }
+                else
+                {
+                    XElement.ValueBox.Enabled = true;
+                    YElement.ValueBox.Enabled = true;
+                    ZElement.ValueBox.Enabled = true;
+                }
             }
 
             private void SetLinkStyle()

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -129,23 +129,23 @@ namespace FlaxEditor.CustomEditors.Editors
 
             if (LinkValues)
             {
-                var valueChange = 0.0f;
+                var valueRatio = 0.0f;
                 switch (_valueChanged)
                 {
                 case ValueChanged.X:
-                    valueChange = xValue - ((Float3)Values[0]).X;
-                    yValue = NewLinkedValue(yValue, valueChange);
-                    zValue = NewLinkedValue(zValue, valueChange);
+                    valueRatio = GetRatio(xValue, ((Float3)Values[0]).X);
+                    yValue = NewLinkedValue(yValue, valueRatio);
+                    zValue = NewLinkedValue(zValue, valueRatio);
                     break;
                 case ValueChanged.Y:
-                    valueChange = yValue - ((Float3)Values[0]).Y;
-                    xValue = NewLinkedValue(xValue, valueChange);
-                    zValue = NewLinkedValue(zValue, valueChange);
+                    valueRatio = GetRatio(yValue, ((Float3)Values[0]).Y);
+                    xValue = NewLinkedValue(xValue, valueRatio);
+                    zValue = NewLinkedValue(zValue, valueRatio);
                     break;
                 case ValueChanged.Z:
-                    valueChange = zValue - ((Float3)Values[0]).Z;
-                    xValue = NewLinkedValue(xValue, valueChange);
-                    yValue = NewLinkedValue(yValue, valueChange);
+                    valueRatio = GetRatio(zValue, ((Float3)Values[0]).Z);
+                    xValue = NewLinkedValue(xValue, valueRatio);
+                    yValue = NewLinkedValue(yValue, valueRatio);
                     break;
                 default: break;
                 }
@@ -164,9 +164,14 @@ namespace FlaxEditor.CustomEditors.Editors
             SetValue(v, token);
         }
 
-        private float NewLinkedValue(float value, float valueChange)
+        private float GetRatio(float value, float initialValue)
         {
-            return Mathf.NearEqual(value, 0) ? value : value + valueChange;
+            return Mathf.Abs(value / initialValue);
+        }
+
+        private float NewLinkedValue(float value, float valueRatio)
+        {
+            return Mathf.NearEqual(value, 0) ? value : value * valueRatio;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -166,7 +166,7 @@ namespace FlaxEditor.CustomEditors.Editors
 
         private float GetRatio(float value, float initialValue)
         {
-            return Mathf.Abs(value / initialValue);
+            return (initialValue == 0) ? Mathf.Abs(value / 0.0001f) : Mathf.Abs(value / initialValue);
         }
 
         private float NewLinkedValue(float value, float valueRatio)

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -135,17 +135,17 @@ namespace FlaxEditor.CustomEditors.Editors
                 case ValueChanged.X:
                     valueChange = xValue - ((Float3)Values[0]).X;
                     yValue = NewLinkedValue(yValue, valueChange);
-                    zValue =  NewLinkedValue(zValue, valueChange);
+                    zValue = NewLinkedValue(zValue, valueChange);
                     break;
                 case ValueChanged.Y:
                     valueChange = yValue - ((Float3)Values[0]).Y;
-                    xValue =  NewLinkedValue(xValue, valueChange);
-                    zValue =  NewLinkedValue(zValue, valueChange);
+                    xValue = NewLinkedValue(xValue, valueChange);
+                    zValue = NewLinkedValue(zValue, valueChange);
                     break;
                 case ValueChanged.Z:
                     valueChange = zValue - ((Float3)Values[0]).Z;
-                    xValue =  NewLinkedValue(xValue, valueChange);
-                    yValue =  NewLinkedValue(yValue, valueChange);
+                    xValue = NewLinkedValue(xValue, valueChange);
+                    yValue = NewLinkedValue(yValue, valueChange);
                     break;
                 default: break;
                 }

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -122,7 +122,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (IsSetBlocked)
                 return;
-
+            
             var xValue = XElement.ValueBox.Value;
             var yValue = YElement.ValueBox.Value;
             var zValue = ZElement.ValueBox.Value;
@@ -134,16 +134,31 @@ namespace FlaxEditor.CustomEditors.Editors
                 {
                 case ValueChanged.X:
                     valueRatio = GetRatio(xValue, ((Float3)Values[0]).X);
+                    if (Mathf.NearEqual(valueRatio, 0))
+                    {
+                        XElement.ValueBox.Enabled = false;
+                        valueRatio = 1;
+                    }
                     yValue = NewLinkedValue(yValue, valueRatio);
                     zValue = NewLinkedValue(zValue, valueRatio);
                     break;
                 case ValueChanged.Y:
                     valueRatio = GetRatio(yValue, ((Float3)Values[0]).Y);
+                    if (Mathf.NearEqual(valueRatio, 0))
+                    {
+                        YElement.ValueBox.Enabled = false;
+                        valueRatio = 1;
+                    }
                     xValue = NewLinkedValue(xValue, valueRatio);
                     zValue = NewLinkedValue(zValue, valueRatio);
                     break;
                 case ValueChanged.Z:
                     valueRatio = GetRatio(zValue, ((Float3)Values[0]).Z);
+                    if (Mathf.NearEqual(valueRatio, 0))
+                    {
+                        ZElement.ValueBox.Enabled = false;
+                        valueRatio = 1;
+                    }
                     xValue = NewLinkedValue(xValue, valueRatio);
                     yValue = NewLinkedValue(yValue, valueRatio);
                     break;
@@ -166,7 +181,7 @@ namespace FlaxEditor.CustomEditors.Editors
 
         private float GetRatio(float value, float initialValue)
         {
-            return (initialValue == 0) ? Mathf.Abs(value / 0.0001f) : Mathf.Abs(value / initialValue);
+            return Mathf.NearEqual(initialValue, 0) ? 0 : value / initialValue;
         }
 
         private float NewLinkedValue(float value, float valueRatio)

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -134,18 +134,18 @@ namespace FlaxEditor.CustomEditors.Editors
                 {
                 case ValueChanged.X:
                     valueChange = xValue - ((Float3)Values[0]).X;
-                    yValue += valueChange;
-                    zValue += valueChange;
+                    yValue = NewLinkedValue(yValue, valueChange);
+                    zValue =  NewLinkedValue(zValue, valueChange);
                     break;
                 case ValueChanged.Y:
                     valueChange = yValue - ((Float3)Values[0]).Y;
-                    xValue += valueChange;
-                    zValue += valueChange;
+                    xValue =  NewLinkedValue(xValue, valueChange);
+                    zValue =  NewLinkedValue(zValue, valueChange);
                     break;
                 case ValueChanged.Z:
                     valueChange = zValue - ((Float3)Values[0]).Z;
-                    xValue += valueChange;
-                    yValue += valueChange;
+                    xValue =  NewLinkedValue(xValue, valueChange);
+                    yValue =  NewLinkedValue(yValue, valueChange);
                     break;
                 default: break;
                 }
@@ -162,6 +162,11 @@ namespace FlaxEditor.CustomEditors.Editors
             else if (v is Double3)
                 v = (Double3)value;
             SetValue(v, token);
+        }
+
+        private float NewLinkedValue(float value, float valueChange)
+        {
+            return Mathf.NearEqual(value, 0) ? value : value + valueChange;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
I compared with other engines and their scale linking goes off of a ratio. Makes sense to follow suit. Fix for #1117 

The way that I handled the zero case is to disable the boxes from being edited if they are zero and linked. This is similar to how unity handles the zero case. Unreal just syncs all of the values to zero when a zero value is edited... I thought this was weird but could be implemented this way if that is the desired behavior.