### PR TITLE
.NET7: Fix managed UTF-8 string allocation not using correct encoding

### DIFF
--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -581,9 +581,9 @@ namespace FlaxEngine.Interop
         }
 
         [UnmanagedCallersOnly]
-        internal static IntPtr NewStringLength(sbyte* text, int length)
+        internal static IntPtr NewStringUTF8(sbyte* text, int length)
         {
-            return ManagedString.ToNativeWeak(new string(text, 0, length));
+            return ManagedString.ToNativeWeak(new string(text, 0, length, System.Text.Encoding.UTF8));
         }
 
         [UnmanagedCallersOnly]

--- a/Source/Engine/Scripting/Runtime/DotNet.cpp
+++ b/Source/Engine/Scripting/Runtime/DotNet.cpp
@@ -365,8 +365,8 @@ MString* MCore::String::GetEmpty(MDomain* domain)
 
 MString* MCore::String::New(const char* str, int32 length, MDomain* domain)
 {
-    static void* NewStringLengthPtr = GetStaticMethodPointer(TEXT("NewStringLength"));
-    return (MString*)CallStaticMethod<void*, const char*, int>(NewStringLengthPtr, str, length);
+    static void* NewStringUTF8Ptr = GetStaticMethodPointer(TEXT("NewStringUTF8"));
+    return (MString*)CallStaticMethod<void*, const char*, int>(NewStringUTF8Ptr, str, length);
 }
 
 MString* MCore::String::New(const Char* str, int32 length, MDomain* domain)


### PR DESCRIPTION
Serializing/deserializing scene objects with strings which had Unicode characters did not get encoded properly (for example the text in UI labels).