### PR TITLE
Fix right clicking on source folder to sometimes select non-visible child

### DIFF
--- a/Source/Engine/UI/GUI/ContainerControl.cs
+++ b/Source/Engine/UI/GUI/ContainerControl.cs
@@ -360,7 +360,7 @@ namespace FlaxEngine.GUI
                 {
                     var containerControl = child as ContainerControl;
                     var childAtRecursive = containerControl?.GetChildAtRecursive(childLocation);
-                    if (childAtRecursive != null)
+                    if (childAtRecursive != null && childAtRecursive.Visible)
                     {
                         child = childAtRecursive;
                     }


### PR DESCRIPTION
Right now if you right click on the source file in the content tree there is a chance that it will select a folder that is not visible (the Properties folder in this case). This adds a visibility check to getting the children of a container control to solve this. I did not find a better place to fix this bug. Maybe I should add a Selectable property to the container control that could act as ignoring it, but for right now this seems fine.