### PR TITLE
`ShadowOfMordor` terrain fix

### DIFF
--- a/Source/Engine/ShadowsOfMordor/Builder.Jobs.cpp
+++ b/Source/Engine/ShadowsOfMordor/Builder.Jobs.cpp
@@ -151,6 +151,12 @@ void ShadowsOfMordor::Builder::onJobRender(GPUContext* context)
                 auto patch = terrain->GetPatch(entry.AsTerrain.PatchIndex);
                 auto chunk = &patch->Chunks[entry.AsTerrain.ChunkIndex];
                 auto chunkSize = terrain->GetChunkSize();
+                if (!patch->Heightmap)
+                {
+                    LOG(Error, "Terrain actor {0} is missing heightmap for baking, skipping baking stage.", terrain->GetName());
+                    _wasStageDone = true;
+                    return;
+                }
                 const auto heightmap = patch->Heightmap.Get()->GetTexture();
 
                 Matrix world;

--- a/Source/Engine/ShadowsOfMordor/Builder.Jobs.cpp
+++ b/Source/Engine/ShadowsOfMordor/Builder.Jobs.cpp
@@ -155,6 +155,7 @@ void ShadowsOfMordor::Builder::onJobRender(GPUContext* context)
                 {
                     LOG(Error, "Terrain actor {0} is missing heightmap for baking, skipping baking stage.", terrain->GetName());
                     _wasStageDone = true;
+                    scene->EntriesLocker.Unlock();
                     return;
                 }
                 const auto heightmap = patch->Heightmap.Get()->GetTexture();


### PR DESCRIPTION
Currently, if you have a terrain actor in your scene that you want to bake a lightmap for, and you (for whatever reason) decided to delete `SceneData/Terrain` folder that contains terrain heightmaps (or did that accidentally like me), this would produce a `nullptr` dereference while building lightmaps. This PR adds a safeguard against that.