### PR TITLE
.NET7: Cache MakeArrayType results in native interop methods

### DIFF
--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -526,7 +526,7 @@ namespace FlaxEngine.Interop
         {
             Type elementType = Unsafe.As<Type>(typeHandle.Target);
             Type marshalledType = ArrayFactory.GetMarshalledType(elementType);
-            Type arrayType = elementType.MakeArrayType();
+            Type arrayType = ArrayFactory.GetArrayType(elementType);
             if (marshalledType.IsValueType)
             {
                 ManagedArray managedArray = ManagedArray.AllocateNewArray((int)size, arrayType, marshalledType);
@@ -544,7 +544,7 @@ namespace FlaxEngine.Interop
         internal static ManagedHandle GetArrayTypeFromElementType(ManagedHandle elementTypeHandle)
         {
             Type elementType = Unsafe.As<Type>(elementTypeHandle.Target);
-            Type classType = elementType.MakeArrayType();
+            Type classType = ArrayFactory.GetArrayType(elementType);
             return GetTypeGCHandle(classType);
         }
 

--- a/Source/Engine/Engine/NativeInterop.cs
+++ b/Source/Engine/Engine/NativeInterop.cs
@@ -967,6 +967,7 @@ namespace FlaxEngine.Interop
             private delegate Array CreateArrayDelegate(long size);
 
             private static ConcurrentDictionary<Type, Type> marshalledTypes = new ConcurrentDictionary<Type, Type>(1, 3);
+            private static ConcurrentDictionary<Type, Type> arrayTypes = new ConcurrentDictionary<Type, Type>(1, 3);
             private static ConcurrentDictionary<Type, CreateArrayDelegate> createArrayDelegates = new ConcurrentDictionary<Type, CreateArrayDelegate>(1, 3);
 
             internal static Type GetMarshalledType(Type elementType)
@@ -984,6 +985,15 @@ namespace FlaxEngine.Interop
                 if (marshalledTypes.TryGetValue(elementType, out var marshalledType))
                     return marshalledType;
                 return marshalledTypes.GetOrAdd(elementType, Factory);
+            }
+
+            internal static Type GetArrayType(Type elementType)
+            {
+                static Type Factory(Type type) => type.MakeArrayType();
+
+                if (arrayTypes.TryGetValue(elementType, out var arrayType))
+                    return arrayType;
+                return arrayTypes.GetOrAdd(elementType, Factory);
             }
 
             internal static Array CreateArray(Type type, long size)


### PR DESCRIPTION
`Type.MakeArrayType` seems quite slow, and this is called quite often, so it makes sense to cache the results.