### PR TITLE
Limits character controller up direction between (-1, 1)

### DIFF
--- a/Source/Engine/Physics/Colliders/CharacterController.h
+++ b/Source/Engine/Physics/Colliders/CharacterController.h
@@ -127,7 +127,7 @@ public:
     /// <summary>
     /// Gets the character up vector.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(240), DefaultValue(typeof(Vector3), \"0,1,0\"), EditorDisplay(\"Character Controller\")")
+    API_PROPERTY(Attributes="EditorOrder(240), DefaultValue(typeof(Vector3), \"0,1,0\"), EditorDisplay(\"Character Controller\"), Limit(-1, 1)")
     Vector3 GetUpDirection() const;
 
     /// <summary>


### PR DESCRIPTION
I dont think there is any reason to have a values other than between -1 and 1 for the character controller up direction (even though I am sure it is normalized on the backend anyways). This limits the vector 3 values between -1 and 1.