### PR TITLE
Fix binding generation for interfaces

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -1239,7 +1239,7 @@ namespace Flax.Build.Bindings
                             throw new Exception($"Class {classInfo.Name} cannot implement interface {interfaceInfo.Name} because it requires ScriptingObject as a base class.");
 
                         contents.AppendLine();
-                        if (functionInfo.Comment.Length != 0)
+                        if (functionInfo.Comment != null && functionInfo.Comment.Length != 0)
                             contents.Append(indent).AppendLine("/// <inheritdoc />");
                         GenerateCSharpAttributes(buildData, contents, indent, classInfo, functionInfo.Attributes, null, false, useUnmanaged);
                         contents.Append(indent).Append(GenerateCSharpAccessLevel(functionInfo.Access));


### PR DESCRIPTION
Currently, if you were going to try and compile this snippet of code:

```
API_INTERFACE() class GAME_API IExample
{
    DECLARE_SCRIPTING_TYPE_MINIMAL(IExample);

    API_FUNCTION() virtual void Test() = 0;
};

API_CLASS() class GAME_API Inherit : public Script, public IExample
{
    DECLARE_SCRIPTING_TYPE_MINIMAL(Inherit);
};
```

you would get this in return:

```
2>Failed to generate C# bindings for class Inherit.
2>Exception: Object reference not set to an instance of an object.
2>Stack trace:
2>   at Flax.Build.Bindings.BindingsGenerator.GenerateCSharpClass(BuildData buildData, StringBuilder contents, String indent, ClassInfo classInfo) in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Bindings\BindingsGenerator.CSharp.cs:line 1242
2>   at Flax.Build.Bindings.BindingsGenerator.GenerateCSharpType(BuildData buildData, StringBuilder contents, String indent, Object type) in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Bindings\BindingsGenerator.CSharp.cs:line 2041
2>   at Flax.Build.Bindings.BindingsGenerator.GenerateCSharp(BuildData buildData, ModuleInfo moduleInfo, BindingsResult& bindings) in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Bindings\BindingsGenerator.CSharp.cs:line 2106
2>   at Flax.Build.Bindings.BindingsGenerator.GenerateBindings(BuildData buildData, Module module, BuildOptions& moduleOptions, BindingsResult& bindings) in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Bindings\BindingsGenerator.cs:line 640
2>   at Flax.Build.Builder.BuildModuleInner(BuildData buildData, Module module, BuildOptions moduleOptions, Boolean withApi) in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Build\NativeCpp\Builder.NativeCpp.cs:line 469
2>   at Flax.Build.Builder.BuildModule(BuildData buildData, Module module) in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Build\NativeCpp\Builder.NativeCpp.cs:line 386
2>   at Flax.Build.Builder.BuildTargetNativeCpp(RulesAssembly rules, TaskGraph graph, Target target, Dictionary`2 buildContext, Toolchain toolchain, TargetConfiguration configuration, Boolean isBuildingReference, Boolean skipBuild) in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Build\NativeCpp\Builder.NativeCpp.cs:line 894
2>   at Flax.Build.Builder.BuildTargets() in S:\SpaceRisk\FlaxEngine\Source\Tools\Flax.Build\Build\Builder.cs:line 361
2>   at Flax.Build.Program.Main()
```

This PR fixes the underlying exception caused by lack of comments over API_FUNCTION() in interfaces.