### PR TITLE
Add to be able to choose sloppy mesh simplification or not in model import settings for LODs

### DIFF
--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -383,7 +383,7 @@ void ModelTool::Options::Serialize(SerializeStream& stream, const void* otherObj
     SERIALIZE(BaseLOD);
     SERIALIZE(LODCount);
     SERIALIZE(TriangleReduction);
-    SERIALIZE(Sloppy);
+    SERIALIZE(SloppyOptimization);
     SERIALIZE(LODTargetError);
     SERIALIZE(ImportMaterials);
     SERIALIZE(ImportTextures);
@@ -426,7 +426,7 @@ void ModelTool::Options::Deserialize(DeserializeStream& stream, ISerializeModifi
     DESERIALIZE(BaseLOD);
     DESERIALIZE(LODCount);
     DESERIALIZE(TriangleReduction);
-    DESERIALIZE(Sloppy);
+    DESERIALIZE(SloppyOptimization);
     DESERIALIZE(LODTargetError);
     DESERIALIZE(ImportMaterials);
     DESERIALIZE(ImportTextures);
@@ -1533,7 +1533,7 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
                 Array<unsigned int> indices;
                 indices.Resize(dstMeshIndexCountTarget);
                 int32 dstMeshIndexCount = {};
-                if (options.Sloppy)
+                if (options.SloppyOptimization)
                     dstMeshIndexCount = (int32)meshopt_simplifySloppy(indices.Get(), srcMesh->Indices.Get(), srcMeshIndexCount, (const float*)srcMesh->Positions.Get(), srcMeshVertexCount, sizeof(Float3), dstMeshIndexCountTarget);
                 else
                     dstMeshIndexCount = (int32)meshopt_simplify(indices.Get(), srcMesh->Indices.Get(), srcMeshIndexCount, (const float*)srcMesh->Positions.Get(), srcMeshVertexCount, sizeof(Float3), dstMeshIndexCountTarget, options.LODTargetError);

--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -383,6 +383,8 @@ void ModelTool::Options::Serialize(SerializeStream& stream, const void* otherObj
     SERIALIZE(BaseLOD);
     SERIALIZE(LODCount);
     SERIALIZE(TriangleReduction);
+    SERIALIZE(Sloppy);
+    SERIALIZE(LODTargetError);
     SERIALIZE(ImportMaterials);
     SERIALIZE(ImportTextures);
     SERIALIZE(RestoreMaterialsOnReimport);
@@ -424,6 +426,8 @@ void ModelTool::Options::Deserialize(DeserializeStream& stream, ISerializeModifi
     DESERIALIZE(BaseLOD);
     DESERIALIZE(LODCount);
     DESERIALIZE(TriangleReduction);
+    DESERIALIZE(Sloppy);
+    DESERIALIZE(LODTargetError);
     DESERIALIZE(ImportMaterials);
     DESERIALIZE(ImportTextures);
     DESERIALIZE(RestoreMaterialsOnReimport);
@@ -1528,7 +1532,11 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
                 int32 dstMeshIndexCountTarget = int32(srcMeshIndexCount * triangleReduction) / 3 * 3;
                 Array<unsigned int> indices;
                 indices.Resize(dstMeshIndexCountTarget);
-                int32 dstMeshIndexCount = (int32)meshopt_simplifySloppy(indices.Get(), srcMesh->Indices.Get(), srcMeshIndexCount, (const float*)srcMesh->Positions.Get(), srcMeshVertexCount, sizeof(Float3), dstMeshIndexCountTarget);
+                int32 dstMeshIndexCount = {};
+                if (options.Sloppy)
+                    dstMeshIndexCount = (int32)meshopt_simplifySloppy(indices.Get(), srcMesh->Indices.Get(), srcMeshIndexCount, (const float*)srcMesh->Positions.Get(), srcMeshVertexCount, sizeof(Float3), dstMeshIndexCountTarget);
+                else
+                    dstMeshIndexCount = (int32)meshopt_simplify(indices.Get(), srcMesh->Indices.Get(), srcMeshIndexCount, (const float*)srcMesh->Positions.Get(), srcMeshVertexCount, sizeof(Float3), dstMeshIndexCountTarget, options.LODTargetError);
                 indices.Resize(dstMeshIndexCount);
                 if (dstMeshIndexCount == 0)
                     continue;

--- a/Source/Engine/Tools/ModelTool/ModelTool.h
+++ b/Source/Engine/Tools/ModelTool/ModelTool.h
@@ -322,6 +322,12 @@ public:
         // The target amount of triangles for the generated LOD (based on the higher LOD). Normalized to range 0-1. For instance 0.4 cuts the triangle count to 40%.
         API_FIELD(Attributes="EditorOrder(1130), EditorDisplay(\"Level Of Detail\"), VisibleIf(nameof(ShowGeometry)), Limit(0, 1, 0.001f)")
         float TriangleReduction = 0.5f;
+        // Whether to do a sloppy mesh optimization. This is faster and does not follow the topology of the original mesh.
+        API_FIELD(Attributes="EditorOrder(1140), EditorDisplay(\"Level Of Detail\"), VisibleIf(nameof(ShowGeometry))")
+        bool Sloppy = true;
+        // Only used if Sloppy is false. Target error is an approximate measure of the deviation from the original mesh using distance normalized to [0..1] range (e.g. 1e-2f means that simplifier will try to maintain the error to be below 1% of the mesh extents).
+        API_FIELD(Attributes="EditorOrder(1150), EditorDisplay(\"Level Of Detail\"), VisibleIf(nameof(ShowGeometry)), Limit(0.01f, 1, 0.001f)")
+        float LODTargetError = 0.1f;
 
     public: // Materials
 

--- a/Source/Engine/Tools/ModelTool/ModelTool.h
+++ b/Source/Engine/Tools/ModelTool/ModelTool.h
@@ -322,11 +322,11 @@ public:
         // The target amount of triangles for the generated LOD (based on the higher LOD). Normalized to range 0-1. For instance 0.4 cuts the triangle count to 40%.
         API_FIELD(Attributes="EditorOrder(1130), EditorDisplay(\"Level Of Detail\"), VisibleIf(nameof(ShowGeometry)), Limit(0, 1, 0.001f)")
         float TriangleReduction = 0.5f;
-        // Whether to do a sloppy mesh optimization. This is faster and does not follow the topology of the original mesh.
+        // Whether to do a sloppy mesh optimization. This is faster but does not follow the topology of the original mesh.
         API_FIELD(Attributes="EditorOrder(1140), EditorDisplay(\"Level Of Detail\"), VisibleIf(nameof(ShowGeometry))")
-        bool Sloppy = true;
+        bool SloppyOptimization = true;
         // Only used if Sloppy is false. Target error is an approximate measure of the deviation from the original mesh using distance normalized to [0..1] range (e.g. 1e-2f means that simplifier will try to maintain the error to be below 1% of the mesh extents).
-        API_FIELD(Attributes="EditorOrder(1150), EditorDisplay(\"Level Of Detail\"), VisibleIf(nameof(ShowGeometry)), Limit(0.01f, 1, 0.001f)")
+        API_FIELD(Attributes="EditorOrder(1150), EditorDisplay(\"Level Of Detail\"), VisibleIf(nameof(SloppyOptimization), true), Limit(0.01f, 1, 0.001f)")
         float LODTargetError = 0.1f;
 
     public: // Materials


### PR DESCRIPTION
This adds the ability do do a non sloppy mesh optimization for LODs if the user wants. It can give some better results than doing a sloppy simplification.