### PR TITLE
Copy content files using Content Database instead of Content Importing

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -611,7 +611,20 @@ namespace FlaxEditor.Windows
         /// <param name="files">The files paths to import.</param>
         public void Paste(string[] files)
         {
-            Editor.ContentImporting.Import(files, CurrentViewFolder);
+            List<string> importFiles = new List<string>();
+            foreach (var sourcePath in files)
+            {
+                var item = Editor.ContentDatabase.Find(sourcePath);
+                if (item != null)
+                {
+                    string targetPath = Path.Combine(CurrentViewFolder.Path, item.FileName);
+                    Editor.ContentDatabase.Copy(item, targetPath);
+                }
+                else
+                    importFiles.Add(sourcePath);
+            }
+
+            Editor.ContentImporting.Import(importFiles, CurrentViewFolder);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an issue where copying asset files does not change the asset ID, causing the copied assets to remain linked to the original files.