### PR TITLE
Rename `CompileCppTask` to `CompileTask`

### DIFF
--- a/Source/Tools/Flax.Build/Build/Graph/CompileTask.cs
+++ b/Source/Tools/Flax.Build/Build/Graph/CompileTask.cs
@@ -6,7 +6,7 @@ namespace Flax.Build.Graph
     /// The C++ file compilation task.
     /// </summary>
     /// <seealso cref="Flax.Build.Graph.Task" />
-    public class CompileCppTask : Task
+    public class CompileTask : Task
     {
     }
 }


### PR DESCRIPTION
I renamed the class to the name of the file to keep order