### PR TITLE
Prevent editor window from maximizing/ minimizing on menu button double click

### DIFF
--- a/Source/Editor/GUI/MainMenu.cs
+++ b/Source/Editor/GUI/MainMenu.cs
@@ -292,7 +292,8 @@ namespace FlaxEditor.GUI
                 return true;
 
 #if PLATFORM_WINDOWS
-            if (_useCustomWindowSystem)
+            var child = GetChildAtRecursive(location);
+            if (_useCustomWindowSystem && child is not Button && child is not MainMenuButton)
             {
                 if (_window.IsMaximized)
                     _window.Restore();


### PR DESCRIPTION
This prevents the editor window from maximizing and minimizing when double clicking on a menu button or button.