### PR TITLE
Fixes Rider 2022 not being detected when installed with toolbox - Windows

### DIFF
--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -187,6 +187,7 @@ void RiderCodeEditor::FindEditors(Array<CodeEditor*>* output)
     SearchRegistry(&installations, HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\WOW6432Node\\JetBrains\\JetBrains Rider"));
 
     // Versions installed via JetBrains Toolbox
+    FileSystem::GetChildDirectories(subDirectories, localAppDataPath / TEXT("Programs"));
     FileSystem::GetChildDirectories(subDirectories, localAppDataPath / TEXT("JetBrains\\Toolbox\\apps\\Rider\\ch-0\\"));
     FileSystem::GetChildDirectories(subDirectories, localAppDataPath / TEXT("JetBrains\\Toolbox\\apps\\Rider\\ch-1\\")); // Beta versions
 #endif

--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -44,6 +44,10 @@ namespace
         if (document.HasParseError())
             return;
 
+        // Check if this is actually rider and not another jetbrains product
+        if (document.FindMember("name")->value != "JetBrains Rider")
+            return;
+
         // Find version
         auto versionMember = document.FindMember("version");
         if (versionMember == document.MemberEnd())


### PR DESCRIPTION
Adds a check for the local programs folder

#1386 