### PR TITLE
Add simple way to remove button border.

### DIFF
--- a/Source/Engine/UI/GUI/Common/Button.cs
+++ b/Source/Engine/UI/GUI/Common/Button.cs
@@ -80,21 +80,27 @@ namespace FlaxEngine.GUI
         public Color BackgroundColorSelected { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of the border.
+        /// Gets or sets whether the button has a border.
         /// </summary>
         [EditorDisplay("Border Style"), EditorOrder(2010), ExpandGroups]
+        public bool HasBorder { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the color of the border.
+        /// </summary>
+        [EditorDisplay("Border Style"), EditorOrder(2011), ExpandGroups]
         public Color BorderColor { get; set; }
 
         /// <summary>
         /// Gets or sets the border color when button is highlighted.
         /// </summary>
-        [EditorDisplay("Border Style"), EditorOrder(2011)]
+        [EditorDisplay("Border Style"), EditorOrder(2012)]
         public Color BorderColorHighlighted { get; set; }
 
         /// <summary>
         /// Gets or sets the border color when button is selected.
         /// </summary>
-        [EditorDisplay("Border Style"), EditorOrder(2012)]
+        [EditorDisplay("Border Style"), EditorOrder(2013)]
         public Color BorderColorSelected { get; set; }
 
         /// <summary>
@@ -245,7 +251,8 @@ namespace FlaxEngine.GUI
                 BackgroundBrush.Draw(clientRect, backgroundColor);
             else
                 Render2D.FillRectangle(clientRect, backgroundColor);
-            Render2D.DrawRectangle(clientRect, borderColor);
+            if (HasBorder)
+                Render2D.DrawRectangle(clientRect, borderColor);
 
             // Draw text
             Render2D.DrawText(_font?.GetFont(), TextMaterial, _text, clientRect, textColor, TextAlignment.Center, TextAlignment.Center);


### PR DESCRIPTION
This adds an exposed boolean as a simple way to not render a button's border. This is helpful as often times I find myself changing all of the border options to transparent anyways.