### PR TITLE
Fix bug of populating asset picker if option platform type does not exist.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/AssetRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/AssetRefEditor.cs
@@ -80,6 +80,8 @@ namespace FlaxEditor.CustomEditors.Editors
                         assetType = customType;
                     else if (!Content.Settings.GameSettings.OptionalPlatformSettings.Contains(assetReference.TypeName))
                         Debug.LogWarning(string.Format("Unknown asset type '{0}' to use for asset picker filter.", assetReference.TypeName));
+                    else
+                        assetType = ScriptType.Void;
                 }
             }
 


### PR DESCRIPTION
Fix for #1259