### PR TITLE
Update build scripts to detect only supported versions of MSBuild

### DIFF
--- a/Development/Scripts/Windows/CallBuildTool.bat
+++ b/Development/Scripts/Windows/CallBuildTool.bat
@@ -11,16 +11,6 @@ for %%I in (Source\Logo.png) do if %%~zI LSS 2000 (
 call "Development\Scripts\Windows\GetMSBuildPath.bat"
 if errorlevel 1 goto Error_NoVisualStudioEnvironment
 
-if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" goto Compile
-for /f "delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath') do (
-	for %%j in (15.0, Current) do (
-		if exist "%%i\MSBuild\%%j\Bin\MSBuild.exe" (
-			set MSBUILD_PATH="%%i\MSBuild\%%j\Bin\MSBuild.exe"
-			goto Compile
-		)
-	)
-)
-
 :Compile
 md Cache\Intermediate >nul 2>nul
 dir /s /b Source\Tools\Flax.Build\*.cs >Cache\Intermediate\Flax.Build.Files.txt
@@ -44,7 +34,7 @@ goto Exit
 echo CallBuildTool ERROR: The script is in invalid directory.
 goto Exit
 :Error_NoVisualStudioEnvironment
-echo CallBuildTool ERROR: Missing Visual Studio 2015 or newer.
+echo CallBuildTool ERROR: Missing Visual Studio 2022 or newer.
 goto Exit
 :Error_CompilationFailed
 echo CallBuildTool ERROR: Failed to compile Flax.Build project.

--- a/Development/Scripts/Windows/GetMSBuildPath.bat
+++ b/Development/Scripts/Windows/GetMSBuildPath.bat
@@ -4,66 +4,26 @@ rem Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 set MSBUILD_PATH=
 
+rem Look for MSBuild version 17.0 or later
 if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" goto VsWhereNotFound
-for /f "delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath') do (
-	if exist "%%i\MSBuild\15.0\Bin\MSBuild.exe" (
-		set MSBUILD_PATH="%%i\MSBuild\15.0\Bin\MSBuild.exe"
-		goto End
-	)
-)
-for /f "delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -property installationPath') do (
-	if exist "%%i\MSBuild\15.0\Bin\MSBuild.exe" (
-		set MSBUILD_PATH="%%i\MSBuild\15.0\Bin\MSBuild.exe"
-		goto End
-	)
+for /f "delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -version 17.0 -latest -products * -requires Microsoft.Component.MSBuild -property installationPath') do (
 	if exist "%%i\MSBuild\Current\Bin\MSBuild.exe" (
 		set MSBUILD_PATH="%%i\MSBuild\Current\Bin\MSBuild.exe"
 		goto End
 	)
 )
-:VsWhereNotFound
 
-if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin\MSBuild.exe" (
-	set MSBUILD_PATH="%ProgramFiles(x86)%\MSBuild\14.0\bin\MSBuild.exe"
-	goto End
+rem Look for MSBuild version 17.0 or later in pre-release versions
+for /f "delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -version 17.0 -latest -prerelease -products * -requires Microsoft.Component.MSBuild -property installationPath') do (
+	if exist "%%i\MSBuild\Current\Bin\MSBuild.exe" (
+		set MSBUILD_PATH="%%i\MSBuild\Current\Bin\MSBuild.exe"
+		goto End
+	)
 )
-
-call :GetInstallPath Microsoft\VisualStudio\SxS\VS7 15.0 MSBuild\15.0\bin\MSBuild.exe
-if not errorlevel 1 goto End
-call :GetInstallPath Microsoft\MSBuild\ToolsVersions\14.0 MSBuildToolsPath MSBuild.exe
-if not errorlevel 1 goto End
-call :GetInstallPath Microsoft\MSBuild\ToolsVersions\12.0 MSBuildToolsPath MSBuild.exe
-if not errorlevel 1 goto End
-call :GetInstallPath Microsoft\MSBuild\ToolsVersions\4.0 MSBuildToolsPath MSBuild.exe
-if not errorlevel 1 goto End
-
+echo GetMSBuildPath ERROR: Could not find MSBuild version 17.0 or later.
+exit /B 1
+:VsWhereNotFound
+echo GetMSBuildPath ERROR: vswhere.exe was not found.
 exit /B 1
 :End
 exit /B 0
-
-:GetInstallPath
-for /f "tokens=2,*" %%A in ('REG.exe query HKCU\SOFTWARE\%1 /v %2 2^>Nul') do (
-	if exist "%%B%%3" (
-		set MSBUILD_PATH="%%B%3"
-		exit /B 0
-	)
-)
-for /f "tokens=2,*" %%A in ('REG.exe query HKLM\SOFTWARE\%1 /v %2 2^>Nul') do (
-	if exist "%%B%3" (
-		set MSBUILD_PATH="%%B%3"
-		exit /B 0
-	)
-)
-for /f "tokens=2,*" %%A in ('REG.exe query HKCU\SOFTWARE\Wow6432Node\%1 /v %2 2^>Nul') do (
-	if exist "%%B%%3" (
-		set MSBUILD_PATH="%%B%3"
-		exit /B 0
-	)
-)
-for /f "tokens=2,*" %%A in ('REG.exe query HKLM\SOFTWARE\Wow6432Node\%1 /v %2 2^>Nul') do (
-	if exist "%%B%3" (
-		set MSBUILD_PATH="%%B%3"
-		exit /B 0
-	)
-)
-exit /B 1

--- a/README.md
+++ b/README.md
@@ -31,19 +31,20 @@ Follow the instructions below to compile and run the engine from source.
 * Install Visual Studio 2022 or newer
 * Install Windows 8.1 SDK or newer (via Visual Studio Installer)
 * Install Microsoft Visual C++ 2015 v140 toolset or newer (via Visual Studio Installer)
-* Install .Net 7 SDK (via Visual Studio Installer or [from web](https://dotnet.microsoft.com/en-us/download/dotnet/7.0))
+* Install .NET 7 SDK for **Windows x64** (via Visual Studio Installer or [from web](https://dotnet.microsoft.com/en-us/download/dotnet/7.0))
 * Install Git with LFS
 * Clone repo (with LFS)
 * Run **GenerateProjectFiles.bat**
 * Open `Flax.sln` and set solution configuration to **Editor.Development** and solution platform to **Win64**
 * Set Flax (C++) or FlaxEngine (C#) as startup project
 * Compile Flax project (hit F7 or CTRL+Shift+B)
+* Optionally set Debug Type to **Managed Only (.NET Core)** to debug C#-only, or **Mixed (.NET Core)** to debug both C++ and C#
 * Run Flax (hit F5 key)
 
 ## Linux
 
 * Install Visual Studio Code
-* Install .Net 7 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0))
+* Install .NET 7 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0))
   * Ubuntu: `sudo apt install dotnet-sdk-7.0`
 * Install Vulkan SDK ([https://vulkan.lunarg.com/](https://vulkan.lunarg.com/))
   * Ubuntu: `sudo apt install vulkan-sdk`
@@ -66,7 +67,7 @@ Follow the instructions below to compile and run the engine from source.
 ## Mac
 
 * Install XCode
-* Install .Net 7 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0))
+* Install .NET 7 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0))
 * Install Vulkan SDK ([https://vulkan.lunarg.com/](https://vulkan.lunarg.com/))
 * Clone repo (with LFS)
 * Run `GenerateProjectFiles.command`


### PR DESCRIPTION
Removed legacy MSBuild path detection logic and included a minimum version filter for MSBuild version to not return MSBuild versions of older Visual Studios