### PR TITLE
.NET7: Slightly improve `MClass::GetMethod` method iteration

### DIFF
--- a/Source/Engine/Scripting/Runtime/DotNet.cpp
+++ b/Source/Engine/Scripting/Runtime/DotNet.cpp
@@ -878,7 +878,7 @@ MMethod* MClass::GetMethod(const char* name, int32 numParams) const
     GetMethods();
     for (int32 i = 0; i < _methods.Count(); i++)
     {
-        if (_methods[i]->GetName() == name && _methods[i]->GetParametersCount() == numParams)
+        if (_methods[i]->GetParametersCount() == numParams && _methods[i]->GetName() == name)
             return _methods[i];
     }
     return nullptr;


### PR DESCRIPTION
Check the number of parameters first before expensive string comparison, seemed to net slight but noticeable improvement in profiler results.