### PR TITLE
Fix API_INJECT_CODE injecting duplicated code

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -2059,7 +2059,7 @@ namespace Flax.Build.Bindings
                         if (code.StartsWith("using"))
                             CSharpUsedNamespaces.Add(code.Substring(6));
                         else if (code.Length > 0)
-                            contents.Append(injectCodeInfo.Code).AppendLine(";");
+                            contents.Append(code).AppendLine(";");
                     }
                 }
                 else


### PR DESCRIPTION
When `API_INJECT_CODE` contains multiple lines and semicolons, the injected code is duplicated.