### PR TITLE
Optimize PhysX collision event handling and onContact callback

### DIFF
--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -667,7 +667,6 @@ PxFilterFlags FilterShader(
     if (PxFilterObjectIsKinematic(attributes0) && PxFilterObjectIsKinematic(attributes1))
     {
         pairFlags |= PxPairFlag::eNOTIFY_TOUCH_FOUND;
-        pairFlags |= PxPairFlag::eNOTIFY_TOUCH_PERSISTS;
         pairFlags |= PxPairFlag::eNOTIFY_TOUCH_LOST;
         pairFlags |= PxPairFlag::eDETECT_DISCRETE_CONTACT;
         return PxFilterFlag::eSUPPRESS;
@@ -679,7 +678,7 @@ PxFilterFlags FilterShader(
         pairFlags |= PxPairFlag::eSOLVE_CONTACT;
         pairFlags |= PxPairFlag::eDETECT_DISCRETE_CONTACT;
         pairFlags |= PxPairFlag::eNOTIFY_TOUCH_FOUND;
-        pairFlags |= PxPairFlag::eNOTIFY_TOUCH_PERSISTS;
+        pairFlags |= PxPairFlag::eNOTIFY_TOUCH_LOST;
         pairFlags |= PxPairFlag::ePOST_SOLVER_VELOCITY;
         pairFlags |= PxPairFlag::eNOTIFY_CONTACT_POINTS;
         return PxFilterFlag::eDEFAULT;

--- a/Source/Engine/Physics/PhysX/SimulationEventCallbackPhysX.h
+++ b/Source/Engine/Physics/PhysX/SimulationEventCallbackPhysX.h
@@ -18,27 +18,16 @@ class SimulationEventCallback : public PxSimulationEventCallback
 {
 public:
     typedef Pair<PhysicsColliderActor*, PhysicsColliderActor*> CollidersPair;
-    typedef Dictionary<CollidersPair, Collision> CollisionsPool;
-
-    /// <summary>
-    /// The collected collisions.
-    /// </summary>
-    CollisionsPool Collisions;
-
-    /// <summary>
-    /// The previous step collisions.
-    /// </summary>
-    CollisionsPool PrevCollisions;
 
     /// <summary>
     /// The new collisions (for enter event).
     /// </summary>
-    Array<CollidersPair> NewCollisions;
+    Array<Collision> NewCollisions;
 
     /// <summary>
     /// The old collisions (for exit event).
     /// </summary>
-    Array<CollidersPair> RemovedCollisions;
+    Array<Collision> RemovedCollisions;
 
     /// <summary>
     /// The new trigger pairs (for enter event).


### PR DESCRIPTION
Few improvements to collision event handling and callbacks:

- Use PhysX `PxContactPairFlag::eACTOR_PAIR_HAS_FIRST_TOUCH` and `PxContactPairFlag::eACTOR_PAIR_LOST_TOUCH` flags to determine enter and exit collision information.
- Unsubscribe from persisting contact information as this is not used by the engine, only initial and last contact information are needed.
- Extract collision velocities more efficiently (this assumes the pairs in extra data stream are in the same order as in the contact stream)