### PR TITLE
Content Browser Improvement [ready]

### DIFF
--- a/Source/Editor/Content/ContentFilter.cs
+++ b/Source/Editor/Content/ContentFilter.cs
@@ -195,7 +195,7 @@ namespace FlaxEditor.Content
         {
             engine.Visible = false;
             engine.Folder.Visible = false;
-            
+
             foreach (var item in plugins)
             {
                 item.Visible = false;
@@ -218,7 +218,6 @@ namespace FlaxEditor.Content
                 {
                     engine.Visible = true;
                     engine.Folder.Visible = true;
-                    Editor.Instance.Windows.ContentWin.RefreshView(engine);
                 }
 
                 if (dropdown.Selection[i] == 1)//Show Plugin Content
@@ -227,7 +226,6 @@ namespace FlaxEditor.Content
                     {
                         item.Visible = true;
                         item.Folder.Visible = true;
-                        Editor.Instance.Windows.ContentWin.RefreshView(item);
                     }
                 }
 
@@ -244,19 +242,16 @@ namespace FlaxEditor.Content
                     gameSettings.Visible = true;
                     settings.Visible = true;
                     settings.Folder.Visible = true;
-                    Editor.Instance.Windows.ContentWin.RefreshView((ContentTreeNode)settings.Parent);
                 }
 
                 if (dropdown.Selection[i] == 4)//"Show Shader Source"
                 {
                     shaders.Visible = true;
                     shaders.Folder.Visible = true;
-                    Editor.Instance.Windows.ContentWin.RefreshView(shaders);
                 }
             }
-
-            
-            
+            engine.ParentTree.PerformLayout();
+            Editor.Instance.Windows.ContentWin.RefreshView();
         }
     }
 }

--- a/Source/Editor/Content/ContentFilter.cs
+++ b/Source/Editor/Content/ContentFilter.cs
@@ -1,0 +1,262 @@
+using FlaxEditor.Content;
+using FlaxEditor.Content.GUI;
+using FlaxEngine;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+namespace FlaxEditor.Content
+{
+    /// <summary>
+    /// class with is controling visability of items in content window
+    /// </summary>
+    internal class ContentFilter
+    {
+        #region Filters Config
+        /// <summary>
+        /// all suported files by engine Content Folder
+        /// </summary>
+        public static readonly List<string> SuportedFileExtencionsInContentFolder = new List<string>()
+        {
+            ".flax",
+            ".json",
+            ".scene",
+            ".prefab",
+        };
+        /// <summary>
+        /// all suported files by engine Source Folder
+        /// </summary>
+        public static readonly List<string> SuportedFileExtencionsInSourceFolder = new List<string>()
+        {
+            ".shader",
+            ".cs",
+            ".h",
+            ".cpp",
+        };
+        /// <summary>
+        /// ignores folders in source folder (top layer),
+        /// for example obj folder is default c# project folder 
+        /// </summary>
+        internal static readonly List<string> HideFoldersInSourceFolder = new List<string>()
+        {
+            "obj",                  // default c# project folder
+            "Properties",           // c# project stuff ?
+        };
+        /// <summary>
+        /// ignores files in source folder (top layer),
+        /// </summary>
+        internal static readonly List<string> HideFilesInSourceFolder = new List<string>() //dont edit
+        {
+            "Game.csproj",                  //solucion file
+            "Game.Gen.cs",                  //auto-generated not be edited
+            "GameEditorTarget.Build.cs",    
+            "GameTarget.Build.cs",          
+        };
+        #endregion
+        internal static ContentItem gameSettings;
+        internal static List<ContentItem> buildFiles;
+
+        internal static ContentTreeNode settings;
+        internal static ContentTreeNode shaders;
+        internal static ProjectTreeNode engine;
+        internal static List<ProjectTreeNode> plugins = new();
+        internal static List<ContentItem> FilterFolder(ContentFolder folder)
+        {
+            return FilterFolder(folder, SuportedFileExtencionsInContentFolder.ToArray(), SuportedFileExtencionsInSourceFolder.ToArray());
+        }
+        internal static List<ContentItem> FilterFolder(ContentFolder folder, string[] FileExtencionsInContentFolder, string[] ExtencionsInSourceFolder)
+        {
+            if (folder.CanHaveAssets)
+            {
+                for (int i = 0; i < folder.Children.Count; i++)
+                {
+                    bool Visible = false;
+                    for (int j = 0; j < FileExtencionsInContentFolder.Length; j++)
+                    {
+                        if ((folder.Children[i].Path.EndsWith(FileExtencionsInContentFolder[j]) || folder.Children[i].IsFolder))
+                        {
+                            if (folder.Children[i].Visible)
+                            {
+                                Visible = true;
+                            }
+                            break;
+                        }
+                    }
+                    folder.Children[i].Visible = Visible;
+                }
+            }
+            else if (folder.CanHaveScripts)
+            {
+                for (int i = 0; i < folder.Children.Count; i++)
+                {
+                    bool Visible = false;
+                    for (int j = 0; j < ExtencionsInSourceFolder.Length; j++)
+                    {
+                        if ((folder.Children[i].Path.EndsWith(ExtencionsInSourceFolder[j]) || folder.Children[i].IsFolder))
+                        {
+                            if (folder.Children[i].Visible)
+                            {
+                                Visible = true;
+                            }
+                            break;
+                        }
+                    }
+                    folder.Children[i].Visible = Visible;
+                }
+            }
+            return folder.Children;
+        }
+        internal static ProjectTreeNode Filter(ProjectTreeNode tree)
+        {
+            var content = tree.Children[0] as ContentTreeNode;
+            var source = tree.Children[1] as ContentTreeNode;
+            //filter content folder (top layer)
+            buildFiles = new();
+            for (int i = 0; i < content.Folder.Children.Count; i++)
+            {
+                if (content.Folder.Children[i].FileName == "GameSettings.json")
+                {
+                    gameSettings = content.Folder.Children[i];
+                    content.Folder.Children[i].Visible = false;
+                    break;
+                }
+            }
+
+            int hindenCount = 0;
+
+            for (int i = content.Children.Count - 1; i >= 0; i--)//we are starting from back it faster
+            {
+                var node = content.Children[i] as ContentTreeNode;
+                if (node.Folder.FileName == "Settings")
+                {
+                    settings = node;
+                    hindenCount++;
+                    node.Visible = false;
+                    node.Folder.Visible = false;
+                }
+                if (node.Folder.FileName == "Shaders")
+                {
+                    shaders = node;
+                    hindenCount++;
+                    node.Visible = false;
+                    node.Folder.Visible = false;
+
+                }
+                if (hindenCount == 2)
+                    break;
+            }
+
+            
+            //-----------------------------------------------------------------------------------------------------
+
+            //filter source folder (top layer)
+            hindenCount = 0;
+            for (int i = 0; i < source.Folder.Children.Count; i++)
+            {
+                for (int j = 0; j < HideFilesInSourceFolder.Count; j++)
+                {
+                    if (source.Folder.Children[i].FileName == HideFilesInSourceFolder[j])
+                    {
+                        source.Folder.Children[i].Visible = false;
+                        hindenCount++;
+                        if(i > 1)
+                        {
+                            buildFiles.Add(source.Folder.Children[i]);
+                        }
+                        if (HideFilesInSourceFolder.Count == hindenCount) goto HideFilesInSourceFolderComplited;
+                        break;
+                    }
+                }
+            }
+        HideFilesInSourceFolderComplited:
+            hindenCount = 0;
+            for (int i = source.Children.Count - 1; i >= 0; i--)
+            {
+                var node = source.Children[i] as ContentTreeNode;
+                for (int j = 0; j < HideFoldersInSourceFolder.Count; j++)
+                {
+                    if (node.Folder.FileName == HideFoldersInSourceFolder[j])
+                    {
+                        node.Visible = false;
+                        node.Folder.Visible = false;
+                        hindenCount++;
+                        if (HideFoldersInSourceFolder.Count == hindenCount) goto HideFoldersInSourceFolderComplited;
+                        break;
+                    }
+                }
+            }
+        HideFoldersInSourceFolderComplited:
+            //content
+            return tree;
+        }
+        internal static void UpdateFilterVisability(ContentSettingsDropdown dropdown)
+        {
+            engine.Visible = false;
+            engine.Folder.Visible = false;
+            
+            foreach (var item in plugins)
+            {
+                item.Visible = false;
+                item.Folder.Visible = false;
+            }
+            foreach (var item in buildFiles)
+            {
+                item.Visible = false;
+            }
+            gameSettings.Visible = false;
+            settings.Visible = false;
+            settings.Folder.Visible = false;
+
+            shaders.Visible = false;
+            shaders.Folder.Visible = false;
+
+            for (int i = 0; i < dropdown.Selection.Count; i++)
+            {
+                if (dropdown.Selection[i] == 0) //Show Engine Content
+                {
+                    engine.Visible = true;
+                    engine.Folder.Visible = true;
+                    Editor.Instance.Windows.ContentWin.RefreshView(engine);
+                }
+
+                if (dropdown.Selection[i] == 1)//Show Plugin Content
+                {
+                    foreach (var item in plugins)
+                    {
+                        item.Visible = true;
+                        item.Folder.Visible = true;
+                        Editor.Instance.Windows.ContentWin.RefreshView(item);
+                    }
+                }
+
+                if (dropdown.Selection[i] == 2)//Show Build Files
+                {
+                    foreach (var item in buildFiles)
+                    {
+                        item.Visible = true;
+                    }
+                }
+
+                if (dropdown.Selection[i] == 3)//Show Game Settings
+                {
+                    gameSettings.Visible = true;
+                    settings.Visible = true;
+                    settings.Folder.Visible = true;
+                    Editor.Instance.Windows.ContentWin.RefreshView((ContentTreeNode)settings.Parent);
+                }
+
+                if (dropdown.Selection[i] == 4)//"Show Shader Source"
+                {
+                    shaders.Visible = true;
+                    shaders.Folder.Visible = true;
+                    Editor.Instance.Windows.ContentWin.RefreshView(shaders);
+                }
+            }
+
+            
+            
+        }
+    }
+}

--- a/Source/Editor/Content/GUI/ContentNavigationBar.cs
+++ b/Source/Editor/Content/GUI/ContentNavigationBar.cs
@@ -1,0 +1,27 @@
+using FlaxEditor.GUI;
+using FlaxEngine;
+
+namespace FlaxEditor.Content.GUI
+{
+    internal class ContentNavigationBar : NavigationBar
+    {
+        ToolStrip _toolstrip;
+        internal float ofssetFromRightEdge = 80;
+        internal ContentNavigationBar(ToolStrip toolstrip) : base()
+        {
+            _toolstrip = toolstrip;
+        }
+        /// <inheritdoc />
+        protected override void Arrange()
+        {
+            base.Arrange();
+            var lastToolstripButton = _toolstrip.LastButton;
+            var parentSize = Parent.Size;
+            Bounds = new Rectangle
+            (
+             new Float2(lastToolstripButton.Right, 0),
+             new Float2(parentSize.X - X - ofssetFromRightEdge, _toolstrip.Height)
+            );
+        }
+    }
+}

--- a/Source/Editor/Content/GUI/ContentNavigationButton.cs
+++ b/Source/Editor/Content/GUI/ContentNavigationButton.cs
@@ -31,7 +31,7 @@ namespace FlaxEditor.Content.GUI
         : base(x, y, height)
         {
             TargetNode = targetNode;
-            Text = targetNode.NavButtonLabel + "/";
+            Text = targetNode.NavButtonLabel;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Content/GUI/ContentNavigationButtonSeparator.cs
+++ b/Source/Editor/Content/GUI/ContentNavigationButtonSeparator.cs
@@ -1,0 +1,85 @@
+using FlaxEditor;
+using FlaxEditor.GUI;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using System.Collections.Generic;
+
+namespace FlaxEditor.Content.GUI
+{
+    internal class ContentNavigationButtonSeparator : ComboBox
+    {
+        public ContentNavigationButton Target { get; }
+        public ContentNavigationButtonSeparator(ContentNavigationButton target, float x, float y,float height)
+        {
+            Target = target;
+            Bounds = new Rectangle(x, y, 16, height);
+            Offsets = new Margin(Bounds.X, Bounds.Width, Bounds.Y, Bounds.Height);
+            UpdateTransform();
+
+            MaximumItemsInViewCount = 20;
+            var style = Style.Current;
+            BackgroundColor = style.BackgroundNormal;
+            BackgroundColorHighlighted = BackgroundColor;
+            BackgroundColorSelected = BackgroundColor;
+        }
+        protected override ContextMenu OnCreatePopup()
+        {
+            UpdateDropDownItems();
+            return base.OnCreatePopup();
+        }
+        internal void UpdateDropDownItems()
+        {
+            ClearItems();
+            _items = new();
+            for (int i = 0; i < Target.TargetNode.Children.Count; i++)
+            {
+                if (Target.TargetNode.Children[i] is ContentTreeNode node)
+                {
+                    if (node.Folder.VisibleInHierarchy) // respect the filter set by ContentFilterConfig.Filter(...)
+                        AddItem(node.Folder.ShortName);
+                }
+            }
+        }
+        /// <inheritdoc />
+        public override void Draw()
+        {
+            // Cache data
+            var style = Style.Current;
+            var clientRect = new Rectangle(Float2.Zero, Size);
+            // Draw background
+            if (IsDragOver)
+            {
+                Render2D.FillRectangle(clientRect, Style.Current.BackgroundSelected * 0.6f);
+            }
+            else if (_mouseDown)
+            {
+                Render2D.FillRectangle(clientRect, style.BackgroundSelected);
+            }
+            else if (IsMouseOver)
+            {
+                Render2D.FillRectangle(clientRect, style.BackgroundHighlighted);
+            }
+
+            Render2D.DrawSprite(Editor.Instance.Icons.ArrowRight12, new Rectangle(clientRect.Location.X, clientRect.Y + ((Size.Y / 2f)/2f), Size.X, Size.X), EnabledInHierarchy ? Style.Current.Foreground : Style.Current.ForegroundDisabled);
+        }
+        protected override void OnLayoutMenuButton(ref ContextMenuButton button, int index, bool construct = false)
+        {
+            var style = Style.Current;
+            button.Icon = Editor.Instance.Icons.FolderClosed32;
+            if (_tooltips != null && _tooltips.Length > index)
+            {
+                button.TooltipText = _tooltips[index];
+            }
+        }
+        protected override void OnItemClicked(int index)
+        {
+            base.OnItemClicked(index);
+            if (Target.TargetNode.Children[index] is ContentTreeNode node)
+            {
+                Editor.Instance.Windows.ContentWin.Navigate(node);
+            }
+            // Navigate calls the OnDestroy at some point dont place code below or editor will crash
+        }
+    }
+}

--- a/Source/Editor/Content/GUI/ContentSettingsDropdown.cs
+++ b/Source/Editor/Content/GUI/ContentSettingsDropdown.cs
@@ -1,0 +1,95 @@
+using FlaxEditor.Content;
+using FlaxEditor.CustomEditors.Editors;
+using FlaxEditor.GUI;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.States;
+using FlaxEditor.Utilities;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using FlaxEngine.Json;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FlaxEditor.Content.GUI
+{
+    class ContentSettingsDropdown : ComboBox
+    {
+        internal readonly List<string> Settings = new()
+        {
+            "Show Engine Content",
+            "Show Plugin Content",
+            "Show Build Files",
+            "Show Game Settings",
+            "Show Shader Source"
+        };
+        public ContentSettingsDropdown()
+        {
+            SupportMultiSelect = true;
+            MaximumItemsInViewCount = 20;
+            var style = Style.Current;
+            BackgroundColor = style.BackgroundNormal;
+            BackgroundColorHighlighted = BackgroundColor;
+            BackgroundColorSelected = BackgroundColor;
+            
+        }
+        protected override ContextMenu OnCreatePopup()
+        {
+            UpdateDropDownItems();
+            return base.OnCreatePopup();
+        }
+        internal void UpdateDropDownItems()
+        {
+            ClearItems();
+            
+            for (int i = 0; i < Settings.Count; i++)
+            {
+                AddItem(Settings[i]);
+            }
+        }
+        /// <inheritdoc />
+        public override void Draw()
+        {
+            // Cache data
+            var style = Style.Current;
+            var clientRect = new Rectangle(Float2.Zero, Size);
+            // Draw background
+            if (IsDragOver)
+            {
+                Render2D.FillRectangle(clientRect, Style.Current.BackgroundSelected * 0.6f);
+            }
+            else if (_mouseDown)
+            {
+                Render2D.FillRectangle(clientRect, style.BackgroundSelected);
+            }
+            else if (IsMouseOver)
+            {
+                Render2D.FillRectangle(clientRect, style.BackgroundHighlighted);
+            }
+            float size = (Size.Y / 1.5f); //Icon size
+            // Draw text
+            Render2D.DrawText(Font.GetFont(), "Settings", new Rectangle(size, 0, Size.X - Size.Y, Size.Y), TextColor, TextAlignment.Center, TextAlignment.Center);
+            Render2D.DrawSprite(Editor.Instance.Icons.Settings12, new Rectangle((Size.Y - size) / 2.0f, (Size.Y - size) / 2.0f, size, size));
+        }
+        protected override void OnLayoutMenuButton(ref ContextMenuButton button, int index, bool construct = false)
+        {
+            var style = Style.Current;
+            if (_selectedIndices.Contains(index))
+            {
+                button.Icon = style.CheckBoxTick;
+            }
+            else
+            {
+                button.Icon = SpriteHandle.Default;
+            }
+            if (_tooltips != null && _tooltips.Length > index)
+            {
+                button.TooltipText = _tooltips[index];
+            }
+        }
+        protected override void OnSelectedIndexChanged()
+        {
+            ContentFilter.UpdateFilterVisability(this);
+            base.OnSelectedIndexChanged();
+        }
+    }
+}

--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -261,11 +261,14 @@ namespace FlaxEditor.Content.GUI
                 ClearItems();
 
             // Add references and link items
-            _items.AddRange(items);
             for (int i = 0; i < items.Count; i++)
             {
-                items[i].Parent = this;
-                items[i].AddReference(this);
+                if (items[i].Visible)
+                {
+                    items[i].Parent = this;
+                    items[i].AddReference(this);
+                    _items.Add(items[i]);
+                }
             }
             if (selection != null)
             {

--- a/Source/Editor/Content/Items/ContentItem.cs
+++ b/Source/Editor/Content/Items/ContentItem.cs
@@ -441,6 +441,11 @@ namespace FlaxEditor.Content
         {
             get
             {
+                if (!Visible)
+                {
+                    return Rectangle.Empty;
+                }
+
                 var view = Parent as ContentView;
                 var size = Size;
                 switch (view?.ViewType ?? ContentViewType.Tiles)
@@ -448,7 +453,7 @@ namespace FlaxEditor.Content
                 case ContentViewType.Tiles:
                 {
                     var textHeight = DefaultTextHeight * size.X / DefaultWidth;
-                    return new Rectangle(0, size.Y - textHeight, size.X, textHeight);
+                    return new Rectangle(0, size.Y - textHeight, size.X - 2, textHeight);
                 }
                 case ContentViewType.List:
                 {
@@ -642,6 +647,7 @@ namespace FlaxEditor.Content
         /// <inheritdoc />
         public override void Draw()
         {
+            
             // Cache data
             var size = Size;
             var style = Style.Current;

--- a/Source/Editor/Windows/ContentWindow.Navigation.cs
+++ b/Source/Editor/Windows/ContentWindow.Navigation.cs
@@ -196,12 +196,18 @@ namespace FlaxEditor.Windows
             }
             float x = NavigationBar.DefaultButtonsMargin;
             float h = _toolStrip.ItemsHeight - 2 * ToolStrip.DefaultMarginV;
-            for (int i = nodes.Count - 1; i >= 0; i--)
+            for (int i = nodes.Count - 2; i >= 0; i--)
             {
-                var button = new ContentNavigationButton(nodes[i], x, ToolStrip.DefaultMarginV, h);
+                var button = new ContentNavigationButton(nodes[i], x - 100, ToolStrip.DefaultMarginV, h);
                 button.PerformLayout();
                 x += button.Width + NavigationBar.DefaultButtonsMargin;
                 _navigationBar.AddChild(button);
+                if (i == 0)
+                    continue;
+                var buttonSeparator = new ContentNavigationButtonSeparator(button, x, ToolStrip.DefaultMarginV, h);
+                buttonSeparator.PerformLayout();
+                x += buttonSeparator.Width + NavigationBar.DefaultButtonsMargin;
+                _navigationBar.AddChild(buttonSeparator);
             }
             nodes.Clear();
 

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -39,11 +39,13 @@ namespace FlaxEditor.Windows
         private readonly ToolStripButton _navigateForwardButton;
         private readonly ToolStripButton _navigateUpButton;
 
-        private NavigationBar _navigationBar;
+        private ContentNavigationBar _navigationBar;
         private Tree _tree;
         private TextBox _foldersSearchBox;
         private TextBox _itemsSearchBox;
         private ViewDropdown _viewDropdown;
+        private ContentSettingsDropdown _ContentSettingDropdown;
+        private const float _ContentDropdownSizeX = 100;
         private SortType _sortType;
 
         private RootContentTreeNode _root;
@@ -73,7 +75,7 @@ namespace FlaxEditor.Windows
         {
             Title = "Content";
             Icon = editor.Icons.Folder32;
-
+                    
             // Content database events
             editor.ContentDatabase.WorkspaceModified += () => _isWorkspaceDirty = true;
             editor.ContentDatabase.ItemRemoved += OnContentDatabaseItemRemoved;
@@ -107,11 +109,25 @@ namespace FlaxEditor.Windows
             _navigateBackwardButton = (ToolStripButton)_toolStrip.AddButton(Editor.Icons.Left64, NavigateBackward).LinkTooltip("Navigate backward");
             _navigateForwardButton = (ToolStripButton)_toolStrip.AddButton(Editor.Icons.Right64, NavigateForward).LinkTooltip("Navigate forward");
             _navigateUpButton = (ToolStripButton)_toolStrip.AddButton(Editor.Icons.Up64, NavigateUp).LinkTooltip("Navigate up");
-
+            _toolStrip.AddSeparator();
             // Navigation bar
-            _navigationBar = new NavigationBar
+            
+            _navigationBar = new ContentNavigationBar(_toolStrip)
             {
-                Parent = this,
+                Parent = _toolStrip,
+                ofssetFromRightEdge = _ContentDropdownSizeX
+            };
+            var DropdownSettingsPanel = new Panel(ScrollBars.None)
+            {
+                Parent = _toolStrip,
+                Size = new Float2(_ContentDropdownSizeX, _toolStrip.Height)
+            };
+            //setings Dropdown
+            _ContentSettingDropdown = new ContentSettingsDropdown
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Parent = DropdownSettingsPanel,
+                Offsets = new Margin(2, 4, 4, 4)
             };
 
             // Split panel
@@ -215,7 +231,7 @@ namespace FlaxEditor.Windows
         private ContextMenu OnViewDropdownPopupCreate(ComboBox comboBox)
         {
             var menu = new ContextMenu();
-
+            
             var showFileExtensionsButton = menu.AddButton("Show file extensions", () => View.ShowFileExtensions = !View.ShowFileExtensions);
             showFileExtensionsButton.Checked = View.ShowFileExtensions;
             showFileExtensionsButton.AutoCheck = true;
@@ -877,8 +893,9 @@ namespace FlaxEditor.Windows
             }
             else
             {
+                
                 // Show folder contents
-                _view.ShowItems(target.Folder.Children, _sortType, false, true);
+                _view.ShowItems(ContentFilter.FilterFolder(target.Folder), _sortType, false, true);
             }
         }
 
@@ -918,15 +935,17 @@ namespace FlaxEditor.Windows
             _root.Expand(true);
 
             // Add game project on top, plugins in the middle and engine at bottom
-            _root.AddChild(Editor.ContentDatabase.Game);
+            _root.AddChild(ContentFilter.Filter(Editor.ContentDatabase.Game));
             foreach (var project in Editor.ContentDatabase.Projects)
             {
                 project.SortChildrenRecursive();
                 if (project == Editor.ContentDatabase.Game || project == Editor.ContentDatabase.Engine)
                     continue;
                 _root.AddChild(project);
+                ContentFilter.plugins.Add(project);
             }
             _root.AddChild(Editor.ContentDatabase.Engine);
+            ContentFilter.engine = Editor.ContentDatabase.Engine;
 
             Editor.ContentDatabase.Game?.Expand(true);
             _tree.Margin = new Margin(0.0f, 0.0f, -16.0f, 2.0f); // Hide root node
@@ -1035,15 +1054,6 @@ namespace FlaxEditor.Windows
 
             return base.OnMouseUp(location, button);
         }
-
-        /// <inheritdoc />
-        protected override void PerformLayoutBeforeChildren()
-        {
-            base.PerformLayoutBeforeChildren();
-
-            _navigationBar?.UpdateBounds(_toolStrip);
-        }
-
         /// <inheritdoc />
         public override bool UseLayoutData => true;
 
@@ -1054,6 +1064,12 @@ namespace FlaxEditor.Windows
             writer.WriteAttributeString("Scale", _view.ViewScale.ToString(CultureInfo.InvariantCulture));
             writer.WriteAttributeString("ShowFileExtensions", _view.ShowFileExtensions.ToString());
             writer.WriteAttributeString("ViewType", _view.ViewType.ToString());
+            for (int i = 0; i < _ContentSettingDropdown.Selection.Count; i++)
+            {
+                if(_ContentSettingDropdown.Selection.Count != 0)
+                    writer.WriteAttributeString(_ContentSettingDropdown.Settings[_ContentSettingDropdown.Selection[i]].Replace(' ', '_'), _ContentSettingDropdown.Selection[i].ToString());
+            }
+            
         }
 
         /// <inheritdoc />
@@ -1066,6 +1082,15 @@ namespace FlaxEditor.Windows
                 _view.ShowFileExtensions = value2;
             if (Enum.TryParse(node.GetAttribute("ViewType"), out ContentViewType viewType))
                 _view.ViewType = viewType;
+
+            for (int i = 0; i < _ContentSettingDropdown.Settings.Count; i++)
+            {
+                int flag;
+                if (int.TryParse(node.GetAttribute(_ContentSettingDropdown.Settings[i].Replace(' ', '_')), out flag))
+                    _ContentSettingDropdown.Selection.Add(flag);
+               
+            }
+            ContentFilter.UpdateFilterVisability(_ContentSettingDropdown);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
content browser is no longer showing source files (.png,/.fbx)
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/4c9779ca-db17-47c5-bc6f-d5ef59bb0510)
inside ContentFilter class there is SuportedFileExtencionsInContentFolder/SuportedFileExtencionsInSourceFolder list as a config if something is missing add extencion there 

folder switcher opened by pressing on separator in navigation bar
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/e92469fc-61a4-4c90-8aba-d886d60660f8)
Settings opcions
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/553dd19f-9160-46bf-90c1-38466557aff5)
it will be hard to expand because how multi selection works