### PR TITLE
add play button actions, number of players

### DIFF
--- a/Source/Editor/GUI/ContextMenu/ContextMenuSingleSelectGroup.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuSingleSelectGroup.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.GUI.ContextMenu
+{
+    /// <summary>
+    /// Context menu single select group.
+    /// </summary>
+    [HideInEditor]
+    class ContextMenuSingleSelectGroup<T>
+    {
+        public struct SingleSelectGroupItem<U>
+        {
+            public string text;
+            public U value;
+            public Action onSelected;
+            public List<ContextMenuButton> buttons;
+        }
+
+        private List<ContextMenu> _menus = new List<ContextMenu>();
+        private List<SingleSelectGroupItem<T>> _items = new List<SingleSelectGroupItem<T>>();
+        public Action<T> OnSelectionChanged;
+
+        public SingleSelectGroupItem<T> activeItem;
+
+        public ContextMenuSingleSelectGroup<T> AddItem(string text, T value, Action onSelected = null)
+        {
+            var item = new SingleSelectGroupItem<T>
+            {
+                text = text,
+                value = value,
+                onSelected = onSelected,
+                buttons = new List<ContextMenuButton>()
+            };
+            _items.Add(item);
+
+            foreach (var contextMenu in _menus)
+                AddItemToContextMenu(contextMenu, item);
+
+            return this;
+        }
+
+        public ContextMenuSingleSelectGroup<T> AddItemsToContextMenu(ContextMenu contextMenu)
+        {
+            _menus.Add(contextMenu);
+
+            for (int i = 0; i < _items.Count; i++)
+            {
+                AddItemToContextMenu(contextMenu, _items[i]);
+            }
+
+            return this;
+        }
+
+        private void AddItemToContextMenu(ContextMenu contextMenu, SingleSelectGroupItem<T> item)
+        {
+            var btn = contextMenu.AddButton(item.text, () =>
+            {
+                SetItemAsActive(item);
+            });
+
+            item.buttons.Add(btn);
+
+            if (item.Equals(activeItem))
+            {
+                btn.Checked = true;
+            }
+        }
+
+        private void DeselectAll()
+        {
+            foreach (var item in _items)
+            {
+                foreach (var btn in item.buttons) btn.Checked = false;
+            }
+        }
+
+        public void SetItemAsActive(T value)
+        {
+            var index = _items.FindIndex(x => x.value.Equals(value));
+
+            if (index == -1) return;
+
+            SetItemAsActive(_items[index]);
+        }
+
+        private void SetItemAsActive(SingleSelectGroupItem<T> item)
+        {
+            DeselectAll();
+
+            var index = _items.IndexOf(item);
+            OnSelectionChanged?.Invoke(item.value);
+            item.onSelected?.Invoke();
+
+            foreach (var btn in item.buttons)
+            {
+                btn.Checked = true;
+            }
+
+            activeItem = item;
+        }
+    }
+}

--- a/Source/Editor/GUI/ContextMenu/ContextMenuSingleSelectGroup.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuSingleSelectGroup.cs
@@ -92,6 +92,7 @@ namespace FlaxEditor.GUI.ContextMenu
         private void SetItemAsActive(SingleSelectGroupItem<T> item)
         {
             DeselectAll();
+            activeItem = item;
 
             var index = _items.IndexOf(item);
             OnSelectionChanged?.Invoke(item.value);
@@ -101,8 +102,6 @@ namespace FlaxEditor.GUI.ContextMenu
             {
                 btn.Checked = true;
             }
-
-            activeItem = item;
         }
     }
 }

--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -23,9 +23,14 @@ namespace FlaxEditor.GUI
         public const int DefaultMarginH = 2;
 
         /// <summary>
-        /// Event fired when button gets clicked.
+        /// Event fired when button gets clicked with the primary mouse button.
         /// </summary>
-        public Action<ToolStripButton> ButtonClicked;
+        public Action<ToolStripButton> ButtonPrimaryClicked;
+
+        /// <summary>
+        /// Event fired when button gets clicked with the secondary mouse button.
+        /// </summary>
+        public Action<ToolStripButton> ButtonSecondaryClicked;
 
         /// <summary>
         /// Tries to get the last button.
@@ -91,7 +96,7 @@ namespace FlaxEditor.GUI
                 Parent = this,
             };
             if (onClick != null)
-                button.Clicked += onClick;
+                button.PrimaryClicked += onClick;
             return button;
         }
 
@@ -110,7 +115,7 @@ namespace FlaxEditor.GUI
                 Parent = this,
             };
             if (onClick != null)
-                button.Clicked += onClick;
+                button.PrimaryClicked += onClick;
             return button;
         }
 
@@ -128,7 +133,7 @@ namespace FlaxEditor.GUI
                 Parent = this,
             };
             if (onClick != null)
-                button.Clicked += onClick;
+                button.PrimaryClicked += onClick;
             return button;
         }
 
@@ -141,9 +146,14 @@ namespace FlaxEditor.GUI
             return AddChild(new ToolStripSeparator(ItemsHeight));
         }
 
-        internal void OnButtonClicked(ToolStripButton button)
+        internal void OnButtonPrimaryClicked(ToolStripButton button)
         {
-            ButtonClicked?.Invoke(button);
+            ButtonPrimaryClicked?.Invoke(button);
+        }
+
+        internal void OnButtonSecondaryClicked(ToolStripButton button)
+        {
+            ButtonSecondaryClicked?.Invoke(button);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -486,6 +486,14 @@ namespace FlaxEditor.Modules
                 options.Interface.NumberOfGameClientsToLaunch = value;
                 Editor.Options.Apply(options);
             };
+
+            Editor.Options.OptionsChanged += (options) =>
+            {
+                if (options.Interface.NumberOfGameClientsToLaunch != _numberOfClientsGroup.activeItem.value)
+                {
+                    _numberOfClientsGroup.SetItemAsActive(options.Interface.NumberOfGameClientsToLaunch);
+                }
+            };
         }
 
         private void InitMainMenu(RootControl mainWindow)
@@ -682,9 +690,16 @@ namespace FlaxEditor.Modules
             playActionGroup.SetItemAsActive(Editor.Options.Options.Interface.PlayButtonAction);
             // important to add the handler after setting the initial item as active above or the editor will crash
             playActionGroup.OnSelectionChanged = SetPlayAction;
-            // TODO: there are some holes in the syncing of these values
+            // TODO: there is a hole in the syncing of these values:
             // - when changing in the editor, the options will be updated, but the options UI in-editor will not
-            // - when updating the value in the options UI, the value in the tool strip will not update (adding an options changed event handler results in a crash)
+
+            Editor.Options.OptionsChanged += (options) =>
+            {
+                if (options.Interface.PlayButtonAction != playActionGroup.activeItem.value)
+                {
+                    playActionGroup.SetItemAsActive(options.Interface.PlayButtonAction);
+                }
+            };
 
             _toolStripPause = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Pause64, Editor.Simulation.RequestResumeOrPause).LinkTooltip($"Pause/Resume game({inputOptions.Pause.ToString()})");
             _toolStripStep = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Skip64, Editor.Simulation.RequestPlayOneFrame).LinkTooltip("Step one frame in game");

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -20,6 +20,8 @@ using FlaxEngine.GUI;
 using FlaxEngine.Json;
 using DockHintWindow = FlaxEditor.GUI.Docking.DockHintWindow;
 using MasterDockPanel = FlaxEditor.GUI.Docking.MasterDockPanel;
+using FlaxEditor.Content.Settings;
+using static FlaxEditor.Options.InterfaceOptions;
 
 namespace FlaxEditor.Modules
 {
@@ -35,6 +37,9 @@ namespace FlaxEditor.Modules
         private List<KeyValuePair<string, DateTime>> _statusMessages;
         private ContentStats _contentStats;
         private bool _progressFailed;
+
+        ContextMenuSingleSelectGroup<int> _numberOfClientsGroup = new ContextMenuSingleSelectGroup<int>();
+        private Scene[] _scenesToReload;
 
         private ContextMenuButton _menuFileSaveScenes;
         private ContextMenuButton _menuFileCloseScenes;
@@ -54,7 +59,9 @@ namespace FlaxEditor.Modules
         private ContextMenuButton _menuSceneAlignViewportWithActor;
         private ContextMenuButton _menuScenePilotActor;
         private ContextMenuButton _menuSceneCreateTerrain;
-        private ContextMenuButton _menuGamePlay;
+        private ContextMenuButton _menuGamePlayGame;
+        private ContextMenuButton _menuGamePlayCurrentScenes;
+        private ContextMenuButton _menuGameStop;
         private ContextMenuButton _menuGamePause;
         private ContextMenuButton _menuToolsBuildScenes;
         private ContextMenuButton _menuToolsBakeLightmaps;
@@ -74,6 +81,7 @@ namespace FlaxEditor.Modules
         private ToolStripButton _toolStripRotate;
         private ToolStripButton _toolStripScale;
         private ToolStripButton _toolStripBuildScenes;
+        private ToolStripButton _toolStripCook;
         private ToolStripButton _toolStripPlay;
         private ToolStripButton _toolStripPause;
         private ToolStripButton _toolStripStep;
@@ -351,6 +359,7 @@ namespace FlaxEditor.Modules
             // Update window background
             mainWindow.BackgroundColor = Style.Current.Background;
 
+            InitSharedMenus();
             InitMainMenu(mainWindow);
             InitToolstrip(mainWindow);
             InitStatusBar(mainWindow);
@@ -466,6 +475,19 @@ namespace FlaxEditor.Modules
             return dialog;
         }
 
+        private void InitSharedMenus()
+        {
+            for (int i = 1; i <= 4; i++) _numberOfClientsGroup.AddItem(i.ToString(), i);
+
+            _numberOfClientsGroup.SetItemAsActive(Editor.Options.Options.Interface.NumberOfGameClientsToLaunch);
+            _numberOfClientsGroup.OnSelectionChanged = (value) =>
+            {
+                var options = Editor.Options.Options;
+                options.Interface.NumberOfGameClientsToLaunch = value;
+                Editor.Options.Apply(options);
+            };
+        }
+
         private void InitMainMenu(RootControl mainWindow)
         {
             MainMenu = new MainMenu(mainWindow)
@@ -523,11 +545,19 @@ namespace FlaxEditor.Modules
             MenuGame = MainMenu.AddButton("Game");
             cm = MenuGame.ContextMenu;
             cm.VisibleChanged += OnMenuGameShowHide;
-            _menuGamePlay = cm.AddButton("Play", inputOptions.Play.ToString(), Editor.Simulation.RequestStartPlay);
+
+            _menuGamePlayGame = cm.AddButton("Play Game", PlayGame);
+            _menuGamePlayCurrentScenes = cm.AddButton("Play Current Scenes", inputOptions.Play.ToString(), PlayScenes);
+            _menuGameStop = cm.AddButton("Stop Game", Editor.Simulation.RequestStopPlay);
             _menuGamePause = cm.AddButton("Pause", inputOptions.Pause.ToString(), Editor.Simulation.RequestPausePlay);
+
             cm.AddSeparator();
-            cm.AddButton("Cook & Run", Editor.Windows.GameCookerWin.BuildAndRun).LinkTooltip("Runs Game Cooker to build the game for this platform and runs the game after.");
-            cm.AddButton("Run cooked game", Editor.Windows.GameCookerWin.RunCooked).LinkTooltip("Runs the game build from the last cooking output. Use Cook&Play or Game Cooker first.");
+            var numberOfClientsMenu = cm.AddChildMenu("Number of game clients");
+            _numberOfClientsGroup.AddItemsToContextMenu(numberOfClientsMenu.ContextMenu);
+
+            cm.AddSeparator();
+            cm.AddButton("Cook & Run", CookAndRun).LinkTooltip("Runs Game Cooker to build the game for this platform and runs the game after.");
+            cm.AddButton("Run cooked game", RunCookedGame).LinkTooltip("Runs the game build from the last cooking output. Use Cook&Play or Game Cooker first.");
 
             // Tools
             MenuTools = MainMenu.AddButton("Tools");
@@ -603,7 +633,7 @@ namespace FlaxEditor.Modules
             _menuEditDuplicate.ShortKeys = inputOptions.Duplicate.ToString();
             _menuEditSelectAll.ShortKeys = inputOptions.SelectAll.ToString();
             _menuEditFind.ShortKeys = inputOptions.Search.ToString();
-            _menuGamePlay.ShortKeys = inputOptions.Play.ToString();
+            _menuGamePlayCurrentScenes.ShortKeys = inputOptions.Play.ToString();
             _menuGamePause.ShortKeys = inputOptions.Pause.ToString();
 
             MainMenuShortcutKeysUpdated?.Invoke();
@@ -611,6 +641,8 @@ namespace FlaxEditor.Modules
 
         private void InitToolstrip(RootControl mainWindow)
         {
+            var inputOptions = Editor.Options.Options.Input;
+
             ToolStrip = new ToolStrip(34.0f, MainMenu.Bottom)
             {
                 Parent = mainWindow,
@@ -627,8 +659,34 @@ namespace FlaxEditor.Modules
             ToolStrip.AddSeparator();
             _toolStripBuildScenes = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Build64, Editor.BuildScenesOrCancel).LinkTooltip("Build scenes data - CSG, navmesh, static lighting, env probes - configurable via Build Actions in editor options (Ctrl+F10)");
             ToolStrip.AddSeparator();
-            _toolStripPlay = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Play64, Editor.Simulation.RequestPlayOrStopPlay).LinkTooltip("Start/Stop game (F5)");
-            _toolStripPause = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Pause64, Editor.Simulation.RequestResumeOrPause).LinkTooltip("Pause/Resume game(F6)");
+
+            // build
+            _toolStripCook = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.BuildSettings128, CookAndRun).LinkTooltip("Cook and run");
+            _toolStripCook.ContextMenu = new ContextMenu();
+            _toolStripCook.ContextMenu.AddButton("Run cooked game", RunCookedGame);
+            _toolStripCook.ContextMenu.AddSeparator();
+            var numberOfClientsMenu = _toolStripCook.ContextMenu.AddChildMenu("Number of game clients");
+            _numberOfClientsGroup.AddItemsToContextMenu(numberOfClientsMenu.ContextMenu);
+
+            // play
+            _toolStripPlay = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Play64, OnPlayPressed).LinkTooltip("Play Game");
+            _toolStripPlay.ContextMenu = new ContextMenu();
+            ContextMenuChildMenu playSubMenu;
+
+            // play - button action
+            playSubMenu = _toolStripPlay.ContextMenu.AddChildMenu("Play button action");
+            var playActionGroup = new ContextMenuSingleSelectGroup<PlayAction>();
+            playActionGroup.AddItem("Play Game", PlayAction.PlayGame);
+            playActionGroup.AddItem("Play Scenes", PlayAction.PlayScenes);
+            playActionGroup.AddItemsToContextMenu(playSubMenu.ContextMenu);
+            playActionGroup.SetItemAsActive(Editor.Options.Options.Interface.PlayButtonAction);
+            // important to add the handler after setting the initial item as active above or the editor will crash
+            playActionGroup.OnSelectionChanged = SetPlayAction;
+            // TODO: there are some holes in the syncing of these values
+            // - when changing in the editor, the options will be updated, but the options UI in-editor will not
+            // - when updating the value in the options UI, the value in the tool strip will not update (adding an options changed event handler results in a crash)
+
+            _toolStripPause = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Pause64, Editor.Simulation.RequestResumeOrPause).LinkTooltip($"Pause/Resume game({inputOptions.Pause.ToString()})");
             _toolStripStep = (ToolStripButton)ToolStrip.AddButton(Editor.Icons.Skip64, Editor.Simulation.RequestPlayOneFrame).LinkTooltip("Step one frame in game");
 
             UpdateToolstrip();
@@ -786,7 +844,9 @@ namespace FlaxEditor.Modules
             var isPlayMode = Editor.StateMachine.IsPlayMode;
             var canPlay = Level.IsAnySceneLoaded;
 
-            _menuGamePlay.Enabled = !isPlayMode && canPlay;
+            _menuGamePlayGame.Enabled = !isPlayMode && canPlay;
+            _menuGamePlayCurrentScenes.Enabled = !isPlayMode && canPlay;
+            _menuGameStop.Enabled = isPlayMode && canPlay;
             _menuGamePause.Enabled = isPlayMode && canPlay;
 
             c.PerformLayout();
@@ -966,6 +1026,70 @@ namespace FlaxEditor.Modules
             projectInfo.DefaultScene = JsonSerializer.GetStringID(Level.Scenes[0].ID);
             projectInfo.DefaultSceneSpawn = Editor.Windows.EditWin.Viewport.ViewRay;
             projectInfo.Save();
+        }
+
+        private void SetPlayAction(PlayAction newPlayAction)
+        {
+            var options = Editor.Options.Options;
+            options.Interface.PlayButtonAction = newPlayAction;
+            Editor.Options.Apply(options);
+        }
+
+        private void OnPlayPressed()
+        {
+            switch (Editor.Options.Options.Interface.PlayButtonAction)
+            {
+                case PlayAction.PlayGame:
+                    if (Editor.IsPlayMode)
+                        Editor.Simulation.RequestStopPlay();
+                    else
+                        PlayGame();
+                    return;
+                case PlayAction.PlayScenes: PlayScenes(); return;
+            }
+        }
+
+        private void PlayGame()
+        {
+            var firstScene = GameSettings.Load().FirstScene;
+
+            if (firstScene == Guid.Empty)
+            {
+                if (Level.IsAnySceneLoaded) Editor.Simulation.RequestStartPlay();
+                return;
+            }
+
+            _scenesToReload = Level.Scenes;
+            Level.UnloadAllScenes();
+            Level.LoadScene(firstScene);
+
+            Editor.PlayModeEnd += OnPlayGameSceneEnding;
+            Editor.Simulation.RequestPlayOrStopPlay();
+        }
+
+        private void OnPlayGameSceneEnding()
+        {
+            Editor.PlayModeEnd -= OnPlayGameSceneEnding;
+
+            Level.UnloadAllScenes();
+
+            foreach (var scene in _scenesToReload)
+                Level.LoadScene(scene.ID);
+        }
+
+        private void PlayScenes()
+        {
+            Editor.Simulation.RequestPlayOrStopPlay();
+        }
+
+        private void CookAndRun()
+        {
+            Editor.Windows.GameCookerWin.BuildAndRun();
+        }
+
+        private void RunCookedGame()
+        {
+            Editor.Windows.GameCookerWin.RunCooked();
         }
 
         private void OnMainWindowClosing()

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -75,6 +75,21 @@ namespace FlaxEditor.Options
         }
 
         /// <summary>
+        /// Options for the action taken by the play button.
+        /// </summary>
+        public enum PlayAction
+        {
+            /// <summary>
+            /// Launches the game from the First Scene defined in the project settings.
+            /// </summary>
+            PlayGame,
+            /// <summary>
+            /// Launches the game using the scenes currently loaded in the editor.
+            /// </summary>
+            PlayScenes
+        }
+
+        /// <summary>
         /// Gets or sets the Editor User Interface scale. Applied to all UI elements, windows and text. Can be used to scale the interface up on a bigger display. Editor restart required.
         /// </summary>
         [DefaultValue(1.0f), Limit(0.1f, 10.0f)]
@@ -196,30 +211,45 @@ namespace FlaxEditor.Options
         [EditorDisplay("Play In-Editor", "Focus Game Window On Play"), EditorOrder(400), Tooltip("Determines whether auto-focus game window on play mode start.")]
         public bool FocusGameWinOnPlay { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets a value indicating what action should be taken upon pressing the play button.
+        /// </summary>
+        [DefaultValue(PlayAction.PlayScenes)]
+        [EditorDisplay("Play In-Editor", "Play Button Action"), EditorOrder(410), Tooltip("Determines the action taken when the play button is pressed.")]
+        public PlayAction PlayButtonAction { get; set; } = PlayAction.PlayScenes;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of game clients to launch when building and/or running cooked game.
+        /// </summary>
+        [DefaultValue(1)]
+        [EditorDisplay("Cook & Run", "Number Of GameClients To Launch"), EditorOrder(500), Tooltip("Determines the number of game clients to launch when building and/or running cooked game.")]
+        [Range(1, 4)]
+        public int NumberOfGameClientsToLaunch = 1;
+
         private static FontAsset DefaultFont => FlaxEngine.Content.LoadAsyncInternal<FontAsset>(EditorAssets.PrimaryFont);
 
         /// <summary>
         /// Gets or sets the title font for editor UI.
         /// </summary>
-        [EditorDisplay("Fonts"), EditorOrder(500), Tooltip("The title font for editor UI.")]
+        [EditorDisplay("Fonts"), EditorOrder(600), Tooltip("The title font for editor UI.")]
         public FontReference TitleFont { get; set; } = new FontReference(DefaultFont, 18);
 
         /// <summary>
         /// Gets or sets the large font for editor UI.
         /// </summary>
-        [EditorDisplay("Fonts"), EditorOrder(510), Tooltip("The large font for editor UI.")]
+        [EditorDisplay("Fonts"), EditorOrder(610), Tooltip("The large font for editor UI.")]
         public FontReference LargeFont { get; set; } = new FontReference(DefaultFont, 14);
 
         /// <summary>
         /// Gets or sets the medium font for editor UI.
         /// </summary>
-        [EditorDisplay("Fonts"), EditorOrder(520), Tooltip("The medium font for editor UI.")]
+        [EditorDisplay("Fonts"), EditorOrder(620), Tooltip("The medium font for editor UI.")]
         public FontReference MediumFont { get; set; } = new FontReference(DefaultFont, 9);
 
         /// <summary>
         /// Gets or sets the small font for editor UI.
         /// </summary>
-        [EditorDisplay("Fonts"), EditorOrder(530), Tooltip("The small font for editor UI.")]
+        [EditorDisplay("Fonts"), EditorOrder(630), Tooltip("The small font for editor UI.")]
         public FontReference SmallFont { get; set; } = new FontReference(DefaultFont, 9);
     }
 }

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -110,14 +110,14 @@ namespace FlaxEditor.Windows
 #if PLATFORM_WINDOWS
                     switch (BuildPlatform)
                     {
-                    case BuildPlatform.MacOSx64:
-                    case BuildPlatform.MacOSARM64:
-                    case BuildPlatform.iOSARM64:
-                        IsSupported = false;
-                        break;
-                    default:
-                        IsSupported = true;
-                        break;
+                        case BuildPlatform.MacOSx64:
+                        case BuildPlatform.MacOSARM64:
+                        case BuildPlatform.iOSARM64:
+                            IsSupported = false;
+                            break;
+                        default:
+                            IsSupported = true;
+                            break;
                     }
 #elif PLATFORM_LINUX
                     switch (BuildPlatform)
@@ -160,17 +160,17 @@ namespace FlaxEditor.Windows
                     {
                         switch (BuildPlatform)
                         {
-                        case BuildPlatform.Windows32:
-                        case BuildPlatform.Windows64:
-                        case BuildPlatform.UWPx86:
-                        case BuildPlatform.UWPx64:
-                        case BuildPlatform.LinuxX64:
-                        case BuildPlatform.AndroidARM64:
-                            layout.Label("Use Flax Launcher and download the required package.", TextAlignment.Center);
-                            break;
-                        default:
-                            layout.Label("Engine source is required to target this platform.", TextAlignment.Center);
-                            break;
+                            case BuildPlatform.Windows32:
+                            case BuildPlatform.Windows64:
+                            case BuildPlatform.UWPx86:
+                            case BuildPlatform.UWPx64:
+                            case BuildPlatform.LinuxX64:
+                            case BuildPlatform.AndroidARM64:
+                                layout.Label("Use Flax Launcher and download the required package.", TextAlignment.Center);
+                                break;
+                            default:
+                                layout.Label("Engine source is required to target this platform.", TextAlignment.Center);
+                                break;
                         }
                     }
                     else
@@ -272,43 +272,43 @@ namespace FlaxEditor.Windows
                         string name;
                         switch (_platform)
                         {
-                        case PlatformType.Windows:
-                            name = "Windows";
-                            break;
-                        case PlatformType.XboxOne:
-                            name = "Xbox One";
-                            break;
-                        case PlatformType.UWP:
-                            name = "Windows Store";
-                            layout.Label("UWP (Windows Store) platform has been deprecated and is no longer supported", TextAlignment.Center).Label.TextColor = Color.Red;
-                            break;
-                        case PlatformType.Linux:
-                            name = "Linux";
-                            break;
-                        case PlatformType.PS4:
-                            name = "PlayStation 4";
-                            break;
-                        case PlatformType.XboxScarlett:
-                            name = "Xbox Scarlett";
-                            break;
-                        case PlatformType.Android:
-                            name = "Android";
-                            break;
-                        case PlatformType.Switch:
-                            name = "Switch";
-                            break;
-                        case PlatformType.PS5:
-                            name = "PlayStation 5";
-                            break;
-                        case PlatformType.Mac:
-                            name = "Mac";
-                            break;
-                        case PlatformType.iOS:
-                            name = "iOS";
-                            break;
-                        default:
-                            name = Utilities.Utils.GetPropertyNameUI(_platform.ToString());
-                            break;
+                            case PlatformType.Windows:
+                                name = "Windows";
+                                break;
+                            case PlatformType.XboxOne:
+                                name = "Xbox One";
+                                break;
+                            case PlatformType.UWP:
+                                name = "Windows Store";
+                                layout.Label("UWP (Windows Store) platform has been deprecated and is no longer supported", TextAlignment.Center).Label.TextColor = Color.Red;
+                                break;
+                            case PlatformType.Linux:
+                                name = "Linux";
+                                break;
+                            case PlatformType.PS4:
+                                name = "PlayStation 4";
+                                break;
+                            case PlatformType.XboxScarlett:
+                                name = "Xbox Scarlett";
+                                break;
+                            case PlatformType.Android:
+                                name = "Android";
+                                break;
+                            case PlatformType.Switch:
+                                name = "Switch";
+                                break;
+                            case PlatformType.PS5:
+                                name = "PlayStation 5";
+                                break;
+                            case PlatformType.Mac:
+                                name = "Mac";
+                                break;
+                            case PlatformType.iOS:
+                                name = "iOS";
+                                break;
+                            default:
+                                name = Utilities.Utils.GetPropertyNameUI(_platform.ToString());
+                                break;
                         }
                         var group = layout.Group(name);
 
@@ -659,16 +659,24 @@ namespace FlaxEditor.Windows
         {
             Editor.Log("Building and running");
             GameCooker.GetCurrentPlatform(out var platform, out var buildPlatform, out var buildConfiguration);
-            _buildingQueue.Enqueue(new QueueItem
+            var numberOfClients = Editor.Options.Options.Interface.NumberOfGameClientsToLaunch;
+
+            for (int i = 0; i < numberOfClients; i++)
             {
-                Target = new BuildTarget
+                var buildOptions = BuildOptions.AutoRun;
+                if (i > 0) buildOptions |= BuildOptions.NoCook;
+
+                _buildingQueue.Enqueue(new QueueItem
                 {
-                    Output = _buildTabProxy.PerPlatformOptions[platform].Output,
-                    Platform = buildPlatform,
-                    Mode = buildConfiguration,
-                },
-                Options = BuildOptions.AutoRun,
-            });
+                    Target = new BuildTarget
+                    {
+                        Output = _buildTabProxy.PerPlatformOptions[platform].Output,
+                        Platform = buildPlatform,
+                        Mode = buildConfiguration,
+                    },
+                    Options = buildOptions,
+                });
+            }
         }
 
         /// <summary>
@@ -678,16 +686,21 @@ namespace FlaxEditor.Windows
         {
             Editor.Log("Running cooked build");
             GameCooker.GetCurrentPlatform(out var platform, out var buildPlatform, out var buildConfiguration);
-            _buildingQueue.Enqueue(new QueueItem
+            var numberOfClients = Editor.Options.Options.Interface.NumberOfGameClientsToLaunch;
+
+            for (int i = 0; i < numberOfClients; i++)
             {
-                Target = new BuildTarget
+                _buildingQueue.Enqueue(new QueueItem
                 {
-                    Output = _buildTabProxy.PerPlatformOptions[platform].Output,
-                    Platform = buildPlatform,
-                    Mode = buildConfiguration,
-                },
-                Options = BuildOptions.AutoRun | BuildOptions.NoCook,
-            });
+                    Target = new BuildTarget
+                    {
+                        Output = _buildTabProxy.PerPlatformOptions[platform].Output,
+                        Platform = buildPlatform,
+                        Mode = buildConfiguration,
+                    },
+                    Options = BuildOptions.AutoRun | BuildOptions.NoCook,
+                });
+            }
         }
 
         private void BuildTarget()

--- a/Source/Editor/Windows/Profiler/ProfilerWindow.cs
+++ b/Source/Editor/Windows/Profiler/ProfilerWindow.cs
@@ -93,7 +93,7 @@ namespace FlaxEditor.Windows.Profiler
             _liveRecordingButton = toolstrip.AddButton(editor.Icons.Play64);
             _liveRecordingButton.LinkTooltip("Live profiling events recording");
             _liveRecordingButton.AutoCheck = true;
-            _liveRecordingButton.Clicked += () => _liveRecordingButton.Icon = LiveRecording ? editor.Icons.Stop64 : editor.Icons.Play64;
+            _liveRecordingButton.PrimaryClicked += () => _liveRecordingButton.Icon = LiveRecording ? editor.Icons.Stop64 : editor.Icons.Play64;
             _clearButton = toolstrip.AddButton(editor.Icons.Rotate32, Clear);
             _clearButton.LinkTooltip("Clear data");
             toolstrip.AddSeparator();


### PR DESCRIPTION
- add context menu support for toolstrip buttons
- add "Play Game" vs. "Play Scenes"
- add context menu for choosing play button action to toolstrip button
- add number of game client selection for cook & run
- add toolstrip button and context menu for cook & run
- add menu items for the above
- add editor option entries for saving user preferences for the above

![build-launch](https://github.com/FlaxEngine/FlaxEngine/assets/17469837/7bf798e0-11ec-40ad-8b2b-c118decc53eb)

Potential icon for new toolstrip button attached.