### PR TITLE
Fixing Flax.Build issues on M1/2 macs

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -207,6 +207,8 @@ namespace Flax.Build
             case TargetPlatform.Mac:
             {
 #if USE_NETCORE
+                dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
+
                 cscPath = Path.Combine(dotnetSdk.RootPath, $"sdk/{dotnetSdk.VersionName}/Roslyn/bincore/csc.dll");
                 referenceAssemblies = Path.Combine(dotnetSdk.RootPath, $"packs/Microsoft.NETCore.App.Ref/{dotnetSdk.RuntimeVersionName}/ref/net{runtimeVersionShort}/");
                 referenceAnalyzers = Path.Combine(dotnetSdk.RootPath, $"packs/Microsoft.NETCore.App.Ref/{dotnetSdk.RuntimeVersionName}/analyzers/dotnet/cs/");

--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -217,7 +217,7 @@ namespace Flax.Build
                 // then lets assume we are building for it and thus should using that rid and that dotnet path
                 if (architecture == TargetArchitecture.ARM64 && (Configuration.BuildArchitectures != null && Configuration.BuildArchitectures[0] == TargetArchitecture.x64))
                 {
-                    rid = $"osx-64";
+                    rid = $"osx-x64";
                     dotnetPath = Path.Combine(dotnetPath, "x64");
                     architecture = TargetArchitecture.x64;
                 }

--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -215,7 +215,7 @@ namespace Flax.Build
 
                 // So there is not a real great way to do this but if the first thing in this list is x64
                 // then lets assume we are building for it and thus should using that rid and that dotnet path
-                if (Configuration.BuildArchitectures != null && Configuration.BuildArchitectures[0] == TargetArchitecture.x64)
+                if (architecture == TargetArchitecture.ARM64 && (Configuration.BuildArchitectures != null && Configuration.BuildArchitectures[0] == TargetArchitecture.x64))
                 {
                     rid = $"osx-64";
                     dotnetPath = Path.Combine(dotnetPath, "x64");

--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -212,6 +212,16 @@ namespace Flax.Build
                 ridFallback = "";
                 if (string.IsNullOrEmpty(dotnetPath))
                     dotnetPath = "/usr/local/share/dotnet/";
+
+                // So there is not a real great way to do this but if the first thing in this list is x64
+                // then lets assume we are building for it and thus should using that rid and that dotnet path
+                if (Configuration.BuildArchitectures != null && Configuration.BuildArchitectures[0] == TargetArchitecture.x64)
+                {
+                    rid = $"osx-64";
+                    dotnetPath = Path.Combine(dotnetPath, "x64");
+                    architecture = TargetArchitecture.x64;
+                }
+
                 break;
             }
             default: throw new InvalidPlatformException(platform);


### PR DESCRIPTION
* This resolves some issues where if you are building the actual C# dlls you also need them to be x64 based if you are targeting an x64 based target. This is a little complicated here because we set all this up ahead of time assuming that all the targets are compatible but in this case they are not so, just following what other places in the code are doing around this specifically dotnet AOT.