### PR TITLE
Visject QoL: Ignore whitespace when opening context menu with spacebar

### DIFF
--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -706,6 +706,8 @@ namespace FlaxEditor.Surface
             {
                 if (_inputBrackets.Count == 0)
                 {
+                    if (currentInputText.StartsWith(' '))
+                        currentInputText = "";
                     ResetInput();
                     ShowPrimaryMenu(_mousePos, false, currentInputText);
                 }


### PR DESCRIPTION
Very minor QoL change when working with graph editors.

I am very used to Unity's Shader Graph, where you can press the spacebar to open the context menu.
Since you can open the primary context menu in Flax with almost every input, you can also open it with the spacebar, which is great and useful, but it keeps the whitespace character as input, which can be annoying when opening the menu a lot.
This has the side effect, that a bunch of search results get filtered out instantly. E.g. when searching for vector constants (see gifs)

Before:
![Before](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/2091f41e-4f5b-40f1-8e47-6462ccff2e34)

After:
![After](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/1afe3c95-7102-4beb-bc7e-0d7d374c2fe9)

I found #934 where a shortcut system was discussed for a little bit, so i don't know how redundant this PR is. But for the time being it might be a nice QoL fix.