### PR TITLE
[Linux] Build on Ubuntu 18.04

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -10,7 +10,7 @@ jobs:
   # Editor
   editor-linux:
     name: Editor (Linux, Development x64)
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-18.04"
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3


### PR DESCRIPTION
Fixes: #1427 

Using Ubuntu 18.04 LTS on CI so Editor will not require Glibc 2.33+.


_Please, trigger build._