### PR TITLE
Fix DXGIFactory use after release

### DIFF
--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUDeviceDX11.cpp
@@ -221,15 +221,6 @@ GPUDevice* GPUDeviceDX11::Create()
         Delete(device);
         return nullptr;
     }
-    
-#if PLATFORM_WINDOWS
-    if (dxgiFactory6 != nullptr)
-        dxgiFactory6->Release();
-    else
-#endif
-    {
-        dxgiFactory->Release();
-    }
 
     return device;
 }

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.cpp
@@ -202,15 +202,6 @@ GPUDevice* GPUDeviceDX12::Create()
         return nullptr;
     }
 
-#if !(PLATFORM_XBOX_SCARLETT || PLATFORM_XBOX_ONE)
-    if (dxgiFactory6 != nullptr)
-        dxgiFactory6->Release();
-    else
-#endif
-    {
-        dxgiFactory->Release();
-    }
-
     return device;
 }
 


### PR DESCRIPTION
Accidentally introduced this in a recent PR, the DXGIFactory is actually still used by the GPUDevice after release...