### PR TITLE
TextBox: Added ctrl+backspace support

### DIFF
--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -12,6 +12,11 @@ namespace FlaxEngine.GUI
     public abstract class TextBoxBase : ContainerControl
     {
         /// <summary>
+        /// The delete control character (used for text filtering).
+        /// </summary>
+        protected const char DelChar = (char)0x7F;
+        
+        /// <summary>
         /// The text separators (used for words skipping).
         /// </summary>
         protected static readonly char[] Separators =
@@ -351,6 +356,10 @@ namespace FlaxEngine.GUI
             if (value.IndexOf('\r') != -1)
                 value = value.Replace("\r", "");
 
+            // Filter text (handle backspace control character)
+            if(value.IndexOf(DelChar) != -1)
+                value = value.Replace(DelChar.ToString(), "");
+                
             // Clamp length
             if (value.Length > MaxLength)
                 value = value.Substring(0, MaxLength);
@@ -673,6 +682,8 @@ namespace FlaxEngine.GUI
             // Filter text
             if (str.IndexOf('\r') != -1)
                 str = str.Replace("\r", "");
+            if (str.IndexOf(DelChar) != -1)
+                str = str.Replace(DelChar.ToString(), "");
             if (!IsMultiline && str.IndexOf('\n') != -1)
                 str = str.Replace("\n", "");
 
@@ -1327,6 +1338,15 @@ namespace FlaxEngine.GUI
                 if (IsReadOnly)
                     return true;
 
+                if (ctrDown)
+                {
+                    int prevWordBegin = FindPrevWordBegin();
+                    _text = _text.Remove(prevWordBegin, CaretPosition-prevWordBegin);
+                    SetSelection(prevWordBegin);
+                    OnTextChanged();
+                    return true;
+                }
+                
                 int left = SelectionLeft;
                 if (HasSelection)
                 {


### PR DESCRIPTION
In a lot of text editors it is common that ctrl+backspace deletes the word before the caret/cursor. Personally i use this key combination a looooot.
But at the moment pressing ctrl+backspace in Flax will only delete the last character and insert the DEL control character (The box character in the before gif).

This PR filters out the DEL character and deletes the word before the caret.

Before:
![Before3](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/d4395fca-f0f6-44d7-9b01-e4989cd58c14)

After:
![After3](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/dc94df6a-e250-4e5b-aba5-8fcfbe23a279)

Note: When putting a ton of spaces after a word this doesn't work as expected, since spaces count as seperator characters and the "FindPrevWordBegin()" function stops at seperator chars. The same happens when there are other seperator chars like . , / etc.
This can probably be fixed pretty easily.