### PR TITLE
[Linux] Use `xdg-open` to open file manager

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
+++ b/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
@@ -136,7 +136,7 @@ bool LinuxFileSystem::ShowFileExplorer(const StringView& path)
 {
     const StringAsANSI<> pathAnsi(*path, path.Length());
     char cmd[2048];
-    sprintf(cmd, "nautilus %s &", pathAnsi.Get());
+    sprintf(cmd, "xdg-open %s &", pathAnsi.Get());
     system(cmd);
     return false;
 }


### PR DESCRIPTION
Fixes: #1384 

`nautilus` is GNOME file manager. Other distros might use another FM.

As a common ground we can use `xdg-open` which is a part of `freedesktop.org` and should be available almost everywhere.