### PR TITLE
Support decimal values in Font sizes

### DIFF
--- a/Source/Editor/Windows/SplashScreen.cpp
+++ b/Source/Editor/Windows/SplashScreen.cpp
@@ -304,6 +304,6 @@ void SplashScreen::OnFontLoaded(Asset* asset)
 
     // Create fonts
     const float s = _dpiScale;
-    _titleFont = font->CreateFont((uint32)(35 * s));
-    _subtitleFont = font->CreateFont((uint32)(9 * s));
+    _titleFont = font->CreateFont(35 * s);
+    _subtitleFont = font->CreateFont(9 * s);
 }

--- a/Source/Engine/Render2D/Font.cpp
+++ b/Source/Engine/Render2D/Font.cpp
@@ -7,7 +7,7 @@
 #include "Engine/Threading/Threading.h"
 #include "IncludeFreeType.h"
 
-Font::Font(FontAsset* parentAsset, int32 size)
+Font::Font(FontAsset* parentAsset, float size)
     : ManagedScriptingObject(SpawnParams(Guid::New(), Font::TypeInitializer))
     , _asset(parentAsset)
     , _size(size)
@@ -436,7 +436,7 @@ void Font::FlushFaceSize() const
 {
     // Set the character size
     const FT_Face face = _asset->GetFTFace();
-    const FT_Error error = FT_Set_Char_Size(face, 0, ConvertPixelTo26Dot6<FT_F26Dot6>((float)_size * FontManager::FontScale), DefaultDPI, DefaultDPI);
+    const FT_Error error = FT_Set_Char_Size(face, 0, ConvertPixelTo26Dot6<FT_F26Dot6>(_size * FontManager::FontScale), DefaultDPI, DefaultDPI);
     if (error)
     {
         LOG_FT_ERROR(error);

--- a/Source/Engine/Render2D/Font.h
+++ b/Source/Engine/Render2D/Font.h
@@ -228,7 +228,7 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(Font);
 private:
 
     FontAsset* _asset;
-    int32 _size;
+    float _size;
     int32 _height;
     int32 _ascender;
     int32 _descender;
@@ -244,7 +244,7 @@ public:
     /// </summary>
     /// <param name="parentAsset">The parent asset.</param>
     /// <param name="size">The size.</param>
-    Font(FontAsset* parentAsset, int32 size);
+    Font(FontAsset* parentAsset, float size);
 
     /// <summary>
     /// Finalizes an instance of the <see cref="Font"/> class.
@@ -264,7 +264,7 @@ public:
     /// <summary>
     /// Gets font size.
     /// </summary>
-    API_PROPERTY() FORCE_INLINE int32 GetSize() const
+    API_PROPERTY() FORCE_INLINE float GetSize() const
     {
         return _size;
     }

--- a/Source/Engine/Render2D/FontAsset.cpp
+++ b/Source/Engine/Render2D/FontAsset.cpp
@@ -92,7 +92,7 @@ void FontAsset::SetOptions(const FontOptions& value)
     _options = value;
 }
 
-Font* FontAsset::CreateFont(int32 size)
+Font* FontAsset::CreateFont(float size)
 {
     PROFILE_CPU();
 

--- a/Source/Engine/Render2D/FontAsset.h
+++ b/Source/Engine/Render2D/FontAsset.h
@@ -139,7 +139,7 @@ public:
     /// </summary>
     /// <param name="size">The font characters size.</param>
     /// <returns>The created font object.</returns>
-    API_FUNCTION() Font* CreateFont(int32 size);
+    API_FUNCTION() Font* CreateFont(float size);
 
     /// <summary>
     /// Gets the font with bold style. Returns itself or creates a new virtual font asset using this font but with bold option enabled.

--- a/Source/Engine/Render2D/FontReference.cs
+++ b/Source/Engine/Render2D/FontReference.cs
@@ -13,7 +13,7 @@ namespace FlaxEngine
         private FontAsset _font;
 
         [NoSerialize]
-        private int _size;
+        private float _size;
 
         [NoSerialize]
         private Font _cachedFont;
@@ -33,7 +33,7 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="font">The font.</param>
         /// <param name="size">The font size.</param>
-        public FontReference(FontAsset font, int size)
+        public FontReference(FontAsset font, float size)
         {
             _font = font;
             _size = size;
@@ -91,7 +91,7 @@ namespace FlaxEngine
         /// The size of the font characters.
         /// </summary>
         [EditorOrder(10), Limit(1, 500, 0.1f), Tooltip("The size of the font characters.")]
-        public int Size
+        public float Size
         {
             get => _size;
             set
@@ -187,7 +187,7 @@ namespace FlaxEngine
             unchecked
             {
                 int hashCode = _font ? _font.GetHashCode() : 0;
-                hashCode = (hashCode * 397) ^ _size;
+                hashCode = (hashCode * 397) ^ _size.GetHashCode();
                 return hashCode;
             }
         }

--- a/Source/Engine/UI/TextRender.cpp
+++ b/Source/Engine/UI/TextRender.cpp
@@ -73,14 +73,14 @@ void TextRender::SetColor(const Color& value)
     }
 }
 
-int32 TextRender::GetFontSize() const
+float TextRender::GetFontSize() const
 {
     return _size;
 }
 
-void TextRender::SetFontSize(int32 value)
+void TextRender::SetFontSize(float value)
 {
-    value = Math::Clamp(value, 1, 1024);
+    value = Math::Clamp(value, 1.0f, 1024.0f);
     if (_size != value)
     {
         _size = value;

--- a/Source/Engine/UI/TextRender.h
+++ b/Source/Engine/UI/TextRender.h
@@ -38,7 +38,7 @@ private:
     LocalizedString _text;
     Color _color;
     TextLayoutOptions _layoutOptions;
-    int32 _size;
+    float _size;
     int32 _sceneRenderingKey = -1;
 
     BoundingBox _localBox;
@@ -91,12 +91,12 @@ public:
     /// Gets the font characters size.
     /// </summary>
     API_PROPERTY(Attributes="EditorOrder(40), DefaultValue(32), Limit(1, 1000), EditorDisplay(\"Text\")")
-    int32 GetFontSize() const;
+    float GetFontSize() const;
 
     /// <summary>
     /// Sets the font characters size.
     /// </summary>
-    API_PROPERTY() void SetFontSize(int32 value);
+    API_PROPERTY() void SetFontSize(float value);
 
     /// <summary>
     /// The draw passes to use for rendering this object.


### PR DESCRIPTION
FreeType supports fractional font sizes, but currently it's impossible to utilize this through out the engine, as the size is stored as an integer. One other issue related to this is, there is no way to override the post-scaling of the font size based on the current DPI.

Storing the size in floating-point precision enables the first case and allows pre-multiplying the font size with the DPI to effectively turn off DPI-scaling of the requested font.