### PR TITLE
Better missing script handling

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/MissingScriptEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/MissingScriptEditor.cs
@@ -1,0 +1,26 @@
+﻿using FlaxEditor.CustomEditors.Editors;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.CustomEditors.Dedicated;
+
+/// <summary>
+/// The missing script editor.
+/// </summary>
+[CustomEditor(typeof(MissingScript)), DefaultEditor]
+public class MissingScriptEditor : GenericEditor
+{
+    /// <inheritdoc />
+    public override void Initialize(LayoutElementsContainer layout)
+    {
+        if (layout.ContainerControl is not DropPanel dropPanel)
+        {
+            base.Initialize(layout);
+            return;
+        }
+
+        dropPanel.HeaderTextColor = Color.OrangeRed;
+        
+        base.Initialize(layout);
+    }
+}

--- a/Source/Engine/Level/Components/DummyScript.h
+++ b/Source/Engine/Level/Components/DummyScript.h
@@ -1,0 +1,67 @@
+﻿#pragma once
+
+#include "Engine/Core/Cache.h"
+#include "Engine/Scripting/Script.h"
+#include "Engine/Scripting/ScriptingObjectReference.h"
+#include "Engine/Serialization/JsonWriters.h"
+
+API_CLASS(Attributes="HideInEditor") class FLAXENGINE_API DummyScript : public Script
+{
+    API_AUTO_SERIALIZATION();
+    DECLARE_SCRIPTING_TYPE(DummyScript);
+
+public:
+    API_PROPERTY(Attributes="ReadOnly")
+    FORCE_INLINE String GetMissingTypeName() const
+    {
+        if(Data.IsEmpty()) return TEXT("");
+        
+        rapidjson_flax::Document doc;
+        doc.Parse(Data.ToStringAnsi().GetText());
+        
+        String str (doc["TypeName"].GetString());
+        
+        return str;
+    }
+    
+    API_PROPERTY()
+    void SetMissingTypeName(String value)
+    {
+        _missingTypeName = value;
+    }
+    
+    API_FIELD(Hidden, Attributes="HideInEditor") String Data;
+    
+    API_PROPERTY()
+    FORCE_INLINE ScriptingObjectReference<Script> GetReferenceScript() const
+    {
+        return _referenceScript;
+    }
+    
+    API_PROPERTY()
+    void SetReferenceScript(ScriptingObjectReference<Script> value)
+    {
+        _referenceScript = value;
+
+        if(Data.IsEmpty()) return;
+        
+        MapToReferenceScript();
+    }
+
+private:
+    ScriptingObjectReference<Script> _referenceScript;
+    String _missingTypeName;
+    
+    void MapToReferenceScript()
+    {
+        rapidjson_flax::Document doc;
+        doc.Parse(Data.ToStringAnsi().GetText());
+        
+        auto modifier = Cache::ISerializeModifier.Get();
+        _referenceScript->Deserialize(doc, modifier.Value);
+
+        this->DeleteObject();
+    }
+};
+
+inline DummyScript::DummyScript(const SpawnParams& params) : Script(params){}

--- a/Source/Engine/Level/Components/MissingScript.h
+++ b/Source/Engine/Level/Components/MissingScript.h
@@ -5,23 +5,38 @@
 #include "Engine/Scripting/ScriptingObjectReference.h"
 #include "Engine/Serialization/JsonWriters.h"
 
+/// <summary>
+/// Actor script component that represents missing script.
+/// </summary>
 API_CLASS(Attributes="HideInEditor") class FLAXENGINE_API MissingScript : public Script
 {
     API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE(MissingScript);
 
 public:
-    
+
+    /// <summary>
+    /// Namespace and type name of missing script.
+    /// </summary>
     API_FIELD(Attributes="ReadOnly") String MissingTypeName;
-    
+
+    /// <summary>
+    /// Missing script serialized data.
+    /// </summary>
     API_FIELD(Hidden, Attributes="HideInEditor") String Data;
-    
+
+    /// <summary>
+    /// Field for assigning new script to transfer data to.
+    /// </summary>
     API_PROPERTY()
     FORCE_INLINE ScriptingObjectReference<Script> GetReferenceScript() const
     {
         return _referenceScript;
     }
-    
+
+    /// <summary>
+    /// Field for assigning new script to transfer data to.
+    /// </summary>
     API_PROPERTY()
     void SetReferenceScript(ScriptingObjectReference<Script> value)
     {

--- a/Source/Engine/Level/Components/MissingScript.h
+++ b/Source/Engine/Level/Components/MissingScript.h
@@ -5,30 +5,14 @@
 #include "Engine/Scripting/ScriptingObjectReference.h"
 #include "Engine/Serialization/JsonWriters.h"
 
-API_CLASS(Attributes="HideInEditor") class FLAXENGINE_API DummyScript : public Script
+API_CLASS(Attributes="HideInEditor") class FLAXENGINE_API MissingScript : public Script
 {
     API_AUTO_SERIALIZATION();
-    DECLARE_SCRIPTING_TYPE(DummyScript);
+    DECLARE_SCRIPTING_TYPE(MissingScript);
 
 public:
-    API_PROPERTY(Attributes="ReadOnly")
-    FORCE_INLINE String GetMissingTypeName() const
-    {
-        if(Data.IsEmpty()) return TEXT("");
-        
-        rapidjson_flax::Document doc;
-        doc.Parse(Data.ToStringAnsi().GetText());
-        
-        String str (doc["TypeName"].GetString());
-        
-        return str;
-    }
     
-    API_PROPERTY()
-    void SetMissingTypeName(String value)
-    {
-        _missingTypeName = value;
-    }
+    API_FIELD(Attributes="ReadOnly") String MissingTypeName;
     
     API_FIELD(Hidden, Attributes="HideInEditor") String Data;
     
@@ -50,7 +34,6 @@ public:
 
 private:
     ScriptingObjectReference<Script> _referenceScript;
-    String _missingTypeName;
     
     void MapToReferenceScript()
     {
@@ -64,4 +47,4 @@ private:
     }
 };
 
-inline DummyScript::DummyScript(const SpawnParams& params) : Script(params){}
+inline MissingScript::MissingScript(const SpawnParams& params) : Script(params){}

--- a/Source/Engine/Level/SceneObjectsFactory.cpp
+++ b/Source/Engine/Level/SceneObjectsFactory.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #include "SceneObjectsFactory.h"
+#include "Components/DummyScript.h"
 #include "Engine/Level/Actor.h"
 #include "Engine/Level/Prefabs/Prefab.h"
 #include "Engine/Content/Content.h"
@@ -238,6 +239,8 @@ void SceneObjectsFactory::HandleObjectDeserializationError(const ISerializable::
     {
         const Guid parentId = JsonTools::GetGuid(parentIdMember->value);
         Actor* parent = Scripting::FindObject<Actor>(parentId);
+        DummyScript* dummyScript = parent->AddScript<DummyScript>();
+        dummyScript->Data = String(buffer.GetString());
         if (parent)
         {
             LOG(Warning, "Parent actor of the missing object: {0}", parent->GetName());

--- a/Source/Engine/Level/SceneObjectsFactory.cpp
+++ b/Source/Engine/Level/SceneObjectsFactory.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #include "SceneObjectsFactory.h"
-#include "Components/DummyScript.h"
+#include "Components/MissingScript.h"
 #include "Engine/Level/Actor.h"
 #include "Engine/Level/Prefabs/Prefab.h"
 #include "Engine/Content/Content.h"
@@ -239,10 +239,14 @@ void SceneObjectsFactory::HandleObjectDeserializationError(const ISerializable::
     {
         const Guid parentId = JsonTools::GetGuid(parentIdMember->value);
         Actor* parent = Scripting::FindObject<Actor>(parentId);
-        DummyScript* dummyScript = parent->AddScript<DummyScript>();
-        dummyScript->Data = String(buffer.GetString());
         if (parent)
         {
+            MissingScript* dummyScript = parent->AddScript<MissingScript>();
+
+            const auto parentIdMember = value.FindMember("TypeName");
+            dummyScript->MissingTypeName = parentIdMember->value.GetString();
+            dummyScript->Data = String(buffer.GetString());
+            
             LOG(Warning, "Parent actor of the missing object: {0}", parent->GetName());
         }
     }


### PR DESCRIPTION
Currently when we change name or namespace of Script it disappears completely and we can only see warning in output log.
This MR adds DummyScript that gets created automatically when deserialization fails.
![image](https://github.com/FlaxEngine/FlaxEngine/assets/29517406/8c5b3de1-02f5-4a7e-a0ad-dd7f25537bd1)
It holds serialized json data, displays missing script type and allows to transfer serialized data to different Script.

TODO:

- [x] Add XML comments

(I know this is planned for 1.8, but disappearing Scripts during refactoring were annoying for me)