### PR TITLE
Add showing rendering material to model entries

### DIFF
--- a/Source/Editor/CustomEditors/Editors/AssetRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/AssetRefEditor.cs
@@ -33,7 +33,10 @@ namespace FlaxEditor.CustomEditors.Editors
     [CustomEditor(typeof(Asset)), DefaultEditor]
     public class AssetRefEditor : CustomEditor
     {
-        private AssetPicker _picker;
+        /// <summary>
+        /// The asset picker used to get a reference to an asset.
+        /// </summary>
+        public AssetPicker Picker;
         private ScriptType _valueType;
 
         /// <inheritdoc />
@@ -44,7 +47,7 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             if (HasDifferentTypes)
                 return;
-            _picker = layout.Custom<AssetPicker>().CustomControl;
+            Picker = layout.Custom<AssetPicker>().CustomControl;
 
             _valueType = Values.Type.Type != typeof(object) || Values[0] == null ? Values.Type : TypeUtils.GetObjectType(Values[0]);
             var assetType = _valueType;
@@ -66,7 +69,7 @@ namespace FlaxEditor.CustomEditors.Editors
                 {
                     // Generic file picker
                     assetType = ScriptType.Null;
-                    _picker.FileExtension = assetReference.TypeName;
+                    Picker.FileExtension = assetReference.TypeName;
                 }
                 else
                 {
@@ -78,23 +81,23 @@ namespace FlaxEditor.CustomEditors.Editors
                 }
             }
 
-            _picker.AssetType = assetType;
-            _picker.Height = height;
-            _picker.SelectedItemChanged += OnSelectedItemChanged;
+            Picker.AssetType = assetType;
+            Picker.Height = height;
+            Picker.SelectedItemChanged += OnSelectedItemChanged;
         }
 
         private void OnSelectedItemChanged()
         {
             if (typeof(AssetItem).IsAssignableFrom(_valueType.Type))
-                SetValue(_picker.SelectedItem);
+                SetValue(Picker.SelectedItem);
             else if (_valueType.Type == typeof(Guid))
-                SetValue(_picker.SelectedID);
+                SetValue(Picker.SelectedID);
             else if (_valueType.Type == typeof(SceneReference))
-                SetValue(new SceneReference(_picker.SelectedID));
+                SetValue(new SceneReference(Picker.SelectedID));
             else if (_valueType.Type == typeof(string))
-                SetValue(_picker.SelectedPath);
+                SetValue(Picker.SelectedPath);
             else
-                SetValue(_picker.SelectedAsset);
+                SetValue(Picker.SelectedAsset);
         }
 
         /// <inheritdoc />
@@ -105,15 +108,15 @@ namespace FlaxEditor.CustomEditors.Editors
             if (!HasDifferentValues)
             {
                 if (Values[0] is AssetItem assetItem)
-                    _picker.SelectedItem = assetItem;
+                    Picker.SelectedItem = assetItem;
                 else if (Values[0] is Guid guid)
-                    _picker.SelectedID = guid;
+                    Picker.SelectedID = guid;
                 else if (Values[0] is SceneReference sceneAsset)
-                    _picker.SelectedItem = Editor.Instance.ContentDatabase.FindAsset(sceneAsset.ID);
+                    Picker.SelectedItem = Editor.Instance.ContentDatabase.FindAsset(sceneAsset.ID);
                 else if (Values[0] is string path)
-                    _picker.SelectedPath = path;
+                    Picker.SelectedPath = path;
                 else
-                    _picker.SelectedAsset = Values[0] as Asset;
+                    Picker.SelectedAsset = Values[0] as Asset;
             }
         }
     }

--- a/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
@@ -108,16 +108,13 @@ namespace FlaxEditor.CustomEditors.Editors
         {
             // Skip material member as it is overridden
             if (item.Info.Name == "Material")
-            {
                 return;
-            }
             base.SpawnProperty(itemLayout, itemValues, item);
         }
 
         /// <inheritdoc />
         public override void Refresh()
         {
-            Debug.Log("Hit");
             if (_updateName &&
                 _group != null &&
                 ParentEditor?.ParentEditor != null &&

--- a/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
@@ -50,7 +50,7 @@ namespace FlaxEditor.CustomEditors.Editors
                         staticModel.SetMaterial(entryIndex, GPUDevice.Instance.DefaultMaterial);
                         materialEditor.Picker.SelectedAsset = GPUDevice.Instance.DefaultMaterial;
                     }
-                    else if (material == staticModel.Model.MaterialSlots[entryIndex])
+                    else if (material == staticModel.Model.MaterialSlots[entryIndex].Material)
                     {
                         staticModel.SetMaterial(entryIndex, null);
                     }
@@ -84,7 +84,7 @@ namespace FlaxEditor.CustomEditors.Editors
                         animatedModel.SetMaterial(entryIndex, GPUDevice.Instance.DefaultMaterial);
                         materialEditor.Picker.SelectedAsset = GPUDevice.Instance.DefaultMaterial;
                     }
-                    else if (material == animatedModel.SkinnedModel.MaterialSlots[entryIndex])
+                    else if (material == animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material)
                     {
                         animatedModel.SetMaterial(entryIndex, null);
                     }
@@ -112,6 +112,7 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <inheritdoc />
         public override void Refresh()
         {
+            Debug.Log("Hit");
             if (_updateName &&
                 _group != null &&
                 ParentEditor?.ParentEditor != null &&

--- a/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
@@ -40,7 +40,7 @@ namespace FlaxEditor.CustomEditors.Editors
 
                 var matContainer = new CustomValueContainer(new ScriptType(typeof(MaterialBase)), _material, (instance, index) => _material, (instance, index, value) => _material = value as MaterialBase);
                 var materialEditor = (_group.Property(materiaLabel, matContainer)) as AssetRefEditor;
-                materialEditor.Values.SetDefaultValue(staticModel.Model.MaterialSlots[entryIndex].Material);
+                materialEditor.Values.SetDefaultValue((staticModel.Model.MaterialSlots[entryIndex].Material) ? staticModel.Model.MaterialSlots[entryIndex].Material : GPUDevice.Instance.DefaultMaterial);
                 materialEditor.RefreshDefaultValue();
                 materialEditor.Picker.SelectedItemChanged += () =>
                 {
@@ -51,6 +51,10 @@ namespace FlaxEditor.CustomEditors.Editors
                         materialEditor.Picker.SelectedAsset = GPUDevice.Instance.DefaultMaterial;
                     }
                     else if (material == staticModel.Model.MaterialSlots[entryIndex].Material)
+                    {
+                        staticModel.SetMaterial(entryIndex, null);
+                    }
+                    else if (material == GPUDevice.Instance.DefaultMaterial && !staticModel.Model.MaterialSlots[entryIndex].Material)
                     {
                         staticModel.SetMaterial(entryIndex, null);
                     }
@@ -69,12 +73,9 @@ namespace FlaxEditor.CustomEditors.Editors
                 }
                 _material = animatedModel.GetMaterial(entryIndex);
                 
-                var matContainer = new CustomValueContainer(new ScriptType(typeof(MaterialBase)), _material, (instance, index) => _material, (instance, index, value) =>
-                {
-                    _material = value as MaterialBase;
-                });
+                var matContainer = new CustomValueContainer(new ScriptType(typeof(MaterialBase)), _material, (instance, index) => _material, (instance, index, value) => _material = value as MaterialBase);
                 var materialEditor = (_group.Property(materiaLabel, matContainer)) as AssetRefEditor;
-                materialEditor.Values.SetDefaultValue(animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material);
+                materialEditor.Values.SetDefaultValue((animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material) ? animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material : GPUDevice.Instance.DefaultMaterial);
                 materialEditor.RefreshDefaultValue();
                 materialEditor.Picker.SelectedItemChanged += () =>
                 {
@@ -85,6 +86,10 @@ namespace FlaxEditor.CustomEditors.Editors
                         materialEditor.Picker.SelectedAsset = GPUDevice.Instance.DefaultMaterial;
                     }
                     else if (material == animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material)
+                    {
+                        animatedModel.SetMaterial(entryIndex, null);
+                    }
+                    else if (material == GPUDevice.Instance.DefaultMaterial && !animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material)
                     {
                         animatedModel.SetMaterial(entryIndex, null);
                     }

--- a/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ModelInstanceEntryEditor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 using FlaxEditor.CustomEditors.Elements;
+using FlaxEditor.CustomEditors.GUI;
+using FlaxEditor.Scripting;
 using FlaxEngine;
 
 namespace FlaxEditor.CustomEditors.Editors
@@ -13,6 +15,8 @@ namespace FlaxEditor.CustomEditors.Editors
     {
         private GroupElement _group;
         private bool _updateName;
+        private MaterialBase _material;
+        private ModelInstanceEntry _entry;
 
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
@@ -20,8 +24,89 @@ namespace FlaxEditor.CustomEditors.Editors
             _updateName = true;
             var group = layout.Group("Entry");
             _group = group;
+            
+            _entry = (ModelInstanceEntry)Values[0];
+            var entryIndex = ParentEditor.ChildrenEditors.IndexOf(this);
+            var materiaLabel = new PropertyNameLabel("Material");
+            materiaLabel.TooltipText = "The mesh surface material used for the rendering.";
+            if (ParentEditor.ParentEditor.Values[0] is StaticModel staticModel)
+            {
+                // Ensure that entry with default material set is set back to null
+                if (_entry.Material == staticModel.Model.MaterialSlots[entryIndex].Material)
+                {
+                    staticModel.SetMaterial(entryIndex, null);
+                }
+                _material = staticModel.GetMaterial(entryIndex);
 
+                var matContainer = new CustomValueContainer(new ScriptType(typeof(MaterialBase)), _material, (instance, index) => _material, (instance, index, value) => _material = value as MaterialBase);
+                var materialEditor = (_group.Property(materiaLabel, matContainer)) as AssetRefEditor;
+                materialEditor.Values.SetDefaultValue(staticModel.Model.MaterialSlots[entryIndex].Material);
+                materialEditor.RefreshDefaultValue();
+                materialEditor.Picker.SelectedItemChanged += () =>
+                {
+                    var material = materialEditor.Picker.SelectedAsset as MaterialBase;
+                    if (!material)
+                    {
+                        staticModel.SetMaterial(entryIndex, GPUDevice.Instance.DefaultMaterial);
+                        materialEditor.Picker.SelectedAsset = GPUDevice.Instance.DefaultMaterial;
+                    }
+                    else if (material == staticModel.Model.MaterialSlots[entryIndex])
+                    {
+                        staticModel.SetMaterial(entryIndex, null);
+                    }
+                    else
+                    {
+                        staticModel.SetMaterial(entryIndex, material);
+                    }
+                };
+            }
+            else if (ParentEditor.ParentEditor.Values[0] is AnimatedModel animatedModel)
+            {
+                // Ensure that entry with default material set is set back to null
+                if (_entry.Material == animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material)
+                {
+                    animatedModel.SetMaterial(entryIndex, null);
+                }
+                _material = animatedModel.GetMaterial(entryIndex);
+                
+                var matContainer = new CustomValueContainer(new ScriptType(typeof(MaterialBase)), _material, (instance, index) => _material, (instance, index, value) =>
+                {
+                    _material = value as MaterialBase;
+                });
+                var materialEditor = (_group.Property(materiaLabel, matContainer)) as AssetRefEditor;
+                materialEditor.Values.SetDefaultValue(animatedModel.SkinnedModel.MaterialSlots[entryIndex].Material);
+                materialEditor.RefreshDefaultValue();
+                materialEditor.Picker.SelectedItemChanged += () =>
+                {
+                    var material = materialEditor.Picker.SelectedAsset as MaterialBase;
+                    if (!material)
+                    {
+                        animatedModel.SetMaterial(entryIndex, GPUDevice.Instance.DefaultMaterial);
+                        materialEditor.Picker.SelectedAsset = GPUDevice.Instance.DefaultMaterial;
+                    }
+                    else if (material == animatedModel.SkinnedModel.MaterialSlots[entryIndex])
+                    {
+                        animatedModel.SetMaterial(entryIndex, null);
+                    }
+                    else
+                    {
+                        animatedModel.SetMaterial(entryIndex, material);
+                    }
+                };
+            }
+            
             base.Initialize(group);
+        }
+
+        /// <inheritdoc />
+        protected override void SpawnProperty(LayoutElementsContainer itemLayout, ValueContainer itemValues, ItemInfo item)
+        {
+            // Skip material member as it is overridden
+            if (item.Info.Name == "Material")
+            {
+                return;
+            }
+            base.SpawnProperty(itemLayout, itemValues, item);
         }
 
         /// <inheritdoc />

--- a/Source/Engine/Graphics/GPUDevice.h
+++ b/Source/Engine/Graphics/GPUDevice.h
@@ -238,7 +238,7 @@ public:
     /// <summary>
     /// Gets the default material.
     /// </summary>
-    MaterialBase* GetDefaultMaterial() const;
+    API_PROPERTY() MaterialBase* GetDefaultMaterial() const;
 
     /// <summary>
     /// Gets the default material (Deformable domain).


### PR DESCRIPTION
Reference: #1157 

This PR adds the ability to see what material is being used for rendering a mesh or skinned mesh.

https://github.com/FlaxEngine/FlaxEngine/assets/71274967/94b68ec6-eeed-4f5c-a1a9-e80b61b4346d

