### PR TITLE
Implement optional object replication

### DIFF
--- a/Source/Engine/Networking/NetworkReplicationHierarchy.cpp
+++ b/Source/Engine/Networking/NetworkReplicationHierarchy.cpp
@@ -80,7 +80,11 @@ void NetworkReplicationNode::Update(NetworkReplicationHierarchyUpdateResult* res
     const float networkFPS = NetworkManager::NetworkFPS / result->ReplicationScale;
     for (NetworkReplicationHierarchyObject& obj : Objects)
     {
-        if (obj.ReplicationFPS <= 0.0f)
+        if (obj.ReplicationFPS < 0.0f)
+        {
+            continue;
+        }
+        else if (obj.ReplicationFPS == 0.0f)
         {
             // Always relevant
             result->AddObject(obj.Object);

--- a/Source/Engine/Networking/NetworkReplicationHierarchy.h
+++ b/Source/Engine/Networking/NetworkReplicationHierarchy.h
@@ -20,7 +20,7 @@ API_STRUCT(NoDefault, Namespace = "FlaxEngine.Networking") struct FLAXENGINE_API
 
     // The object to replicate.
     API_FIELD() ScriptingObjectReference<ScriptingObject> Object;
-    // The target amount of the replication updates per second (frequency of the replication). Constrained by NetworkManager::NetworkFPS. Use 0 for 'always relevant' object.
+    // The target amount of the replication updates per second (frequency of the replication). Constrained by NetworkManager::NetworkFPS. Use 0 for 'always relevant' object and < 0 for 'never relevant' objects that would only get synched on client join once.
     API_FIELD() float ReplicationFPS = 60;
     // The minimum distance from the player to the object at which it can process replication. For example, players further away won't receive object data. Use 0 if unused.
     API_FIELD() float CullDistance = 15000;


### PR DESCRIPTION
This PR makes sure to abide by guidelines of other use cases of `ReplicationFPS` being expected to be either a zero or higher for different behavior:
https://github.com/FlaxEngine/FlaxEngine/blob/228ef4e1306d8d38468d2e41d578154bdd90046b/Source/Engine/Networking/NetworkReplicationHierarchy.cpp#L50-L59
This opens up a possibility of making it that if you indeed were going to pass a negative `ReplicationFPS`, it would mean that the object would only get replicated on spawn without any future replications.
This solves https://github.com/FlaxEngine/FlaxEngine/issues/1178