### PR TITLE
Allow for better support for running on m1/2 machines

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -215,8 +215,12 @@ namespace Flax.Build
                     }
                 }
 
-                // Use x64 when cross-compiling from ARM64
-                if (architecture == TargetArchitecture.ARM64 && (Configuration.BuildArchitectures != null && Configuration.BuildArchitectures[0] == TargetArchitecture.x64))
+                bool isRunningOnArm64Targetx64 = architecture == TargetArchitecture.ARM64 && (Configuration.BuildArchitectures != null && Configuration.BuildArchitectures[0] == TargetArchitecture.x64);
+
+                // We need to support two paths here: 
+                // 1. We are running an x64 binary and we are running on an arm64 host machine 
+                // 2. We are running an Arm64 binary and we are targeting an x64 host machine
+                if (Flax.Build.Platforms.MacPlatform.GetProcessIsTranslated() || isRunningOnArm64Targetx64) 
                 {
                     rid = "osx-x64";
                     dotnetPath = Path.Combine(dotnetPath, "x64");

--- a/Source/Tools/Flax.Build/Platforms/Mac/MacPlatform.cs
+++ b/Source/Tools/Flax.Build/Platforms/Mac/MacPlatform.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
+using System.Runtime.InteropServices;
 
 namespace Flax.Build.Platforms
 {
@@ -41,5 +42,20 @@ namespace Flax.Build.Platforms
             default: return false;
             }
         }
+
+        [DllImport ("c")]
+		public static unsafe extern int sysctlbyname (
+			string name, void* oldp, ulong *oldlenp, void* newp, ulong newlen);
+
+        public unsafe static bool GetProcessIsTranslated()
+		{
+			int ret = 0;
+			ulong size = sizeof (int);
+			if (sysctlbyname ("sysctl.proc_translated", &ret, &size, null, 0) == -1) {
+				return false;
+			}
+
+			return ret != 0;
+		}
     }
 }


### PR DESCRIPTION
* So we need to account for 2 possible situations where you are running under an emulated process and a native process with a different target host in this case x64