### PR TITLE
Prevent generating VS configurations for Win32 and engine projects

### DIFF
--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -126,6 +126,10 @@ namespace Flax.Build
                             if (!platform.HasRequiredSDKsInstalled && (!projectInfo.IsCSharpOnlyProject || platform != Platform.BuildPlatform))
                                 continue;
 
+                            // Prevent generating configuration data for Windows x86
+                            if (architecture == TargetArchitecture.x86 && targetPlatform == TargetPlatform.Windows)
+                                continue;
+
                             string configurationText = targetName + '.' + platformName + '.' + configurationName;
                             string architectureName = architecture.ToString();
                             if (platform is IProjectCustomizer customizer)

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
@@ -402,6 +402,10 @@ namespace Flax.Build.Projects.VisualStudio
                     if (project.Configurations == null || project.Configurations.Count == 0)
                         throw new Exception("Missing configurations for project " + project.Name);
 
+                    // Prevent generating default Debug|AnyCPU and Release|AnyCPU configurations from Flax projects
+                    if (project.Name == "BuildScripts" || project.Name == "Flax.Build" || project.Name == "Flax.Build.Tests")
+                        continue;
+
                     foreach (var configuration in project.Configurations)
                     {
                         configurations.Add(new SolutionConfiguration(configuration));


### PR DESCRIPTION
Removes the `Debug` and `Release` solution configurations and `Any CPU` and `Win32` solution platforms from generated Visual Studio solution files sourced from Flax projects. This should hopefully fix Intellisense issues with default solution settings and effectively changes the defaults to `Editor.Debug` and `Win64`.