### PR TITLE
Add filter to content window to hide generated files.

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -46,7 +46,7 @@ namespace FlaxEditor.Windows
         private TextBox _itemsSearchBox;
         private ViewDropdown _viewDropdown;
         private SortType _sortType;
-        private bool _showEngineFiles = true, _showPluginsFiles = true, _showAllFiles = true;
+        private bool _showEngineFiles = true, _showPluginsFiles = true, _showAllFiles = true, _showGeneratedFiles = false;
 
         private RootContentTreeNode _root;
 
@@ -102,6 +102,19 @@ namespace FlaxEditor.Windows
                         RefreshView();
                         _tree.PerformLayout();
                     }
+                }
+            }
+        }
+
+        internal bool ShowGeneratedFiles
+        {
+            get => _showGeneratedFiles;
+            set
+            {
+                if (_showGeneratedFiles != value)
+                {
+                    _showGeneratedFiles = value;
+                    RefreshView();
                 }
             }
         }
@@ -312,6 +325,12 @@ namespace FlaxEditor.Windows
                 b = show.ContextMenu.AddButton("Plugins files", () => ShowPluginsFiles = !ShowPluginsFiles);
                 b.TooltipText = "Shows plugin projects content";
                 b.Checked = ShowPluginsFiles;
+                b.CloseMenuOnClick = false;
+                b.AutoCheck = true;
+                
+                b = show.ContextMenu.AddButton("Generated files", () => ShowGeneratedFiles = !ShowGeneratedFiles);
+                b.TooltipText = "Shows generated files";
+                b.Checked = ShowGeneratedFiles;
                 b.CloseMenuOnClick = false;
                 b.AutoCheck = true;
 
@@ -969,6 +988,8 @@ namespace FlaxEditor.Windows
                 var items = target.Folder.Children;
                 if (!_showAllFiles)
                     items = items.Where(x => !(x is FileItem)).ToList();
+                if (!_showGeneratedFiles)
+                    items = items.Where(x => !(x.Path.Contains(".Gen.cs") || x.Path.Contains(".Gen.h") || x.Path.Contains(".Gen.cpp") || x.Path.Contains(".csproj") || x.Path.Contains(".CSharp"))).ToList();
                 _view.ShowItems(items, _sortType, false, true);
             }
         }
@@ -1145,6 +1166,7 @@ namespace FlaxEditor.Windows
             writer.WriteAttributeString("ShowEngineFiles", ShowEngineFiles.ToString());
             writer.WriteAttributeString("ShowPluginsFiles", ShowPluginsFiles.ToString());
             writer.WriteAttributeString("ShowAllFiles", ShowAllFiles.ToString());
+            writer.WriteAttributeString("ShowGeneratedFiles", ShowGeneratedFiles.ToString());
             writer.WriteAttributeString("ViewType", _view.ViewType.ToString());
         }
 
@@ -1162,6 +1184,8 @@ namespace FlaxEditor.Windows
                 ShowPluginsFiles = value2;
             if (bool.TryParse(node.GetAttribute("ShowAllFiles"), out value2))
                 ShowAllFiles = value2;
+            if (bool.TryParse(node.GetAttribute("ShowGeneratedFiles"), out value2))
+                ShowGeneratedFiles = value2;
             if (Enum.TryParse(node.GetAttribute("ViewType"), out ContentViewType viewType))
                 _view.ViewType = viewType;
         }


### PR DESCRIPTION
This adds a filter to hide generated files form the content view. Hides them by default as most users wont need them.