### PR TITLE
Visject: Bend connections around nodes

### DIFF
--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -33,11 +33,20 @@ namespace FlaxEditor.Surface.Elements
         /// <param name="thickness">The connection thickness.</param>
         public static void DrawConnection(ref Float2 start, ref Float2 end, ref Color color, float thickness = 1)
         {
+            // Control points parameters
+            const float minControlLength = 100f;
+            const float maxControlLength = 150f;
+            var dst = (end - start).Length;
+            var yDst = Mathf.Abs(start.Y - end.Y);
+            
             // Calculate control points
-            var dst = (end - start) * new Float2(0.5f, 0.05f);
-            var control1 = new Float2(start.X + dst.X, start.Y + dst.Y);
-            var control2 = new Float2(end.X - dst.X, end.Y + dst.Y);
-
+            var minControlDst = dst * 0.5f;
+            var maxControlDst = Mathf.Max(Mathf.Min(maxControlLength, dst), minControlLength);
+            var controlDst = Mathf.Lerp(minControlDst, maxControlDst, Mathf.Clamp(yDst / minControlLength, 0f, 1f));
+            
+            var control1 = new Float2(start.X + controlDst, start.Y);
+            var control2 = new Float2(end.X - controlDst, end.Y);
+            
             // Draw line
             Render2D.DrawBezier(start, control1, control2, end, color, thickness);
 

--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -33,19 +33,8 @@ namespace FlaxEditor.Surface.Elements
         /// <param name="thickness">The connection thickness.</param>
         public static void DrawConnection(ref Float2 start, ref Float2 end, ref Color color, float thickness = 1)
         {
-            // Control points parameters
-            const float minControlLength = 100f;
-            const float maxControlLength = 150f;
-            var dst = (end - start).Length;
-            var yDst = Mathf.Abs(start.Y - end.Y);
-            
             // Calculate control points
-            var minControlDst = dst * 0.5f;
-            var maxControlDst = Mathf.Max(Mathf.Min(maxControlLength, dst), minControlLength);
-            var controlDst = Mathf.Lerp(minControlDst, maxControlDst, Mathf.Clamp(yDst / minControlLength, 0f, 1f));
-            
-            var control1 = new Float2(start.X + controlDst, start.Y);
-            var control2 = new Float2(end.X - controlDst, end.Y);
+            CalculateBezierControlPoints(start, end, out var control1, out var control2);
             
             // Draw line
             Render2D.DrawBezier(start, control1, control2, end, color, thickness);
@@ -58,6 +47,23 @@ namespace FlaxEditor.Surface.Elements
             */
         }
 
+        private static void CalculateBezierControlPoints(Float2 start, Float2 end, out Float2 control1, out Float2 control2)
+        {
+            // Control points parameters
+            const float minControlLength = 100f;
+            const float maxControlLength = 150f;
+            var dst = (end - start).Length;
+            var yDst = Mathf.Abs(start.Y - end.Y);
+            
+            // Calculate control points
+            var minControlDst = dst * 0.5f;
+            var maxControlDst = Mathf.Max(Mathf.Min(maxControlLength, dst), minControlLength);
+            var controlDst = Mathf.Lerp(minControlDst, maxControlDst, Mathf.Clamp(yDst / minControlLength, 0f, 1f));
+            
+            control1 = new Float2(start.X + controlDst, start.Y);
+            control2 = new Float2(end.X - controlDst, end.Y);
+        }
+        
         /// <summary>
         /// Checks if a point intersects a connection
         /// </summary>
@@ -84,13 +90,9 @@ namespace FlaxEditor.Surface.Elements
 
             float offset = Mathf.Sign(end.Y - start.Y) * distance;
             if ((point.Y - (start.Y - offset)) * ((end.Y + offset) - point.Y) < 0) return false;
-
-            // Taken from the Render2D.DrawBezier code
+            
             float squaredDistance = distance;
-
-            var dst = (end - start) * new Float2(0.5f, 0.05f);
-            var control1 = new Float2(start.X + dst.X, start.Y + dst.Y);
-            var control2 = new Float2(end.X - dst.X, end.Y + dst.Y);
+            CalculateBezierControlPoints(start, end, out var control1, out var control2);
 
             var d1 = control1 - start;
             var d2 = control2 - control1;


### PR DESCRIPTION
Another minor change to visject.
I noticed when nodes are arranged more vertically, or when nodes are arranged on top of each other, that the connection bezier curve stays rather straight and static. (See before)
So i thought i make the curve bend a bit:

Before
![Before2](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/bd0e1640-9779-445e-84cf-712bf7621cd5)

After
![After2](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/cec03907-9b12-4f9c-8eff-0f1777c3ce6e)

This makes the curves look a bit more like Unity's and Unreal's connections. It's not quite there, but close enough. And personally i think it looks prettier ^^

Note: It does add a couple more operations compared to the previous solution, so if pure performance is the goal, since big graphs can have a ton of connections, then this PRs code can probably be a bit more optimized or ignored.