### PR TITLE
Pivot Relative UI Sizing

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
@@ -497,8 +497,9 @@ namespace FlaxEditor.CustomEditors.Dedicated
 
         private void BuildExtraButtons(VerticalPanelElement group)
         {
-            // Set to default for UI editing
-            (Values[0] as Control).PivotRelative = true;
+            (Values[0] as Control).PivotRelative = Editor.Instance.Windows.PropertiesWin.PivotRelativeSize;
+
+            var current = Editor.Instance.Windows.PropertiesWin.PivotRelativeSize;
 
             var panel = group.CustomContainer<Panel>();
             panel.CustomControl.Height = TextBoxBase.DefaultHeight;
@@ -515,7 +516,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 X = 77,
             };
 
-            SetStyle(true);
+            SetStyle(current);
             _pivotRelativeButton.Clicked += PivotRelativeClicked;
         }
 
@@ -523,6 +524,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
         {
             var current = (Values[0] as Control).PivotRelative;
             (Values[0] as Control).PivotRelative = !current;
+            Editor.Instance.Windows.PropertiesWin.PivotRelativeSize = !current;
             SetStyle((Values[0] as Control).PivotRelative);
         }
 

--- a/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
@@ -487,8 +487,35 @@ namespace FlaxEditor.CustomEditors.Dedicated
 
             BuildLocationSizeOffsets(horUp, horDown, _cachedXEq, _cachedYEq, valueTypes);
 
+            BuildExtraButtons(group);
+
             main.Space(10);
             BuildAnchorsDropper(main, valueTypes);
+        }
+
+        private void BuildExtraButtons(VerticalPanelElement group)
+        {
+            var panel = group.CustomContainer<Panel>();
+            panel.CustomControl.Height = TextBoxBase.DefaultHeight;
+            panel.CustomControl.ClipChildren = false;
+            panel.CustomControl.Parent = group.ContainerControl;
+            panel.CustomControl.Y += 50;
+
+            var pivotSizeRelativeBtn = new Button()
+            {
+                Parent = panel.ContainerControl,
+                Width = 18,
+                Height = 18,
+                BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Scale32),
+                AnchorPreset = AnchorPresets.TopRight,
+            };
+            pivotSizeRelativeBtn.Clicked += () =>
+            {
+                var current = (Values[0] as Control).PivotRelative;
+                (Values[0] as Control).PivotRelative = !current;
+                pivotSizeRelativeBtn.BorderColor = current ? Color.Transparent : Color.AliceBlue;
+                pivotSizeRelativeBtn.BackgroundColor = current ? Color.Gray : Color.White;
+            };
         }
 
         private void BuildAnchorsDropper(LayoutElementsContainer main, ScriptType[] valueTypes)

--- a/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
@@ -408,6 +408,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
     {
         private Type _cachedType;
         private bool _anchorDropDownClosed = true;
+        private Button _pivotRelativeButton;
+
 
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
@@ -495,27 +497,40 @@ namespace FlaxEditor.CustomEditors.Dedicated
 
         private void BuildExtraButtons(VerticalPanelElement group)
         {
+            // Set to default for UI editing
+            (Values[0] as Control).PivotRelative = true;
+
             var panel = group.CustomContainer<Panel>();
             panel.CustomControl.Height = TextBoxBase.DefaultHeight;
             panel.CustomControl.ClipChildren = false;
             panel.CustomControl.Parent = group.ContainerControl;
-            panel.CustomControl.Y += 50;
 
-            var pivotSizeRelativeBtn = new Button()
+            _pivotRelativeButton = new Button()
             {
                 Parent = panel.ContainerControl,
                 Width = 18,
                 Height = 18,
                 BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Scale32),
                 AnchorPreset = AnchorPresets.TopRight,
+                X = 77,
             };
-            pivotSizeRelativeBtn.Clicked += () =>
-            {
-                var current = (Values[0] as Control).PivotRelative;
-                (Values[0] as Control).PivotRelative = !current;
-                pivotSizeRelativeBtn.BorderColor = current ? Color.Transparent : Color.AliceBlue;
-                pivotSizeRelativeBtn.BackgroundColor = current ? Color.Gray : Color.White;
-            };
+
+            SetStyle(true);
+            _pivotRelativeButton.Clicked += PivotRelativeClicked;
+        }
+
+        private void PivotRelativeClicked()
+        {
+            var current = (Values[0] as Control).PivotRelative;
+            (Values[0] as Control).PivotRelative = !current;
+            SetStyle((Values[0] as Control).PivotRelative);
+        }
+
+        private void SetStyle(bool current)
+        {
+            var style = FlaxEngine.GUI.Style.Current;
+            var backgroundColor = current ? style.Foreground : style.ForegroundDisabled;
+            _pivotRelativeButton.SetColors(backgroundColor);
         }
 
         private void BuildAnchorsDropper(LayoutElementsContainer main, ScriptType[] valueTypes)

--- a/Source/Editor/Windows/PropertiesWindow.cs
+++ b/Source/Editor/Windows/PropertiesWindow.cs
@@ -31,6 +31,11 @@ namespace FlaxEditor.Windows
         public bool ScaleLinked = false;
 
         /// <summary>
+        /// Indictation of if UI elements should size relative to the pivot point
+        /// </summary>
+        public bool PivotRelativeSize = true;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PropertiesWindow"/> class.
         /// </summary>
         /// <param name="editor">The editor.</param>

--- a/Source/Engine/UI/GUI/Control.Bounds.cs
+++ b/Source/Engine/UI/GUI/Control.Bounds.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 using System;
+using System.Runtime.Remoting.Messaging;
 
 namespace FlaxEngine.GUI
 {
@@ -172,8 +173,12 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Whether to resize the UI Control based on where the pivot is rather than just the top-left.
         /// </summary>
-        [ExpandGroups, EditorDisplay("Transform"), EditorOrder(1060)]
-        public bool PivotRelative = false;
+        [NoSerialize, HideInEditor]
+        public bool PivotRelative
+        {
+            get => _pivotRelativeSizing;
+            set => _pivotRelativeSizing = value;
+        }
 
         /// <summary>
         /// Gets or sets width of the control.

--- a/Source/Engine/UI/GUI/Control.Bounds.cs
+++ b/Source/Engine/UI/GUI/Control.Bounds.cs
@@ -170,6 +170,12 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
+        /// Whether to resize the UI Control based on where the pivot is rather than just the top-left.
+        /// </summary>
+        [ExpandGroups, EditorDisplay("Transform"), EditorOrder(1060)]
+        public bool PivotRelative = false;
+
+        /// <summary>
         /// Gets or sets width of the control.
         /// </summary>
         [NoSerialize, HideInEditor]
@@ -180,7 +186,13 @@ namespace FlaxEngine.GUI
             {
                 if (Mathf.NearEqual(_bounds.Size.X, value))
                     return;
-                var bounds = new Rectangle(_bounds.Location, value, _bounds.Size.Y);
+                var rectLocation = _bounds.Location;
+                if (PivotRelative)
+                {
+                    var delta = _bounds.Size.X - value;
+                    rectLocation.X += delta * Pivot.X;
+                }
+                var bounds = new Rectangle(rectLocation, value, _bounds.Size.Y);
                 SetBounds(ref bounds);
             }
         }
@@ -196,7 +208,13 @@ namespace FlaxEngine.GUI
             {
                 if (Mathf.NearEqual(_bounds.Size.Y, value))
                     return;
-                var bounds = new Rectangle(_bounds.Location, _bounds.Size.X, value);
+                var rectLocation = _bounds.Location;
+                if (PivotRelative)
+                {
+                    var delta = _bounds.Size.Y - value;
+                    rectLocation.Y += delta * Pivot.Y;
+                }
+                var bounds = new Rectangle(rectLocation, _bounds.Size.X, value);
                 SetBounds(ref bounds);
             }
         }

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -76,6 +76,7 @@ namespace FlaxEngine.GUI
         private float _rotation;
         internal Matrix3x3 _cachedTransform;
         internal Matrix3x3 _cachedTransformInv;
+        private bool _pivotRelativeSizing = false;
 
         // Style
 


### PR DESCRIPTION
When making UI controls that are right-aligned or center-aligned it gets tedious having to reposition it after changing the width or height. This alleviates that by making it so that the controls will change size relative to their pivot point. I have included a toggle below the width/height control that can turn this on or off quickly for people that prefer the old way of changing the size.