### PR TITLE
Support changing C# nullable references context build option

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Flax.Build.Graph;
+using Flax.Build.NativeCpp;
 using Flax.Deploy;
 
 namespace Flax.Build
@@ -242,7 +243,9 @@ namespace Flax.Build
             args.Add("/filealign:512");
 #if USE_NETCORE
             args.Add("/langversion:11.0");
-            args.Add("-nowarn:8632"); // Nullable
+            args.Add(string.Format("/nullable:{0}", buildOptions.ScriptingAPI.CSharpNullableReferences.ToString().ToLowerInvariant()));
+            if (buildOptions.ScriptingAPI.CSharpNullableReferences == CSharpNullableReferences.Disable)
+                args.Add("-nowarn:8632"); // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 #else
             args.Add("/langversion:7.3");
 #endif

--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -24,6 +24,32 @@ namespace Flax.Build.NativeCpp
     }
 
     /// <summary>
+    /// The nullable context type used with reference types (C#).
+    /// </summary>
+    public enum CSharpNullableReferences
+    {
+        /// <summary>
+        /// The code is nullable oblivious, nullable warnings and language analysis features are disabled.
+        /// </summary>
+        Disable,
+
+        /// <summary>
+        /// The compiler enables all null reference analysis and all language features.
+        /// </summary>
+        Enable,
+
+        /// <summary>
+        /// The compiler performs all null analysis and emits warnings when code might dereference null.
+        /// </summary>
+        Warnings,
+
+        /// <summary>
+        /// The compiler doesn't perform null analysis or emit warnings when code might dereference null.
+        /// </summary>
+        Annotations,
+    }
+
+    /// <summary>
     /// The native C++ module build settings container.
     /// </summary>
     public sealed class BuildOptions
@@ -187,6 +213,15 @@ namespace Flax.Build.NativeCpp
             /// True if ignore compilation warnings due to missing code documentation comments.
             /// </summary>
             public bool IgnoreMissingDocumentationWarnings;
+
+            /// <summary>
+            /// The nullable context used in C# project.
+            /// </summary>
+            public CSharpNullableReferences CSharpNullableReferences = CSharpNullableReferences.Disable;
+
+            public ScriptingAPIOptions()
+            {
+            }
 
             /// <summary>
             /// Adds the other options into this.

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -88,7 +88,7 @@ namespace Flax.Build.Projects.VisualStudio
 
             csProjectFileContent.AppendLine("    <TargetFramework>net7.0</TargetFramework>");
             csProjectFileContent.AppendLine("    <ImplicitUsings>disable</ImplicitUsings>");
-            csProjectFileContent.AppendLine("    <Nullable>annotations</Nullable>");
+            csProjectFileContent.AppendLine(string.Format("    <Nullable>{0}</Nullable>", baseConfiguration.TargetBuildOptions.ScriptingAPI.CSharpNullableReferences.ToString().ToLowerInvariant()));
             csProjectFileContent.AppendLine("    <IsPackable>false</IsPackable>");
             csProjectFileContent.AppendLine("    <EnableDefaultItems>false</EnableDefaultItems>");
             csProjectFileContent.AppendLine("    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>");


### PR DESCRIPTION
Defaults currently to "Disabled", which is the default setting when the option is missing (same as before). I also changed the setting value in generated .csproj-files to match with the default setting or setting that is overridden in the build options.

Rider seems to be especially picky with this setting, when it was previously set to "annotations", most of the code got marked as unreachable when checking reference types equality.