### PR TITLE
.NET7: Optimize ScriptingObject managed initialization and marshalling

### DIFF
--- a/Source/Engine/Engine/NativeInterop.Invoker.cs
+++ b/Source/Engine/Engine/NativeInterop.Invoker.cs
@@ -31,7 +31,7 @@ namespace FlaxEngine.Interop
                 if (typeof(TRet) == typeof(bool))
                     return (bool)(object)returnValue ? boolTruePtr : boolFalsePtr;
                 if (typeof(TRet) == typeof(Type))
-                    return ManagedHandle.ToIntPtr(GetTypeGCHandle(Unsafe.As<Type>(returnValue)));
+                    return ManagedHandle.ToIntPtr(GetTypeManagedHandle(Unsafe.As<Type>(returnValue)));
                 if (typeof(TRet).IsArray)
                 {
                     var elementType = typeof(TRet).GetElementType();
@@ -52,8 +52,8 @@ namespace FlaxEngine.Interop
                     return ManagedHandle.ToIntPtr((ManagedHandle)(object)returnObject);
                 if (returnType == typeof(bool))
                     return (bool)returnObject ? boolTruePtr : boolFalsePtr;
-                if (returnType == typeof(Type))
-                    return ManagedHandle.ToIntPtr(GetTypeGCHandle(Unsafe.As<Type>(returnObject)));
+                if (returnType == typeof(Type) || returnType == typeof(TypeHolder))
+                    return ManagedHandle.ToIntPtr(GetTypeManagedHandle(Unsafe.As<Type>(returnObject)));
                 if (returnType.IsArray && ArrayFactory.GetMarshalledType(returnType.GetElementType()) == returnType.GetElementType())
                     return ManagedHandle.ToIntPtr(ManagedArray.WrapNewArray(Unsafe.As<Array>(returnObject)), GCHandleType.Weak);
                 if (returnType.IsArray)
@@ -72,7 +72,7 @@ namespace FlaxEngine.Interop
                 if (typeof(TRet) == typeof(ManagedHandle))
                     return ManagedHandle.ToIntPtr((ManagedHandle)(object)returnValue);
                 if (typeof(TRet) == typeof(Type))
-                    return ManagedHandle.ToIntPtr(GetTypeGCHandle(Unsafe.As<Type>(returnValue)));
+                    return ManagedHandle.ToIntPtr(GetTypeManagedHandle(Unsafe.As<Type>(returnValue)));
                 if (typeof(TRet).IsArray)
                 {
                     var elementType = typeof(TRet).GetElementType();
@@ -108,8 +108,8 @@ namespace FlaxEngine.Interop
                     return (IntPtr)(object)returnObject;
                 if (returnType == typeof(ManagedHandle))
                     return ManagedHandle.ToIntPtr((ManagedHandle)(object)returnObject);
-                if (returnType == typeof(Type))
-                    return returnObject != null ? ManagedHandle.ToIntPtr(GetTypeGCHandle(Unsafe.As<Type>(returnObject))) : IntPtr.Zero;
+                if (returnType == typeof(Type) || returnType == typeof(TypeHolder))
+                    return returnObject != null ? ManagedHandle.ToIntPtr(GetTypeManagedHandle(Unsafe.As<Type>(returnObject))) : IntPtr.Zero;
                 if (returnType.IsArray)
                 {
                     var elementType = returnType.GetElementType();

--- a/Source/Engine/Engine/NativeInterop.Invoker.cs
+++ b/Source/Engine/Engine/NativeInterop.Invoker.cs
@@ -84,7 +84,7 @@ namespace FlaxEngine.Interop
 
             internal static IntPtr MarshalReturnValueType(ref Type returnValue)
             {
-                return returnValue != null ? ManagedHandle.ToIntPtr(GetTypeGCHandle(returnValue)) : IntPtr.Zero;
+                return returnValue != null ? ManagedHandle.ToIntPtr(GetTypeManagedHandle(returnValue)) : IntPtr.Zero;
             }
 
             internal static IntPtr MarshalReturnValueArray<TRet>(ref TRet returnValue)

--- a/Source/Engine/Engine/NativeInterop.Marshallers.cs
+++ b/Source/Engine/Engine/NativeInterop.Marshallers.cs
@@ -117,13 +117,13 @@ namespace FlaxEngine.Interop
     [CustomMarshaller(typeof(Type), MarshalMode.Default, typeof(SystemTypeMarshaller))]
     public static class SystemTypeMarshaller
     {
-        public static Type ConvertToManaged(IntPtr unmanaged) => Unsafe.As<Type>(ManagedHandleMarshaller.ConvertToManaged(unmanaged));
+        public static Type ConvertToManaged(IntPtr unmanaged) => unmanaged != IntPtr.Zero ? Unsafe.As<FlaxEngine.Interop.NativeInterop.TypeHolder>(ManagedHandleMarshaller.ConvertToManaged(unmanaged)).type : null;
 
         public static IntPtr ConvertToUnmanaged(Type managed)
         {
             if (managed == null)
                 return IntPtr.Zero;
-            ManagedHandle handle = NativeInterop.GetTypeGCHandle(managed);
+            ManagedHandle handle = NativeInterop.GetTypeManagedHandle(managed);
             return ManagedHandle.ToIntPtr(handle);
         }
 

--- a/Source/Engine/Scripting/ManagedCLR/MAssembly.h
+++ b/Source/Engine/Scripting/ManagedCLR/MAssembly.h
@@ -52,6 +52,15 @@ public:
     MAssembly(MDomain* domain, const StringAnsiView& name);
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="MAssembly"/> class.
+    /// </summary>
+    /// <param name="domain">The assembly domain.</param>
+    /// <param name="name">The assembly name.</param>
+    /// <param name="fullname">The assembly full name.</param>
+    /// <param name="handle">The managed handle of the assembly.</param>
+    MAssembly(MDomain* domain, const StringAnsiView& name, const StringAnsiView& fullname, void* handle);
+
+    /// <summary>
     /// Finalizes an instance of the <see cref="MAssembly"/> class.
     /// </summary>
     ~MAssembly();

--- a/Source/Engine/Scripting/ManagedCLR/MCore.cpp
+++ b/Source/Engine/Scripting/ManagedCLR/MCore.cpp
@@ -48,6 +48,18 @@ MAssembly::MAssembly(MDomain* domain, const StringAnsiView& name)
 {
 }
 
+MAssembly::MAssembly(MDomain* domain, const StringAnsiView& name, const StringAnsiView& fullname, void* handle)
+    : _domain(domain)
+    , _isLoaded(false)
+    , _isLoading(false)
+    , _hasCachedClasses(false)
+    , _reloadCount(0)
+    , _name(name)
+    , _fullname(fullname)
+    , _handle(handle)
+{
+}
+
 MAssembly::~MAssembly()
 {
     Unload();

--- a/Source/Engine/Scripting/ManagedCLR/MCore.h
+++ b/Source/Engine/Scripting/ManagedCLR/MCore.h
@@ -189,4 +189,13 @@ public:
         static MClass* Double;
         static MClass* String;
     };
+
+    /// <summary>
+    /// Utilities for ScriptingObject management.
+    /// </summary>
+    struct FLAXENGINE_API ScriptingObject
+    {
+        static void SetInternalValues(MObject* object, void* unmanagedPtr, const Guid* id);
+        static MObject* CreateScriptingObject(MClass* klass, void* unmanagedPtr, const Guid* id);
+    };
 };

--- a/Source/Engine/Scripting/ManagedCLR/MField.h
+++ b/Source/Engine/Scripting/ManagedCLR/MField.h
@@ -19,6 +19,7 @@ protected:
 #elif USE_NETCORE
     void* _handle;
     void* _type;
+    int32 _fieldOffset;
 #endif
 
     MClass* _parentClass;
@@ -35,7 +36,7 @@ public:
 #if USE_MONO
     explicit MField(MonoClassField* monoField, const char* name, MClass* parentClass);
 #elif USE_NETCORE
-    MField(MClass* parentClass, void* handle, const char* name, void* type, MFieldAttributes attributes);
+    MField(MClass* parentClass, void* handle, const char* name, void* type, int fieldOffset, MFieldAttributes attributes);
 #endif
 
 public:
@@ -101,6 +102,16 @@ public:
     /// <param name="instance">The object of given type to get value from.</param>
     /// <param name="result">The return value of undefined type.</param>
     void GetValue(MObject* instance, void* result) const;
+
+    /// <summary>
+    /// Retrieves value currently set in the field on the specified object instance. If field is static object instance can be null.
+    /// </summary>
+    /// <remarks>
+    /// Value will be a pointer.
+    /// </remarks>
+    /// <param name="instance">The object of given type to get value from.</param>
+    /// <param name="result">The return value of undefined type.</param>
+    void GetValueReference(MObject* instance, void* result) const;
 
     /// <summary>
     /// Retrieves value currently set in the field on the specified object instance. If field is static object instance can be null. If returned value is a value type it will be boxed.

--- a/Source/Engine/Scripting/Object.cs
+++ b/Source/Engine/Scripting/Object.cs
@@ -48,7 +48,7 @@ namespace FlaxEngine
             // Construct missing native object if managed objects gets created in managed world
             if (__unmanagedPtr == IntPtr.Zero)
             {
-                Internal_ManagedInstanceCreated(this);
+                Internal_ManagedInstanceCreated(this, FlaxEngine.Interop.NativeInterop.GetTypeHolder(GetType()).managedClassPointer);
                 if (__unmanagedPtr == IntPtr.Zero)
                     throw new Exception($"Failed to create native instance for object of type {GetType().FullName} (assembly: {GetType().Assembly.FullName}).");
             }
@@ -308,7 +308,7 @@ namespace FlaxEngine
         internal static partial Object Internal_Create2(string typeName);
 
         [LibraryImport("FlaxEngine", EntryPoint = "ObjectInternal_ManagedInstanceCreated", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Interop.StringMarshaller))]
-        internal static partial void Internal_ManagedInstanceCreated(Object managedInstance);
+        internal static partial void Internal_ManagedInstanceCreated(Object managedInstance, IntPtr theKlass);
 
         [LibraryImport("FlaxEngine", EntryPoint = "ObjectInternal_ManagedInstanceDeleted", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Interop.StringMarshaller))]
         internal static partial void Internal_ManagedInstanceDeleted(IntPtr nativeInstance);

--- a/Source/Engine/Scripting/Runtime/DotNet.cpp
+++ b/Source/Engine/Scripting/Runtime/DotNet.cpp
@@ -13,6 +13,7 @@
 #include "Engine/Platform/Platform.h"
 #include "Engine/Platform/File.h"
 #include "Engine/Platform/FileSystem.h"
+#include "Engine/Scripting/Internal/InternalCalls.h"
 #include "Engine/Scripting/ManagedCLR/MCore.h"
 #include "Engine/Scripting/ManagedCLR/MAssembly.h"
 #include "Engine/Scripting/ManagedCLR/MClass.h"
@@ -214,6 +215,7 @@ void* GetCustomAttribute(const MClass* klass, const MClass* attributeClass);
 struct NativeClassDefinitions
 {
     void* typeHandle;
+    MClass* nativePointer;
     const char* name;
     const char* fullname;
     const char* namespace_;
@@ -233,6 +235,7 @@ struct NativeFieldDefinitions
     const char* name;
     void* fieldHandle;
     void* fieldType;
+    int fieldOffset;
     MFieldAttributes fieldAttributes;
 };
 
@@ -341,8 +344,8 @@ void MCore::Object::Init(MObject* obj)
 MClass* MCore::Object::GetClass(MObject* obj)
 {
     ASSERT(obj);
-    MType* typeHandle = GetObjectType(obj);
-    return GetOrCreateClass(typeHandle);
+    static void* GetObjectClassPtr = GetStaticMethodPointer(TEXT("GetObjectClass"));
+    return (MClass*)CallStaticMethod<MClass*, void*>(GetObjectClassPtr, obj);
 }
 
 MString* MCore::Object::ToString(MObject* obj)
@@ -568,8 +571,7 @@ MObject* MCore::Exception::GetNotSupported(const char* msg)
 MClass* MCore::Type::GetClass(MType* type)
 {
     static void* GetTypeClassPtr = GetStaticMethodPointer(TEXT("GetTypeClass"));
-    type = (MType*)CallStaticMethod<void*, void*>(GetTypeClassPtr, type);
-    return GetOrCreateClass(type);
+    return CallStaticMethod<MClass*, void*>(GetTypeClassPtr, type);
 }
 
 MType* MCore::Type::GetElementType(MType* type)
@@ -634,10 +636,16 @@ const MAssembly::ClassesDictionary& MAssembly::GetClasses() const
         MClass* klass = New<MClass>(this, managedClass.typeHandle, managedClass.name, managedClass.fullname, managedClass.namespace_, managedClass.typeAttributes);
         _classes.Add(klass->GetFullName(), klass);
 
+        managedClass.nativePointer = klass;
+
         MCore::GC::FreeMemory((void*)managedClasses[i].name);
         MCore::GC::FreeMemory((void*)managedClasses[i].fullname);
         MCore::GC::FreeMemory((void*)managedClasses[i].namespace_);
     }
+
+    static void* RegisterManagedClassNativePointersPtr = GetStaticMethodPointer(TEXT("RegisterManagedClassNativePointers"));
+    CallStaticMethod<void, NativeClassDefinitions**, int>(RegisterManagedClassNativePointersPtr, &managedClasses, classCount);
+
     MCore::GC::FreeMemory(managedClasses);
 
     const auto endTime = DateTime::NowUTC();
@@ -650,6 +658,39 @@ const MAssembly::ClassesDictionary& MAssembly::GetClasses() const
 
     _hasCachedClasses = true;
     return _classes;
+}
+
+void GetAssemblyName(void* assemblyHandle, StringAnsi& name, StringAnsi& fullname)
+{
+    static void* GetAssemblyNamePtr = GetStaticMethodPointer(TEXT("GetAssemblyName"));
+    const char* name_;
+    const char* fullname_;
+    CallStaticMethod<void, void*, const char**, const char**>(GetAssemblyNamePtr, assemblyHandle, &name_, &fullname_);
+    name = name_;
+    fullname = fullname_;
+    MCore::GC::FreeMemory((void*)name_);
+    MCore::GC::FreeMemory((void*)fullname_);
+}
+
+DEFINE_INTERNAL_CALL(void) NativeInterop_CreateClass(NativeClassDefinitions* managedClass, void* assemblyHandle)
+{
+    MAssembly* assembly = GetAssembly(assemblyHandle);
+    if (assembly == nullptr)
+    {
+        StringAnsi assemblyName;
+        StringAnsi assemblyFullName;
+        GetAssemblyName(assemblyHandle, assemblyName, assemblyFullName);
+
+        assembly = New<MAssembly>(nullptr, assemblyName, assemblyFullName, assemblyHandle);
+        CachedAssemblyHandles.Add(assemblyHandle, assembly);
+    }
+
+    MClass* klass = New<MClass>(assembly, managedClass->typeHandle, managedClass->name, managedClass->fullname, managedClass->namespace_, managedClass->typeAttributes);
+    if (assembly != nullptr)
+    {
+        const_cast<MAssembly::ClassesDictionary&>(assembly->GetClasses()).Add(klass->GetFullName(), klass);
+    }
+    managedClass->nativePointer = klass;
 }
 
 bool MAssembly::LoadCorlib()
@@ -671,14 +712,9 @@ bool MAssembly::LoadCorlib()
 
     // Load
     {
-        const char* name;
-        const char* fullname;
         static void* GetAssemblyByNamePtr = GetStaticMethodPointer(TEXT("GetAssemblyByName"));
-        _handle = CallStaticMethod<void*, const char*, const char**, const char**>(GetAssemblyByNamePtr, "System.Private.CoreLib", &name, &fullname);
-        _name = name;
-        _fullname = fullname;
-        MCore::GC::FreeMemory((void*)name);
-        MCore::GC::FreeMemory((void*)fullname);
+        _handle = CallStaticMethod<void*, const char*>(GetAssemblyByNamePtr, "System.Private.CoreLib");
+        GetAssemblyName(_handle, _name, _fullname);
     }
     if (_handle == nullptr)
     {
@@ -698,19 +734,14 @@ bool MAssembly::LoadImage(const String& assemblyPath, const StringView& nativePa
     // TODO: Use new hostfxr delegate load_assembly_bytes? (.NET 8+)
     // Open .Net assembly
     const StringAnsi assemblyPathAnsi = assemblyPath.ToStringAnsi();
-    const char* name;
-    const char* fullname;
     static void* LoadAssemblyImagePtr = GetStaticMethodPointer(TEXT("LoadAssemblyImage"));
-    _handle = CallStaticMethod<void*, const char*, const char**, const char**>(LoadAssemblyImagePtr, assemblyPathAnsi.Get(), &name, &fullname);
-    _name = name;
-    _fullname = fullname;
-    MCore::GC::FreeMemory((void*)name);
-    MCore::GC::FreeMemory((void*)fullname);
+    _handle = CallStaticMethod<void*, const char*>(LoadAssemblyImagePtr, assemblyPathAnsi.Get());
     if (_handle == nullptr)
     {
         Log::CLRInnerException(TEXT(".NET assembly image is invalid at ") + assemblyPath);
         return true;
     }
+    GetAssemblyName(_handle, _name, _fullname);
     CachedAssemblyHandles.Add(_handle, this);
 
     // Provide new path of hot-reloaded native library path for managed DllImport
@@ -833,8 +864,7 @@ MType* MClass::GetType() const
 MClass* MClass::GetBaseClass() const
 {
     static void* GetClassParentPtr = GetStaticMethodPointer(TEXT("GetClassParent"));
-    MType* parentTypeHandle = CallStaticMethod<MType*, void*>(GetClassParentPtr, _handle);
-    return GetOrCreateClass(parentTypeHandle);
+    return CallStaticMethod<MClass*, void*>(GetClassParentPtr, _handle);
 }
 
 bool MClass::IsSubClassOf(const MClass* klass, bool checkInterfaces) const
@@ -869,8 +899,7 @@ uint32 MClass::GetInstanceSize() const
 MClass* MClass::GetElementClass() const
 {
     static void* GetElementClassPtr = GetStaticMethodPointer(TEXT("GetElementClass"));
-    MType* elementTypeHandle = CallStaticMethod<MType*, void*>(GetElementClassPtr, _handle);
-    return GetOrCreateClass(elementTypeHandle);
+    return CallStaticMethod<MClass*, void*>(GetElementClassPtr, _handle);
 }
 
 MMethod* MClass::GetMethod(const char* name, int32 numParams) const
@@ -930,7 +959,7 @@ const Array<MField*>& MClass::GetFields() const
     for (int32 i = 0; i < numFields; i++)
     {
         NativeFieldDefinitions& definition = fields[i];
-        MField* field = New<MField>(const_cast<MClass*>(this), definition.fieldHandle, definition.name, definition.fieldType, definition.fieldAttributes);
+        MField* field = New<MField>(const_cast<MClass*>(this), definition.fieldHandle, definition.name, definition.fieldType, definition.fieldOffset, definition.fieldAttributes);
         _fields.Add(field);
 
         MCore::GC::FreeMemory((void*)definition.name);
@@ -1013,7 +1042,7 @@ bool MClass::HasAttribute(const MClass* monoClass) const
 
 bool MClass::HasAttribute() const
 {
-    return GetCustomAttribute(this, nullptr) != nullptr;
+    return !GetAttributes().IsEmpty();
 }
 
 MObject* MClass::GetAttribute(const MClass* monoClass) const
@@ -1123,11 +1152,12 @@ MException::~MException()
         Delete(InnerException);
 }
 
-MField::MField(MClass* parentClass, void* handle, const char* name, void* type, MFieldAttributes attributes)
+MField::MField(MClass* parentClass, void* handle, const char* name, void* type, int fieldOffset, MFieldAttributes attributes)
     : _handle(handle)
     , _type(type)
     , _parentClass(parentClass)
     , _name(name)
+    , _fieldOffset(fieldOffset)
     , _hasCachedAttributes(false)
 {
     switch (attributes & MFieldAttributes::FieldAccessMask)
@@ -1163,14 +1193,19 @@ MType* MField::GetType() const
 
 int32 MField::GetOffset() const
 {
-    static void* FieldGetOffsetPtr = GetStaticMethodPointer(TEXT("FieldGetOffset"));
-    return CallStaticMethod<int32, void*>(FieldGetOffsetPtr, _handle);
+    return _fieldOffset;
 }
 
 void MField::GetValue(MObject* instance, void* result) const
 {
     static void* FieldGetValuePtr = GetStaticMethodPointer(TEXT("FieldGetValue"));
     CallStaticMethod<void, void*, void*, void*>(FieldGetValuePtr, instance, _handle, result);
+}
+
+void MField::GetValueReference(MObject* instance, void* result) const
+{
+    static void* FieldGetValueReferencePtr = GetStaticMethodPointer(TEXT("FieldGetValueReferenceWithOffset"));
+    CallStaticMethod<void, void*, int, void*>(FieldGetValueReferencePtr, instance, _fieldOffset, result);
 }
 
 MObject* MField::GetValueBoxed(MObject* instance) const
@@ -1505,8 +1540,7 @@ void* GetCustomAttribute(const MClass* klass, const MClass* attributeClass)
     const Array<MObject*>& attributes = klass->GetAttributes();
     for (MObject* attr : attributes)
     {
-        MType* typeHandle = GetObjectType(attr);
-        MClass* attrClass = GetOrCreateClass(typeHandle);
+        MClass* attrClass = MCore::Object::GetClass(attr);
         if (attrClass == attributeClass)
             return attr;
     }
@@ -1659,6 +1693,18 @@ void* GetStaticMethodPointer(const String& methodName)
         LOG(Fatal, "Failed to get unmanaged function pointer for method {0}: 0x{1:x}", methodName.Get(), (unsigned int)rc);
     CachedFunctions.Add(methodName, fun);
     return fun;
+}
+
+void MCore::ScriptingObject::SetInternalValues(MObject* object, void* unmanagedPtr, const Guid* id)
+{
+    static void* ScriptingObjectSetInternalValuesPtr = GetStaticMethodPointer(TEXT("ScriptingObjectSetInternalValues"));
+    CallStaticMethod<void, MObject*, void*, const Guid*>(ScriptingObjectSetInternalValuesPtr, object, unmanagedPtr, id);
+}
+
+MObject* MCore::ScriptingObject::CreateScriptingObject(MClass* klass, void* unmanagedPtr, const Guid* id)
+{
+    static void* ScriptingObjectSetInternalValuesPtr = GetStaticMethodPointer(TEXT("ScriptingObjectCreate"));
+    return CallStaticMethod<MObject*, void*, void*, const Guid*>(ScriptingObjectSetInternalValuesPtr, klass->_handle, unmanagedPtr, id);
 }
 
 #elif DOTNET_HOST_MONO

--- a/Source/Engine/Scripting/Runtime/Mono.cpp
+++ b/Source/Engine/Scripting/Runtime/Mono.cpp
@@ -2122,6 +2122,15 @@ const Array<MObject*>& MProperty::GetAttributes() const
     return _attributes;
 }
 
+void MCore::ScriptingObject::SetInternalValues(MObject* object, void* unmanagedPtr, const Guid* id)
+{
+}
+
+MObject* MCore::ScriptingObject::CreateScriptingObject(MClass* klass, void* unmanagedPtr, const Guid* id)
+{
+    return nullptr;
+}
+
 #endif
 
 #if USE_MONO && PLATFORM_WIN32 && !USE_MONO_DYNAMIC_LIB

--- a/Source/Engine/Scripting/Runtime/None.cpp
+++ b/Source/Engine/Scripting/Runtime/None.cpp
@@ -560,4 +560,13 @@ const Array<MObject*>& MProperty::GetAttributes() const
     return _attributes;
 }
 
+void MCore::ScriptingObject::SetInternalValues(MObject* object, void* unmanagedPtr, const Guid* id)
+{
+}
+
+MObject* MCore::ScriptingObject::CreateScriptingObject(MClass* klass, void* unmanagedPtr, const Guid* id)
+{
+    return nullptr;
+}
+
 #endif

--- a/Source/Engine/Scripting/ScriptingObject.h
+++ b/Source/Engine/Scripting/ScriptingObject.h
@@ -206,6 +206,13 @@ public:
     /// </summary>
     void UnregisterObject();
 
+#if USE_CSHARP
+    /// <summary>
+    /// Sets the internal values in managed object.
+    /// </summary>
+    static void SetInternalValues(MClass* monoClass, MObject* managedInstance, void* unmanagedPtr, const Guid* id);
+#endif
+
 protected:
 #if USE_CSHARP
     /// <summary>


### PR DESCRIPTION
Some notable changes in this PR:
- `MClass` is now stored in managed side, and is directly returned through some interop methods to avoid excessive dictionary lookups.
- Most of the `ScriptingObject`s initialization in managed side is now done in `ScriptingObjectCreate` interop method, and changing the internal values are done via `SetInternalValues` to combine small managed method calls into larger ones.
- Split marshalling delegates (`ToManaged*`/`ToNative*` methods) to further apart in order to avoid runtime type checks in marshalling methods.
- `Type` is internally wrapped with `TypeHolder` to contain commonly accessed information of the type.
- Field offsets are cached and used in the marshalling methods over `FieldInfo`. The `__unmanagedPtr` field offset is cached in native side and accessed with more direct method now.
- Minor changes like `GetTypeGCHandle` -> `GetTypeManagedHandle`
