### PR TITLE
Fix WindowsPlatform::LoadLibrary to not modify the string parameter

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -1191,11 +1191,8 @@ void* WindowsPlatform::LoadLibrary(const Char* filename)
         folder = StringView::Empty;
     if (folder.HasChars())
     {
-        Char& end = ((Char*)folder.Get())[folder.Length()];
-        const Char c = end;
-        end = 0;
-        SetDllDirectoryW(*folder);
-        end = c;
+        String folderNullTerminated(folder);
+        SetDllDirectoryW(folderNullTerminated.Get());
     }
 
     // Avoiding windows dialog boxes if missing


### PR DESCRIPTION
Previous version may modify read-only memory and crash when passing string literal as parameter.