### PR TITLE
Require semicolon after most engine API macros

### DIFF
--- a/Source/Engine/Content/BinaryAsset.h
+++ b/Source/Engine/Content/BinaryAsset.h
@@ -10,7 +10,8 @@
 #define DECLARE_BINARY_ASSET_HEADER(type, serializedVersion) \
 	DECLARE_ASSET_HEADER(type); \
 	static const uint32 SerializedVersion = serializedVersion; \
-	uint32 GetSerializedVersion() const override { return SerializedVersion; }
+	uint32 GetSerializedVersion() const override { return SerializedVersion; } \
+    static_assert(true, "")
 
 #define REGISTER_BINARY_ASSET_ABSTRACT(type, typeName) \
 	const String type::TypeName = TEXT(typeName)

--- a/Source/Engine/ContentImporters/Types.h
+++ b/Source/Engine/ContentImporters/Types.h
@@ -149,6 +149,6 @@ public:
     CreateAssetFunction Callback;
 };
 
-#define IMPORT_SETUP(type, serializedVersion) context.Data.Header.TypeName = type::TypeName; context.Data.SerializedVersion = serializedVersion;
+#define IMPORT_SETUP(type, serializedVersion) context.Data.Header.TypeName = type::TypeName; context.Data.SerializedVersion = serializedVersion
 
 #endif

--- a/Source/Engine/Core/Config.h
+++ b/Source/Engine/Core/Config.h
@@ -53,5 +53,5 @@
 #define API_PARAM(...)
 #define API_TYPEDEF(...)
 #define API_INJECT_CODE(...)
-#define API_AUTO_SERIALIZATION(...) public: void Serialize(SerializeStream& stream, const void* otherObj) override; void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
-#define DECLARE_SCRIPTING_TYPE_MINIMAL(type) public: friend class type##Internal; static struct ScriptingTypeInitializer TypeInitializer;
+#define API_AUTO_SERIALIZATION(...) public: void Serialize(SerializeStream& stream, const void* otherObj) override; void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override
+#define DECLARE_SCRIPTING_TYPE_MINIMAL(type) public: friend class type##Internal; static struct ScriptingTypeInitializer TypeInitializer

--- a/Source/Engine/Core/Config/Settings.h
+++ b/Source/Engine/Core/Config/Settings.h
@@ -45,7 +45,7 @@ public:
             } \
         } \
         return result; \
-    }
+    } static_assert(true, "")
 
 // [Deprecated on 20.01.2022, expires on 20.01.2024]
 #define IMPLEMENT_SETTINGS_GETTER(type, field) IMPLEMENT_ENGINE_SETTINGS_GETTER(type, field)
@@ -69,6 +69,6 @@ public:
             } \
         } \
         return result; \
-    }
+    } static_assert(true, "")
 
 #define DECLARE_SETTINGS_GETTER(type) static type* Get()

--- a/Source/Engine/Core/Core.h
+++ b/Source/Engine/Core/Core.h
@@ -4,9 +4,9 @@
 
 #include "Compiler.h"
 
-#define SAFE_DISPOSE(x) if(x) { (x)->Dispose(); (x) = nullptr; }
-#define SAFE_RELEASE(x) if(x) { (x)->Release(); (x) = nullptr; }
-#define SAFE_DELETE(x) if(x) { ::Delete(x); (x) = nullptr; }
+#define SAFE_DISPOSE(x) if(x) { (x)->Dispose(); (x) = nullptr; } static_assert(true, "")
+#define SAFE_RELEASE(x) if(x) { (x)->Release(); (x) = nullptr; } static_assert(true, "")
+#define SAFE_DELETE(x) if(x) { ::Delete(x); (x) = nullptr; } static_assert(true, "")
 #define INVALID_INDEX (-1)
 #define _INTERNAL_CONCAT_MACROS(a, b) a ## b
 #define CONCAT_MACROS(a, b) _INTERNAL_CONCAT_MACROS(a, b)
@@ -22,9 +22,9 @@
     }
 #define OUT_OF_MEMORY Platform::OutOfMemory(__LINE__, __FILE__)
 #define MISSING_CODE(info) Platform::MissingCode(__LINE__, __FILE__, info)
-#define NON_COPYABLE(type) type(type&&) = delete; type(const type&) = delete; type& operator=(const type&) = delete; type& operator=(type&&) = delete;
+#define NON_COPYABLE(type) type(type&&) = delete; type(const type&) = delete; type& operator=(const type&) = delete; type& operator=(type&&) = delete
 #define POD_COPYABLE(type) \
     type(const type& other) { Platform::MemoryCopy(this, &other, sizeof(type)); } \
     type(type&& other) noexcept { Platform::MemoryCopy(this, &other, sizeof(type)); } \
     type& operator=(const type& other) { Platform::MemoryCopy(this, &other, sizeof(type)); return *this; } \
-    type& operator=(type&& other) noexcept { Platform::MemoryCopy(this, &other, sizeof(type)); return *this; }
+    type& operator=(type&& other) noexcept { Platform::MemoryCopy(this, &other, sizeof(type)); return *this; } static_assert(true, "")

--- a/Source/Engine/Core/Enums.h
+++ b/Source/Engine/Core/Enums.h
@@ -13,154 +13,154 @@
 #define DECLARE_ENUM_1(name, t0) enum class name{t0=0};\
 static const int name##_Count = 1;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_2(name, t0, t1) enum class name{t0=0,t1};\
 static const int name##_Count = 2;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_3(name, t0, t1, t2) enum class name{t0=0,t1,t2};\
 static const int name##_Count = 3;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_4(name, t0, t1, t2, t3) enum class name{t0=0,t1,t2,t3};\
 static const int name##_Count = 4;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_5(name, t0, t1, t2, t3, t4) enum class name{t0=0,t1,t2,t3,t4};\
 static const int name##_Count = 5;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_6(name, t0, t1, t2, t3, t4, t5) enum class name{t0=0,t1,t2,t3,t4,t5};\
 static const int name##_Count = 6;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_7(name, t0, t1, t2, t3, t4, t5, t6) enum class name{t0=0,t1,t2,t3,t4,t5,t6};\
 static const int name##_Count = 7;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_8(name, t0, t1, t2, t3, t4, t5, t6, t7) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7};\
 static const int name##_Count = 8;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_9(name, t0, t1, t2, t3, t4, t5, t6, t7, t8) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8};\
 static const int name##_Count = 9;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_10(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9};\
 static const int name##_Count = 10;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_11(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10};\
 static const int name##_Count = 11;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_12(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11};\
 static const int name##_Count = 12;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_13(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12};\
 static const int name##_Count = 13;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11),ENUM_TO_STR(t12)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_14(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13};\
 static const int name##_Count = 14;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11),ENUM_TO_STR(t12),ENUM_TO_STR(t13)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_15(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14};\
 static const int name##_Count = 15;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11),ENUM_TO_STR(t12),ENUM_TO_STR(t13),ENUM_TO_STR(t14)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_16(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15};\
 static const int name##_Count = 16;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11),ENUM_TO_STR(t12),ENUM_TO_STR(t13),ENUM_TO_STR(t14),ENUM_TO_STR(t15)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_17(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16};\
 static const int name##_Count = 17;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11),ENUM_TO_STR(t12),ENUM_TO_STR(t13),ENUM_TO_STR(t14),ENUM_TO_STR(t15),ENUM_TO_STR(t16)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 #define DECLARE_ENUM_18(name, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17) enum class name{t0=0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17};\
 static const int name##_Count = 17;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11),ENUM_TO_STR(t12),ENUM_TO_STR(t13),ENUM_TO_STR(t14),ENUM_TO_STR(t15),ENUM_TO_STR(t16),ENUM_TO_STR(t17)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e];}static_assert(true, "")
 
 // ..and those with base type and base value
 
 #define DECLARE_ENUM_EX_1(name, baseType, baseVal, t0) enum class name:baseType{t0=baseVal};\
 static const int name##_Count = 1;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_2(name, baseType, baseVal, t0, t1) enum class name:baseType{t0=baseVal,t1};\
 static const int name##_Count = 2;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_3(name, baseType, baseVal, t0, t1, t2) enum class name:baseType{t0=baseVal,t1,t2};\
 static const int name##_Count = 3;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_4(name, baseType, baseVal, t0, t1, t2, t3) enum class name:baseType{t0=baseVal,t1,t2,t3};\
 static const int name##_Count = 4;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_5(name, baseType, baseVal, t0, t1, t2, t3, t4) enum class name:baseType{t0=baseVal,t1,t2,t3,t4};\
 static const int name##_Count = 5;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_6(name, baseType, baseVal, t0, t1, t2, t3, t4, t5) enum class name:baseType{t0=baseVal,t1,t2,t3,t4,t5};\
 static const int name##_Count = 6;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_7(name, baseType, baseVal, t0, t1, t2, t3, t4, t5, t6) enum class name:baseType{t0=baseVal,t1,t2,t3,t4,t5,t6};\
 static const int name##_Count = 7;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_8(name, baseType, baseVal, t0, t1, t2, t3, t4, t5, t6, t7) enum class name:baseType{t0=baseVal,t1,t2,t3,t4,t5,t6,t7};\
 static const int name##_Count = 8;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_9(name, baseType, baseVal, t0, t1, t2, t3, t4, t5, t6, t7, t8) enum class name:baseType{t0=baseVal,t1,t2,t3,t4,t5,t6,t7,t8};\
 static const int name##_Count = 9;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_10(name, baseType, baseVal, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9) enum class name:baseType{t0=baseVal,t1,t2,t3,t4,t5,t6,t7,t8,t9};\
 static const int name##_Count = 10;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_11(name, baseType, baseVal, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) enum class name:baseType{t0=baseVal,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10};\
 static const int name##_Count = 11;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 #define DECLARE_ENUM_EX_12(name, baseType, baseVal, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) enum class name:baseType{t0=baseVal,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11};\
 static const int name##_Count = 11;static const Char**name##_Str(){static const Char* str[]={\
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9),ENUM_TO_STR(t10),ENUM_TO_STR(t11)};\
-return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}
+return str;}static inline const Char*ToString(name e){return name##_Str()[(int)e - baseVal];}static_assert(true, "")
 
 // ..and those for flags
 
@@ -170,7 +170,7 @@ static const int name##_Count = 1;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_2(name, baseType, t0, v0, t1, v1) \
 enum class name:baseType{t0=v0,t1=v1};\
@@ -178,7 +178,7 @@ static const int name##_Count = 2;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_3(name, baseType, t0, v0, t1, v1, t2, v2) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2};\
@@ -186,7 +186,7 @@ static const int name##_Count = 3;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_4(name, baseType, t0, v0, t1, v1, t2, v2, t3, v3) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2,t3=v3};\
@@ -194,7 +194,7 @@ static const int name##_Count = 4;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2), (baseType)(v3)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_5(name, baseType, t0, v0, t1, v1, t2, v2, t3, v3, t4, v4) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2,t3=v3,t4=v4};\
@@ -202,7 +202,7 @@ static const int name##_Count = 5;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2), (baseType)(v3), (baseType)(v4)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_6(name, baseType, t0, v0, t1, v1, t2, v2, t3, v3, t4, v4, t5, v5) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2,t3=v3,t4=v4,t5=v5};\
@@ -210,7 +210,7 @@ static const int name##_Count = 6;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2), (baseType)(v3), (baseType)(v4), (baseType)(v5)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_7(name, baseType, t0, v0, t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2,t3=v3,t4=v4,t5=v5,t6=v6};\
@@ -218,7 +218,7 @@ static const int name##_Count = 7;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2), (baseType)(v3), (baseType)(v4), (baseType)(v5), (baseType)(v6)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_8(name, baseType, t0, v0, t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6, t7, v7) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2,t3=v3,t4=v4,t5=v5,t6=v6,t7=v7};\
@@ -226,7 +226,7 @@ static const int name##_Count = 8;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2), (baseType)(v3), (baseType)(v4), (baseType)(v5), (baseType)(v6), (baseType)(v7)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_9(name, baseType, t0, v0, t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6, t7, v7, t8, v8) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2,t3=v3,t4=v4,t5=v5,t6=v6,t7=v7,t8=v8};\
@@ -234,7 +234,7 @@ static const int name##_Count = 9;static const Char**name##_Str(){static const C
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2), (baseType)(v3), (baseType)(v4), (baseType)(v5), (baseType)(v6), (baseType)(v7), (baseType)(v8)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")
 
 #define DECLARE_ENUM_FLAGS_10(name, baseType, t0, v0, t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6, t7, v7, t8, v8, t9, v9) \
 enum class name:baseType{t0=v0,t1=v1,t2=v2,t3=v3,t4=v4,t5=v5,t6=v6,t7=v7,t8=v8,t9=v9};\
@@ -242,4 +242,4 @@ static const int name##_Count = 10;static const Char**name##_Str(){static const 
 ENUM_TO_STR(t0),ENUM_TO_STR(t1),ENUM_TO_STR(t2),ENUM_TO_STR(t3),ENUM_TO_STR(t4),ENUM_TO_STR(t5),ENUM_TO_STR(t6),ENUM_TO_STR(t7),ENUM_TO_STR(t8),ENUM_TO_STR(t9)};\
 return str;}static inline const Char*ToString(name e){static baseType val[]={\
 (baseType)(v0), (baseType)(v1), (baseType)(v2), (baseType)(v3), (baseType)(v4), (baseType)(v5), (baseType)(v6), (baseType)(v7), (baseType)(v8), (baseType)(v9)}; \
-for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }
+for (baseType i = 0; i < name##_Count; i++) { if (val[i] == (baseType)e) return name##_Str()[(int)i]; } return ENUM_TO_STR_FALLBACK; }static_assert(true, "")

--- a/Source/Engine/Core/Formatting.h
+++ b/Source/Engine/Core/Formatting.h
@@ -39,7 +39,7 @@ namespace fmt_flax
                 return fmt::format_to(ctx.out(), basic_string_view<Char>(TEXT(formatText)), ##__VA_ARGS__); \
             } \
         }; \
-    }
+    } static_assert(true, "")
 
 #define DEFINE_DEFAULT_FORMATTING_VIA_TO_STRING(type) \
     namespace fmt \
@@ -59,4 +59,4 @@ namespace fmt_flax
                 return fmt::detail::copy_str<Char>(str.Get(), str.Get() + str.Length(), ctx.out()); \
             } \
         }; \
-    }
+    } static_assert(true, "")

--- a/Source/Engine/Core/LogContext.h
+++ b/Source/Engine/Core/LogContext.h
@@ -14,7 +14,7 @@ struct Guid;
 /// </summary>
 API_STRUCT(NoDefault) struct FLAXENGINE_API LogContextData
 {
-    DECLARE_SCRIPTING_TYPE_STRUCTURE(LogContextData)
+    DECLARE_SCRIPTING_TYPE_STRUCTURE(LogContextData);
 
     /// <summary>
     /// A GUID for an object which this context applies to.
@@ -40,7 +40,7 @@ struct TIsPODType<LogContextData>
 /// </summary>
 API_CLASS(Static) class FLAXENGINE_API LogContext
 {
-    DECLARE_SCRIPTING_TYPE_MINIMAL(LogContext)
+    DECLARE_SCRIPTING_TYPE_MINIMAL(LogContext);
 
     /// <summary>
     /// Adds a log context element to the stack to be displayed in warning and error logs.

--- a/Source/Engine/Core/Types/BaseTypes.h
+++ b/Source/Engine/Core/Types/BaseTypes.h
@@ -154,7 +154,8 @@ typedef Matrix Real4x4;
     inline constexpr T operator^(T a, T b) { return (T)((__underlying_type(T))a ^ (__underlying_type(T))b); } \
     inline T& operator|=(T& a, T b) { return a = (T)((__underlying_type(T))a | (__underlying_type(T))b); } \
     inline T& operator&=(T& a, T b) { return a = (T)((__underlying_type(T))a & (__underlying_type(T))b); } \
-    inline T& operator^=(T& a, T b) { return a = (T)((__underlying_type(T))a ^ (__underlying_type(T))b); }
+    inline T& operator^=(T& a, T b) { return a = (T)((__underlying_type(T))a ^ (__underlying_type(T))b); } \
+    static_assert(true, "")
 
 // Returns true if given enum value has one or more enum flags set
 template<typename T>

--- a/Source/Engine/Engine/EngineService.h
+++ b/Source/Engine/Engine/EngineService.h
@@ -39,7 +39,7 @@ public:
     const Char* Name;
     int32 Order;
 
-#define DECLARE_ENGINE_SERVICE_EVENT(result, name) virtual result name(); static void On##name();
+#define DECLARE_ENGINE_SERVICE_EVENT(result, name) virtual result name(); static void On##name()
     DECLARE_ENGINE_SERVICE_EVENT(bool, Init);
     DECLARE_ENGINE_SERVICE_EVENT(void, FixedUpdate);
     DECLARE_ENGINE_SERVICE_EVENT(void, Update);

--- a/Source/Engine/Foliage/Foliage.cpp
+++ b/Source/Engine/Foliage/Foliage.cpp
@@ -543,7 +543,7 @@ int32 Foliage::GetFoliageTypesCount() const
 
 FoliageType* Foliage::GetFoliageType(int32 index)
 {
-    CHECK_RETURN(index >= 0 && index < FoliageTypes.Count(), nullptr)
+    CHECK_RETURN(index >= 0 && index < FoliageTypes.Count(), nullptr);
     return &FoliageTypes[index];
 }
 

--- a/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.cpp
@@ -280,7 +280,7 @@ void CmdBufferManagerVulkan::WaitForCmdBuffer(CmdBufferVulkan* cmdBuffer, float 
 void CmdBufferManagerVulkan::PrepareForNewActiveCommandBuffer()
 {
     PROFILE_CPU();
-    ASSERT_LOW_LAYER(_activeCmdBuffer == nullptr)
+    ASSERT_LOW_LAYER(_activeCmdBuffer == nullptr);
     for (int32 i = 0; i < _pool._cmdBuffers.Count(); i++)
     {
         auto cmdBuffer = _pool._cmdBuffers.Get()[i];

--- a/Source/Engine/Level/Actors/Spline.cpp
+++ b/Source/Engine/Level/Actors/Spline.cpp
@@ -101,25 +101,25 @@ Vector3 Spline::GetSplineLocalDirection(float time) const
 
 Vector3 Spline::GetSplinePoint(int32 index) const
 {
-    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Vector3::Zero)
+    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Vector3::Zero);
     return _transform.LocalToWorld(Curve[index].Value.Translation);
 }
 
 Vector3 Spline::GetSplineLocalPoint(int32 index) const
 {
-    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Vector3::Zero)
+    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Vector3::Zero);
     return Curve[index].Value.Translation;
 }
 
 Transform Spline::GetSplineTransform(int32 index) const
 {
-    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Transform::Identity)
+    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Transform::Identity);
     return _transform.LocalToWorld(Curve[index].Value);
 }
 
 Transform Spline::GetSplineLocalTransform(int32 index) const
 {
-    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Transform::Identity)
+    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Transform::Identity);
     return Curve[index].Value;
 }
 
@@ -130,7 +130,7 @@ Transform Spline::GetSplineTangent(int32 index, bool isIn)
 
 Transform Spline::GetSplineLocalTangent(int32 index, bool isIn)
 {
-    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Transform::Identity)
+    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), Transform::Identity);
     const auto& k = Curve[index];
     const auto& tangent = isIn ? k.TangentIn : k.TangentOut;
     return tangent + k.Value;
@@ -209,7 +209,7 @@ float Spline::GetSplineSegmentLength(int32 index) const
 
 float Spline::GetSplineTime(int32 index) const
 {
-    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), 0.0f)
+    CHECK_RETURN(index >= 0 && index < GetSplinePointsCount(), 0.0f);
     return Curve[index].Time;
 }
 

--- a/Source/Engine/Level/Actors/SplineModel.cpp
+++ b/Source/Engine/Level/Actors/SplineModel.cpp
@@ -489,7 +489,7 @@ void SplineModel::Serialize(SerializeStream& stream, const void* otherObj)
     SERIALIZE_MEMBER(BoundsScale, _boundsScale);
     SERIALIZE_MEMBER(LODBias, _lodBias);
     SERIALIZE_MEMBER(ForcedLOD, _forcedLod);
-    SERIALIZE_MEMBER(PreTransform, _preTransform)
+    SERIALIZE_MEMBER(PreTransform, _preTransform);
     SERIALIZE(Model);
     SERIALIZE(DrawModes);
 

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -2202,7 +2202,7 @@ bool PhysicsBackend::CapsuleCastAll(void* scene, const Vector3& center, const fl
 
 bool PhysicsBackend::ConvexCast(void* scene, const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false)
+    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false);
     SCENE_QUERY_SETUP_SWEEP_1();
     const PxTransform pose(C2P(center - scenePhysX->Origin), C2P(rotation));
     const PxConvexMeshGeometry geometry((PxConvexMesh*)convexMesh->GetConvex(), PxMeshScale(C2P(scale)));
@@ -2211,7 +2211,7 @@ bool PhysicsBackend::ConvexCast(void* scene, const Vector3& center, const Collis
 
 bool PhysicsBackend::ConvexCast(void* scene, const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false)
+    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false);
     SCENE_QUERY_SETUP_SWEEP_1();
     const PxTransform pose(C2P(center - scenePhysX->Origin), C2P(rotation));
     const PxConvexMeshGeometry geometry((PxConvexMesh*)convexMesh->GetConvex(), PxMeshScale(C2P(scale)));
@@ -2223,7 +2223,7 @@ bool PhysicsBackend::ConvexCast(void* scene, const Vector3& center, const Collis
 
 bool PhysicsBackend::ConvexCastAll(void* scene, const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, Array<RayCastHit>& results, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false)
+    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false);
     SCENE_QUERY_SETUP_SWEEP();
     const PxTransform pose(C2P(center - scenePhysX->Origin), C2P(rotation));
     const PxConvexMeshGeometry geometry((PxConvexMesh*)convexMesh->GetConvex(), PxMeshScale(C2P(scale)));
@@ -2259,7 +2259,7 @@ bool PhysicsBackend::CheckCapsule(void* scene, const Vector3& center, const floa
 
 bool PhysicsBackend::CheckConvex(void* scene, const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Quaternion& rotation, uint32 layerMask, bool hitTriggers)
 {
-    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false)
+    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false);
     SCENE_QUERY_SETUP_OVERLAP_1();
     const PxTransform pose(C2P(center - scenePhysX->Origin), C2P(rotation));
     const PxConvexMeshGeometry geometry((PxConvexMesh*)convexMesh->GetConvex(), PxMeshScale(C2P(scale)));
@@ -2301,7 +2301,7 @@ bool PhysicsBackend::OverlapCapsule(void* scene, const Vector3& center, const fl
 
 bool PhysicsBackend::OverlapConvex(void* scene, const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, Array<Collider*>& results, const Quaternion& rotation, uint32 layerMask, bool hitTriggers)
 {
-    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false)
+    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false);
     SCENE_QUERY_SETUP_OVERLAP();
     const PxTransform pose(C2P(center - scenePhysX->Origin), C2P(rotation));
     const PxConvexMeshGeometry geometry((PxConvexMesh*)convexMesh->GetConvex(), PxMeshScale(C2P(scale)));
@@ -2346,7 +2346,7 @@ bool PhysicsBackend::OverlapCapsule(void* scene, const Vector3& center, const fl
 
 bool PhysicsBackend::OverlapConvex(void* scene, const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, Array<PhysicsColliderActor*>& results, const Quaternion& rotation, uint32 layerMask, bool hitTriggers)
 {
-    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false)
+    CHECK_RETURN(convexMesh && convexMesh->GetOptions().Type == CollisionDataType::ConvexMesh, false);
     SCENE_QUERY_SETUP_OVERLAP();
     const PxTransform pose(C2P(center - scenePhysX->Origin), C2P(rotation));
     const PxConvexMeshGeometry geometry((PxConvexMesh*)convexMesh->GetConvex(), PxMeshScale(C2P(scale)));

--- a/Source/Engine/Platform/Base/NetworkBase.h
+++ b/Source/Engine/Platform/Base/NetworkBase.h
@@ -38,7 +38,7 @@ API_ENUM() enum class NetworkIPVersion
 /// </summary>
 API_STRUCT() struct FLAXENGINE_API NetworkSocket
 {
-DECLARE_SCRIPTING_TYPE_MINIMAL(NetworkSocketGroup)
+DECLARE_SCRIPTING_TYPE_MINIMAL(NetworkSocketGroup);
 
     /// <summary>Socket protocol type.</summary>
     API_FIELD() NetworkProtocol Protocol = NetworkProtocol::Undefined;
@@ -52,7 +52,7 @@ DECLARE_SCRIPTING_TYPE_MINIMAL(NetworkSocketGroup)
 /// </summary>
 API_STRUCT() struct FLAXENGINE_API NetworkEndPoint
 {
-DECLARE_SCRIPTING_TYPE_MINIMAL(NetworkSocketGroup)
+DECLARE_SCRIPTING_TYPE_MINIMAL(NetworkSocketGroup);
 
     /// <summary>End-point IP version.</summary>
     API_FIELD(ReadOnly) NetworkIPVersion IPVersion = NetworkIPVersion::Undefined;
@@ -126,7 +126,7 @@ DECLARE_ENUM_OPERATORS(NetworkSocketState);
 /// </summary>
 API_STRUCT() struct FLAXENGINE_API NetworkSocketGroup
 {
-DECLARE_SCRIPTING_TYPE_MINIMAL(NetworkSocketGroup)
+DECLARE_SCRIPTING_TYPE_MINIMAL(NetworkSocketGroup);
 
     /// <summary>Group size.</summary>
     API_FIELD(ReadOnly) uint32 Count = 0;

--- a/Source/Engine/Platform/Platform.h
+++ b/Source/Engine/Platform/Platform.h
@@ -44,7 +44,7 @@
             PLATFORM_DEBUG_BREAK; \
         } \
         Platform::Assert(#expression, __FILE__, __LINE__); \
-    }
+    } static_assert(true, "")
 #else
 // Performs a hard assertion of the expression. Crashes the engine and triggers a debugger break if the expression fails.
 #define ASSERT(expression) ((void)0)
@@ -63,14 +63,14 @@
     { \
         Platform::CheckFailed(#expression, __FILE__, __LINE__); \
         return; \
-    }
+    } static_assert(true, "")
 // Performs a soft check of the expression. Logs the expression failure and returns from the function call using the given return value.
 #define CHECK_RETURN(expression, returnValue) \
     if (!(expression)) \
     { \
         Platform::CheckFailed(#expression, __FILE__, __LINE__); \
         return returnValue; \
-    }
+    } static_assert(true, "")
 
 #if ENABLE_ASSERTION
 // Performs a soft check of the expression. Logs the expression failure and returns from the function call.

--- a/Source/Engine/Scripting/ScriptingType.h
+++ b/Source/Engine/Scripting/ScriptingType.h
@@ -370,7 +370,8 @@ struct ScriptingObjectSpawnParams
     friend class type##Internal; \
     static ScriptingTypeInitializer TypeInitializer; \
     FORCE_INLINE static const ScriptingType& GetStaticType() { return TypeInitializer.GetType(); } \
-    FORCE_INLINE static MClass* GetStaticClass() { return TypeInitializer.GetType().ManagedClass; }
+    FORCE_INLINE static MClass* GetStaticClass() { return TypeInitializer.GetType().ManagedClass; } \
+    static_assert(true, "")
 
 /// <summary>
 /// Helper define used to declare required components for native types that have managed type (for objects that cannot be spawned).
@@ -380,7 +381,8 @@ struct ScriptingObjectSpawnParams
     friend class type##Internal; \
     static ScriptingTypeInitializer TypeInitializer; \
     FORCE_INLINE static const ScriptingType& GetStaticType() { return TypeInitializer.GetType(); } \
-    FORCE_INLINE static MClass* GetStaticClass() { return TypeInitializer.GetType().ManagedClass; }
+    FORCE_INLINE static MClass* GetStaticClass() { return TypeInitializer.GetType().ManagedClass; } \
+    static_assert(true, "")
 
 /// <summary>
 /// Helper define used to declare required components for native types that have managed type (for objects that can be spawned).
@@ -398,7 +400,8 @@ struct ScriptingObjectSpawnParams
     DECLARE_SCRIPTING_TYPE_NO_SPAWN(type); \
     static type* Spawn(const SpawnParams& params) { return ::New<type>(params); } \
     explicit type(const SpawnParams& params) : baseType(params) { } \
-    explicit type() : baseType(SpawnParams(Guid::New(), type::TypeInitializer)) { }
+    explicit type() : baseType(SpawnParams(Guid::New(), type::TypeInitializer)) { } \
+    static_assert(true, "")
 
 /// <summary>
 /// Helper define used to implement required components for native types that have managed type (for objects that can be spawned).
@@ -414,7 +417,7 @@ struct ScriptingObjectSpawnParams
 	    &baseType::TypeInitializer, \
 	    setupScriptVTable, \
 	    setupScriptObjectVTable \
-    );
+    )
 
 /// <summary>
 /// Helper define used to implement required components for native types that have managed type (for objects that can be spawned).
@@ -430,7 +433,7 @@ struct ScriptingObjectSpawnParams
 	    nullptr, \
 	    setupScriptVTable, \
 	    setupScriptObjectVTable \
-    );
+    )
 
 /// <summary>
 /// Helper define used to implement required components for native types that have managed type (for objects that cannot be spawned). With base class specified.
@@ -446,7 +449,7 @@ struct ScriptingObjectSpawnParams
 	    &baseType::TypeInitializer, \
 	    setupScriptVTable, \
 	    setupScriptObjectVTable \
-    );
+    )
 
 /// <summary>
 /// Helper define used to implement required components for native types that have managed type (for objects that cannot be spawned).
@@ -462,7 +465,7 @@ struct ScriptingObjectSpawnParams
 	    nullptr, \
 	    setupScriptVTable, \
 	    setupScriptObjectVTable \
-    );
+    )
 
 /// <summary>
 /// The core library assembly. Main C# library with core functionalities.

--- a/Source/Engine/Serialization/SerializationFwd.h
+++ b/Source/Engine/Serialization/SerializationFwd.h
@@ -24,7 +24,7 @@ class ISerializeModifier;
 	{ \
 		stream.JKEY(#name); \
 		Serialization::Serialize(stream, name, other ? &other->name : nullptr); \
-	}
+	} static_assert(true, "")
 
 // Serialization helper macro (for private members, or with custom member name)
 #define SERIALIZE_MEMBER(name, member) \
@@ -32,7 +32,7 @@ class ISerializeModifier;
 	{ \
 		stream.JKEY(#name); \
 		Serialization::Serialize(stream, member, other ? &other->member : nullptr); \
-	}
+	} static_assert(true, "")
 
 // Deserialization helper macro
 #define DESERIALIZE(name)  \
@@ -40,7 +40,7 @@ class ISerializeModifier;
         const auto e = SERIALIZE_FIND_MEMBER(stream, #name); \
         if (e != stream.MemberEnd()) \
             Serialization::Deserialize(e->value, name, modifier); \
-    }
+    } static_assert(true, "")
 
 // Deserialization helper macro (for private members, or with custom member name)
 #define DESERIALIZE_MEMBER(name, member) \
@@ -48,7 +48,7 @@ class ISerializeModifier;
         const auto e = SERIALIZE_FIND_MEMBER(stream, #name); \
         if (e != stream.MemberEnd()) \
             Serialization::Deserialize(e->value, member, modifier); \
-    }
+    } static_assert(true, "")
 
 // Helper macros for bit fields
 


### PR DESCRIPTION
The documentation seems to suggest adding semicolon after most API macros, but this was not enforced in any way. IDEs seems to nag about the unnecessary semicolons after these macros, so why not enforce the usage of semicolons?

The trick to enforce this uses `static_assert` at the end of the macro to trigger a compile time error when the semicolon is missing. For same cases just removing the semicolon at the end was enough.