### PR TITLE
Fix error on try invoke actions by childrens on OnDestroy 

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -877,6 +877,15 @@ void Actor::EndPlay()
 #endif
 
     // Fire event for scripting
+    for (auto* script : Scripts)
+    {
+        CHECK_EXECUTE_IN_EDITOR
+        {
+            script->OnDestroy();
+        }
+    }
+
+    // Fire event for scripting
     if (IsActiveInHierarchy() && GetScene())
     {
         ASSERT(GetScene());
@@ -893,15 +902,6 @@ void Actor::EndPlay()
     {
         if (Children[i]->IsDuringPlay())
             Children[i]->EndPlay();
-    }
-
-    // Fire event for scripting
-    for (auto* script : Scripts)
-    {
-        CHECK_EXECUTE_IN_EDITOR
-        {
-            script->OnDestroy();
-        }
     }
 
     // Inform attached scripts


### PR DESCRIPTION
If i create an action on my script that executes on OnDestroy of the script and call it executing actions from another actors (children of the actor) the editor throw errors because the actors and scripts has ben destroyed before call OnDestroy.

Example:

```
public class A: Script
{
  public Action Destroyed;

  public override void OnDestroy()
  {
     Destroyed?.Invoke();
  }
}

public class B: Script
{
  public A a;

  public override void OnAwake()
  {
      a.Destroyed += () =>
      {
           // some code
      };
   }
}

```