### PR TITLE
Add functionality to add collider anywhere as a child a rigidbody.

### DIFF
--- a/Source/Engine/Core/Utilities.h
+++ b/Source/Engine/Core/Utilities.h
@@ -5,6 +5,7 @@
 #include "Types/BaseTypes.h"
 #include "Types/String.h"
 #include "Types/Span.h"
+#include "Engine/Level/Actor.h"
 #if _MSC_VER && PLATFORM_SIMD_SSE4_2
 #include <intrin.h>
 #endif
@@ -89,5 +90,18 @@ namespace Utilities
         x = (x + (x >> 4)) & 0x0F0F0F0F;
         return (x * 0x01010101) >> 24;
 #endif  
+    }
+
+    /// <summary>
+    /// Gets the whole actor children tree including the initial actor.
+    /// </summary>
+    static inline void GetActorsTree(Array<Actor*>& list, Actor* a)
+    {
+        list.Add(a);
+        int cnt = a->Children.Count();
+        for (int i = 0; i < cnt; i++)
+        {
+            GetActorsTree(list, a->Children[i]);
+        }
     }
 }

--- a/Source/Engine/Physics/Actors/RigidBody.cpp
+++ b/Source/Engine/Physics/Actors/RigidBody.cpp
@@ -2,6 +2,7 @@
 
 #include "RigidBody.h"
 #include "Engine/Core/Log.h"
+#include "Engine/Core/Utilities.h"
 #include "Engine/Physics/Colliders/Collider.h"
 #include "Engine/Physics/PhysicsBackend.h"
 #include "Engine/Physics/PhysicsScene.h"
@@ -445,10 +446,13 @@ void RigidBody::BeginPlay(SceneBeginData* data)
     PhysicsBackend::SetRigidDynamicActorMaxAngularVelocity(_actor, _maxAngularVelocity);
     PhysicsBackend::SetRigidDynamicActorConstraints(_actor, _constraints);
 
+    Array<Actor*> allChildren;
+    Utilities::GetActorsTree(allChildren, this);
+    
     // Find colliders to attach
-    for (int32 i = 0; i < Children.Count(); i++)
+    for (int32 i = 0; i < allChildren.Count(); i++)
     {
-        auto collider = dynamic_cast<Collider*>(Children[i]);
+        auto collider = dynamic_cast<Collider*>(allChildren[i]);
         if (collider && collider->CanAttach(this))
         {
             collider->Attach(this);

--- a/Source/Engine/Physics/Colliders/Collider.cpp
+++ b/Source/Engine/Physics/Colliders/Collider.cpp
@@ -130,7 +130,7 @@ RigidBody* Collider::GetAttachedRigidBody() const
 {
     if (_shape && _staticActor == nullptr)
     {
-        return dynamic_cast<RigidBody*>(GetParent());
+        return FindRigidBodyParent(GetParent());
     }
     return nullptr;
 }
@@ -236,7 +236,7 @@ void Collider::UpdateGeometry()
         // Reattach again (only if can, see CanAttach function)
         if (actor)
         {
-            const auto rigidBody = dynamic_cast<RigidBody*>(GetParent());
+            const auto rigidBody = FindRigidBodyParent(GetParent());
             if (_staticActor != nullptr || (rigidBody && CanAttach(rigidBody)))
             {
                 PhysicsBackend::AttachShape(_shape, actor);
@@ -292,6 +292,18 @@ void Collider::OnMaterialChanged()
         PhysicsBackend::SetShapeMaterial(_shape, Material.Get());
 }
 
+RigidBody* Collider::FindRigidBodyParent(Actor* actor) const
+{
+    if (actor == (Actor*)_scene)
+        return nullptr;
+    
+    auto rb = dynamic_cast<RigidBody*>(actor);
+    if (rb)
+        return rb;
+    
+    return FindRigidBodyParent(actor->GetParent());
+}
+
 void Collider::Serialize(SerializeStream& stream, const void* otherObj)
 {
     // Base
@@ -324,7 +336,7 @@ void Collider::BeginPlay(SceneBeginData* data)
         CreateShape();
 
         // Check if parent is a rigidbody
-        const auto rigidBody = dynamic_cast<RigidBody*>(GetParent());
+        const auto rigidBody = FindRigidBodyParent(GetParent());
         if (rigidBody && CanAttach(rigidBody))
         {
             // Attach to the rigidbody
@@ -405,7 +417,7 @@ void Collider::OnParentChanged()
         }
 
         // Check if the new parent is a rigidbody
-        rigidBody = dynamic_cast<RigidBody*>(GetParent());
+        rigidBody = FindRigidBodyParent(GetParent());
         if (rigidBody && CanAttach(rigidBody))
         {
             // Attach to the rigidbody

--- a/Source/Engine/Physics/Colliders/Collider.h
+++ b/Source/Engine/Physics/Colliders/Collider.h
@@ -205,6 +205,7 @@ protected:
 
 private:
     void OnMaterialChanged();
+    RigidBody* FindRigidBodyParent(Actor* actor) const;
 
 public:
     // [PhysicsColliderActor]


### PR DESCRIPTION
 This is some nice functionality to not limit the rigid body of only havening colliders directly as a child but can have a collider as a child of a child. #1229