### PR TITLE
Add search actors by parent tag

### DIFF
--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -783,6 +783,20 @@ void FindActorsRecursive(Actor* node, const Tag& tag, Array<Actor*>& result)
         FindActorsRecursive(child, tag, result);
 }
 
+void FindActorsRecursiveByParentTags(Actor* node, const Array<Tag>& tags, Array<Actor*>& result)
+{
+    for (Tag tag : tags)
+    {
+        if (node->HasTag(tag)) {
+            result.Add(node);
+            break;
+        }
+    }
+
+    for (Actor* child : node->Children)
+        FindActorsRecursiveByParentTags(child, tags, result);
+}
+
 Actor* Level::FindActor(const Tag& tag, Actor* root)
 {
     PROFILE_CPU();
@@ -819,6 +833,36 @@ Array<Actor*> Level::FindActors(const Tag& tag, Actor* root)
         for (Scene* scene : Scenes)
             FindActorsRecursive(scene, tag, result);
     }
+    return result;
+}
+
+API_FUNCTION()Array<Actor*> Level::FindActorsByParentTag(const Tag& parentTag, Actor* root)
+{
+    PROFILE_CPU();
+    Array<Actor*> result;
+    const Array<Tag> subTags = Tags::GetSubTags(parentTag);
+
+    if (subTags.Count() == 0)
+    {
+        return result;
+    }
+
+    if (subTags.Count() == 1)
+    {
+        result = FindActors(subTags[0], root);
+        return result;
+    }
+
+    if (root)
+    {
+        FindActorsRecursiveByParentTags(root, subTags, result);
+    }
+    else
+    {
+        for (Scene* scene : Scenes)
+            FindActorsRecursiveByParentTags(scene, subTags, result);
+    }
+
     return result;
 }
 
@@ -1301,7 +1345,7 @@ bool Level::SaveSceneToBytes(Scene* scene, rapidjson_flax::StringBuffer& outData
     }
 
     // Info
-    LOG(Info, "Scene saved! Time {0} ms", Math::CeilToInt(static_cast<float>((DateTime::NowUTC()- startTime).GetTotalMilliseconds())));
+    LOG(Info, "Scene saved! Time {0} ms", Math::CeilToInt(static_cast<float>((DateTime::NowUTC() - startTime).GetTotalMilliseconds())));
 
     // Fire event
     CallSceneEvent(SceneEventType::OnSceneSaved, scene, scene->GetID());

--- a/Source/Engine/Level/Level.h
+++ b/Source/Engine/Level/Level.h
@@ -397,6 +397,7 @@ public:
     /// <returns>Found actors list.</returns>
     API_FUNCTION() static Array<Actor*> GetActors(API_PARAM(Attributes="TypeReference(typeof(Actor))") const MClass* type);
 
+
     /// <summary>
     /// Finds all the scripts of the given type in all the loaded scenes.
     /// </summary>
@@ -478,6 +479,8 @@ public:
     /// <param name="root">The custom root actor to start searching from (hierarchical), otherwise null to search all loaded scenes.</param>
     /// <returns>Found actors or empty if none.</returns>
     API_FUNCTION() static Array<Actor*> FindActors(const Tag& tag, Actor* root = nullptr);
+
+    API_FUNCTION() static Array<Actor*> FindActorsByParentTag(const Tag& tag, Actor* root = nullptr);
 
 private:
     // Actor API

--- a/Source/Engine/Level/Level.h
+++ b/Source/Engine/Level/Level.h
@@ -465,17 +465,17 @@ public:
 
 public:
     /// <summary>
-    /// Tries to find the actor with the given parentTag (returns the first one found).
+    /// Tries to find the actor with the given tag (returns the first one found).
     /// </summary>
-    /// <param name="parentTag">The parentTag of the actor to search for.</param>
+    /// <param name="tag">The tag of the actor to search for.</param>
     /// <param name="root">The custom root actor to start searching from (hierarchical), otherwise null to search all loaded scenes.</param>
     /// <returns>Found actor or null.</returns>
     API_FUNCTION() static Actor* FindActor(const Tag& tag, Actor* root = nullptr);
 
     /// <summary>
-    /// Tries to find the actors with the given parentTag (returns all found).
+    /// Tries to find the actors with the given tag (returns all found).
     /// </summary>
-    /// <param name="parentTag">The parentTag of the actor to search for.</param>
+    /// <param name="tag">The tag of the actor to search for.</param>
     /// <param name="root">The custom root actor to start searching from (hierarchical), otherwise null to search all loaded scenes.</param>
     /// <returns>Found actors or empty if none.</returns>
     API_FUNCTION() static Array<Actor*> FindActors(const Tag& tag, Actor* root = nullptr);

--- a/Source/Engine/Level/Level.h
+++ b/Source/Engine/Level/Level.h
@@ -465,22 +465,28 @@ public:
 
 public:
     /// <summary>
-    /// Tries to find the actor with the given tag (returns the first one found).
+    /// Tries to find the actor with the given parentTag (returns the first one found).
     /// </summary>
-    /// <param name="tag">The tag of the actor to search for.</param>
+    /// <param name="parentTag">The parentTag of the actor to search for.</param>
     /// <param name="root">The custom root actor to start searching from (hierarchical), otherwise null to search all loaded scenes.</param>
     /// <returns>Found actor or null.</returns>
     API_FUNCTION() static Actor* FindActor(const Tag& tag, Actor* root = nullptr);
 
     /// <summary>
-    /// Tries to find the actors with the given tag (returns all found).
+    /// Tries to find the actors with the given parentTag (returns all found).
     /// </summary>
-    /// <param name="tag">The tag of the actor to search for.</param>
+    /// <param name="parentTag">The parentTag of the actor to search for.</param>
     /// <param name="root">The custom root actor to start searching from (hierarchical), otherwise null to search all loaded scenes.</param>
     /// <returns>Found actors or empty if none.</returns>
     API_FUNCTION() static Array<Actor*> FindActors(const Tag& tag, Actor* root = nullptr);
 
-    API_FUNCTION() static Array<Actor*> FindActorsByParentTag(const Tag& tag, Actor* root = nullptr);
+    /// <summary>
+    /// Search actors using a parent parentTag.
+    /// </summary>
+    /// <param name="parentTag">The tag to search actors with subtags belonging to this tag</param>
+    /// <param name="root">The custom root actor to start searching from (hierarchical), otherwise null to search all loaded scenes.</param>
+    /// <returns>Returns all actors that have subtags belonging to the given parent parentTag</returns>
+    API_FUNCTION() static Array<Actor*> FindActorsByParentTag(const Tag& parentTag, Actor* root = nullptr);
 
 private:
     // Actor API


### PR DESCRIPTION
This pr adds the ability to search actors using a parent tag. For example, there is a tag "Characters", this tag has subtags "Player", "Enemy". With this method I can find all players and enemies using the "Characters" tag