### PR TITLE
Add eol=lf to gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+* text=auto eol=lf
 
 # Explicitly declare text files you want to always be normalized and converted to native line endings on checkout.
 *.c text diff=cpp


### PR DESCRIPTION
This fixes an issue I was having with the editor targets having extra characters when I pulled them from a git repo.
<https://discord.com/channels/437989205315158016/438013600821673994/1120858570917941338>