### PR TITLE
Adjustments in the preview of some windows

### DIFF
--- a/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
@@ -15,11 +15,13 @@ namespace FlaxEditor.Viewport.Previews
     /// <seealso cref="AssetPreview" />
     public class AnimatedModelPreview : AssetPreview
     {
+        /// <inheritdoc />
+        public AnimatedModel _previewModel;
+
         private ContextMenuButton _showNodesButton, _showBoundsButton, _showFloorButton, _showNodesNamesButton;
-        private bool _showNodes, _showBounds, _showFloor, _showCurrentLOD, _showNodesNames;
-        private AnimatedModel _previewModel;
+        private bool _showNodes, _showBounds, _showFloor, _showNodesNames;
         private StaticModel _floorModel;
-        private ContextMenuButton _showCurrentLODButton;
+        
         private bool _playAnimation, _playAnimationOnce;
         private float _playSpeed = 1.0f;
 
@@ -207,26 +209,6 @@ namespace FlaxEditor.Viewport.Previews
                 // Show Floor
                 _showFloorButton = ViewWidgetShowMenu.AddButton("Floor", button => ShowFloor = !ShowFloor);
                 _showFloorButton.IndexInParent = 1;
-
-                // Show Current LOD
-                _showCurrentLODButton = ViewWidgetShowMenu.AddButton("Current LOD", button =>
-                {
-                    _showCurrentLOD = !_showCurrentLOD;
-                    _showCurrentLODButton.Icon = _showCurrentLOD ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
-                });
-                _showCurrentLODButton.IndexInParent = 2;
-
-                // Preview LOD
-                {
-                    var previewLOD = ViewWidgetButtonMenu.AddButton("Preview LOD");
-                    previewLOD.CloseMenuOnClick = false;
-                    var previewLODValue = new IntValueBox(-1, 90, 2, 70.0f, -1, 10, 0.02f)
-                    {
-                        Parent = previewLOD
-                    };
-                    previewLODValue.ValueChanged += () => _previewModel.ForcedLOD = previewLODValue.Value;
-                    ViewWidgetButtonMenu.VisibleChanged += control => previewLODValue.Value = _previewModel.ForcedLOD;
-                }
             }
 
             // Enable shadows
@@ -339,44 +321,6 @@ namespace FlaxEditor.Viewport.Previews
             _previewModel.ResetAnimation();
         }
 
-        private int ComputeLODIndex(SkinnedModel model)
-        {
-            if (PreviewActor.ForcedLOD != -1)
-                return PreviewActor.ForcedLOD;
-
-            // Based on RenderTools::ComputeModelLOD
-            CreateProjectionMatrix(out var projectionMatrix);
-            float screenMultiple = 0.5f * Mathf.Max(projectionMatrix.M11, projectionMatrix.M22);
-            var sphere = PreviewActor.Sphere;
-            var viewOrigin = ViewPosition;
-            var distSqr = Vector3.DistanceSquared(ref sphere.Center, ref viewOrigin);
-            var screenRadiusSquared = Mathf.Square(screenMultiple * sphere.Radius) / Mathf.Max(1.0f, distSqr);
-
-            // Check if model is being culled
-            if (Mathf.Square(model.MinScreenSize * 0.5f) > screenRadiusSquared)
-                return -1;
-
-            // Skip if no need to calculate LOD
-            if (model.LoadedLODs == 0)
-                return -1;
-            var lods = model.LODs;
-            if (lods.Length == 0)
-                return -1;
-            if (lods.Length == 1)
-                return 0;
-
-            // Iterate backwards and return the first matching LOD
-            for (int lodIndex = lods.Length - 1; lodIndex >= 0; lodIndex--)
-            {
-                if (Mathf.Square(lods[lodIndex].ScreenSize * 0.5f) >= screenRadiusSquared)
-                {
-                    return lodIndex + PreviewActor.LODBias;
-                }
-            }
-
-            return 0;
-        }
-
         /// <inheritdoc />
         protected override void OnDebugDraw(GPUContext context, ref RenderContext renderContext)
         {
@@ -441,45 +385,6 @@ namespace FlaxEditor.Viewport.Previews
         }
 
         /// <inheritdoc />
-        public override void Draw()
-        {
-            base.Draw();
-
-            var skinnedModel = _previewModel.SkinnedModel;
-            if (skinnedModel == null || !skinnedModel.IsLoaded)
-                return;
-            var lods = skinnedModel.LODs;
-            if (lods.Length == 0)
-            {
-                // Force show skeleton for models without geometry
-                ShowNodes = true;
-                return;
-            }
-            if (_showCurrentLOD)
-            {
-                var lodIndex = ComputeLODIndex(skinnedModel);
-                string text = string.Format("Current LOD: {0}", lodIndex);
-                if (lodIndex != -1)
-                {
-                    lodIndex = Mathf.Clamp(lodIndex + PreviewActor.LODBias, 0, lods.Length - 1);
-                    var lod = lods[lodIndex];
-                    int triangleCount = 0, vertexCount = 0;
-                    for (int meshIndex = 0; meshIndex < lod.Meshes.Length; meshIndex++)
-                    {
-                        var mesh = lod.Meshes[meshIndex];
-                        triangleCount += mesh.TriangleCount;
-                        vertexCount += mesh.VertexCount;
-                    }
-                    text += string.Format("\nTriangles: {0:N0}\nVertices: {1:N0}", triangleCount, vertexCount);
-                }
-                var font = Style.Current.FontMedium;
-                var pos = new Float2(10, 50);
-                Render2D.DrawText(font, text, new Rectangle(pos + Float2.One, Size), Color.Black);
-                Render2D.DrawText(font, text, new Rectangle(pos, Size), Color.White);
-            }
-        }
-
-        /// <inheritdoc />
         public override void Update(float deltaTime)
         {
             base.Update(deltaTime);
@@ -498,6 +403,14 @@ namespace FlaxEditor.Viewport.Previews
             }
         }
 
+        /// <summary>
+        /// Calls SetArcBallView from ViewportCamera
+        /// </summary>
+        public void CallSetArcBallView()
+        {
+            ViewportCamera.SetArcBallView(_previewModel.Box);
+        }
+
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {
@@ -505,7 +418,7 @@ namespace FlaxEditor.Viewport.Previews
             {
             case KeyboardKeys.F:
                 // Pay respect..
-                ViewportCamera.SetArcBallView(_previewModel.Box);
+                CallSetArcBallView();
                 return true;
             case KeyboardKeys.Spacebar:
                 PlayAnimation = !PlayAnimation;
@@ -525,7 +438,6 @@ namespace FlaxEditor.Viewport.Previews
             _showNodesButton = null;
             _showBoundsButton = null;
             _showFloorButton = null;
-            _showCurrentLODButton = null;
             _showNodesNamesButton = null;
 
             base.OnDestroy();

--- a/Source/Editor/Viewport/Previews/MaterialPreview.cs
+++ b/Source/Editor/Viewport/Previews/MaterialPreview.cs
@@ -4,6 +4,8 @@ using System;
 using FlaxEditor.Surface;
 using FlaxEngine;
 using FlaxEngine.GUI;
+using FlaxEditor.Viewport.Widgets;
+using FlaxEditor.GUI.ContextMenu;
 using Object = FlaxEngine.Object;
 
 namespace FlaxEditor.Viewport.Previews
@@ -64,6 +66,11 @@ namespace FlaxEditor.Viewport.Previews
         }
 
         /// <summary>
+        /// The "Model" widget button context menu.
+        /// </summary>
+        private ContextMenu modelWidgetButtonMenu;
+
+        /// <summary>
         /// Gets or sets the selected preview model index.
         /// </summary>
         public int SelectedModelIndex
@@ -77,6 +84,27 @@ namespace FlaxEditor.Viewport.Previews
                 _selectedModelIndex = value;
                 _previewModel.Model = FlaxEngine.Content.LoadAsyncInternal<Model>("Editor/Primitives/" + Models[value]);
                 _previewModel.Transform = Transforms[value];
+            }
+        }
+
+        /// <summary>
+        /// Fill out all models
+        /// </summary>
+        /// <param name="control"></param>
+        private void ModelWidgetMenuOnVisibleChanged(Control control)
+        {
+            if (!control.Visible) return;
+
+            modelWidgetButtonMenu.ItemsContainer.DisposeChildren();
+
+            // Fill out all models
+            for (int i = 0; i < Models.Length; i++)
+            {
+                var index = i;
+                var button = modelWidgetButtonMenu.AddButton(Models[index]);
+                button.ButtonClicked += (button) => SelectedModelIndex = index;
+                button.Checked = SelectedModelIndex == index;
+                button.Tag = index;
             }
         }
 
@@ -95,20 +123,18 @@ namespace FlaxEditor.Viewport.Previews
             Task.AddCustomActor(_previewModel);
 
             // Create context menu for primitive switching
-            if (useWidgets && ViewWidgetButtonMenu != null)
+            if (useWidgets)
             {
-                ViewWidgetButtonMenu.AddSeparator();
-                var modelSelect = ViewWidgetButtonMenu.AddChildMenu("Model").ContextMenu;
-
-                // Fill out all models 
-                for (int i = 0; i < Models.Length; i++)
+                // Model mode widget
+                var modelMode = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
+                modelWidgetButtonMenu = new ContextMenu();
+                modelWidgetButtonMenu.VisibleChanged += ModelWidgetMenuOnVisibleChanged;
+                var previewLODSModeButton = new ViewportWidgetButton("Model", SpriteHandle.Invalid, modelWidgetButtonMenu)
                 {
-                    var button = modelSelect.AddButton(Models[i]);
-                    button.Tag = i;
-                }
-
-                // Link the action
-                modelSelect.ButtonClicked += (button) => SelectedModelIndex = (int)button.Tag;
+                    TooltipText = "Change material model",
+                    Parent = modelMode,
+                };
+                modelMode.Parent = this;
             }
         }
 

--- a/Source/Editor/Viewport/Previews/ModelBasePreview.cs
+++ b/Source/Editor/Viewport/Previews/ModelBasePreview.cs
@@ -56,25 +56,14 @@ namespace FlaxEditor.Viewport.Previews
             // Link actors for rendering
             Task.AddCustomActor(StaticModel);
             Task.AddCustomActor(AnimatedModel);
+        }
 
-            if (useWidgets)
-            {
-                // Preview LOD
-                {
-                    var previewLOD = ViewWidgetButtonMenu.AddButton("Preview LOD");
-                    previewLOD.CloseMenuOnClick = false;
-                    var previewLODValue = new IntValueBox(-1, 90, 2, 70.0f, -1, 10, 0.02f)
-                    {
-                        Parent = previewLOD
-                    };
-                    previewLODValue.ValueChanged += () =>
-                    {
-                        StaticModel.ForcedLOD = previewLODValue.Value;
-                        AnimatedModel.ForcedLOD = previewLODValue.Value;
-                    };
-                    ViewWidgetButtonMenu.VisibleChanged += control => previewLODValue.Value = StaticModel.ForcedLOD;
-                }
-            }
+        /// <summary>
+        /// Calls SetArcBallView from ViewportCamera
+        /// </summary>
+        public void CallSetArcBallView()
+        {
+            ViewportCamera.SetArcBallView(StaticModel.Model != null ? StaticModel.Box : AnimatedModel.Box);
         }
 
         private void OnBegin(RenderTask task, GPUContext context)
@@ -104,7 +93,7 @@ namespace FlaxEditor.Viewport.Previews
             {
             case KeyboardKeys.F:
                 // Pay respect..
-                ViewportCamera.SetArcBallView(StaticModel.Model != null ? StaticModel.Box : AnimatedModel.Box);
+                CallSetArcBallView();
                 break;
             }
             return base.OnKeyDown(key);

--- a/Source/Editor/Viewport/Previews/ModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/ModelPreview.cs
@@ -5,6 +5,7 @@ using FlaxEditor.GUI.Input;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Utilities;
+using FlaxEditor.Viewport.Widgets;
 using Object = FlaxEngine.Object;
 
 namespace FlaxEditor.Viewport.Previews
@@ -19,6 +20,29 @@ namespace FlaxEditor.Viewport.Previews
         private StaticModel _previewModel, _floorModel;
         private bool _showBounds, _showCurrentLOD, _showNormals, _showTangents, _showBitangents, _showFloor;
         private MeshDataCache _meshDatas;
+
+        /// <summary>
+        /// The "PreviewLODS" widget button context menu.
+        /// </summary>
+        private ContextMenu previewLODSWidgetButtonMenu;
+
+        /// <summary>
+        /// Gets or sets a value that shows LOD statistics
+        /// </summary>
+        public bool ShowCurrentLOD
+        {
+            get => _showCurrentLOD;
+            set
+            {
+                if (_showCurrentLOD == value)
+                    return;
+                _showCurrentLOD = value;
+                if (value)
+                    ShowDebugDraw = true;
+                if (_showCurrentLODButton != null)
+                    _showCurrentLODButton.Checked = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the model asset to preview.
@@ -198,16 +222,41 @@ namespace FlaxEditor.Viewport.Previews
                 });
                 _showCurrentLODButton.IndexInParent = 2;
 
-                // Preview LOD
+                // PreviewLODS mode widget
+                var PreviewLODSMode = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
+                previewLODSWidgetButtonMenu = new ContextMenu();
+                previewLODSWidgetButtonMenu.VisibleChanged += PreviewLODSWidgetMenuOnVisibleChanged;
+                var previewLODSModeButton = new ViewportWidgetButton("Preview LOD", SpriteHandle.Invalid, previewLODSWidgetButtonMenu)
                 {
-                    var previewLOD = ViewWidgetButtonMenu.AddButton("Preview LOD");
-                    previewLOD.CloseMenuOnClick = false;
-                    var previewLODValue = new IntValueBox(-1, 90, 2, 70.0f, -1, 10, 0.02f)
-                    {
-                        Parent = previewLOD
-                    };
-                    previewLODValue.ValueChanged += () => _previewModel.ForcedLOD = previewLODValue.Value;
-                    ViewWidgetButtonMenu.VisibleChanged += control => previewLODValue.Value = _previewModel.ForcedLOD;
+                    TooltipText = "Preview LOD properties",
+                    Parent = PreviewLODSMode,
+                };
+                PreviewLODSMode.Parent = this;
+            }
+        }
+
+        /// <summary>
+        /// Fill out all Model LODS
+        /// </summary>
+        /// <param name="control"></param>
+        private void PreviewLODSWidgetMenuOnVisibleChanged(Control control)
+        {
+            if (!control.Visible)
+                return;
+
+            var model = _previewModel.Model;
+            if (model && !model.WaitForLoaded() && model.IsLoaded)
+            {
+                previewLODSWidgetButtonMenu.ItemsContainer.DisposeChildren();
+                var lods = model.LODs.Length;
+                for (int i = -1; i < lods; i++)
+                {
+                    var index = i;
+                    var button = previewLODSWidgetButtonMenu.AddButton("LOD " + (index == -1 ? "Auto" : index));
+                    button.ButtonClicked += (button) => _previewModel.ForcedLOD = index;
+                    button.Checked = _previewModel.ForcedLOD == index;
+                    button.Tag = index;
+                    if (lods <= 1) return;
                 }
             }
         }
@@ -346,8 +395,11 @@ namespace FlaxEditor.Viewport.Previews
             if (_showCurrentLOD)
             {
                 var asset = Model;
-                var lodIndex = ComputeLODIndex(asset, out  var screenSize);
-                string text = string.Format("Current LOD: {0}\nScreen Size: {1:F2}", lodIndex, screenSize);
+                var lodIndex = ComputeLODIndex(asset, out var screenSize);
+                var auto = _previewModel.ForcedLOD == -1;
+                string text = auto ? "LOD Automatic" : "";
+                text += auto ? string.Format("\nScreen Size: {0:F2}", screenSize) : "";
+                text += string.Format("\nCurrent LOD: {0}", lodIndex);
                 if (lodIndex != -1)
                 {
                     var lods = asset.LODs;
@@ -369,6 +421,14 @@ namespace FlaxEditor.Viewport.Previews
             }
         }
 
+        /// <summary>
+        /// Calls SetArcBallView from ViewportCamera
+        /// </summary>
+        public void CallSetArcBallView()
+        {
+            ViewportCamera.SetArcBallView(_previewModel.Box);
+        }
+
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {
@@ -376,7 +436,7 @@ namespace FlaxEditor.Viewport.Previews
             {
             case KeyboardKeys.F:
                 // Pay respect..
-                ViewportCamera.SetArcBallView(_previewModel.Box);
+                CallSetArcBallView();
                 break;
             }
             return base.OnKeyDown(key);

--- a/Source/Editor/Viewport/Previews/SkinnedModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/SkinnedModelPreview.cs
@@ -1,0 +1,188 @@
+using System;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using FlaxEditor.Viewport.Widgets;
+
+namespace FlaxEditor.Viewport.Previews
+{
+    /// <summary>
+    /// Animation asset preview editor viewport.
+    /// </summary>
+    /// <seealso cref="AnimatedModelPreview" />
+    public class SkinnedModelPreview : AnimatedModelPreview
+    {
+        private bool _showCurrentLOD;
+        private ContextMenuButton _showCurrentLODButton;
+
+        /// <summary>
+        /// The "PreviewLODS" widget button context menu.
+        /// </summary>
+        private ContextMenu previewLODSWidgetButtonMenu;
+
+        /// <summary>
+        /// Gets or sets a value that shows LOD statistics
+        /// </summary>
+        public bool ShowCurrentLOD
+        {
+            get => _showCurrentLOD;
+            set
+            {
+                if (_showCurrentLOD == value)
+                    return;
+                _showCurrentLOD = value;
+                if (value)
+                    ShowDebugDraw = true;
+                if (_showCurrentLODButton != null)
+                    _showCurrentLODButton.Checked = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SkinnedModelPreview"/> class.
+        /// </summary>
+        /// <param name="useWidgets">if set to <c>true</c> use widgets.</param>
+        public SkinnedModelPreview(bool useWidgets)
+        : base(useWidgets)
+        {
+            if (useWidgets)
+            {
+                // Show Current LOD
+                _showCurrentLODButton = ViewWidgetShowMenu.AddButton("Current LOD", button =>
+                {
+                    _showCurrentLOD = !_showCurrentLOD;
+                    _showCurrentLODButton.Icon = _showCurrentLOD ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
+                });
+                _showCurrentLODButton.IndexInParent = 2;
+
+                // PreviewLODS mode widget
+                var PreviewLODSMode = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
+                previewLODSWidgetButtonMenu = new ContextMenu();
+                previewLODSWidgetButtonMenu.VisibleChanged += PreviewLODSWidgetMenuOnVisibleChanged;
+                var previewLODSModeButton = new ViewportWidgetButton("Preview LOD", SpriteHandle.Invalid, previewLODSWidgetButtonMenu)
+                {
+                    TooltipText = "Preview LOD properties",
+                    Parent = PreviewLODSMode,
+                };
+                PreviewLODSMode.Parent = this;
+            }
+        }
+
+        /// <summary>
+        /// Fill out all SkinnedModel LODS
+        /// </summary>
+        /// <param name="control"></param>
+        private void PreviewLODSWidgetMenuOnVisibleChanged(Control control)
+        {
+            if (!control.Visible)
+                return;
+
+            var skinned = _previewModel.SkinnedModel;
+            if (skinned && !skinned.WaitForLoaded() && skinned.IsLoaded)
+            {
+                previewLODSWidgetButtonMenu.ItemsContainer.DisposeChildren();
+                var lods = skinned.LODs.Length;
+                for (int i = -1; i < lods; i++)
+                {
+                    var index = i;
+                    var button = previewLODSWidgetButtonMenu.AddButton("LOD " + (index == -1 ? "Auto" : index));
+                    button.ButtonClicked += (button) => _previewModel.ForcedLOD = index;
+                    button.Checked = _previewModel.ForcedLOD == index;
+                    button.Tag = index;
+                    if (lods <= 1) return;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        private int ComputeLODIndex(SkinnedModel model, out float screenSize)
+        {
+            screenSize = 1.0f;
+            if (PreviewActor.ForcedLOD != -1)
+                return PreviewActor.ForcedLOD;
+
+            // Based on RenderTools::ComputeModelLOD
+            CreateProjectionMatrix(out var projectionMatrix);
+            float screenMultiple = 0.5f * Mathf.Max(projectionMatrix.M11, projectionMatrix.M22);
+            var sphere = PreviewActor.Sphere;
+            var viewOrigin = ViewPosition;
+            var distSqr = Vector3.DistanceSquared(ref sphere.Center, ref viewOrigin);
+            var screenRadiusSquared = Mathf.Square(screenMultiple * sphere.Radius) / Mathf.Max(1.0f, distSqr);
+            screenSize = Mathf.Sqrt((float)screenRadiusSquared) * 2.0f;
+
+            // Check if model is being culled
+            if (Mathf.Square(model.MinScreenSize * 0.5f) > screenRadiusSquared)
+                return -1;
+
+            // Skip if no need to calculate LOD
+            if (model.LoadedLODs == 0)
+                return -1;
+            var lods = model.LODs;
+            if (lods.Length == 0)
+                return -1;
+            if (lods.Length == 1)
+                return 0;
+
+            // Iterate backwards and return the first matching LOD
+            for (int lodIndex = lods.Length - 1; lodIndex >= 0; lodIndex--)
+            {
+                if (Mathf.Square(lods[lodIndex].ScreenSize * 0.5f) >= screenRadiusSquared)
+                {
+                    return lodIndex + PreviewActor.LODBias;
+                }
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc />
+        public override void Draw()
+        {
+            base.Draw();
+
+            var skinnedModel = _previewModel.SkinnedModel;
+            if (skinnedModel == null || !skinnedModel.IsLoaded)
+                return;
+            var lods = skinnedModel.LODs;
+            if (lods.Length == 0)
+            {
+                // Force show skeleton for models without geometry
+                ShowNodes = true;
+                return;
+            }
+            if (_showCurrentLOD)
+            {
+                var lodIndex = ComputeLODIndex(skinnedModel, out var screenSize);
+                var auto = _previewModel.ForcedLOD == -1;
+                string text = auto ? "LOD Automatic" : "";
+                text += auto ? string.Format("\nScreen Size: {0:F2}", screenSize) : "";
+                text += string.Format("\nCurrent LOD: {0}", lodIndex);
+                if (lodIndex != -1)
+                {
+                    lodIndex = Mathf.Clamp(lodIndex + PreviewActor.LODBias, 0, lods.Length - 1);
+                    var lod = lods[lodIndex];
+                    int triangleCount = 0, vertexCount = 0;
+                    for (int meshIndex = 0; meshIndex < lod.Meshes.Length; meshIndex++)
+                    {
+                        var mesh = lod.Meshes[meshIndex];
+                        triangleCount += mesh.TriangleCount;
+                        vertexCount += mesh.VertexCount;
+                    }
+                    text += string.Format("\nTriangles: {0:N0}\nVertices: {1:N0}", triangleCount, vertexCount);
+                }
+                var font = Style.Current.FontMedium;
+                var pos = new Float2(10, 50);
+                Render2D.DrawText(font, text, new Rectangle(pos + Float2.One, Size), Color.Black);
+                Render2D.DrawText(font, text, new Rectangle(pos, Size), Color.White);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void OnDestroy()
+        {
+            _showCurrentLODButton = null;
+
+            base.OnDestroy();
+        }
+    }
+}

--- a/Source/Editor/Windows/Assets/CollisionDataWindow.cs
+++ b/Source/Editor/Windows/Assets/CollisionDataWindow.cs
@@ -182,6 +182,9 @@ namespace FlaxEditor.Windows.Assets
         {
             // Toolstrip
             _toolstrip.AddSeparator();
+
+            _toolstrip.AddButton(editor.Icons.CenterView64, () => _preview.CallSetArcBallView()).LinkTooltip("Show whole collision");
+
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/physics/colliders/collision-data.html")).LinkTooltip("See documentation to learn more");
 
             // Split Panel

--- a/Source/Editor/Windows/Assets/ModelWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelWindow.cs
@@ -779,12 +779,18 @@ namespace FlaxEditor.Windows.Assets
         private MeshDataCache _meshData;
         private ModelImportSettings _importSettings = new ModelImportSettings();
         private float _backfacesThreshold = 0.6f;
+        private ToolStripButton _showCurrentLODButton;
 
         /// <inheritdoc />
         public ModelWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
             // Toolstrip
+            _toolstrip.AddSeparator();
+            _showCurrentLODButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Info64, () => _preview.ShowCurrentLOD = !_preview.ShowCurrentLOD).LinkTooltip("Show LOD statistics");
+
+            _toolstrip.AddButton(editor.Icons.CenterView64, () => _preview.CallSetArcBallView()).LinkTooltip("Show whole model");
+
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/graphics/models/index.html")).LinkTooltip("See documentation to learn more");
 
@@ -869,6 +875,8 @@ namespace FlaxEditor.Windows.Assets
                 }
             }
 
+            _showCurrentLODButton.Checked = _preview.ShowCurrentLOD;
+
             base.Update(deltaTime);
         }
 
@@ -946,6 +954,7 @@ namespace FlaxEditor.Windows.Assets
             base.OnDestroy();
 
             Object.Destroy(ref _highlightActor);
+            _showCurrentLODButton = null;
         }
     }
 }

--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -31,7 +31,7 @@ namespace FlaxEditor.Windows.Assets
     /// <seealso cref="FlaxEditor.Windows.Assets.AssetEditorWindow" />
     public sealed class SkinnedModelWindow : ModelBaseWindow<SkinnedModel, SkinnedModelWindow>
     {
-        private sealed class Preview : AnimatedModelPreview
+        private sealed class Preview : SkinnedModelPreview
         {
             private readonly SkinnedModelWindow _window;
 
@@ -1105,6 +1105,7 @@ namespace FlaxEditor.Windows.Assets
         private Preview _preview;
         private AnimatedModel _highlightActor;
         private ToolStripButton _showNodesButton;
+        private ToolStripButton _showCurrentLODButton;
 
         private MeshData[][] _meshDatas;
         private bool _meshDatasInProgress;
@@ -1116,7 +1117,13 @@ namespace FlaxEditor.Windows.Assets
         {
             // Toolstrip
             _toolstrip.AddSeparator();
+
+            _showCurrentLODButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Info64, () => _preview.ShowCurrentLOD = !_preview.ShowCurrentLOD).LinkTooltip("Show LOD statistics");
+
             _showNodesButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Bone64, () => _preview.ShowNodes = !_preview.ShowNodes).LinkTooltip("Show animated model nodes debug view");
+
+            _toolstrip.AddButton(editor.Icons.CenterView64, () => _preview.CallSetArcBallView()).LinkTooltip("Show whole model");
+
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/skinned-model/index.html")).LinkTooltip("See documentation to learn more");
 
@@ -1265,6 +1272,7 @@ namespace FlaxEditor.Windows.Assets
                 }
             }
 
+            _showCurrentLODButton.Checked = _preview.ShowCurrentLOD;
             _showNodesButton.Checked = _preview.ShowNodes;
 
             base.Update(deltaTime);
@@ -1349,6 +1357,7 @@ namespace FlaxEditor.Windows.Assets
             Object.Destroy(ref _highlightActor);
             _preview = null;
             _showNodesButton = null;
+            _showCurrentLODButton = null;
         }
     }
 }


### PR DESCRIPTION
**This pr is a new version of my old pr that contains a new approach** https://github.com/FlaxEngine/FlaxEngine/pull/1148

**Improvements to model windows**

- I added a Button for the CurrentLOD.
- I added a Button that centers the model.
- I fixed the ScreenSize and added a callsign for Auto LOD.
- I added a DropdownButton to the PreviewLOD that works dynamically based on the amount of LODS in the model.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/101017436/499eed34-0aeb-44e2-a1f4-2cd195803d96)

**Improved material window**

- I added a DropdownButton to the model

![image](https://github.com/FlaxEngine/FlaxEngine/assets/101017436/ed9725d4-cda8-49d0-9a26-5020995433d2)

**I made some small tweaks to other previews as well**