### PR TITLE
Add `FindActor` by type and name.

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -1323,6 +1323,20 @@ Actor* Actor::FindActor(const MClass* type) const
     return nullptr;
 }
 
+Actor* Actor::FindActor(const MClass* type, const StringView& name) const
+{
+    CHECK_RETURN(type, nullptr);
+    if (GetClass()->IsSubClassOf(type) && StringUtils::Compare(*_name, *name) == 0)
+        return const_cast<Actor*>(this);
+    for (auto child : Children)
+    {
+        const auto actor = child->FindActor(type, name);
+        if (actor)
+            return actor;
+    }
+    return nullptr;
+}
+
 Script* Actor::FindScript(const MClass* type) const
 {
     CHECK_RETURN(type, nullptr);

--- a/Source/Engine/Level/Actor.cs
+++ b/Source/Engine/Level/Actor.cs
@@ -260,6 +260,17 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Tries to find the actor of the given type and name in this actor hierarchy (checks this actor and all children hierarchy).
+        /// </summary>
+        /// <param name="name">Name of the object.</param>
+        /// <typeparam name="T">Type of the object.</typeparam>
+        /// <returns>Actor instance if found, null otherwise.</returns>
+        public T FindActor<T>(string name) where T : Actor
+        {
+            return FindActor(typeof(T), name) as T;
+        }
+
+        /// <summary>
         /// Searches for all actors of a specific type in this actor children list.
         /// </summary>
         /// <typeparam name="T">Type of the actor to search for. Includes any actors derived from the type.</typeparam>

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -735,6 +735,14 @@ public:
     API_FUNCTION() Actor* FindActor(API_PARAM(Attributes="TypeReference(typeof(Actor))") const MClass* type) const;
 
     /// <summary>
+    /// Tries to find the actor of the given type and name in this actor hierarchy (checks this actor and all children hierarchy).
+    /// </summary>
+    /// <param name="type">Type of the actor to search for. Includes any actors derived from the type.</param>
+    /// <param name="name">The name of the actor.</param>
+    /// <returns>Actor instance if found, null otherwise.</returns>
+    API_FUNCTION() Actor* FindActor(API_PARAM(Attributes="TypeReference(typeof(Actor))") const MClass* type, const StringView& name) const;
+
+    /// <summary>
     /// Tries to find the actor of the given type in this actor hierarchy (checks this actor and all children hierarchy).
     /// </summary>
     /// <returns>Actor instance if found, null otherwise.</returns>
@@ -742,6 +750,17 @@ public:
     FORCE_INLINE T* FindActor() const
     {
         return (T*)FindActor(T::GetStaticClass());
+    }
+
+    /// <summary>
+    /// Tries to find the actor of the given type and name in this actor hierarchy (checks this actor and all children hierarchy).
+    /// </summary>
+    /// <param name="name">The name of the actor.</param>
+    /// <returns>Actor instance if found, null otherwise.</returns>
+    template<typename T>
+    FORCE_INLINE T* FindActor(const StringView& name) const
+    {
+        return (T*)FindActor(T::GetStaticClass(), name);
     }
 
     /// <summary>


### PR DESCRIPTION
This adds the ability to find an actor by a type and name which is usefully as it will cast for a user when they are looking for a specific actor type with a name. 

![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/ab067d54-5ff9-418c-8a9f-8b576120ad57)