### PR TITLE
Fix not capturing the the Debug.Log line in the DebugLogWindow

### DIFF
--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -544,7 +544,7 @@ namespace FlaxEditor.Windows
                         if (noLocation)
                         {
                             desc.LocationFile = match.Groups[2].Value;
-                            int.TryParse(match.Groups[5].Value, out desc.LocationLine);
+                            int.TryParse(match.Groups[4].Value, out desc.LocationLine);
                             noLocation = false;
                         }
                         fineStackTrace.AppendLine(match.Groups[0].Value);


### PR DESCRIPTION
In the debug log window, when using regex to analyze stack traces from Debug.Log, the incorrect group was used to get the line. As a result, when clicking on the log entries on the window, no code editor would open the file at the correct line.