### PR TITLE
Launching Rider on macOS

### DIFF
--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -268,8 +268,16 @@ void RiderCodeEditor::OpenFile(const String& path, int32 line)
     // Open file
     line = line > 0 ? line : 1;
     CreateProcessSettings procSettings;
+
+#if !PLATFORM_MAC
     procSettings.FileName = _execPath;
     procSettings.Arguments = String::Format(TEXT("\"{0}\" --line {2} \"{1}\""), _solutionPath, path, line);
+#else
+    // This follows pretty much how all the other engines open rider which deals with cross architecture issues
+    procSettings.FileName = "/usr/bin/open";
+    procSettings.Arguments = String::Format(TEXT("-n -a \"{0}\" --args \"{1}\" --line {3} \"{2}\""), _execPath, _solutionPath, path, line);
+#endif
+
     procSettings.HiddenWindow = false;
     procSettings.WaitForEnd = false;
     procSettings.LogOutput = false;
@@ -287,8 +295,14 @@ void RiderCodeEditor::OpenSolution()
 
     // Open solution
     CreateProcessSettings procSettings;
+#if !PLATFORM_MAC
     procSettings.FileName = _execPath;
     procSettings.Arguments = String::Format(TEXT("\"{0}\""), _solutionPath);
+#else
+    // This follows pretty much how all the other engines open rider which deals with cross architecture issues
+    procSettings.FileName = "/usr/bin/open";
+    procSettings.Arguments = String::Format(TEXT("-n -a \"{0}\" \"{1}\""), _execPath, _solutionPath);
+#endif
     procSettings.HiddenWindow = false;
     procSettings.WaitForEnd = false;
     procSettings.LogOutput = false;

--- a/Source/Engine/Platform/Apple/ApplePlatform.cpp
+++ b/Source/Engine/Platform/Apple/ApplePlatform.cpp
@@ -85,25 +85,32 @@ NSString* AppleUtils::ToNSString(const char* string)
 
 NSArray* AppleUtils::ParseArguments(NSString* argsString) {
     NSMutableArray *argsArray = [NSMutableArray array];
-    NSScanner *scanner = [NSScanner scannerWithString:argsString];
-    NSString *currentArg = nil;
+    NSMutableString *currentArg = [NSMutableString string];
     BOOL insideQuotes = NO;
     
-    while (![scanner isAtEnd]) {
-        if (insideQuotes) {
-            [scanner scanUpToString:@"\"" intoString:&currentArg];
-            [scanner scanString:@"\"" intoString:NULL];
-            insideQuotes = NO;
-        } else {
-            [scanner scanUpToString:@" " intoString:&currentArg];
-            [scanner scanString:@" " intoString:NULL];
-        }
+    for (NSInteger i = 0; i < argsString.length; ++i) {
+        unichar c = [argsString characterAtIndex:i];
         
-        if ([currentArg isEqualToString:@"\""]) {
-            insideQuotes = YES;
-        } else if (currentArg) {
-            [argsArray addObject:currentArg];
+        if (c == '\"') {
+            if (insideQuotes) {
+                [argsArray addObject:[currentArg copy]];
+                [currentArg setString:@""];
+                insideQuotes = NO;
+            } else {
+                insideQuotes = YES;
+            }
+        } else if (c == ' ' && !insideQuotes) {
+            if (currentArg.length > 0) {
+                [argsArray addObject:[currentArg copy]];
+                [currentArg setString:@""];
+            }
+        } else {
+            [currentArg appendFormat:@"%C", c];
         }
+    }
+    
+    if (currentArg.length > 0) {
+        [argsArray addObject:[currentArg copy]];
     }
     
     return [argsArray copy];


### PR DESCRIPTION
* Fixing issues where when the editor would try and launch rider on an M1/2 machine it would not properly open because it was the wrong architecture which is now resolved because open will do the right thing
* Making the ParseArgs function a little more resilient against escaped arguments