### PR TITLE
.NET7: Add common .NET SDK preprocessor definitions

### DIFF
--- a/Source/Engine/Scripting/Scripting.Build.cs
+++ b/Source/Engine/Scripting/Scripting.Build.cs
@@ -17,9 +17,28 @@ public class Scripting : EngineModule
         {
             if (EngineConfiguration.WithDotNet(options))
             {
+                void AddFrameworkDefines(string template, int major, int latestMinor)
+                {
+                    for (int minor = latestMinor; minor >= 0; minor--)
+                    {
+                        options.ScriptingAPI.Defines.Add(string.Format(template, major, minor));
+                        options.ScriptingAPI.Defines.Add(string.Format($"{template}_OR_GREATER", major, minor));
+                    }
+                }
+
                 // .NET
                 options.PrivateDependencies.Add("nethost");
                 options.ScriptingAPI.Defines.Add("USE_NETCORE");
+
+                // .NET SDK
+                AddFrameworkDefines("NET{0}_{1}", 7, 0); // "NET7_0" and "NET7_0_OR_GREATER"
+                AddFrameworkDefines("NET{0}_{1}", 6, 0);
+                AddFrameworkDefines("NET{0}_{1}", 5, 0);
+                options.ScriptingAPI.Defines.Add("NET");
+                AddFrameworkDefines("NETCOREAPP{0}_{1}", 3, 1); // "NETCOREAPP3_1" and "NETCOREAPP3_1_OR_GREATER"
+                AddFrameworkDefines("NETCOREAPP{0}_{1}", 2, 2);
+                AddFrameworkDefines("NETCOREAPP{0}_{1}", 1, 1);
+                options.ScriptingAPI.Defines.Add("NETCOREAPP");
 
                 if (options.Target is EngineTarget engineTarget && engineTarget.UseSeparateMainExecutable(options))
                 {


### PR DESCRIPTION
Fixes an issue with `MemoryPack` library where the source generator emits different code by looking up for `NET7_0_OR_GREATER` definitions.