### PR TITLE
Add build option to change code optimization level in C# modules

### DIFF
--- a/Source/Editor/Editor.Build.cs
+++ b/Source/Editor/Editor.Build.cs
@@ -42,6 +42,10 @@ public class Editor : EditorModule
         options.ScriptingAPI.SystemReferences.Add("System.Text.RegularExpressions");
         options.ScriptingAPI.SystemReferences.Add("System.ComponentModel.TypeConverter");
 
+        // Enable optimizations for Editor, disable this for debugging the editor
+        if (options.Configuration == TargetConfiguration.Development)
+            options.ScriptingAPI.Optimization = true;
+
         options.PublicDependencies.Add("Engine");
         options.PrivateDependencies.Add("pugixml");
         options.PrivateDependencies.Add("curl");

--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -255,11 +255,13 @@ namespace Flax.Build
 #endif
             if (buildOptions.ScriptingAPI.IgnoreMissingDocumentationWarnings)
                 args.Add("-nowarn:1591");
-#if USE_NETCORE
+
             // Optimizations prevent debugging, only enable in release builds
-            args.Add(buildData.Configuration == TargetConfiguration.Release ? "/optimize+" : "/optimize-");
-#else
-            args.Add(buildData.Configuration == TargetConfiguration.Debug ? "/optimize-" : "/optimize+");
+            var optimize = buildData.Configuration == TargetConfiguration.Release;
+            if (buildData.TargetOptions.ScriptingAPI.Optimization.HasValue)
+                optimize = buildData.TargetOptions.ScriptingAPI.Optimization.Value;
+            args.Add(optimize ? "/optimize+" : "/optimize-");
+#if !USE_NETCORE
             args.Add(string.Format("/reference:\"{0}mscorlib.dll\"", referenceAssemblies));
 #endif
             args.Add(string.Format("/out:\"{0}\"", outputFile));

--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -185,7 +185,7 @@ namespace Flax.Build.NativeCpp
         public string DepsFolder => Path.Combine(Globals.EngineRoot, "Source", "Platforms", Platform.Target.ToString(), "Binaries", "ThirdParty", Architecture.ToString());
 
         /// <summary>
-        /// The scripting API building options.
+        /// The C# scripting API building options.
         /// </summary>
         public struct ScriptingAPIOptions
         {
@@ -224,6 +224,11 @@ namespace Flax.Build.NativeCpp
             /// </summary>
             public CSharpNullableReferences CSharpNullableReferences = CSharpNullableReferences.Disable;
 
+            /// <summary>
+            /// Enable code optimization.
+            /// </summary>
+            public bool? Optimization;
+
             public ScriptingAPIOptions()
             {
             }
@@ -232,13 +237,19 @@ namespace Flax.Build.NativeCpp
             /// Adds the other options into this.
             /// </summary>
             /// <param name="other">The other.</param>
-            public void Add(ScriptingAPIOptions other)
+            public void Add(ScriptingAPIOptions other, bool addBuildOptions = true)
             {
                 Defines.AddRange(other.Defines);
                 SystemReferences.AddRange(other.SystemReferences);
                 FileReferences.AddRange(other.FileReferences);
                 Analyzers.AddRange(other.Analyzers);
                 IgnoreMissingDocumentationWarnings |= other.IgnoreMissingDocumentationWarnings;
+
+                if (addBuildOptions)
+                {
+                    if (other.Optimization.HasValue)
+                        Optimization |= other.Optimization;
+                }
             }
         }
 

--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -403,7 +403,7 @@ namespace Flax.Build
                     moduleOptions.PrivateIncludePaths.AddRange(dependencyOptions.PublicIncludePaths);
                     moduleOptions.Libraries.AddRange(dependencyOptions.Libraries);
                     moduleOptions.DelayLoadLibraries.AddRange(dependencyOptions.DelayLoadLibraries);
-                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI);
+                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI, false);
                     moduleOptions.ExternalModules.AddRange(dependencyOptions.ExternalModules);
                 }
             }
@@ -418,7 +418,7 @@ namespace Flax.Build
                     moduleOptions.PublicIncludePaths.AddRange(dependencyOptions.PublicIncludePaths);
                     moduleOptions.Libraries.AddRange(dependencyOptions.Libraries);
                     moduleOptions.DelayLoadLibraries.AddRange(dependencyOptions.DelayLoadLibraries);
-                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI);
+                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI, false);
                     moduleOptions.ExternalModules.AddRange(dependencyOptions.ExternalModules);
                 }
             }


### PR DESCRIPTION
Also enables optimizations for Editor in Development builds. Optimizations seems to affect interop methods a lot so it makes sense to enable them for everyone as the `Editor.Development` is the preferred default configuration for development. Game projects still have optimizations off by default in `Editor.Development` configuration, but can be enabled when needed with the new option.