### PR TITLE
Add collider direction for orienting capsule collider.

### DIFF
--- a/Source/Engine/Physics/Colliders/CapsuleCollider.cpp
+++ b/Source/Engine/Physics/Colliders/CapsuleCollider.cpp
@@ -7,7 +7,9 @@ CapsuleCollider::CapsuleCollider(const SpawnParams& params)
     : Collider(params)
     , _radius(20.0f)
     , _height(100.0f)
+    , _direction(ColliderOrientationDirection::YAxis)
 {
+    SetDirection(_direction);
 }
 
 void CapsuleCollider::SetRadius(const float value)
@@ -42,8 +44,10 @@ void CapsuleCollider::DrawPhysicsDebug(RenderView& view)
     const BoundingSphere sphere(_sphere.Center - view.Origin, _sphere.Radius);
     if (!view.CullingFrustum.Intersects(sphere))
         return;
+    Quaternion collRot;
+    Quaternion::Multiply( _colliderOrientation, Quaternion::Euler(0, 90, 0), collRot);
     Quaternion rot;
-    Quaternion::Multiply(_transform.Orientation, Quaternion::Euler(0, 90, 0), rot);
+    Quaternion::Multiply(_transform.Orientation, collRot, rot);
     const float scaling = _cachedScale.GetAbsolute().MaxValue();
     const float minSize = 0.001f;
     const float radius = Math::Max(Math::Abs(_radius) * scaling, minSize);
@@ -54,10 +58,30 @@ void CapsuleCollider::DrawPhysicsDebug(RenderView& view)
         DEBUG_DRAW_WIRE_TUBE(_transform.LocalToWorld(_center), rot, radius, height, Color::GreenYellow * 0.8f, 0, true);
 }
 
+void CapsuleCollider::SetDirection(ColliderOrientationDirection value)
+{
+    _direction = value;
+    switch (value)
+    {
+    case ColliderOrientationDirection::XAxis:
+        SetColliderOrientation(Quaternion::Identity);
+        break;
+    case ColliderOrientationDirection::YAxis:
+        SetColliderOrientation(Quaternion::Euler(0, 0, 90));
+        break;
+    case ColliderOrientationDirection::ZAxis:
+        SetColliderOrientation(Quaternion::Euler(0, 90, 0));
+        break;
+    default: ;
+    }
+}
+
 void CapsuleCollider::OnDebugDrawSelected()
 {
+    Quaternion collRot;
+    Quaternion::Multiply( _colliderOrientation, Quaternion::Euler(0, 90, 0), collRot);
     Quaternion rot;
-    Quaternion::Multiply(_transform.Orientation, Quaternion::Euler(0, 90, 0), rot);
+    Quaternion::Multiply(_transform.Orientation, collRot, rot);
     const float scaling = _cachedScale.GetAbsolute().MaxValue();
     const float minSize = 0.001f;
     const float radius = Math::Max(Math::Abs(_radius) * scaling, minSize);
@@ -84,6 +108,7 @@ void CapsuleCollider::Serialize(SerializeStream& stream, const void* otherObj)
 
     SERIALIZE_MEMBER(Radius, _radius);
     SERIALIZE_MEMBER(Height, _height);
+    SERIALIZE(_direction);
 }
 
 void CapsuleCollider::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
@@ -93,6 +118,8 @@ void CapsuleCollider::Deserialize(DeserializeStream& stream, ISerializeModifier*
 
     DESERIALIZE_MEMBER(Radius, _radius);
     DESERIALIZE_MEMBER(Height, _height);
+    DESERIALIZE(_direction);
+    SetDirection(_direction);
 }
 
 void CapsuleCollider::UpdateBounds()
@@ -100,7 +127,11 @@ void CapsuleCollider::UpdateBounds()
     // Cache bounds
     const float radiusTwice = _radius * 2.0f;
     OrientedBoundingBox::CreateCentered(_center, Vector3(_height + radiusTwice, radiusTwice, radiusTwice), _orientedBox);
-    _orientedBox.Transform(_transform);
+    Transform transform = _transform;
+    Quaternion rot;
+    Quaternion::Multiply(transform.Orientation, _colliderOrientation, rot);
+    transform.Orientation = rot;
+    _orientedBox.Transform(transform);
     _orientedBox.GetBoundingBox(_box);
     BoundingSphere::FromBox(_box, _sphere);
 }

--- a/Source/Engine/Physics/Colliders/CapsuleCollider.cpp
+++ b/Source/Engine/Physics/Colliders/CapsuleCollider.cpp
@@ -9,7 +9,7 @@ CapsuleCollider::CapsuleCollider(const SpawnParams& params)
     , _height(100.0f)
     , _direction(ColliderOrientationDirection::YAxis)
 {
-    SetDirection(_direction);
+    SetColliderDirection(_direction);
 }
 
 void CapsuleCollider::SetRadius(const float value)
@@ -34,6 +34,24 @@ void CapsuleCollider::SetHeight(const float value)
     UpdateBounds();
 }
 
+void CapsuleCollider::SetColliderDirection(ColliderOrientationDirection value)
+{
+    _direction = value;
+    switch (value)
+    {
+    case ColliderOrientationDirection::XAxis:
+        SetColliderOrientation(Quaternion::Identity);
+        break;
+    case ColliderOrientationDirection::YAxis:
+        SetColliderOrientation(Quaternion::Euler(0, 0, 90));
+        break;
+    case ColliderOrientationDirection::ZAxis:
+        SetColliderOrientation(Quaternion::Euler(0, 90, 0));
+        break;
+    default: ;
+    }
+}
+
 #if USE_EDITOR
 
 #include "Engine/Debug/DebugDraw.h"
@@ -56,24 +74,6 @@ void CapsuleCollider::DrawPhysicsDebug(RenderView& view)
         DEBUG_DRAW_TUBE(_transform.LocalToWorld(_center), rot, radius, height, _staticActor ? Color::CornflowerBlue : Color::Orchid, 0, true);
     else
         DEBUG_DRAW_WIRE_TUBE(_transform.LocalToWorld(_center), rot, radius, height, Color::GreenYellow * 0.8f, 0, true);
-}
-
-void CapsuleCollider::SetDirection(ColliderOrientationDirection value)
-{
-    _direction = value;
-    switch (value)
-    {
-    case ColliderOrientationDirection::XAxis:
-        SetColliderOrientation(Quaternion::Identity);
-        break;
-    case ColliderOrientationDirection::YAxis:
-        SetColliderOrientation(Quaternion::Euler(0, 0, 90));
-        break;
-    case ColliderOrientationDirection::ZAxis:
-        SetColliderOrientation(Quaternion::Euler(0, 90, 0));
-        break;
-    default: ;
-    }
 }
 
 void CapsuleCollider::OnDebugDrawSelected()
@@ -119,7 +119,7 @@ void CapsuleCollider::Deserialize(DeserializeStream& stream, ISerializeModifier*
     DESERIALIZE_MEMBER(Radius, _radius);
     DESERIALIZE_MEMBER(Height, _height);
     DESERIALIZE(_direction);
-    SetDirection(_direction);
+    SetColliderDirection(_direction);
 }
 
 void CapsuleCollider::UpdateBounds()

--- a/Source/Engine/Physics/Colliders/CapsuleCollider.h
+++ b/Source/Engine/Physics/Colliders/CapsuleCollider.h
@@ -10,8 +10,19 @@
 /// </summary>
 API_ENUM() enum class ColliderOrientationDirection
 {
+    /// <summary>
+    /// Orient to the X-Axis.
+    /// </summary>
     XAxis,
+
+    /// <summary>
+    /// Orient to the Y-Axis.
+    /// </summary>
     YAxis,
+
+    /// <summary>
+    /// Orient to the Z-Axis.
+    /// </summary>
     ZAxis
 };
 
@@ -66,9 +77,8 @@ public:
     /// <summary>
     /// Gets the orientation direction of the capsule collider.
     /// </summary>
-    /// <remarks>The capsule height will be scaled by the actor's world scale.</remarks>
     API_PROPERTY(Attributes="EditorOrder(111), DefaultValue(typeof(ColliderOrientationDirection), \"YAxis\"), EditorDisplay(\"Collider\")")
-    FORCE_INLINE ColliderOrientationDirection GetDirection() const
+    FORCE_INLINE ColliderOrientationDirection GetColliderDirection() const
     {
         return _direction;
     }
@@ -76,8 +86,7 @@ public:
     /// <summary>
     /// Sets the orientation direction of the capsule collider.
     /// </summary>
-    /// <remarks>The capsule height will be scaled by the actor's world scale.</remarks>
-    API_PROPERTY() void SetDirection(ColliderOrientationDirection value);
+    API_PROPERTY() void SetColliderDirection(ColliderOrientationDirection value);
 
 public:
     // [Collider]

--- a/Source/Engine/Physics/Colliders/CapsuleCollider.h
+++ b/Source/Engine/Physics/Colliders/CapsuleCollider.h
@@ -6,6 +6,16 @@
 #include "Engine/Core/Math/OrientedBoundingBox.h"
 
 /// <summary>
+/// The collider orientation direction.
+/// </summary>
+API_ENUM() enum class ColliderOrientationDirection
+{
+    XAxis,
+    YAxis,
+    ZAxis
+};
+
+/// <summary>
 /// A capsule-shaped primitive collider.
 /// </summary>
 /// <remarks>Capsules are cylinders with a half-sphere at each end centered at the origin and extending along the X axis, and two hemispherical ends.</remarks>
@@ -18,6 +28,7 @@ private:
     float _radius;
     float _height;
     OrientedBoundingBox _orientedBox;
+    ColliderOrientationDirection _direction;
 
 public:
     /// <summary>
@@ -51,6 +62,22 @@ public:
     /// </summary>
     /// <remarks>The capsule height will be scaled by the actor's world scale.</remarks>
     API_PROPERTY() void SetHeight(float value);
+
+    /// <summary>
+    /// Gets the orientation direction of the capsule collider.
+    /// </summary>
+    /// <remarks>The capsule height will be scaled by the actor's world scale.</remarks>
+    API_PROPERTY(Attributes="EditorOrder(111), DefaultValue(typeof(ColliderOrientationDirection), \"YAxis\"), EditorDisplay(\"Collider\")")
+    FORCE_INLINE ColliderOrientationDirection GetDirection() const
+    {
+        return _direction;
+    }
+
+    /// <summary>
+    /// Sets the orientation direction of the capsule collider.
+    /// </summary>
+    /// <remarks>The capsule height will be scaled by the actor's world scale.</remarks>
+    API_PROPERTY() void SetDirection(ColliderOrientationDirection value);
 
 public:
     // [Collider]

--- a/Source/Engine/Physics/Colliders/Collider.h
+++ b/Source/Engine/Physics/Colliders/Collider.h
@@ -20,6 +20,7 @@ API_CLASS(Abstract) class FLAXENGINE_API Collider : public PhysicsColliderActor
     DECLARE_SCENE_OBJECT_ABSTRACT(Collider);
 protected:
     Vector3 _center;
+    Quaternion _colliderOrientation;
     bool _isTrigger;
     void* _shape;
     void* _staticActor;
@@ -87,6 +88,19 @@ public:
     /// Colliders whose distance is less than the sum of their ContactOffset values will generate contacts. The contact offset must be positive. Contact offset allows the collision detection system to predictively enforce the contact constraint even when the objects are slightly separated.
     /// </remarks>
     API_PROPERTY() void SetContactOffset(float value);
+
+    /// <summary>
+    /// Gets the collider's orientation, measured in the object's local space.
+    /// </summary>
+    FORCE_INLINE Quaternion GetColliderOrientation() const
+    {
+        return _colliderOrientation;
+    }
+
+    /// <summary>
+    /// Sets the orientation of the collider, measured in the object's local space.
+    /// </summary>
+    void SetColliderOrientation(const Quaternion& value);
 
     /// <summary>
     /// The physical material used to define the collider physical properties.


### PR DESCRIPTION
Adds the ability to rotate capsule collider to the x, y, or z axis. This also adds the ability to orient any collider without changing the orientation of the actor (although it is not exposed to the editor as the main purpose of this PR is for the capsule collider). #1081

![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/865e4291-5013-4a64-8bc3-7fcf3a111256)
Image shows the name "Direction" but it has been changed to "Collider Direction" because otherwise it will hide Actor.Direction. if there is a better name, let me know and I will update it.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/008279c0-94ac-4ffa-89bf-eab497f85fd1)
