### PR TITLE
Fix visibility of string wrapper methods used in binding code

### DIFF
--- a/Source/Engine/Engine/NativeInterop.Managed.cs
+++ b/Source/Engine/Engine/NativeInterop.Managed.cs
@@ -274,12 +274,12 @@ namespace FlaxEngine.Interop
 #if FLAX_EDITOR
     [HideInEditor]
 #endif
-    internal static class ManagedString
+    public static class ManagedString
     {
         internal static ManagedHandle EmptyStringHandle = ManagedHandle.Alloc(string.Empty);
 
         [System.Diagnostics.DebuggerStepThrough]
-        internal static unsafe IntPtr ToNative(string str)
+        public static unsafe IntPtr ToNative(string str)
         {
             if (str == null)
                 return IntPtr.Zero;
@@ -290,7 +290,7 @@ namespace FlaxEngine.Interop
         }
 
         [System.Diagnostics.DebuggerStepThrough]
-        internal static unsafe IntPtr ToNativeWeak(string str)
+        public static unsafe IntPtr ToNativeWeak(string str)
         {
             if (str == null)
                 return IntPtr.Zero;
@@ -301,7 +301,7 @@ namespace FlaxEngine.Interop
         }
 
         [System.Diagnostics.DebuggerStepThrough]
-        internal static string ToManaged(IntPtr ptr)
+        public static string ToManaged(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
                 return null;
@@ -309,7 +309,7 @@ namespace FlaxEngine.Interop
         }
 
         [System.Diagnostics.DebuggerStepThrough]
-        internal static void Free(IntPtr ptr)
+        public static void Free(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
                 return;


### PR DESCRIPTION
This PR adrresses the issue with string wrapper methods visibility in generated code. Reproducing the issue is very simple - it requires creating an API field of type String in any type in a game module, for example `API_FIELD() String Nick`.

> I'm not sure, if those methods should be exposed. I tried to mimic usage of those methods in different part of the engine.