### PR TITLE
Ensure ShaderGraphValue floating numbers are formatted with enough precision

### DIFF
--- a/Source/Engine/Visject/ShaderGraphValue.cpp
+++ b/Source/Engine/Visject/ShaderGraphValue.cpp
@@ -40,11 +40,11 @@ ShaderGraphValue::ShaderGraphValue(const Variant& v)
         break;
     case VariantType::Float:
         Type = VariantType::Types::Float;
-        Value = String::Format(TEXT("{}"), v.AsFloat);
+        Value = String::Format(TEXT("{:.8f}"), v.AsFloat);
         break;
     case VariantType::Double:
         Type = VariantType::Types::Float;
-        Value = String::Format(TEXT("{}"), (float)v.AsDouble);
+        Value = String::Format(TEXT("{:.8f}"), (float)v.AsDouble);
         break;
     case VariantType::Float2:
     {


### PR DESCRIPTION
Fixes #1472
Floating numbers with no fractional part get formatted as integers and as such, the generated code for a division looks like `1 / 2`, which is an integer division. The simplest fix is to ask fmt to always include enough digits. Ideally, we would ask to it include at least 1 digit, so numbers like 42 would be formatted to "42.0" and numbers like 42.123321 would stay the same but it's not supported. Another option would be to manually format the number but i'm not sure it's worth it. This PR seems like the simplest option.