### PR TITLE
Don't treat '.' in folder names as extensions.

### DIFF
--- a/Source/Editor/Modules/ContentEditingModule.cs
+++ b/Source/Editor/Modules/ContentEditingModule.cs
@@ -90,6 +90,12 @@ namespace FlaxEditor.Modules
                     hint = "Too long name.";
                     return false;
                 }
+                
+                if (item.IsFolder && shortName.EndsWith("."))
+                {
+                    hint = "Name cannot end with '.'";
+                    return false;
+                }
 
                 // Find invalid characters
                 if (Utilities.Utils.HasInvalidPathChar(shortName))
@@ -120,7 +126,7 @@ namespace FlaxEditor.Modules
                 // Cache data
                 string sourcePath = item.Path;
                 string sourceFolder = System.IO.Path.GetDirectoryName(sourcePath);
-                string extension = System.IO.Path.GetExtension(sourcePath);
+                string extension = item.IsFolder ? "" : System.IO.Path.GetExtension(sourcePath);
                 string destinationPath = StringUtils.CombinePaths(sourceFolder, shortName + extension);
 
                 if (item.IsFolder)

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -520,7 +520,7 @@ namespace FlaxEditor.Windows
             }
 
             // Cache data
-            string extension = Path.GetExtension(item.Path);
+            string extension = item.IsFolder ? "" : Path.GetExtension(item.Path);
             var newPath = StringUtils.CombinePaths(item.ParentFolder.Path, newShortName + extension);
 
             // Check if was renaming mock element


### PR DESCRIPTION
Fixes #1392.