### PR TITLE
.NET7: Implement a generic version of `AssetReferenceAttribute`

### DIFF
--- a/Source/Engine/Scripting/Attributes/Editor/AssetReferenceAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/AssetReferenceAttribute.cs
@@ -53,4 +53,21 @@ namespace FlaxEngine
             UseSmallPicker = useSmallPicker;
         }
     }
+
+    /// <summary>
+    /// Specifies a options for an asset reference picker in the editor. Allows to customize view or provide custom value assign policy.
+    /// </summary>
+    /// <seealso cref="System.Attribute" />
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class AssetReferenceAttribute<T> : AssetReferenceAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssetReferenceAttribute"/> class for generic type T.
+        /// </summary>
+        /// <param name="useSmallPicker">True if use asset picker with a smaller height (single line), otherwise will use with full icon.</param>
+        public AssetReferenceAttribute(bool useSmallPicker = false)
+            : base(typeof(T), useSmallPicker)
+        {
+        }
+    }
 }

--- a/Source/Engine/Scripting/Attributes/Editor/AssetReferenceAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/AssetReferenceAttribute.cs
@@ -54,6 +54,7 @@ namespace FlaxEngine
         }
     }
 
+#if USE_NETCORE
     /// <summary>
     /// Specifies a options for an asset reference picker in the editor. Allows to customize view or provide custom value assign policy.
     /// </summary>
@@ -70,4 +71,5 @@ namespace FlaxEngine
         {
         }
     }
+#endif
 }


### PR DESCRIPTION
Adds a support for passing the asset type as a generic parameter:
```csharp
// Before:
[AssetReference(typeof(MyAsset), true)]
public JsonAsset asset;

// After:
[AssetReference<MyAsset>(true)]
public JsonAsset asset;
```