### PR TITLE
Change default script name to MyScript

### DIFF
--- a/Source/Editor/Content/Proxy/ScriptProxy.cs
+++ b/Source/Editor/Content/Proxy/ScriptProxy.cs
@@ -45,7 +45,7 @@ namespace FlaxEditor.Content
         }
 
         /// <inheritdoc />
-        public override string NewItemName => "Script";
+        public override string NewItemName => "MyScript";
 
         /// <inheritdoc />
         public override bool CanCreate(ContentFolder targetLocation)
@@ -71,6 +71,8 @@ namespace FlaxEditor.Content
         {
             // Scripts cannot start with digit. 
             if (Char.IsDigit(filename[0]))
+                return false;
+            if (filename.Equals("Script"))
                 return false;
             return true;
         }


### PR DESCRIPTION
This PR changes the default script name on creation to `MyScript` and makes the name `Script` invalid to avoid a circular dependency.