### PR TITLE
Add `View Layers` button & `Reset`/`Disable`/`Copy`/`Paste` buttons to `View Flags`/`Debug View` & Camera `RenderFlags`/`RenderView` addition

### DIFF
--- a/Source/Engine/Graphics/RenderView.cpp
+++ b/Source/Engine/Graphics/RenderView.cpp
@@ -192,6 +192,8 @@ void RenderView::CopyFrom(Camera* camera, Viewport* viewport)
     Frustum.GetInvMatrix(IVP);
     CullingFrustum = Frustum;
     RenderLayersMask = camera->RenderLayersMask;
+    Flags = camera->RenderFlags;
+    Mode = camera->RenderView;
 }
 
 void RenderView::GetWorldMatrix(const Transform& transform, Matrix& world) const

--- a/Source/Engine/Graphics/RenderView.cs
+++ b/Source/Engine/Graphics/RenderView.cs
@@ -102,6 +102,8 @@ namespace FlaxEngine
             NonJitteredProjection = Projection;
             TemporalAAJitter = Float4.Zero;
             RenderLayersMask = camera.RenderLayersMask;
+            Flags = camera.RenderFlags;
+            Mode = camera.RenderView;
 
             UpdateCachedData();
         }

--- a/Source/Engine/Level/Actors/Camera.cpp
+++ b/Source/Engine/Level/Actors/Camera.cpp
@@ -415,6 +415,8 @@ void Camera::Serialize(SerializeStream& stream, const void* otherObj)
     SERIALIZE_MEMBER(Far, _far);
     SERIALIZE_MEMBER(OrthoScale, _orthoScale);
     SERIALIZE(RenderLayersMask);
+    SERIALIZE(RenderFlags);
+    SERIALIZE(RenderView);
 }
 
 void Camera::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
@@ -429,6 +431,8 @@ void Camera::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier
     DESERIALIZE_MEMBER(Far, _far);
     DESERIALIZE_MEMBER(OrthoScale, _orthoScale);
     DESERIALIZE(RenderLayersMask);
+    DESERIALIZE(RenderFlags);
+    DESERIALIZE(RenderView);
 }
 
 void Camera::OnEnable()

--- a/Source/Engine/Level/Actors/Camera.h
+++ b/Source/Engine/Level/Actors/Camera.h
@@ -7,6 +7,7 @@
 #include "Engine/Core/Math/Viewport.h"
 #include "Engine/Core/Math/Ray.h"
 #include "Engine/Core/Types/LayersMask.h"
+#include "Engine/Graphics/Enums.h"
 #include "Engine/Scripting/ScriptingObjectReference.h"
 #if USE_EDITOR
 #include "Engine/Content/AssetReference.h"
@@ -133,6 +134,18 @@ public:
     /// </summary>
     API_FIELD(Attributes="EditorOrder(100), EditorDisplay(\"Camera\")")
     LayersMask RenderLayersMask;
+
+    /// <summary>
+    /// Frame rendering flags used to switch between graphics features for this camera.
+    /// </summary>
+    API_FIELD(Attributes = "EditorOrder(110), EditorDisplay(\"Camera\")")
+    ViewFlags RenderFlags = ViewFlags::DefaultGame;
+
+    /// <summary>
+    /// Describes frame rendering modes for this camera.
+    /// </summary>
+    API_FIELD(Attributes = "EditorOrder(120), EditorDisplay(\"Camera\")")
+    ViewMode RenderView = ViewMode::Default;
 
 public:
     /// <summary>


### PR DESCRIPTION
Main goal of this PR was to standardize viewing/rendering abilities of editor viewport camera and of `Camera` actor without having to resort to custom scene rendering tasks. Now they both have exactly the same feature set of selective layer/flag/view rendering:

![image](https://github.com/FlaxEngine/FlaxEngine/assets/118038102/349fd6f1-782c-4e9b-8f54-cc5c81859f74)

I also added a lot of additional Qol buttons to the editor viewport camera in order to simplify working with it and with `Camera` actors.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/118038102/c42befac-d3b1-4f8d-8c61-8d66f3dbad84)

This allows you to easily copy/paste stuff back and forward

![image](https://github.com/FlaxEngine/FlaxEngine/assets/118038102/40080ab0-fa7c-437d-964b-228d2871f07f)

![image](https://github.com/FlaxEngine/FlaxEngine/assets/118038102/0d5e8d69-7be0-4b01-9077-1d0782ba877c)

