### PR TITLE
.NET7: Optimize UnboxValue performance, safety and memory usage

### DIFF
--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -650,7 +650,6 @@ namespace FlaxEngine.Interop
             if (!type.IsValueType)
                 return ManagedHandle.ToIntPtr(handle);
 
-            // HACK: Get the address of a non-pinned value
             return ValueTypeUnboxer.GetPointer(value, type);
         }
 


### PR DESCRIPTION
- Avoids unnecessary boxing of the converted values by storing them in unmanaged memory.
- Wrap ToNative-method in a delegate and cache it.
- Fixes returning address to unpinned memory by pinning POD-types for a short period of time.