### PR TITLE
iphonesdk is not required to build macOS Editor

### DIFF
--- a/Source/Tools/Flax.Build/Platforms/iOS/iOSPlatform.cs
+++ b/Source/Tools/Flax.Build/Platforms/iOS/iOSPlatform.cs
@@ -40,6 +40,8 @@ namespace Flax.Build.Platforms
                 Log.Warning("Missing iPhoneSDK. Cannot build for iOS platform.");
                 HasRequiredSDKsInstalled = false;
             }
+            else 
+                HasRequiredSDKsInstalled = true;
         }
 
         /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Platforms/iOS/iOSPlatform.cs
+++ b/Source/Tools/Flax.Build/Platforms/iOS/iOSPlatform.cs
@@ -1,5 +1,8 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
+using System;
+using System.IO;
+
 namespace Flax.Build.Platforms
 {
     /// <summary>
@@ -12,6 +15,9 @@ namespace Flax.Build.Platforms
         public override TargetPlatform Target => TargetPlatform.iOS;
 
         /// <inheritdoc />
+        public override bool HasRequiredSDKsInstalled { get; }
+
+        /// <inheritdoc />
         public override bool HasDynamicCodeExecutionSupport => false;
 
         /// <summary>
@@ -21,10 +27,18 @@ namespace Flax.Build.Platforms
         {
             if (Platform.BuildTargetPlatform != TargetPlatform.Mac)
                 return;
-            if (!HasRequiredSDKsInstalled)
+
+            if (!XCode.Instance.IsValid)
             {
                 Log.Warning("Missing XCode. Cannot build for iOS platform.");
                 return;
+            }
+
+            // We should check and see if the actual iphoneSDK is installed
+            string iphoneSDKPath = Utilities.ReadProcessOutput("/usr/bin/xcrun", "--sdk iphoneos --show-sdk-path");
+            if (string.IsNullOrEmpty(iphoneSDKPath) || !Directory.Exists(iphoneSDKPath)) {
+                Log.Warning("Missing iPhoneSDK. Cannot build for iOS platform.");
+                HasRequiredSDKsInstalled = false;
             }
         }
 


### PR DESCRIPTION
Currently when you try and build macOS editor it assumes you also want to build iOS because of the way this check works which assumes if you have Xcode Installed you are ready to go. This really should not be the case, so instead lets check to see if you have the iophonesdk installed for your current Xcode if not then skip it.