### PR TITLE
Fixing x64 editor/runtime on M1/2 macs

### DIFF
--- a/Source/Engine/Scripting/Runtime/DotNet.cpp
+++ b/Source/Engine/Scripting/Runtime/DotNet.cpp
@@ -1541,7 +1541,16 @@ bool InitHostfxr()
     get_hostfxr_params.size = sizeof(hostfxr_initialize_parameters);
     get_hostfxr_params.assembly_path = libraryPath.Get();
 #if PLATFORM_MAC
-    get_hostfxr_params.dotnet_root = "/usr/local/share/dotnet";
+    ::String macOSDotnetRoot = TEXT("/usr/local/share/dotnet");
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
+    // When emulating x64 on arm
+    const ::String dotnetRootEmulated = macOSDotnetRoot / TEXT("x64");
+    if (FileSystem::FileExists(dotnetRootEmulated / TEXT("dotnet"))) {
+        macOSDotnetRoot = dotnetRootEmulated;
+    }
+#endif
+    const FLAX_CORECLR_STRING& finalDotnetRootPath = FLAX_CORECLR_STRING(macOSDotnetRoot);
+    get_hostfxr_params.dotnet_root = finalDotnetRootPath.Get();
 #else
     get_hostfxr_params.dotnet_root = nullptr;
 #endif


### PR DESCRIPTION
This resolves part of #1254 where when running x64 compiled versions of the runtime/editor on M1/2 macs, it would not properly check the correct location for the x64 version of the dotnet runtime.

This does not fix many of the issues that exist in the build system for building x64 binaries on an M1/2 macs but this does allow folks who download the editor from the CI page to actually be able to run it on a M1/2 mac. 