### PR TITLE
Add tab breaks for window tabs.

### DIFF
--- a/Source/Editor/GUI/Docking/DockPanelProxy.cs
+++ b/Source/Editor/GUI/Docking/DockPanelProxy.cs
@@ -253,6 +253,12 @@ namespace FlaxEditor.GUI.Docking
                         tabColor = style.BackgroundHighlighted;
                         Render2D.FillRectangle(tabRect, tabColor);
                     }
+                    else
+                    {
+                        tabColor = style.BackgroundHighlighted;
+                        Render2D.DrawLine(tabRect.BottomLeft - new Float2(0 , 1), tabRect.UpperLeft, tabColor);
+                        Render2D.DrawLine(tabRect.BottomRight - new Float2(0 , 1), tabRect.UpperRight, tabColor);
+                    }
 
                     if (tab.Icon.IsValid)
                     {


### PR DESCRIPTION
This adds some visual breaks for where the docked window tabs are for better UX.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/ab32876e-c7df-410a-882b-fac68ea2cae1)
