### PR TITLE
.NET7: Support user defined analyzers/source generators in Flax.Build

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -272,8 +272,10 @@ namespace Flax.Build
             foreach (var reference in fileReferences)
                 args.Add(string.Format("/reference:\"{0}\"", reference));
 #if USE_NETCORE
-            foreach (var analyzer in buildOptions.ScriptingAPI.SystemAnalyzers)
-                args.Add(string.Format("/analyzer:\"{0}{1}.dll\"", referenceAnalyzers, analyzer));
+            foreach (var systemAnalyzer in buildOptions.ScriptingAPI.SystemAnalyzers)
+                args.Add(string.Format("/analyzer:\"{0}{1}.dll\"", referenceAnalyzers, systemAnalyzer));
+            foreach (var analyzer in buildOptions.ScriptingAPI.Analyzers)
+                args.Add(string.Format("/analyzer:\"{0}\"", analyzer));
 #endif
             foreach (var sourceFile in sourceFiles)
                 args.Add("\"" + sourceFile + "\"");

--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -159,6 +159,7 @@ namespace Flax.Build
             var outputPath = Path.GetDirectoryName(buildData.Target.GetOutputFilePath(buildOptions));
             var outputFile = Path.Combine(outputPath, name + ".dll");
             var outputDocFile = Path.Combine(outputPath, name + ".xml");
+            var outputGeneratedFiles = Path.Combine(buildOptions.IntermediateFolder);
             string cscPath, referenceAssemblies;
 #if USE_NETCORE
             var dotnetSdk = DotNetSdk.Instance;
@@ -263,6 +264,9 @@ namespace Flax.Build
 #endif
             args.Add(string.Format("/out:\"{0}\"", outputFile));
             args.Add(string.Format("/doc:\"{0}\"", outputDocFile));
+#if USE_NETCORE
+            args.Add(string.Format("/generatedfilesout:\"{0}\"", outputGeneratedFiles));
+#endif
             if (buildOptions.ScriptingAPI.Defines.Count != 0)
                 args.Add("/define:" + string.Join(";", buildOptions.ScriptingAPI.Defines));
             if (buildData.Configuration == TargetConfiguration.Debug)

--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -200,14 +200,19 @@ namespace Flax.Build.NativeCpp
             public HashSet<string> SystemReferences;
 
             /// <summary>
-            /// The .Net libraries references (dll or exe files paths).
+            /// The system analyzers/source generators.
+            /// </summary>
+            public HashSet<string> SystemAnalyzers;
+
+            /// <summary>
+            /// The .NET libraries references (dll or exe files paths).
             /// </summary>
             public HashSet<string> FileReferences;
 
             /// <summary>
-            /// The .Net libraries references (dll or exe files paths).
+            /// The .NET analyzers (dll or exe files paths).
             /// </summary>
-            public HashSet<string> SystemAnalyzers;
+            public HashSet<string> Analyzers;
 
             /// <summary>
             /// True if ignore compilation warnings due to missing code documentation comments.
@@ -232,6 +237,7 @@ namespace Flax.Build.NativeCpp
                 Defines.AddRange(other.Defines);
                 SystemReferences.AddRange(other.SystemReferences);
                 FileReferences.AddRange(other.FileReferences);
+                Analyzers.AddRange(other.Analyzers);
                 IgnoreMissingDocumentationWarnings |= other.IgnoreMissingDocumentationWarnings;
             }
         }
@@ -305,6 +311,7 @@ namespace Flax.Build.NativeCpp
                 "Microsoft.Interop.SourceGeneration",
             },
             FileReferences = new HashSet<string>(),
+            Analyzers = new HashSet<string>(),
         };
 
         /// <summary>

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -247,6 +247,14 @@ namespace Flax.Build.Projects.VisualStudio
                     csProjectFileContent.AppendLine("  </ItemGroup>");
                 }
             }
+            foreach (var analyzer in configuration.TargetBuildOptions.ScriptingAPI.Analyzers)
+            {
+                csProjectFileContent.AppendLine(string.Format("  <ItemGroup Condition=\" '$(Configuration)|$(Platform)' == '{0}' \">", configuration.Name));
+                csProjectFileContent.AppendLine(string.Format("    <Analyzer Include=\"{0}\">", Path.GetFileNameWithoutExtension(analyzer)));
+                csProjectFileContent.AppendLine(string.Format("      <HintPath>{0}</HintPath>", Utilities.MakePathRelativeTo(analyzer, projectDirectory).Replace('/', '\\')));
+                csProjectFileContent.AppendLine("    </Analyzer>");
+                csProjectFileContent.AppendLine("  </ItemGroup>");
+            }
 
             csProjectFileContent.AppendLine("");
         }


### PR DESCRIPTION
Example case with `MemoryPack` library which uses source generators to generate serializers/deserializers for classes annotated with `[MemoryPackable]` attribute. The following lines would need to be added to `Game.Build.cs` to reference both the core library and the source generator:
```csharp
options.ScriptingAPI.FileReferences.Add(Path.Combine(FolderPath, "..", "..", "Content", "MemoryPack.Core.dll"));
options.ScriptingAPI.Analyzers.Add(Path.Combine(FolderPath, "..", "..", "Content", "MemoryPack.Generator.dll"));
```