### PR TITLE
Add scroll to selected asset/content item on asset picker select menu open.

### DIFF
--- a/Source/Editor/GUI/AssetPicker.cs
+++ b/Source/Editor/GUI/AssetPicker.cs
@@ -484,18 +484,7 @@ namespace FlaxEditor.GUI
                         if (_selected != null)
                         {
                             var selectedAssetName = Path.GetFileNameWithoutExtension(_selected.Path);
-                            foreach (var child in popup.ItemsPanel.Children)
-                            {
-                                if (child is not ItemsListContextMenu.Item item)
-                                    continue;
-                                if (string.Equals(item.Name, selectedAssetName, StringComparison.Ordinal))
-                                {
-                                    // Highlight and scroll to item
-                                    item.Focus();
-                                    popup.ScrollViewTo(item);
-                                    break;
-                                }
-                            }
+                           popup.ScrollToAndHighlightItemByName(selectedAssetName);
                         }
                     }
                     else
@@ -509,19 +498,7 @@ namespace FlaxEditor.GUI
                         });
                         if (_selectedItem != null)
                         {
-                            var selectedItemName = _selectedItem.ShortName;
-                            foreach (var child in popup.ItemsPanel.Children)
-                            {
-                                if (child is not ItemsListContextMenu.Item item)
-                                    continue;
-                                if (string.Equals(item.Name, selectedItemName, StringComparison.Ordinal))
-                                {
-                                    // Highlight and scroll to item
-                                    item.Focus();
-                                    popup.ScrollViewTo(item);
-                                    break;
-                                }
-                            }
+                            popup.ScrollToAndHighlightItemByName(_selectedItem.ShortName);
                         }
                     }
                 }

--- a/Source/Editor/GUI/AssetPicker.cs
+++ b/Source/Editor/GUI/AssetPicker.cs
@@ -475,22 +475,54 @@ namespace FlaxEditor.GUI
                     if (_type != ScriptType.Null)
                     {
                         // Show asset picker popup
-                        AssetSearchPopup.Show(this, Button1Rect.BottomLeft, IsValid, item =>
+                        var popup = AssetSearchPopup.Show(this, Button1Rect.BottomLeft, IsValid, item =>
                         {
                             SelectedItem = item;
                             RootWindow.Focus();
                             Focus();
                         });
+                        if (_selected != null)
+                        {
+                            var selectedAssetName = Path.GetFileNameWithoutExtension(_selected.Path);
+                            foreach (var child in popup.ItemsPanel.Children)
+                            {
+                                if (child is not ItemsListContextMenu.Item item)
+                                    continue;
+                                if (string.Equals(item.Name, selectedAssetName, StringComparison.Ordinal))
+                                {
+                                    // Highlight and scroll to item
+                                    item.Focus();
+                                    popup.ScrollViewTo(item);
+                                    break;
+                                }
+                            }
+                        }
                     }
                     else
                     {
                         // Show content item picker popup
-                        ContentSearchPopup.Show(this, Button1Rect.BottomLeft, IsValid, item =>
+                        var popup = ContentSearchPopup.Show(this, Button1Rect.BottomLeft, IsValid, item =>
                         {
                             SelectedItem = item;
                             RootWindow.Focus();
                             Focus();
                         });
+                        if (_selectedItem != null)
+                        {
+                            var selectedItemName = _selectedItem.ShortName;
+                            foreach (var child in popup.ItemsPanel.Children)
+                            {
+                                if (child is not ItemsListContextMenu.Item item)
+                                    continue;
+                                if (string.Equals(item.Name, selectedItemName, StringComparison.Ordinal))
+                                {
+                                    // Highlight and scroll to item
+                                    item.Focus();
+                                    popup.ScrollViewTo(item);
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
                 else if (_selected != null || _selectedItem != null)

--- a/Source/Editor/GUI/AssetPicker.cs
+++ b/Source/Editor/GUI/AssetPicker.cs
@@ -482,9 +482,9 @@ namespace FlaxEditor.GUI
                             Focus();
                         });
                         if (_selected != null)
-                        {
-                            var selectedAssetName = Path.GetFileNameWithoutExtension(_selected.Path);
-                           popup.ScrollToAndHighlightItemByName(selectedAssetName);
+                        { 
+                            var selectedAssetName = Path.GetFileNameWithoutExtension(_selected.Path); 
+                            popup.ScrollToAndHighlightItemByName(selectedAssetName);
                         }
                     }
                     else

--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -266,6 +266,15 @@ namespace FlaxEditor.GUI
         }
 
         /// <summary>
+        /// Scrolls the scroll panel to a specific Item
+        /// </summary>
+        /// <param name="item">The item to scroll to.</param>
+        public void ScrollViewTo(Item item)
+        {
+            _scrollPanel.ScrollViewTo(item, true);
+        }
+
+        /// <summary>
         /// Sorts the items list (by item name by default).
         /// </summary>
         public void SortItems()

--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -275,6 +275,26 @@ namespace FlaxEditor.GUI
         }
 
         /// <summary>
+        /// Scrolls to the item and focuses it by name.
+        /// </summary>
+        /// <param name="itemName">The item name.</param>
+        public void ScrollToAndHighlightItemByName(string itemName)
+        {
+            foreach (var child in ItemsPanel.Children)
+            {
+                if (child is not ItemsListContextMenu.Item item)
+                    continue;
+                if (string.Equals(item.Name, itemName, StringComparison.Ordinal))
+                {
+                    // Highlight and scroll to item
+                    item.Focus();
+                    ScrollViewTo(item);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
         /// Sorts the items list (by item name by default).
         /// </summary>
         public void SortItems()


### PR DESCRIPTION
This PR will automatically scroll to the selected asset/content item and highlights it when the asset picker drop down is opened. This is a QoL addition that helps when users have assets that are similarly named in their projects and have a lot of assets.