### PR TITLE
Fix white window flickering in context menus

### DIFF
--- a/Source/Editor/GUI/Docking/DockHintWindow.cs
+++ b/Source/Editor/GUI/Docking/DockHintWindow.cs
@@ -476,6 +476,7 @@ namespace FlaxEditor.GUI.Docking
                 settings.ShowInTaskbar = false;
                 settings.ActivateWhenFirstShown = false;
                 settings.IsTopmost = true;
+                settings.ShowAfterFirstPaint = false;
 
                 win = Platform.CreateWindow(ref settings);
 

--- a/Source/Engine/Platform/CreateWindowSettings.cs
+++ b/Source/Engine/Platform/CreateWindowSettings.cs
@@ -23,6 +23,7 @@ namespace FlaxEngine
             AllowDragAndDrop = true,
             IsRegularWindow = true,
             HasSizingFrame = true,
+            ShowAfterFirstPaint = true,
         };
     }
 }

--- a/Source/Engine/Platform/CreateWindowSettings.h
+++ b/Source/Engine/Platform/CreateWindowSettings.h
@@ -131,7 +131,7 @@ DECLARE_SCRIPTING_TYPE_MINIMAL(CreateWindowSettings);
     /// <summary>
     /// Enable/disable window auto-show after the first paint.
     /// </summary>
-    API_FIELD() bool ShowAfterFirstPaint = false;
+    API_FIELD() bool ShowAfterFirstPaint = true;
 
     /// <summary>
     /// The custom data (platform dependant).


### PR DESCRIPTION
Avoid showing the window before the first frame is rendered to that window.