### PR TITLE
Add borderless window switch at runtime on Windows platform

### DIFF
--- a/Source/Engine/Engine/Screen.cpp
+++ b/Source/Engine/Engine/Screen.cpp
@@ -137,20 +137,28 @@ void Screen::SetCursorLock(CursorLockMode mode)
 
 void Screen::SetGameWindowMode(GameWindowMode windowMode)
 {
-#if (PLATFORM_WINDOWS) && !USE_EDITOR
+#if !USE_EDITOR
     switch (windowMode)
     {
     case GameWindowMode::Windowed:
+        if (GetIsFullscreen())
+            SetIsFullscreen(false);
+#if (PLATFORM_WINDOWS)
         Engine::MainWindow->SetBorderless(false, false);
+#endif
         break;
     case GameWindowMode::Fullscreen:
         SetIsFullscreen(true);
         break;
     case GameWindowMode::Borderless:
+#if (PLATFORM_WINDOWS)
         Engine::MainWindow->SetBorderless(true, false);
+#endif
         break;
     case GameWindowMode::FullscreenBorderless:
+#if (PLATFORM_WINDOWS)
         Engine::MainWindow->SetBorderless(true, true);
+#endif
         break;
     default: ;
     }

--- a/Source/Engine/Engine/Screen.cpp
+++ b/Source/Engine/Engine/Screen.cpp
@@ -135,6 +135,28 @@ void Screen::SetCursorLock(CursorLockMode mode)
     CursorLock = mode;
 }
 
+void Screen::SetGameWindowMode(GameWindowMode windowMode)
+{
+#if (PLATFORM_WINDOWS) && !USE_EDITOR
+    switch (windowMode)
+    {
+    case GameWindowMode::Windowed:
+        Engine::MainWindow->SetBorderless(false, false);
+        break;
+    case GameWindowMode::Fullscreen:
+        SetIsFullscreen(true);
+        break;
+    case GameWindowMode::Borderless:
+        Engine::MainWindow->SetBorderless(true, false);
+        break;
+    case GameWindowMode::FullscreenBorderless:
+        Engine::MainWindow->SetBorderless(true, true);
+        break;
+    default: ;
+    }
+#endif
+}
+
 void ScreenService::Update()
 {
 #if USE_EDITOR

--- a/Source/Engine/Engine/Screen.h
+++ b/Source/Engine/Engine/Screen.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Engine/Core/Config/PlatformSettingsBase.h"
 #include "Engine/Scripting/ScriptingType.h"
 #include "Engine/Input/Enums.h"
 #include "Engine/Core/Math/Vector2.h"
@@ -80,4 +81,13 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(Screen);
     /// </summary>
     /// <param name="mode">The mode.</param>
     API_PROPERTY() static void SetCursorLock(CursorLockMode mode);
+
+    /// <summary>
+    /// Sets the game window mode.
+    /// </summary>
+    /// <remarks>
+    /// A fullscreen mode switch may not happen immediately. It will be performed before next frame rendering. Will not work in editor.
+    /// </remarks>
+    /// <param name="windowMode">The window mode.</param>
+    API_PROPERTY() static void SetGameWindowMode(GameWindowMode windowMode);
 };

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -446,6 +446,15 @@ public:
     }
 
     /// <summary>
+    /// Sets the window to be borderless or not and to be fullscreen.
+    /// </summary>
+    /// <param name="isBorderless">Whether or not to have borders on window.</param>
+    /// <param name="fullscreen">Whether or not to make the borderless window fullscreen.</param>
+    API_FUNCTION() virtual void SetBorderless(bool isBorderless, bool fullscreen)
+    {
+    }
+
+    /// <summary>
     /// Restores the window state before minimizing or maximizing.
     /// </summary>
     API_FUNCTION() virtual void Restore()

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -260,6 +260,76 @@ void WindowsWindow::Maximize()
     _isDuringMaximize = false;
 }
 
+void WindowsWindow::SetBorderless(bool isBorderless, bool fullscreen)
+{
+    ASSERT(HasHWND());
+    
+    if (IsFullscreen())
+        SetIsFullscreen(false);
+
+    // Fixes issue of borderless window not going full screen
+    if (IsMaximized())
+        Restore();
+
+    _settings.HasBorder = !isBorderless;
+
+    BringToFront();
+
+    if (isBorderless)
+    {
+        LONG lStyle = GetWindowLong(_handle, GWL_STYLE);
+        lStyle &= ~(WS_THICKFRAME | WS_SYSMENU | WS_OVERLAPPED | WS_BORDER | WS_CAPTION);
+        lStyle |=  WS_POPUP;
+        lStyle |= WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
+#if WINDOWS_USE_NEW_BORDER_LESS
+        if (_settings.IsRegularWindow)
+            style |= WS_BORDER | WS_CAPTION | WS_DLGFRAME | WS_SYSMENU | WS_THICKFRAME | WS_GROUP;
+#elif WINDOWS_USE_NEWER_BORDER_LESS
+        if (_settings.IsRegularWindow)
+            lStyle |= WS_THICKFRAME | WS_SYSMENU;
+#endif
+
+        SetWindowLong(_handle, GWL_STYLE, lStyle);
+        SetWindowPos(_handle, HWND_TOP,  0, 0,0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+        
+        
+        if (fullscreen)
+        {
+            ShowWindow(_handle, SW_SHOWMAXIMIZED);
+        }
+        else
+        {
+            ShowWindow(_handle, SW_SHOW);
+        }
+    }
+    else
+    {
+        LONG lStyle = GetWindowLong(_handle, GWL_STYLE);
+        lStyle &= ~(WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS);
+        if (_settings.AllowMaximize)
+            lStyle |= WS_MAXIMIZEBOX;
+        if (_settings.AllowMinimize)
+            lStyle |= WS_MINIMIZEBOX;
+        if (_settings.HasSizingFrame)
+            lStyle |= WS_THICKFRAME;
+        // Create window style flags
+        lStyle |= WS_OVERLAPPED | WS_SYSMENU | WS_BORDER | WS_CAPTION;
+    
+        SetWindowLong(_handle, GWL_STYLE, lStyle);
+        SetWindowPos(_handle, nullptr,  0, 0, (int)_settings.Size.X, (int)_settings.Size.Y, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+        
+        if (fullscreen)
+        {
+            Maximize();
+        }
+        else
+        {
+            ShowWindow(_handle, SW_SHOW);
+        }
+    }
+    CheckForWindowResize();
+}
+
 void WindowsWindow::Restore()
 {
     ASSERT(HasHWND());

--- a/Source/Engine/Platform/Windows/WindowsWindow.h
+++ b/Source/Engine/Platform/Windows/WindowsWindow.h
@@ -100,6 +100,7 @@ public:
     void Hide() override;
     void Minimize() override;
     void Maximize() override;
+    void SetBorderless(bool isBorderless, bool fullscreen) override;
     void Restore() override;
     bool IsClosed() const override;
     bool IsForegroundWindow() const override;


### PR DESCRIPTION
Add changing to borderless window at game runtime. This also adds a nice utility function in the `Screen` class to easily change window mode. I do not have Linux or Mac, so I did not implement on those platforms. #1298 