### PR TITLE
Prevent initial editor window from covering the task bar on restore of windows window

### DIFF
--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -746,7 +746,6 @@ namespace FlaxEditor.Modules
                 return;
             }
             UpdateWindowTitle();
-            MainWindow.Maximize();
 
             // Link for main window events
             MainWindow.Closing += MainWindow_OnClosing;

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -721,7 +721,7 @@ namespace FlaxEditor.Modules
             // Create main window
             var settings = CreateWindowSettings.Default;
             settings.Title = "Flax Editor";
-            settings.Size = Platform.DesktopSize;
+            //settings.Size = Platform.DesktopSize;
             settings.StartPosition = WindowStartPosition.CenterScreen;
             settings.ShowAfterFirstPaint = true;
 
@@ -746,6 +746,7 @@ namespace FlaxEditor.Modules
                 return;
             }
             UpdateWindowTitle();
+            MainWindow.Maximize();
 
             // Link for main window events
             MainWindow.Closing += MainWindow_OnClosing;


### PR DESCRIPTION
The editor window will restore to cover the task bar in Windows until it is re-sized. This sets the initial size to the default.