### PR TITLE
Fix build issues in Visual Studio 2022 Preview 5

### DIFF
--- a/Source/ThirdParty/fmt/format.h
+++ b/Source/ThirdParty/fmt/format.h
@@ -36,6 +36,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <limits>
+#include <initializer_list>
 
 #include "core.h"
 


### PR DESCRIPTION
Building the engine started to fail after updating to latest VS2022 preview with the following errors:
`
2>C:\dev\Flax\FlaxEngine\Source\ThirdParty\fmt\format.h(467): error C2039: 'begin': is not a member of 'std'
2>C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.37.32820\include\limits(38): note: see declaration of 'std'
`