### PR TITLE
`NetworkReplicator::ResolveForeignObject`

### DIFF
--- a/Source/Engine/Networking/NetworkReplicator.cpp
+++ b/Source/Engine/Networking/NetworkReplicator.cpp
@@ -941,6 +941,13 @@ bool NetworkReplicator::HasObject(const ScriptingObject* obj)
     return false;
 }
 
+ScriptingObject* NetworkReplicator::ResolveForeignObject(Guid objectId)
+{
+    if (const auto& object = ResolveObject(objectId))
+        return object->Object.Get();
+    return nullptr;
+}
+
 uint32 NetworkReplicator::GetObjectOwnerClientId(const ScriptingObject* obj)
 {
     uint32 id = NetworkManager::ServerClientId;

--- a/Source/Engine/Networking/NetworkReplicator.h
+++ b/Source/Engine/Networking/NetworkReplicator.h
@@ -116,6 +116,13 @@ public:
     /// <param name="obj">The network object.</param>
     /// <returns>True if object exists in networking, otherwise false.</returns>
     API_FUNCTION() static bool HasObject(const ScriptingObject* obj);
+	
+    /// <summary>
+    /// Resolves foreign Guid into a local ScriptingObject
+    /// </summary>
+    /// <param name="objectId">The Guid of a foreign object.</param>
+    /// <returns>Object if managed to resolve, otherwise null.</returns>
+    API_FUNCTION() static ScriptingObject* ResolveForeignObject(Guid objectId);
 
     /// <summary>
     /// Gets the Client Id of the network object owner.


### PR DESCRIPTION
This is a useful tool that allows you to, for example, send an object id with an RPC call and then resolve it back on the receiving end of an RPC call.