### PR TITLE
.NET7: Separate managed assembly unloading and scripting ALC reinitialization

### DIFF
--- a/Source/Engine/Scripting/ManagedCLR/MCore.h
+++ b/Source/Engine/Scripting/ManagedCLR/MCore.h
@@ -47,7 +47,7 @@ public:
 
 #if USE_EDITOR
     // Called by Scripting in a middle of hot-reload (after unloading modules but before loading them again).
-    static void OnMidHotReload();
+    static void ReloadScriptingAssemblyLoadContext();
 #endif
 
 public:

--- a/Source/Engine/Scripting/Runtime/Mono.cpp
+++ b/Source/Engine/Scripting/Runtime/Mono.cpp
@@ -716,7 +716,7 @@ void MCore::UnloadEngine()
 
 #if USE_EDITOR
 
-void MCore::OnMidHotReload()
+void MCore::ReloadScriptingAssemblyLoadContext()
 {
 }
 

--- a/Source/Engine/Scripting/Runtime/None.cpp
+++ b/Source/Engine/Scripting/Runtime/None.cpp
@@ -61,7 +61,7 @@ void MCore::UnloadEngine()
 
 #if USE_EDITOR
 
-void MCore::OnMidHotReload()
+void MCore::ReloadScriptingAssemblyLoadContext()
 {
 }
 

--- a/Source/Engine/Scripting/Scripting.cpp
+++ b/Source/Engine/Scripting/Scripting.cpp
@@ -706,7 +706,9 @@ void Scripting::Reload(bool canTriggerSceneReload)
     modules.Clear();
     _nonNativeModules.ClearDelete();
     _hasGameModulesLoaded = false;
-    MCore::OnMidHotReload();
+
+    // Release and create a new assembly load context for user assemblies
+    MCore::ReloadScriptingAssemblyLoadContext();
 
     // Give GC a try to cleanup old user objects and the other mess
     MCore::GC::Collect();


### PR DESCRIPTION
Fixes an issue with multiple managed assemblies unloading and releasing all cached data before native resources were fully released in other assemblies.

Fixes #1255 