### PR TITLE
Usability improvements in Model/SkinnedModel/Material windows

### DIFF
--- a/Source/Editor/Viewport/Previews/MaterialPreview.cs
+++ b/Source/Editor/Viewport/Previews/MaterialPreview.cs
@@ -4,7 +4,9 @@ using System;
 using FlaxEditor.Surface;
 using FlaxEngine;
 using FlaxEngine.GUI;
+using FlaxEditor.Viewport.Widgets;
 using Object = FlaxEngine.Object;
+using FlaxEditor.GUI.ContextMenu;
 
 namespace FlaxEditor.Viewport.Previews
 {
@@ -64,6 +66,11 @@ namespace FlaxEditor.Viewport.Previews
         }
 
         /// <summary>
+        /// The "Model" widget button context menu.
+        /// </summary>
+        private ContextMenu modelWidgetButtonMenu;
+
+        /// <summary>
         /// Gets or sets the selected preview model index.
         /// </summary>
         public int SelectedModelIndex
@@ -95,20 +102,39 @@ namespace FlaxEditor.Viewport.Previews
             Task.AddCustomActor(_previewModel);
 
             // Create context menu for primitive switching
-            if (useWidgets && ViewWidgetButtonMenu != null)
+            if (useWidgets)
             {
-                ViewWidgetButtonMenu.AddSeparator();
-                var modelSelect = ViewWidgetButtonMenu.AddChildMenu("Model").ContextMenu;
-
-                // Fill out all models 
-                for (int i = 0; i < Models.Length; i++)
+                // Model mode widget
+                var modelMode = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
+                modelWidgetButtonMenu = new ContextMenu();
+                modelWidgetButtonMenu.VisibleChanged += ModelWidgetMenuOnVisibleChanged;
+                var previewLODSModeButton = new ViewportWidgetButton("Model", SpriteHandle.Invalid, modelWidgetButtonMenu)
                 {
-                    var button = modelSelect.AddButton(Models[i]);
-                    button.Tag = i;
-                }
+                    TooltipText = "Change material model",
+                    Parent = modelMode,
+                };
+                modelMode.Parent = this;
+            }
+        }
 
-                // Link the action
-                modelSelect.ButtonClicked += (button) => SelectedModelIndex = (int)button.Tag;
+        /// <summary>
+        /// Fill out all models
+        /// </summary>
+        /// <param name="control"></param>
+        private void ModelWidgetMenuOnVisibleChanged(Control control)
+        {
+            if (!control.Visible) return;
+
+            modelWidgetButtonMenu.ItemsContainer.DisposeChildren();
+
+            // Fill out all models
+            for (int i = 0; i < Models.Length; i++)
+            {
+                var index = i;
+                var button = modelWidgetButtonMenu.AddButton(Models[index]);
+                button.ButtonClicked += (button) => SelectedModelIndex = index;
+                button.Checked = SelectedModelIndex == index;
+                button.Tag = index;
             }
         }
 

--- a/Source/Editor/Viewport/Previews/ModelBasePreview.cs
+++ b/Source/Editor/Viewport/Previews/ModelBasePreview.cs
@@ -56,25 +56,6 @@ namespace FlaxEditor.Viewport.Previews
             // Link actors for rendering
             Task.AddCustomActor(StaticModel);
             Task.AddCustomActor(AnimatedModel);
-
-            if (useWidgets)
-            {
-                // Preview LOD
-                {
-                    var previewLOD = ViewWidgetButtonMenu.AddButton("Preview LOD");
-                    previewLOD.CloseMenuOnClick = false;
-                    var previewLODValue = new IntValueBox(-1, 90, 2, 70.0f, -1, 10, 0.02f)
-                    {
-                        Parent = previewLOD
-                    };
-                    previewLODValue.ValueChanged += () =>
-                    {
-                        StaticModel.ForcedLOD = previewLODValue.Value;
-                        AnimatedModel.ForcedLOD = previewLODValue.Value;
-                    };
-                    ViewWidgetButtonMenu.VisibleChanged += control => previewLODValue.Value = StaticModel.ForcedLOD;
-                }
-            }
         }
 
         private void OnBegin(RenderTask task, GPUContext context)
@@ -97,14 +78,22 @@ namespace FlaxEditor.Viewport.Previews
             AnimatedModel.Transform = new Transform(position, AnimatedModel.Orientation, scale);
         }
 
+        /// <summary>
+        /// Calls SetArcBallView from ViewportCamera
+        /// </summary>
+        public void CallSetArcBallView()
+        {
+            ViewportCamera.SetArcBallView(StaticModel.Model != null ? StaticModel.Box : AnimatedModel.Box);
+        }
+
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {
             switch (key)
             {
             case KeyboardKeys.F:
-                // Pay respect..
-                ViewportCamera.SetArcBallView(StaticModel.Model != null ? StaticModel.Box : AnimatedModel.Box);
+                    // Pay respect..
+                    CallSetArcBallView();
                 break;
             }
             return base.OnKeyDown(key);

--- a/Source/Editor/Windows/Assets/AnimationGraphWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationGraphWindow.cs
@@ -27,8 +27,8 @@ namespace FlaxEditor.Windows.Assets
     /// </summary>
     /// <seealso cref="AnimationGraph" />
     /// <seealso cref="AnimGraphSurface" />
-    /// <seealso cref="AnimatedModelPreview" />
-    public sealed class AnimationGraphWindow : VisjectSurfaceWindow<AnimationGraph, AnimGraphSurface, AnimatedModelPreview>, ISearchWindow
+    /// <seealso cref="AnimationPreview" />
+    public sealed class AnimationGraphWindow : VisjectSurfaceWindow<AnimationGraph, AnimGraphSurface, AnimationPreview>, ISearchWindow
     {
         internal static Guid BaseModelId = new Guid(1000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 

--- a/Source/Editor/Windows/Assets/CollisionDataWindow.cs
+++ b/Source/Editor/Windows/Assets/CollisionDataWindow.cs
@@ -182,6 +182,9 @@ namespace FlaxEditor.Windows.Assets
         {
             // Toolstrip
             _toolstrip.AddSeparator();
+
+            _toolstrip.AddButton(editor.Icons.CenterView64, () => _preview.CallSetArcBallView()).LinkTooltip("Show whole collision");
+
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/physics/colliders/collision-data.html")).LinkTooltip("See documentation to learn more");
 
             // Split Panel

--- a/Source/Editor/Windows/Assets/ModelWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelWindow.cs
@@ -778,12 +778,18 @@ namespace FlaxEditor.Windows.Assets
         private MeshDataCache _meshData;
         private ModelImportSettings _importSettings = new ModelImportSettings();
         private float _backfacesThreshold = 0.6f;
+        private ToolStripButton _showCurrentLODButton;
 
         /// <inheritdoc />
         public ModelWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
             // Toolstrip
+            _toolstrip.AddSeparator();
+            _showCurrentLODButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Info64, () => _preview.ShowCurrentLOD = !_preview.ShowCurrentLOD).LinkTooltip("Show LOD statistics");
+
+            _toolstrip.AddButton(editor.Icons.CenterView64, () => _preview.CallSetArcBallView()).LinkTooltip("Show whole model");
+
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/graphics/models/index.html")).LinkTooltip("See documentation to learn more");
 
@@ -868,6 +874,8 @@ namespace FlaxEditor.Windows.Assets
                 }
             }
 
+            _showCurrentLODButton.Checked = _preview.ShowCurrentLOD;
+
             base.Update(deltaTime);
         }
 
@@ -945,6 +953,7 @@ namespace FlaxEditor.Windows.Assets
             base.OnDestroy();
 
             Object.Destroy(ref _highlightActor);
+            _showCurrentLODButton = null;
         }
     }
 }

--- a/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
+++ b/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
@@ -186,7 +186,7 @@ namespace FlaxEditor.Windows.Assets
         }
 
         private readonly SplitPanel _split;
-        private readonly AnimatedModelPreview _preview;
+        private readonly SkeletonMaskPreview _preview;
         private readonly CustomEditorPresenter _propertiesPresenter;
         private readonly PropertiesProxy _properties;
         private readonly ToolStripButton _saveButton;
@@ -198,6 +198,9 @@ namespace FlaxEditor.Windows.Assets
             // Toolstrip
             _saveButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save asset to the file");
             _toolstrip.AddSeparator();
+
+            _toolstrip.AddButton(editor.Icons.CenterView64, () => _preview.CallSetArcBallView()).LinkTooltip("Show whole model");
+
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/skeleton-mask.html")).LinkTooltip("See documentation to learn more");
 
             // Split Panel
@@ -210,7 +213,7 @@ namespace FlaxEditor.Windows.Assets
             };
 
             // Model preview
-            _preview = new AnimatedModelPreview(true)
+            _preview = new SkeletonMaskPreview(true)
             {
                 ViewportCamera = new FPSCamera(),
                 ShowNodes = true,

--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -1121,7 +1121,7 @@ namespace FlaxEditor.Windows.Assets
 
             _showNodesButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Bone64, () => _preview.ShowNodes = !_preview.ShowNodes).LinkTooltip("Show animated model nodes debug view");
 
-            _toolstrip.AddButton(editor.Icons.CenterView64, () =>  _preview.CallSetArcBallView()).LinkTooltip("Show whole model");
+            _toolstrip.AddButton(editor.Icons.CenterView64, () => _preview.CallSetArcBallView()).LinkTooltip("Show whole model");
 
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/skinned-model/index.html")).LinkTooltip("See documentation to learn more");

--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -1105,6 +1105,7 @@ namespace FlaxEditor.Windows.Assets
         private Preview _preview;
         private AnimatedModel _highlightActor;
         private ToolStripButton _showNodesButton;
+        private ToolStripButton _showCurrentLODButton;
 
         private MeshData[][] _meshDatas;
         private bool _meshDatasInProgress;
@@ -1116,7 +1117,12 @@ namespace FlaxEditor.Windows.Assets
         {
             // Toolstrip
             _toolstrip.AddSeparator();
+            _showCurrentLODButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Info64, () => _preview.ShowCurrentLOD = !_preview.ShowCurrentLOD).LinkTooltip("Show LOD statistics");
+
             _showNodesButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Bone64, () => _preview.ShowNodes = !_preview.ShowNodes).LinkTooltip("Show animated model nodes debug view");
+
+            _toolstrip.AddButton(editor.Icons.CenterView64, () =>  _preview.CallSetArcBallView()).LinkTooltip("Show whole model");
+
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/skinned-model/index.html")).LinkTooltip("See documentation to learn more");
 
@@ -1265,6 +1271,7 @@ namespace FlaxEditor.Windows.Assets
                 }
             }
 
+            _showCurrentLODButton.Checked = _preview.ShowCurrentLOD;
             _showNodesButton.Checked = _preview.ShowNodes;
 
             base.Update(deltaTime);
@@ -1348,6 +1355,7 @@ namespace FlaxEditor.Windows.Assets
 
             Object.Destroy(ref _highlightActor);
             _preview = null;
+            _showCurrentLODButton = null;
             _showNodesButton = null;
         }
     }


### PR DESCRIPTION
**Improvements to Model / SkinnedModel windows**
- I added a Button for the **CurrentLOD**.
- I added a Button that centers the model.
- I fixed the **ScreenSize** and added a callsign for Auto LOD.
- I added a DropdownButton to the **PreviewLOD** that works dynamically based on the amount of LODS in the model.

![Captura de Tela (276)](https://github.com/FlaxEngine/FlaxEngine/assets/101017436/7d4398b4-9dc2-42c0-9044-0f39937d4e86)

**Improved material window**
- I added a DropdownButton to the model

![Captura de Tela (277)](https://github.com/FlaxEngine/FlaxEngine/assets/101017436/63de7a5b-900b-4a26-8cd0-9e7a5c5cb239)

⚠️**This commit of mine `Separation of some Previews to fix bugs` corrects some problems with the `AnimationGraph` / `SkeletonMask` windows and adds a `Button CenterModel` for the `SkeletonMask` and for the `CollisionData`**

**Before:**
![12](https://github.com/FlaxEngine/FlaxEngine/assets/101017436/0d65e1d5-79a5-49ce-ae5e-7c2104c38072)

**After:**
![13](https://github.com/FlaxEngine/FlaxEngine/assets/101017436/c5171f66-5d9a-4c22-9676-390cb680914f)

