### PR TITLE
Fix Intellisense errors with referenced binary module structures

### DIFF
--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -330,7 +330,7 @@ namespace Flax.Build
                                             var referenceBuildOptions = GetBuildOptions(referenceTarget, configurationData.TargetBuildOptions.Platform, configurationData.TargetBuildOptions.Toolchain, configurationData.Architecture, configurationData.Configuration, reference.Project.ProjectFolderPath);
                                             referenceBuildOptions.Flags |= BuildFlags.GenerateProject;
                                             var referenceModules = CollectModules(rules, referenceBuildOptions.Platform, referenceTarget, referenceBuildOptions, referenceBuildOptions.Toolchain, referenceBuildOptions.Architecture, referenceBuildOptions.Configuration);
-                                            var referenceBinaryModules = GetBinaryModules(projectInfo, referenceTarget, referenceModules);
+                                            var referenceBinaryModules = referenceModules.Keys.GroupBy(x => x.BinaryModuleName).ToArray();
                                             foreach (var binaryModule in referenceBinaryModules)
                                             {
                                                 project.Defines.Add(binaryModule.Key.ToUpperInvariant() + "_API=");


### PR DESCRIPTION
The missing API-definition is causing Intellisense to throw errors of any referenced structures marked for export:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/4064397/f459b1c6-f485-4122-b194-1f226730a8ce)