### PR TITLE
Fix assets getting deleted when modified by external applications

### DIFF
--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -643,7 +643,8 @@ namespace FlaxEditor.Modules
         /// Deletes the specified item.
         /// </summary>
         /// <param name="item">The item.</param>
-        public void Delete(ContentItem item)
+        /// <param name="deletedByUser">If the file was deleted by the user and not outside the editor.</param>
+        public void Delete(ContentItem item, bool deletedByUser = false)
         {
             if (item == null)
                 throw new ArgumentNullException();
@@ -667,12 +668,12 @@ namespace FlaxEditor.Modules
                     var children = folder.Children.ToArray();
                     for (int i = 0; i < children.Length; i++)
                     {
-                        Delete(children[i]);
+                        Delete(children[i], deletedByUser);
                     }
                 }
 
                 // Remove directory
-                if (Directory.Exists(path))
+                if (deletedByUser && Directory.Exists(path))
                 {
                     try
                     {
@@ -701,7 +702,7 @@ namespace FlaxEditor.Modules
                     // Delete asset by using content pool
                     FlaxEngine.Content.DeleteAsset(path);
                 }
-                else
+                else if (deletedByUser)
                 {
                     // Delete file
                     if (File.Exists(path))
@@ -847,7 +848,7 @@ namespace FlaxEditor.Modules
                         Editor.Log(string.Format($"Content item \'{child.Path}\' has been removed"));
 
                         // Destroy it
-                        Delete(child);
+                        Delete(child, false);
 
                         i--;
                     }

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -626,7 +626,7 @@ namespace FlaxEditor.Windows
 
             // Delete items
             for (int i = 0; i < toDelete.Count; i++)
-                Editor.ContentDatabase.Delete(toDelete[i]);
+                Editor.ContentDatabase.Delete(toDelete[i], true);
 
             RefreshView();
         }


### PR DESCRIPTION
There is a very small window of files getting erroneously deleted after external application like Visual Studio modifies the file upon saving by creating temporary files and then renaming those to original filename. We should never attempt to delete the file detected as being deleted unless it was prompted by the user.

The way to reproduce the issue can be done by modifying a file in Visual Studio 2022 for example by adding a space and then hitting CTRL+S until the Flax Editor detects the file removed and then generates the solution files again. Thanks to MineBill from Discord for discovering the steps for reproducing this.