### PR TITLE
Debug Log and Output Log color customization

### DIFF
--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -186,14 +186,14 @@ namespace FlaxEditor.Options
         /// Gets or sets the output log text shadow offset. Set to 0 to disable this feature.
         /// </summary>
         [DefaultValue(typeof(Float2), "1,1")]
-        [EditorDisplay("Output Log", "Text Shadow Offset"), EditorOrder(340), Tooltip("The output log text shadow offset. Set to 0 to disable this feature.")]
+        [EditorDisplay("Output Log", "Text Shadow Offset"), EditorOrder(350), Tooltip("The output log text shadow offset. Set to 0 to disable this feature.")]
         public Float2 OutputLogTextShadowOffset { get; set; } = new Float2(1);
 
         /// <summary>
         /// Gets or sets the output log text color for warnings
         /// </summary>
         [DefaultValue(typeof(Color), "1,1,0,1")]
-        [EditorDisplay("Output Log", "Warning Color"), EditorOrder(341), Tooltip("The output log text color for warnings.")]
+        [EditorDisplay("Output Log", "Warning Color"), EditorOrder(360), Tooltip("The output log text color for warnings.")]
         public Color OutputLogWarningTextColor { get; set; } = Color.Yellow;
 
 
@@ -201,7 +201,7 @@ namespace FlaxEditor.Options
         /// Gets or sets the output log text color for errors
         /// </summary>
         [DefaultValue(typeof(Color), "1,0,0,1")]
-        [EditorDisplay("Output Log", "Error Color"), EditorOrder(342), Tooltip("The output log text color for errors.")]
+        [EditorDisplay("Output Log", "Error Color"), EditorOrder(370), Tooltip("The output log text color for errors.")]
         public Color OutputLogErrorTextColor { get; set; } = Color.Red;
 
 
@@ -209,14 +209,14 @@ namespace FlaxEditor.Options
         /// Gets or sets a value indicating whether auto-focus output log window on code compilation error.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Output Log", "Focus Output Log On Compilation Error"), EditorOrder(350), Tooltip("Determines whether auto-focus output log window on code compilation error.")]
+        [EditorDisplay("Output Log", "Focus Output Log On Compilation Error"), EditorOrder(380), Tooltip("Determines whether auto-focus output log window on code compilation error.")]
         public bool FocusOutputLogOnCompilationError { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether auto-focus output log window on game build error.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Output Log", "Focus Output Log On Game Build Error"), EditorOrder(360), Tooltip("Determines whether auto-focus output log window on game build error.")]
+        [EditorDisplay("Output Log", "Focus Output Log On Game Build Error"), EditorOrder(390), Tooltip("Determines whether auto-focus output log window on game build error.")]
         public bool FocusOutputLogOnGameBuildError { get; set; } = true;
 
         /// <summary>

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -190,6 +190,22 @@ namespace FlaxEditor.Options
         public Float2 OutputLogTextShadowOffset { get; set; } = new Float2(1);
 
         /// <summary>
+        /// Gets or sets the output log text color for warnings
+        /// </summary>
+        [DefaultValue(typeof(Color), "1,1,0,1")]
+        [EditorDisplay("Output Log", "Warning Color"), EditorOrder(341), Tooltip("The output log text color for warnings.")]
+        public Color OutputLogWarningTextColor { get; set; } = Color.Yellow;
+
+
+        /// <summary>
+        /// Gets or sets the output log text color for errors
+        /// </summary>
+        [DefaultValue(typeof(Color), "1,0,0,1")]
+        [EditorDisplay("Output Log", "Error Color"), EditorOrder(342), Tooltip("The output log text color for errors.")]
+        public Color OutputLogErrorTextColor { get; set; } = Color.Red;
+
+
+        /// <summary>
         /// Gets or sets a value indicating whether auto-focus output log window on code compilation error.
         /// </summary>
         [DefaultValue(true)]

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -878,7 +878,7 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool CanSelect(ref Float2 location)
         {
-            return _headerRect.MakeOffsetted(Location).Contains(ref location);
+            return _headerRect.MakeOffsetted(Location).Contains(ref location) || new Rectangle(Float2.Zero, Size).MakeOffsetted(Location).Contains(ref location);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -878,7 +878,7 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool CanSelect(ref Float2 location)
         {
-            return _headerRect.MakeOffsetted(Location).Contains(ref location) || new Rectangle(Float2.Zero, Size).MakeOffsetted(Location).Contains(ref location);
+            return _headerRect.MakeOffsetted(Location).Contains(ref location);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -131,20 +131,21 @@ namespace FlaxEditor.Windows
                 else if (index % 2 == 0)
                     Render2D.FillRectangle(clientRect, style.Background * 0.9f);
 
+                var color = Group == LogGroup.Error ? _window.ErrorColor : (Group == LogGroup.Warning ? _window.WarningColor : _window.InfoColor);
+
                 // Icon
-                var iconColor = Group == LogGroup.Error ? Color.Red : (Group == LogGroup.Warning ? Color.Yellow : style.Foreground);
-                Render2D.DrawSprite(Icon, new Rectangle(5, 0, 32, 32), iconColor);
+                Render2D.DrawSprite(Icon, new Rectangle(5, 0, 32, 32), color);
 
                 // Title
                 var textRect = new Rectangle(38, 2, clientRect.Width - 40, clientRect.Height - 10);
                 Render2D.PushClip(ref clientRect);
                 if (LogCount == 1)
                 {
-                    Render2D.DrawText(style.FontMedium, Desc.Title, textRect, style.Foreground);
+                    Render2D.DrawText(style.FontMedium, Desc.Title, textRect, color);
                 }
                 else if (LogCount > 1)
                 {
-                    Render2D.DrawText(style.FontMedium, $"{Desc.Title} ({LogCount})", textRect, style.Foreground);
+                    Render2D.DrawText(style.FontMedium, $"{Desc.Title} ({LogCount})", textRect, color);
                 }
                 Render2D.PopClip();
             }
@@ -304,8 +305,12 @@ namespace FlaxEditor.Windows
         private LogType _iconType = LogType.Info;
 
         internal SpriteHandle IconInfo;
+        internal Color InfoColor;
         internal SpriteHandle IconWarning;
+        internal Color WarningColor;
         internal SpriteHandle IconError;
+        internal Color ErrorColor;
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugLogWindow"/> class.
@@ -368,15 +373,33 @@ namespace FlaxEditor.Windows
             IconWarning = Editor.Icons.Warning64;
             IconError = Editor.Icons.Error64;
 
+            //Cache entries color
+            var interfaceOptions = Editor.Options.Options.Interface;
+            InfoColor = interfaceOptions.OutputLogTextColor;
+            WarningColor = interfaceOptions.OutputLogWarningTextColor;
+            ErrorColor = interfaceOptions.OutputLogErrorTextColor;
+
             // Bind events
             Editor.Options.OptionsChanged += OnEditorOptionsChanged;
+            OnEditorOptionsChanged(Editor.Options.Options);
+
             Debug.Logger.LogHandler.SendLog += LogHandlerOnSendLog;
             Debug.Logger.LogHandler.SendExceptionLog += LogHandlerOnSendExceptionLog;
         }
 
         private void OnEditorOptionsChanged(EditorOptions options)
         {
+            if (_timestampsFormats == options.Interface.DebugLogTimestampsFormat &&
+                InfoColor == options.Interface.OutputLogTextColor &&
+                WarningColor == options.Interface.OutputLogWarningTextColor &&
+                ErrorColor == options.Interface.OutputLogErrorTextColor)
+                return;
+
             _timestampsFormats = options.Interface.DebugLogTimestampsFormat;
+
+            InfoColor = options.Interface.OutputLogTextColor;
+            WarningColor = options.Interface.OutputLogWarningTextColor;
+            ErrorColor = options.Interface.OutputLogErrorTextColor;
         }
 
         /// <summary>

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -274,7 +274,9 @@ namespace FlaxEditor.Windows
                 _output.DefaultStyle.Font == options.Interface.OutputLogTextFont &&
                 _output.DefaultStyle.Color == options.Interface.OutputLogTextColor &&
                 _output.DefaultStyle.ShadowColor == options.Interface.OutputLogTextShadowColor &&
-                _output.DefaultStyle.ShadowOffset == options.Interface.OutputLogTextShadowOffset)
+                _output.DefaultStyle.ShadowOffset == options.Interface.OutputLogTextShadowOffset &&
+                _output.WarningStyle.Color == options.Interface.OutputLogWarningTextColor &&
+                _output.ErrorStyle.Color == options.Interface.OutputLogErrorTextColor)
                 return;
 
             _output.DefaultStyle = new TextBlockStyle
@@ -285,10 +287,11 @@ namespace FlaxEditor.Windows
                 ShadowOffset = options.Interface.OutputLogTextShadowOffset,
                 BackgroundSelectedBrush = new SolidColorBrush(Style.Current.BackgroundSelected),
             };
+
             _output.WarningStyle = _output.DefaultStyle;
-            _output.WarningStyle.Color = Color.Yellow;
+            _output.WarningStyle.Color = options.Interface.OutputLogWarningTextColor;
             _output.ErrorStyle = _output.DefaultStyle;
-            _output.ErrorStyle.Color = Color.Red;
+            _output.ErrorStyle.Color = options.Interface.OutputLogErrorTextColor;
 
             _timestampsFormats = options.Interface.OutputLogTimestampsFormat;
             _showLogType = options.Interface.OutputLogShowLogType;


### PR DESCRIPTION
Allows users to customize Debug Log and Output Log entry colors. Can be found under Tools > Options > Interface > Output Log


![ErrorLog](https://github.com/FlaxEngine/FlaxEngine/assets/90315501/a7ccc652-6872-4b33-829b-31edd696c2b1)
