### PR TITLE
Remove popup from appearing if the content item cannot be renamed.

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -340,6 +340,9 @@ namespace FlaxEditor.Windows
         /// <returns>The created renaming popup.</returns>
         public void Rename(ContentItem item)
         {
+            if (!item.CanRename)
+                return;
+            
             // Show element in the view
             Select(item, true);
 


### PR DESCRIPTION
This removes the popup from appearing when trying to rename the content and source folders.