### PR TITLE
Fix right click deselecting scene tree nodes.

### DIFF
--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -762,7 +762,11 @@ namespace FlaxEditor.GUI.Tree
                         // Add/Remove
                         tree.AddOrRemoveSelection(this);
                     }
-                    else if (button != MouseButton.Right)
+                    else if (button == MouseButton.Right && tree.Selection.Contains(this))
+                    {
+                        // Do nothing
+                    }
+                    else
                     {
                         // Select
                         tree.Select(this);

--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -762,7 +762,7 @@ namespace FlaxEditor.GUI.Tree
                         // Add/Remove
                         tree.AddOrRemoveSelection(this);
                     }
-                    else
+                    else if (button != MouseButton.Right)
                     {
                         // Select
                         tree.Select(this);


### PR DESCRIPTION
This fixes a bug of when multiple tree nodes are selected, all of them will be de-selected except the node that the mouse is over when the user is right clicking.