### PR TITLE
Max distance audio source

### DIFF
--- a/Source/Engine/Audio/Audio.cpp
+++ b/Source/Engine/Audio/Audio.cpp
@@ -265,6 +265,14 @@ void AudioService::Update()
     AudioBackend::Update();
 }
 
+Array<AudioSource*>& Audio::GetAudioSources() {
+    return Sources;
+}
+
+Array<AudioListener*>& Audio::GetAudioListeners() {
+    return Listeners;
+}
+
 void AudioService::Dispose()
 {
     ASSERT(Audio::Sources.IsEmpty() && Audio::Listeners.IsEmpty());

--- a/Source/Engine/Audio/Audio.h
+++ b/Source/Engine/Audio/Audio.h
@@ -104,4 +104,6 @@ public:
 
     static void OnAddSource(AudioSource* source);
     static void OnRemoveSource(AudioSource* source);
+    static Array<AudioSource*>& GetAudioSources();
+    static Array<AudioListener*>& GetAudioListeners();
 };

--- a/Source/Engine/Audio/AudioSource.cpp
+++ b/Source/Engine/Audio/AudioSource.cpp
@@ -138,7 +138,7 @@ void AudioSource::CheckMaxDistance(Vector3 pos)
     bool audioEnabled = false;
 
     // Check if spacialization is allowed
-    if (!_allowSpatialization)
+    if (!_allowSpatialization || _maxDistance <= 0)
     {
         audioEnabled = true; // Force 2D audio playback
     }

--- a/Source/Engine/Audio/AudioSource.h
+++ b/Source/Engine/Audio/AudioSource.h
@@ -171,7 +171,7 @@ public:
     /// <summary>
     /// Gets the maximum distance at which it is responsible for stopping the audio
     /// </summary>
-    API_PROPERTY(Attributes = "EditorOrder(70), DefaultValue(1000.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
+    API_PROPERTY(Attributes = "EditorOrder(70), DefaultValue(1000.0f), Limit(0.1f, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
     FORCE_INLINE float GetMaxDistance() const
     {
         return _maxDistance;
@@ -187,7 +187,7 @@ public:
     /// <summary>
     /// Gets the minimum distance at which audio attenuation starts. When the listener is closer to the source than this value, audio is heard at full volume. Once farther away the audio starts attenuating.
     /// </summary>
-    API_PROPERTY(Attributes = "EditorOrder(80), DefaultValue(100.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
+    API_PROPERTY(Attributes = "EditorOrder(80), DefaultValue(100.0f), Limit(0.1f, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
         FORCE_INLINE float GetMinDistance() const
     {
         return _minDistance;

--- a/Source/Engine/Audio/AudioSource.h
+++ b/Source/Engine/Audio/AudioSource.h
@@ -169,16 +169,16 @@ public:
     API_PROPERTY() void SetAllowSpatialization(bool value);
 
     /// <summary>
-    /// Gets the maximum distance at which it is responsible for stopping the audio
+    /// Gets the maximum distance at which it is responsible for clipping the audio. It is possible to disable the Max Distance by setting the value 0
     /// </summary>
-    API_PROPERTY(Attributes = "EditorOrder(70), DefaultValue(1000.0f), Limit(0.1f, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
+    API_PROPERTY(Attributes = "EditorOrder(70), DefaultValue(1000.0f), Limit(0.0f, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
     FORCE_INLINE float GetMaxDistance() const
     {
         return _maxDistance;
     }
 
     /// <summary>
-    /// Sets the maximum distance at which it is responsible for stopping the audio
+    /// Sets the maximum distance at which it is responsible for clipping the audio. It is possible to disable the Max Distance by setting the value 0
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>

--- a/Source/Engine/Audio/AudioSource.h
+++ b/Source/Engine/Audio/AudioSource.h
@@ -48,11 +48,13 @@ private:
     float _pitch;
     float _pan = 0.0f;
     float _minDistance;
+    float _maxDistance;
     float _attenuation = 1.0f;
     float _dopplerFactor = 1.0f;
     bool _loop;
     bool _playOnStart;
     bool _allowSpatialization;
+    bool _audioEnabled;
 
     bool _isActuallyPlayingSth = false;
     bool _needToUpdateStreamingBuffers = false;
@@ -153,10 +155,40 @@ public:
     API_PROPERTY() void SetPlayOnStart(bool value);
 
     /// <summary>
+    /// If checked, source can play spatial 3d audio (when audio clip supports it), otherwise will always play as 2d sound. At 0, no distance attenuation ever occurs.
+    /// </summary>
+    API_PROPERTY(Attributes = "EditorOrder(60), DefaultValue(false), EditorDisplay(\"Audio Source\"), Header(\"3D settings\")")
+    FORCE_INLINE bool GetAllowSpatialization() const
+    {
+        return _allowSpatialization;
+    }
+
+    /// <summary>
+    /// If checked, source can play spatial 3d audio (when audio clip supports it), otherwise will always play as 2d sound.
+    /// </summary>
+    API_PROPERTY() void SetAllowSpatialization(bool value);
+
+    /// <summary>
+    /// Gets the maximum distance at which it is responsible for stopping the audio
+    /// </summary>
+    API_PROPERTY(Attributes = "EditorOrder(70), DefaultValue(1000.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
+    FORCE_INLINE float GetMaxDistance() const
+    {
+        return _maxDistance;
+    }
+
+    /// <summary>
+    /// Sets the maximum distance at which it is responsible for stopping the audio
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    API_PROPERTY() void SetMaxDistance(float value);
+
+    /// <summary>
     /// Gets the minimum distance at which audio attenuation starts. When the listener is closer to the source than this value, audio is heard at full volume. Once farther away the audio starts attenuating.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(60), DefaultValue(1000.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\")")
-    FORCE_INLINE float GetMinDistance() const
+    API_PROPERTY(Attributes = "EditorOrder(80), DefaultValue(100.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
+        FORCE_INLINE float GetMinDistance() const
     {
         return _minDistance;
     }
@@ -169,7 +201,7 @@ public:
     /// <summary>
     /// Gets the attenuation that controls how quickly does audio volume drop off as the listener moves further from the source.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(70), DefaultValue(1.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\")")
+    API_PROPERTY(Attributes="EditorOrder(90), DefaultValue(1.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
     FORCE_INLINE float GetAttenuation() const
     {
         return _attenuation;
@@ -183,7 +215,7 @@ public:
     /// <summary>
     /// Gets the doppler effect factor. Scale for source velocity. Default is 1.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(75), DefaultValue(1.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\")")
+    API_PROPERTY(Attributes="EditorOrder(100), DefaultValue(1.0f), Limit(0, float.MaxValue, 0.1f), EditorDisplay(\"Audio Source\"), VisibleIf(nameof(AllowSpatialization))")
     FORCE_INLINE float GetDopplerFactor() const
     {
         return _dopplerFactor;
@@ -193,20 +225,6 @@ public:
     /// Sets the doppler effect factor. Scale for source velocity. Default is 1.
     /// </summary>
     API_PROPERTY() void SetDopplerFactor(float value);
-
-    /// <summary>
-    /// If checked, source can play spatial 3d audio (when audio clip supports it), otherwise will always play as 2d sound. At 0, no distance attenuation ever occurs.
-    /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(80), DefaultValue(true), EditorDisplay(\"Audio Source\")")
-    FORCE_INLINE bool GetAllowSpatialization() const
-    {
-        return _allowSpatialization;
-    }
-
-    /// <summary>
-    /// If checked, source can play spatial 3d audio (when audio clip supports it), otherwise will always play as 2d sound.
-    /// </summary>
-    API_PROPERTY() void SetAllowSpatialization(bool value);
 
 public:
     /// <summary>
@@ -277,6 +295,18 @@ public:
     /// </summary>
     void Cleanup();
 
+    /// <summary>
+    /// Sets a value for the controller that is responsible for turning audio on and off based on maximum distance
+    /// </summary>
+    /// <param name="value"></param>
+    void SetAudioEnabled(bool enabled);
+
+    /// <summary>
+    /// Gets a value for the controller that is responsible for turning audio on and off based on maximum distance
+    /// </summary>
+    /// <returns></returns>
+    bool GetAudioEnabled() const { return _audioEnabled; }
+
 private:
     void OnClipChanged();
     void OnClipLoaded();
@@ -290,6 +320,11 @@ private:
     /// Plays the audio source. Should have buffer(s) binded before.
     /// </summary>
     void PlayInternal();
+
+    /// <summary>
+    /// System responsible for all the calculation of the distance from the AudioListener to the AudioSource based on the maximum distance, thus assigning a value to the controller of that system
+    /// </summary>
+    void CheckMaxDistance(Vector3 pos);
 
     void Update();
 

--- a/Source/Engine/Audio/OpenAL/AudioBackendOAL.cpp
+++ b/Source/Engine/Audio/OpenAL/AudioBackendOAL.cpp
@@ -423,23 +423,38 @@ void AudioBackendOAL::Source_SpatialSetupChanged(AudioSource* source)
     const bool is3D = source->Is3D();
     ALC_FOR_EACH_CONTEXT()
         const uint32 sourceID = source->SourceIDs[i];
-        alSourcei(sourceID, AL_SOURCE_RELATIVE, !is3D);
-        if (is3D)
-        {
+    alSourcei(sourceID, AL_SOURCE_RELATIVE, !is3D);
+    if (is3D)
+    {
 #ifdef AL_SOFT_source_spatialize
-            alSourcei(sourceID, AL_SOURCE_SPATIALIZE_SOFT, AL_TRUE);
+        alSourcei(sourceID, AL_SOURCE_SPATIALIZE_SOFT, AL_TRUE);
 #endif
-            alSourcef(sourceID, AL_ROLLOFF_FACTOR, source->GetAttenuation());
-            alSourcef(sourceID, AL_DOPPLER_FACTOR, source->GetDopplerFactor());
-            alSourcef(sourceID, AL_REFERENCE_DISTANCE, FLAX_DST_TO_OAL(source->GetMinDistance()));
+        alSourcef(sourceID, AL_ROLLOFF_FACTOR, source->GetAttenuation());
+        alSourcef(sourceID, AL_DOPPLER_FACTOR, source->GetDopplerFactor());
+        alSourcef(sourceID, AL_REFERENCE_DISTANCE, FLAX_DST_TO_OAL(source->GetMinDistance()));
+
+        // Check if audio is enabled
+        if (!source->GetAudioEnabled())
+        {
+            // Set volume to zero if audio is disabled
+            alSourcef(sourceID, AL_GAIN, 0.0f);
         }
         else
         {
-            alSourcef(sourceID, AL_ROLLOFF_FACTOR, 0.0f);
-            alSourcef(sourceID, AL_DOPPLER_FACTOR, 1.0f);
-            alSourcef(sourceID, AL_REFERENCE_DISTANCE, 0.0f);
+            // Set volume based on AudioSource volume
+            alSourcef(sourceID, AL_GAIN, source->GetVolume());
         }
     }
+    else
+    {
+        // Set volume based on AudioSource volume
+        alSourcef(sourceID, AL_GAIN, source->GetVolume());
+
+        alSourcef(sourceID, AL_ROLLOFF_FACTOR, 0.0f);
+        alSourcef(sourceID, AL_DOPPLER_FACTOR, 1.0f);
+        alSourcef(sourceID, AL_REFERENCE_DISTANCE, 0.0f);
+    }
+}
 }
 
 void AudioBackendOAL::Source_ClipLoaded(AudioSource* source)

--- a/Source/Engine/Audio/OpenAL/AudioBackendOAL.cpp
+++ b/Source/Engine/Audio/OpenAL/AudioBackendOAL.cpp
@@ -383,10 +383,13 @@ void AudioBackendOAL::Source_TransformChanged(AudioSource* source)
 
 void AudioBackendOAL::Source_VolumeChanged(AudioSource* source)
 {
-    ALC_FOR_EACH_CONTEXT()
-        const uint32 sourceID = source->SourceIDs[i];
+    if (source->GetAudioEnabled())
+    {
+        ALC_FOR_EACH_CONTEXT()
+            const uint32 sourceID = source->SourceIDs[i];
         alSourcef(sourceID, AL_GAIN, source->GetVolume());
     }
+}
 }
 
 void AudioBackendOAL::Source_PitchChanged(AudioSource* source)
@@ -434,15 +437,15 @@ void AudioBackendOAL::Source_SpatialSetupChanged(AudioSource* source)
         alSourcef(sourceID, AL_REFERENCE_DISTANCE, FLAX_DST_TO_OAL(source->GetMinDistance()));
 
         // Check if audio is enabled
-        if (!source->GetAudioEnabled())
-        {
-            // Set volume to zero if audio is disabled
-            alSourcef(sourceID, AL_GAIN, 0.0f);
-        }
-        else
+        if (source->GetAudioEnabled())
         {
             // Set volume based on AudioSource volume
             alSourcef(sourceID, AL_GAIN, source->GetVolume());
+        }
+        else
+        {
+            // Set volume to zero if audio is disabled
+            alSourcef(sourceID, AL_GAIN, 0.0f);
         }
     }
     else


### PR DESCRIPTION
🎧 This PR adds a `MaxDistance` parameter for Audio 3D in `AudioSource`. The purpose of Max Distance is to cut the audio based on the value defined in relation to the distance of the `AudioListener` . I added a `VisibleIf` to `Allow Spatialization`

**This demo video contains audio**

https://github.com/FlaxEngine/FlaxEngine/assets/101017436/de6bc10f-fe87-4183-839d-aa2699c87912

