### PR TITLE
Fix exceptions in Debug Log Window not using correct line numbers

### DIFF
--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -573,7 +573,7 @@ namespace FlaxEditor.Windows
                 if (match.Success)
                 {
                     desc.LocationFile = match.Groups[2].Value;
-                    int.TryParse(match.Groups[3].Value, out desc.LocationLine);
+                    int.TryParse(match.Groups[4].Value, out desc.LocationLine);
                 }
             }
 


### PR DESCRIPTION
Fixes one more case related to https://github.com/FlaxEngine/FlaxEngine/pull/1493