### PR TITLE
Use mutex over atomic operations in `Delegate`

### DIFF
--- a/Source/Engine/Scripting/Scripting.cpp
+++ b/Source/Engine/Scripting/Scripting.cpp
@@ -128,11 +128,6 @@ bool ScriptingService::Init()
 {
     const auto startTime = DateTime::NowUTC();
 
-    // Link for assemblies events
-    auto engineAssembly = ((NativeBinaryModule*)GetBinaryModuleFlaxEngine())->Assembly;
-    engineAssembly->Loaded.Bind(onEngineLoaded);
-    engineAssembly->Unloading.Bind(onEngineUnloading);
-
     // Initialize managed runtime
     if (MCore::LoadEngine())
     {
@@ -483,6 +478,8 @@ bool Scripting::Load()
         return true;
     }
 
+    onEngineLoaded(flaxEngineModule->Assembly);
+
     // Insert type aliases for vector types that don't exist in C++ but are just typedef (properly redirect them to actual types)
     // TODO: add support for automatic typedef aliases setup for scripting module to properly lookup type from the alias typename
 #if USE_LARGE_WORLDS
@@ -584,6 +581,9 @@ void Scripting::Release()
 
         asset->DeleteObjectNow();
     }
+
+    auto* flaxEngineModule = (NativeBinaryModule*)GetBinaryModuleFlaxEngine();
+    onEngineUnloading(flaxEngineModule->Assembly);
 
     // Unload assemblies (from back to front)
     {


### PR DESCRIPTION
Using mutex seems to perform faster in heavy operations like deserializing thousands of `Model`s in prefab at once.