### PR TITLE
Fix duplicating actor in scene on shift click if the actor has not been moved

### DIFF
--- a/Source/Editor/Gizmo/TransformGizmoBase.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.cs
@@ -469,7 +469,7 @@ namespace FlaxEditor.Gizmo
                     }
 
                     // Apply transformation (but to the parents, not whole selection pool)
-                    if (anyValid || (!_isTransforming && Owner.UseDuplicate))
+                    if (anyValid || (_isTransforming && Owner.UseDuplicate))
                     {
                         StartTransforming();
                         LastDelta = new Transform(translationDelta, rotationDelta, scaleDelta);


### PR DESCRIPTION
Fixed a small bug of when the user holds the shift key and clicks in the editor viewport that it will duplicate an actor without having to move the actor.