### PR TITLE
PE: Fix - Game Cooker Crash

### DIFF
--- a/Source/Editor/Content/Settings/BuildTarget.cs
+++ b/Source/Editor/Content/Settings/BuildTarget.cs
@@ -39,7 +39,7 @@ namespace FlaxEditor.Content.Settings
         /// The list of custom defines passed to the build tool when compiling project scripts. Can be used in build scripts for configuration (Configuration.CustomDefines).
         /// </summary>
         [EditorOrder(90), Tooltip("The list of custom defines passed to the build tool when compiling project scripts. Can be used in build scripts for configuration (Configuration.CustomDefines).")]
-        public string[] CustomDefines;
+        public string[] CustomDefines = { };
 
         /// <summary>
         /// The pre-build action command line.

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -87,7 +87,7 @@ namespace FlaxEditor.Windows
                 public BuildConfiguration ConfigurationMode = BuildConfiguration.Development;
 
                 [EditorOrder(90), Tooltip("The list of custom defines passed to the build tool when compiling project scripts. Can be used in build scripts for configuration (Configuration.CustomDefines).")]
-                public string[] CustomDefines;
+                public string[] CustomDefines = { };
 
                 protected abstract BuildPlatform BuildPlatform { get; }
 


### PR DESCRIPTION
.NET will crash (LibraryImports.g.cs) if you sent a string[] == null , if .length == 0 there is no problem so: public string[] CustomDefines = { };
