### PR TITLE
Vector labels redesign

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -40,12 +40,16 @@ namespace FlaxEditor.CustomEditors.Editors
                 // Override colors
                 var back = FlaxEngine.GUI.Style.Current.TextBoxBackground;
                 var grayOutFactor = 0.6f;
-                XElement.ValueBox.BorderColor = Color.Lerp(AxisColorX, back, grayOutFactor);
-                XElement.ValueBox.BorderSelectedColor = AxisColorX;
-                YElement.ValueBox.BorderColor = Color.Lerp(AxisColorY, back, grayOutFactor);
-                YElement.ValueBox.BorderSelectedColor = AxisColorY;
-                ZElement.ValueBox.BorderColor = Color.Lerp(AxisColorZ, back, grayOutFactor);
-                ZElement.ValueBox.BorderSelectedColor = AxisColorZ;
+                var borderSides = new Vector4(0, 1, 0, 1);
+                var xAxisColor = Color.Lerp(AxisColorX, back, grayOutFactor);
+                var yAxisColor = Color.Lerp(AxisColorY, back, grayOutFactor);
+                var zAxisColor = Color.Lerp(AxisColorZ, back, grayOutFactor);
+                XElement.ValueBox.Border = new TextBoxBase.TextBoxBorder(xAxisColor, AxisColorX, borderSides);
+                XLabel.Control.BackgroundColor = xAxisColor;
+                YElement.ValueBox.Border = new TextBoxBase.TextBoxBorder(yAxisColor, AxisColorY, borderSides);
+                YLabel.Control.BackgroundColor = yAxisColor;
+                ZElement.ValueBox.Border = new TextBoxBase.TextBoxBorder(zAxisColor, AxisColorZ, borderSides);
+                ZLabel.Control.BackgroundColor = zAxisColor;
             }
         }
 
@@ -63,12 +67,16 @@ namespace FlaxEditor.CustomEditors.Editors
                 // Override colors
                 var back = FlaxEngine.GUI.Style.Current.TextBoxBackground;
                 var grayOutFactor = 0.6f;
-                XElement.ValueBox.BorderColor = Color.Lerp(AxisColorX, back, grayOutFactor);
-                XElement.ValueBox.BorderSelectedColor = AxisColorX;
-                YElement.ValueBox.BorderColor = Color.Lerp(AxisColorY, back, grayOutFactor);
-                YElement.ValueBox.BorderSelectedColor = AxisColorY;
-                ZElement.ValueBox.BorderColor = Color.Lerp(AxisColorZ, back, grayOutFactor);
-                ZElement.ValueBox.BorderSelectedColor = AxisColorZ;
+                var borderSides = new Vector4(0, 1, 0, 1);
+                var xAxisColor = Color.Lerp(AxisColorX, back, grayOutFactor);
+                var yAxisColor = Color.Lerp(AxisColorY, back, grayOutFactor);
+                var zAxisColor = Color.Lerp(AxisColorZ, back, grayOutFactor);
+                XElement.ValueBox.Border = new TextBoxBase.TextBoxBorder(xAxisColor, AxisColorX, borderSides);
+                XLabel.Control.BackgroundColor = xAxisColor;
+                YElement.ValueBox.Border = new TextBoxBase.TextBoxBorder(yAxisColor, AxisColorY, borderSides);
+                YLabel.Control.BackgroundColor = yAxisColor;
+                ZElement.ValueBox.Border = new TextBoxBase.TextBoxBorder(zAxisColor, AxisColorZ, borderSides);
+                ZLabel.Control.BackgroundColor = zAxisColor;
             }
         }
 

--- a/Source/Editor/CustomEditors/Editors/CustomEditorUtils.cs
+++ b/Source/Editor/CustomEditors/Editors/CustomEditorUtils.cs
@@ -1,0 +1,43 @@
+﻿using FlaxEditor.CustomEditors.Elements;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.CustomEditors.Editors;
+
+internal static class CustomEditorUtils
+{
+    public static CustomElementsContainer<GridPanel> CreateGridContainer(CustomElementsContainer<UniformGridPanel> grid, string unit, out LabelElement label)
+    {
+        var container = grid.CustomContainer<GridPanel>();
+        var containerControl = container.CustomControl;
+        containerControl.ClipChildren = false;
+        containerControl.Height = grid.CustomControl.Height;
+        containerControl.RowFill = new[] { 1f, 1f };
+        containerControl.ColumnFill = new[] { -20f, 1f };
+        containerControl.SlotPadding = new Margin(0);
+            
+        label = container.Label(unit);
+        var labelElement = label.Label;
+        labelElement.VerticalAlignment = TextAlignment.Center;
+        labelElement.HorizontalAlignment = TextAlignment.Center;
+        labelElement.BackgroundColor = FlaxEngine.GUI.Style.Current.TextBoxBackground;
+            
+        return container;
+    }
+    
+    public static FloatValueElement CreateFloatValue(CustomElementsContainer<GridPanel> container, LimitAttribute limit)
+    {
+        var element = container.FloatValue();
+        element.SetLimits(limit);
+            
+        return element;
+    }
+    
+    public static DoubleValueElement CreateDoubleValue(CustomElementsContainer<GridPanel> container, LimitAttribute limit)
+    {
+        var element = container.DoubleValue();
+        element.SetLimits(limit);
+            
+        return element;
+    }
+}

--- a/Source/Editor/CustomEditors/Editors/CustomEditorUtils.cs
+++ b/Source/Editor/CustomEditors/Editors/CustomEditorUtils.cs
@@ -40,4 +40,12 @@ internal static class CustomEditorUtils
             
         return element;
     }
+    
+    public static IntegerValueElement CreateIntValue(CustomElementsContainer<GridPanel> container, LimitAttribute limit)
+    {
+        var element = container.IntegerValue();
+        element.SetLimits(limit);
+            
+        return element;
+    }
 }

--- a/Source/Editor/CustomEditors/Editors/QuaternionEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/QuaternionEditor.cs
@@ -30,6 +30,21 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The Z component element
         /// </summary>
         protected FloatValueElement ZElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
+        
+        /// <summary>
+        /// The Z label.
+        /// </summary>
+        protected LabelElement ZLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -44,15 +59,24 @@ namespace FlaxEditor.CustomEditors.Editors
             gridControl.SlotsHorizontally = 3;
             gridControl.SlotsVertically = 1;
 
-            XElement = grid.FloatValue();
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = xContainer.FloatValue();
             XElement.ValueBox.ValueChanged += OnValueChanged;
             XElement.ValueBox.SlidingEnd += ClearToken;
 
-            YElement = grid.FloatValue();
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = yContainer.FloatValue();
             YElement.ValueBox.ValueChanged += OnValueChanged;
             YElement.ValueBox.SlidingEnd += ClearToken;
 
-            ZElement = grid.FloatValue();
+            var zContainer = CustomEditorUtils.CreateGridContainer(grid, "Z", out var zLabel);
+            ZLabel = zLabel;
+            
+            ZElement = zContainer.FloatValue();
             ZElement.ValueBox.ValueChanged += OnValueChanged;
             ZElement.ValueBox.SlidingEnd += ClearToken;
 

--- a/Source/Editor/CustomEditors/Editors/Vector2Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector2Editor.cs
@@ -241,6 +241,16 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The Y component editor.
         /// </summary>
         protected IntegerValueElement YElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -262,13 +272,17 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.IntegerValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateIntValue(xContainer, limit);
             XElement.IntValue.ValueChanged += OnValueChanged;
             XElement.IntValue.SlidingEnd += ClearToken;
-
-            YElement = grid.IntegerValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateIntValue(yContainer, limit);
             YElement.IntValue.ValueChanged += OnValueChanged;
             YElement.IntValue.SlidingEnd += ClearToken;
         }

--- a/Source/Editor/CustomEditors/Editors/Vector2Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector2Editor.cs
@@ -35,6 +35,16 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The Y component editor.
         /// </summary>
         protected FloatValueElement YElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -56,13 +66,17 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.FloatValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateFloatValue(xContainer, limit);
             XElement.ValueBox.ValueChanged += OnValueChanged;
             XElement.ValueBox.SlidingEnd += ClearToken;
-
-            YElement = grid.FloatValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateFloatValue(yContainer, limit);
             YElement.ValueBox.ValueChanged += OnValueChanged;
             YElement.ValueBox.SlidingEnd += ClearToken;
         }
@@ -124,6 +138,16 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The Y component editor.
         /// </summary>
         protected DoubleValueElement YElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -145,13 +169,17 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.DoubleValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateDoubleValue(xContainer, limit);
             XElement.ValueBox.ValueChanged += OnValueChanged;
             XElement.ValueBox.SlidingEnd += ClearToken;
-
-            YElement = grid.DoubleValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateDoubleValue(yContainer, limit);
             YElement.ValueBox.ValueChanged += OnValueChanged;
             YElement.ValueBox.SlidingEnd += ClearToken;
         }

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -80,7 +80,7 @@ namespace FlaxEditor.CustomEditors.Editors
             var grid = layout.CustomContainer<UniformGridPanel>();
             var gridControl = grid.CustomControl;
             gridControl.ClipChildren = false;
-            gridControl.Height = TextBox.DefaultHeight + 4;
+            gridControl.Height = TextBox.DefaultHeight;
             gridControl.SlotsHorizontally = 3;
             gridControl.SlotsVertically = 1;
 

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using FlaxEditor.CustomEditors.Elements;
+using FlaxEditor.Surface.Elements;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -41,6 +42,21 @@ namespace FlaxEditor.CustomEditors.Editors
         /// </summary>
         protected FloatValueElement ZElement;
 
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
+        
+        /// <summary>
+        /// The Z label.
+        /// </summary>
+        protected LabelElement ZLabel;
+
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
 
@@ -64,7 +80,7 @@ namespace FlaxEditor.CustomEditors.Editors
             var grid = layout.CustomContainer<UniformGridPanel>();
             var gridControl = grid.CustomControl;
             gridControl.ClipChildren = false;
-            gridControl.Height = TextBox.DefaultHeight;
+            gridControl.Height = TextBox.DefaultHeight + 4;
             gridControl.SlotsHorizontally = 3;
             gridControl.SlotsVertically = 1;
 
@@ -74,19 +90,25 @@ namespace FlaxEditor.CustomEditors.Editors
             {
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
-
-            XElement = grid.FloatValue();
-            XElement.SetLimits(limit);
+            
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateFloatValue(xContainer, limit);
             XElement.ValueBox.ValueChanged += OnXValueChanged;
             XElement.ValueBox.SlidingEnd += ClearToken;
-
-            YElement = grid.FloatValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateFloatValue(yContainer, limit);
             YElement.ValueBox.ValueChanged += OnYValueChanged;
             YElement.ValueBox.SlidingEnd += ClearToken;
-
-            ZElement = grid.FloatValue();
-            ZElement.SetLimits(limit);
+            
+            var zContainer = CustomEditorUtils.CreateGridContainer(grid, "Z", out var zLabel);
+            ZLabel = zLabel;
+            
+            ZElement = CustomEditorUtils.CreateFloatValue(zContainer, limit);
             ZElement.ValueBox.ValueChanged += OnZValueChanged;
             ZElement.ValueBox.SlidingEnd += ClearToken;
         }
@@ -233,6 +255,21 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The Z component editor.
         /// </summary>
         protected DoubleValueElement ZElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
+        
+        /// <summary>
+        /// The Z label.
+        /// </summary>
+        protected LabelElement ZLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -254,18 +291,24 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.DoubleValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateDoubleValue(xContainer, limit);
             XElement.ValueBox.ValueChanged += OnValueChanged;
             XElement.ValueBox.SlidingEnd += ClearToken;
-
-            YElement = grid.DoubleValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateDoubleValue(yContainer, limit);
             YElement.ValueBox.ValueChanged += OnValueChanged;
             YElement.ValueBox.SlidingEnd += ClearToken;
-
-            ZElement = grid.DoubleValue();
-            ZElement.SetLimits(limit);
+            
+            var zContainer = CustomEditorUtils.CreateGridContainer(grid, "Z", out var zLabel);
+            ZLabel = zLabel;
+            
+            ZElement = CustomEditorUtils.CreateDoubleValue(zContainer, limit);
             ZElement.ValueBox.ValueChanged += OnValueChanged;
             ZElement.ValueBox.SlidingEnd += ClearToken;
         }

--- a/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector3Editor.cs
@@ -376,6 +376,21 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The Z component editor.
         /// </summary>
         protected IntegerValueElement ZElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
+        
+        /// <summary>
+        /// The Z label.
+        /// </summary>
+        protected LabelElement ZLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -397,18 +412,24 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.IntegerValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateIntValue(xContainer, limit);
             XElement.IntValue.ValueChanged += OnValueChanged;
             XElement.IntValue.SlidingEnd += ClearToken;
-
-            YElement = grid.IntegerValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateIntValue(yContainer, limit);
             YElement.IntValue.ValueChanged += OnValueChanged;
             YElement.IntValue.SlidingEnd += ClearToken;
-
-            ZElement = grid.IntegerValue();
-            ZElement.SetLimits(limit);
+            
+            var zContainer = CustomEditorUtils.CreateGridContainer(grid, "Z", out var zLabel);
+            ZLabel = zLabel;
+            
+            ZElement = CustomEditorUtils.CreateIntValue(zContainer, limit);
             ZElement.IntValue.ValueChanged += OnValueChanged;
             ZElement.IntValue.SlidingEnd += ClearToken;
         }

--- a/Source/Editor/CustomEditors/Editors/Vector4Editor.cs
+++ b/Source/Editor/CustomEditors/Editors/Vector4Editor.cs
@@ -45,6 +45,26 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The W component editor.
         /// </summary>
         protected FloatValueElement WElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
+        
+        /// <summary>
+        /// The Z label.
+        /// </summary>
+        protected LabelElement ZLabel;
+        
+        /// <summary>
+        /// The W label.
+        /// </summary>
+        protected LabelElement WLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -66,23 +86,31 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.FloatValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateFloatValue(xContainer, limit);
             XElement.ValueBox.ValueChanged += OnValueChanged;
             XElement.ValueBox.SlidingEnd += ClearToken;
-
-            YElement = grid.FloatValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateFloatValue(yContainer, limit);
             YElement.ValueBox.ValueChanged += OnValueChanged;
             YElement.ValueBox.SlidingEnd += ClearToken;
-
-            ZElement = grid.FloatValue();
-            ZElement.SetLimits(limit);
+            
+            var zContainer = CustomEditorUtils.CreateGridContainer(grid, "Z", out var zLabel);
+            ZLabel = zLabel;
+            
+            ZElement = CustomEditorUtils.CreateFloatValue(zContainer, limit);
             ZElement.ValueBox.ValueChanged += OnValueChanged;
             ZElement.ValueBox.SlidingEnd += ClearToken;
-
-            WElement = grid.FloatValue();
-            WElement.SetLimits(limit);
+            
+            var wContainer = CustomEditorUtils.CreateGridContainer(grid, "W", out var wLabel);
+            WLabel = wLabel;
+            
+            WElement = CustomEditorUtils.CreateFloatValue(wContainer, limit);
             WElement.ValueBox.ValueChanged += OnValueChanged;
             WElement.ValueBox.SlidingEnd += ClearToken;
         }
@@ -156,6 +184,26 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The W component editor.
         /// </summary>
         protected DoubleValueElement WElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
+        
+        /// <summary>
+        /// The Z label.
+        /// </summary>
+        protected LabelElement ZLabel;
+        
+        /// <summary>
+        /// The W label.
+        /// </summary>
+        protected LabelElement WLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -177,23 +225,31 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.DoubleValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateDoubleValue(xContainer, limit);
             XElement.ValueBox.ValueChanged += OnValueChanged;
             XElement.ValueBox.SlidingEnd += ClearToken;
-
-            YElement = grid.DoubleValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateDoubleValue(yContainer, limit);
             YElement.ValueBox.ValueChanged += OnValueChanged;
             YElement.ValueBox.SlidingEnd += ClearToken;
-
-            ZElement = grid.DoubleValue();
-            ZElement.SetLimits(limit);
+            
+            var zContainer = CustomEditorUtils.CreateGridContainer(grid, "Z", out var zLabel);
+            ZLabel = zLabel;
+            
+            ZElement = CustomEditorUtils.CreateDoubleValue(zContainer, limit);
             ZElement.ValueBox.ValueChanged += OnValueChanged;
             ZElement.ValueBox.SlidingEnd += ClearToken;
-
-            WElement = grid.DoubleValue();
-            WElement.SetLimits(limit);
+            
+            var wContainer = CustomEditorUtils.CreateGridContainer(grid, "W", out var wLabel);
+            WLabel = wLabel;
+            
+            WElement = CustomEditorUtils.CreateDoubleValue(wContainer, limit);
             WElement.ValueBox.ValueChanged += OnValueChanged;
             WElement.ValueBox.SlidingEnd += ClearToken;
         }
@@ -267,6 +323,26 @@ namespace FlaxEditor.CustomEditors.Editors
         /// The W component editor.
         /// </summary>
         protected IntegerValueElement WElement;
+        
+        /// <summary>
+        /// The X label.
+        /// </summary>
+        protected LabelElement XLabel;
+        
+        /// <summary>
+        /// The Y label.
+        /// </summary>
+        protected LabelElement YLabel;
+        
+        /// <summary>
+        /// The Z label.
+        /// </summary>
+        protected LabelElement ZLabel;
+        
+        /// <summary>
+        /// The W label.
+        /// </summary>
+        protected LabelElement WLabel;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -288,23 +364,31 @@ namespace FlaxEditor.CustomEditors.Editors
                 limit = (LimitAttribute)attributes.FirstOrDefault(x => x is LimitAttribute);
             }
 
-            XElement = grid.IntegerValue();
-            XElement.SetLimits(limit);
+            var xContainer = CustomEditorUtils.CreateGridContainer(grid, "X", out var xLabel);
+            XLabel = xLabel;
+            
+            XElement = CustomEditorUtils.CreateIntValue(xContainer, limit);
             XElement.IntValue.ValueChanged += OnValueChanged;
             XElement.IntValue.SlidingEnd += ClearToken;
-
-            YElement = grid.IntegerValue();
-            YElement.SetLimits(limit);
+            
+            var yContainer = CustomEditorUtils.CreateGridContainer(grid, "Y", out var yLabel);
+            YLabel = yLabel;
+            
+            YElement = CustomEditorUtils.CreateIntValue(yContainer, limit);
             YElement.IntValue.ValueChanged += OnValueChanged;
             YElement.IntValue.SlidingEnd += ClearToken;
-
-            ZElement = grid.IntegerValue();
-            ZElement.SetLimits(limit);
+            
+            var zContainer = CustomEditorUtils.CreateGridContainer(grid, "Z", out var zLabel);
+            ZLabel = zLabel;
+            
+            ZElement = CustomEditorUtils.CreateIntValue(zContainer, limit);
             ZElement.IntValue.ValueChanged += OnValueChanged;
             ZElement.IntValue.SlidingEnd += ClearToken;
-
-            WElement = grid.IntegerValue();
-            WElement.SetLimits(limit);
+            
+            var wContainer = CustomEditorUtils.CreateGridContainer(grid, "W", out var wLabel);
+            WLabel = wLabel;
+            
+            WElement = CustomEditorUtils.CreateIntValue(wContainer, limit);
             WElement.IntValue.ValueChanged += OnValueChanged;
             WElement.IntValue.SlidingEnd += ClearToken;
         }

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -255,8 +255,16 @@ namespace FlaxEngine.GUI
             var leftWidth = border.LeftWidth * 0.5f;
             var rightWidth = border.RightWidth * 0.5f;
             var bottomWidth = border.BottomWidth * 0.5f;
+            var width = border.Width * 0.5f;
 
-            // TODO: This needs to be optimized
+            // This needs to be optimized, ideally we would want a better way to draw the border in a single call instead of individual borders for each side
+
+            if (width > 0)
+            {
+                CreateRect(new Rectangle(0, 0, Width, Height));
+
+                return;
+            }
             
             // Add top border
             if (topWidth > 0)

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -155,7 +155,11 @@ namespace FlaxEngine.GUI
             if (IsMouseOver || IsNavFocused)
                 backColor = BackgroundSelectedColor;
             Render2D.FillRectangle(rect, backColor);
-            Render2D.DrawRectangle(rect, IsFocused ? BorderSelectedColor : BorderColor);
+            
+            var borderColor = Border.Color != Color.Transparent ? Border.Color : BorderColor;
+            var borderSelectedColor = Border.SelectedColor != Color.Transparent ? Border.SelectedColor : BorderSelectedColor;
+
+            GenerateBorder(borderColor, borderSelectedColor);
 
             // Apply view offset and clip mask
             if (ClipText)
@@ -229,6 +233,54 @@ namespace FlaxEngine.GUI
                 Render2D.PopTransform();
             if (ClipText)
                 Render2D.PopClip();
+        }
+
+        private void GenerateBorder(Color borderColor, Color selectedBorderColor)
+        {
+            // Determine if a border is needed to spawn
+            if (borderColor == Color.Transparent && selectedBorderColor == Color.Transparent)
+            {
+                return;
+            }
+
+            // Create as little new rectangles as possible and group them together when possible
+
+            void CreateRect(Rectangle rect)
+            {
+                Render2D.DrawRectangle(rect, IsFocused ? selectedBorderColor : borderColor);
+            }
+
+            var border = Border;
+            var topWidth = border.TopWidth * 0.5f;
+            var leftWidth = border.LeftWidth * 0.5f;
+            var rightWidth = border.RightWidth * 0.5f;
+            var bottomWidth = border.BottomWidth * 0.5f;
+
+            // TODO: This needs to be optimized
+            
+            // Add top border
+            if (topWidth > 0)
+            {
+                CreateRect(new Rectangle(0, 0, Width, topWidth));
+            }
+
+            // Add bottom border
+            if (bottomWidth > 0)
+            {
+                CreateRect(new Rectangle(0, Height - bottomWidth, Width, bottomWidth));
+            }
+            
+            // Add left border
+            if (leftWidth > 0)
+            {
+                CreateRect(new Rectangle(0, topWidth, leftWidth, Height - topWidth - bottomWidth));
+            }
+
+            // Add right border
+            if (rightWidth > 0)
+            {
+                CreateRect(new Rectangle(Width - rightWidth, topWidth, rightWidth, Height - topWidth - bottomWidth));
+            }
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -283,6 +283,117 @@ namespace FlaxEngine.GUI
         public Color BorderSelectedColor { get; set; }
 
         /// <summary>
+        /// The border rectangle. Used to draw border around the text box.
+        /// </summary>
+        [EditorDisplay("Border Style"), EditorOrder(2012), Tooltip("The border rectangle. Used to draw border around the text box.")]
+        public TextBoxBorder Border { get; set; } = new TextBoxBorder();
+
+        /// <summary>
+        /// The background rectangle. Used to draw background of the text box.
+        /// </summary>
+        [Serializable]
+        public struct TextBoxBorder
+        {
+            public Color Color { get; set; } = Color.Transparent;
+            public Color SelectedColor { get; set; } = Color.Transparent;
+
+            /// <summary>
+            /// The border lines width. Use 0 to disable border.
+            /// </summary>
+            public float Width
+            {
+                get => _width;
+                set => LeftWidth = RightWidth = TopWidth = BottomWidth = value;
+            }
+            
+            /// <summary>
+            /// The vertical border lines width. Use 0 to disable border. Top and bottom width.
+            /// </summary>
+            public float VerticalWidth
+            {
+                get => TopWidth;
+                set => TopWidth = BottomWidth = value;
+            }
+            
+            /// <summary>
+            /// The horizontal border lines width. Use 0 to disable border. Left and right width.
+            /// </summary>
+            public float HorizontalWidth
+            {
+                get => LeftWidth;
+                set => LeftWidth = RightWidth = value;
+            }
+
+            /// <summary>
+            /// The left border line width. Use 0 to disable border.
+            /// </summary>
+            public float LeftWidth { get; set; }
+            /// <summary>
+            /// The right border line width. Use 0 to disable border.
+            /// </summary>
+            public float RightWidth { get; set; }
+            /// <summary>
+            /// The top border line width. Use 0 to disable border.
+            /// </summary>
+            public float TopWidth { get; set; }
+            /// <summary>
+            /// The bottom border line width. Use 0 to disable border.
+            /// </summary>
+            public float BottomWidth { get; set; }
+
+            private float _width { get; }
+            
+            public TextBoxBorder(Color color, Color selectedColor, float width)
+            {
+                Color = color;
+                SelectedColor = selectedColor;
+                Width = width;
+            }
+            
+            public TextBoxBorder(Color color, Color selectedColor, float topWidth, float bottomWidth, float leftWidth, float rightWidth)
+            {
+                Color = color;
+                SelectedColor = selectedColor;
+                TopWidth = topWidth;
+                BottomWidth = bottomWidth;
+                LeftWidth = leftWidth;
+                RightWidth = rightWidth;
+                _width = 0;
+            }
+            
+            public TextBoxBorder(Color color, Color selectedColor, float verticalWidth, float horizontalWidth)
+            {
+                Color = color;
+                SelectedColor = selectedColor;
+                LeftWidth = RightWidth = horizontalWidth;
+                TopWidth = BottomWidth = verticalWidth;
+                _width = 0;
+            }
+            
+            public TextBoxBorder(Color color, Color selectedColor, Vector4 width)
+            {
+                Color = color;
+                SelectedColor = selectedColor;
+                TopWidth = width.X;
+                BottomWidth = width.Y;
+                LeftWidth = width.Z;
+                RightWidth = width.W;
+                _width = 0;
+            }
+            
+            public TextBoxBorder(Color color, Color selectedColor, Vector2 verticalWidth, Vector2 horizontalWidth)
+            {
+                Color = color;
+                SelectedColor = selectedColor;
+                TopWidth = verticalWidth.X;
+                BottomWidth = verticalWidth.Y;
+                LeftWidth = horizontalWidth.X;
+                RightWidth = horizontalWidth.Y;
+                _width = 0;
+            }
+        }
+        
+        /// <summary>
         /// Gets the size of the text (cached).
         /// </summary>
         public Float2 TextSize => _textSize;

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -37,7 +37,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Default height of the text box
         /// </summary>
-        public static float DefaultHeight = 18;
+        public static float DefaultHeight = 22;
 
         /// <summary>
         /// Left and right margin for text inside the text box bounds rectangle

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -286,7 +286,7 @@ namespace FlaxEngine.GUI
         /// The border rectangle. Used to draw border around the text box.
         /// </summary>
         [EditorDisplay("Border Style"), EditorOrder(2012), Tooltip("The border rectangle. Used to draw border around the text box.")]
-        public TextBoxBorder Border { get; set; } = new TextBoxBorder();
+        public TextBoxBorder Border { get; set; }
 
         /// <summary>
         /// The background rectangle. Used to draw background of the text box.
@@ -300,11 +300,7 @@ namespace FlaxEngine.GUI
             /// <summary>
             /// The border lines width. Use 0 to disable border.
             /// </summary>
-            public float Width
-            {
-                get => _width;
-                set => LeftWidth = RightWidth = TopWidth = BottomWidth = value;
-            }
+            public float Width { get; set; }
             
             /// <summary>
             /// The vertical border lines width. Use 0 to disable border. Top and bottom width.
@@ -341,8 +337,6 @@ namespace FlaxEngine.GUI
             /// </summary>
             public float BottomWidth { get; set; }
 
-            private float _width { get; }
-            
             public TextBoxBorder(Color color, Color selectedColor, float width)
             {
                 Color = color;
@@ -358,16 +352,16 @@ namespace FlaxEngine.GUI
                 BottomWidth = bottomWidth;
                 LeftWidth = leftWidth;
                 RightWidth = rightWidth;
-                _width = 0;
+                Width = 0;
             }
             
             public TextBoxBorder(Color color, Color selectedColor, float verticalWidth, float horizontalWidth)
             {
                 Color = color;
                 SelectedColor = selectedColor;
-                LeftWidth = RightWidth = horizontalWidth;
-                TopWidth = BottomWidth = verticalWidth;
-                _width = 0;
+                VerticalWidth = verticalWidth;
+                HorizontalWidth = horizontalWidth;
+                Width = 0;
             }
             
             public TextBoxBorder(Color color, Color selectedColor, Vector4 width)
@@ -378,7 +372,7 @@ namespace FlaxEngine.GUI
                 BottomWidth = width.Y;
                 LeftWidth = width.Z;
                 RightWidth = width.W;
-                _width = 0;
+                Width = 0;
             }
             
             public TextBoxBorder(Color color, Color selectedColor, Vector2 verticalWidth, Vector2 horizontalWidth)
@@ -389,7 +383,7 @@ namespace FlaxEngine.GUI
                 BottomWidth = verticalWidth.Y;
                 LeftWidth = horizontalWidth.X;
                 RightWidth = horizontalWidth.Y;
-                _width = 0;
+                Width = 0;
             }
         }
         


### PR DESCRIPTION
Adds a new way to deal with borders, ideally, this should be updated in the future to be more optimized, but this should not be a significant performance concern, only displays them when needed anyways
Changes how all vectors are displayed to include a label that can be modified