### PR TITLE
Double click actions + open prefab ctxmenu

### DIFF
--- a/Source/Editor/Modules/PrefabsModule.cs
+++ b/Source/Editor/Modules/PrefabsModule.cs
@@ -113,15 +113,18 @@ namespace FlaxEditor.Modules
         /// Open a prefab in a Prefab Editor
         /// </summary>
         /// <returns>Whether the prefab was successfully opened in a Prefab Editor</returns>
-        public bool OpenPrefab()
+        public bool OpenPrefab(Guid prefabID = default)
         {
-            var selection = Editor.SceneEditing.Selection.Where(x => x is ActorNode actorNode && actorNode.HasPrefabLink).ToList().BuildNodesParents();
-            if (selection.Count == 0 || !((ActorNode)selection[0]).Actor.HasPrefabLink)
-                return false;
+            if(prefabID == Guid.Empty)
+            {
+                var selection = Editor.SceneEditing.Selection.Where(x => x is ActorNode actorNode && actorNode.HasPrefabLink).ToList().BuildNodesParents();
+                if (selection.Count == 0 || !((ActorNode)selection[0]).Actor.HasPrefabLink)
+                    return false;
 
-            var prefabId = ((ActorNode)selection[0]).Actor.PrefabID;
-            var item = Editor.Instance.ContentDatabase.Find(prefabId);
+                prefabID = ((ActorNode)selection[0]).Actor.PrefabID;
+            }
 
+            var item = Editor.Instance.ContentDatabase.Find(prefabID);
             if(item != null)
             {
                 Editor.Instance.ContentEditing.Open(item);

--- a/Source/Editor/Modules/PrefabsModule.cs
+++ b/Source/Editor/Modules/PrefabsModule.cs
@@ -109,6 +109,27 @@ namespace FlaxEditor.Modules
             Editor.Windows.ContentWin.NewItem(proxy, actor, OnPrefabCreated, actor.Name, rename);
         }
 
+        /// <summary>
+        /// Open a prefab in a Prefab Editor
+        /// </summary>
+        /// <returns>Whether the prefab was successfully opened in a Prefab Editor</returns>
+        public bool OpenPrefab()
+        {
+            var selection = Editor.SceneEditing.Selection.Where(x => x is ActorNode actorNode && actorNode.HasPrefabLink).ToList().BuildNodesParents();
+            if (selection.Count == 0 || !((ActorNode)selection[0]).Actor.HasPrefabLink)
+                return false;
+
+            var prefabId = ((ActorNode)selection[0]).Actor.PrefabID;
+            var item = Editor.Instance.ContentDatabase.Find(prefabId);
+
+            if(item != null)
+            {
+                Editor.Instance.ContentEditing.Open(item);
+                return true;
+            }
+            return false;
+        }
+
         private void OnPrefabCreated(ContentItem contentItem)
         {
             if (contentItem is PrefabItem prefabItem)

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -200,6 +200,9 @@ namespace FlaxEditor.Options
         [EditorDisplay("Interface"), EditorOrder(2020)]
         public InputBinding PreviousTab = new InputBinding(KeyboardKeys.Tab, KeyboardKeys.Control, KeyboardKeys.Shift);
 
+        [DefaultValue(Windows.SceneNodeDoubleClick.None)]
+        [EditorDisplay("Interface"), EditorOrder(2030)]
+        public Windows.SceneNodeDoubleClick DoubleClickSceneNode = Windows.SceneNodeDoubleClick.None;
         #endregion
     }
 }

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -133,14 +133,15 @@ namespace FlaxEditor.Windows
 
             contextMenu.AddSeparator();
 
+            ActorNode actorNode = (ActorNode)Editor.SceneEditing.Selection[0];
             b = contextMenu.AddButton("Create Prefab", Editor.Prefabs.CreatePrefab);
-            b.Enabled = isSingleActorSelected &&
-                        ((ActorNode)Editor.SceneEditing.Selection[0]).CanCreatePrefab &&
+            b.Enabled = isSingleActorSelected && actorNode.CanCreatePrefab &&
                         Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets;
 
-            bool hasPrefabLink = canEditScene && isSingleActorSelected && (Editor.SceneEditing.Selection[0] as ActorNode).HasPrefabLink;
+            bool hasPrefabLink = canEditScene && isSingleActorSelected && actorNode.HasPrefabLink;
             if (hasPrefabLink)
             {
+                contextMenu.AddButton("Open Prefab", () => Editor.Prefabs.OpenPrefab());
                 contextMenu.AddButton("Select Prefab", Editor.Prefabs.SelectPrefab);
                 contextMenu.AddButton("Break Prefab Link", Editor.Prefabs.BreakLinks);
             }

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -141,7 +141,7 @@ namespace FlaxEditor.Windows
             bool hasPrefabLink = canEditScene && isSingleActorSelected && actorNode.HasPrefabLink;
             if (hasPrefabLink)
             {
-                contextMenu.AddButton("Open Prefab", () => Editor.Prefabs.OpenPrefab());
+                contextMenu.AddButton("Open Prefab", () => Editor.Prefabs.OpenPrefab(actorNode.Actor.PrefabID));
                 contextMenu.AddButton("Select Prefab", Editor.Prefabs.SelectPrefab);
                 contextMenu.AddButton("Break Prefab Link", Editor.Prefabs.BreakLinks);
             }

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -354,13 +354,13 @@ namespace FlaxEditor.Windows
             {
                 switch (Editor.Options.Options.Input.DoubleClickSceneNode)
                 {
-                    case SceneNodeDoubleClick.Rename:
+                    case SceneNodeDoubleClick.RenameActor:
                         Rename();
                         return true;
-                    case SceneNodeDoubleClick.Focus:
+                    case SceneNodeDoubleClick.FocusActor:
                         Editor.Windows.EditWin.Viewport.FocusSelection();
                         return true;
-                    case SceneNodeDoubleClick.Open:
+                    case SceneNodeDoubleClick.OpenPrefab:
                         return Editor.Prefabs.OpenPrefab();
                     case SceneNodeDoubleClick.None:
                     default:
@@ -496,14 +496,14 @@ namespace FlaxEditor.Windows
         /// <summary>
         /// Rename the Scene Node
         /// </summary>
-        Rename,
+        RenameActor,
         /// <summary>
         /// Focus the Scene Node object in the Scene View
         /// </summary>
-        Focus,
+        FocusActor,
         /// <summary>
         /// If possible, open the scene node in an associated Editor (e.g. Prefab Editor)
         /// </summary>
-        Open
+        OpenPrefab
     }
 }

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -346,6 +346,29 @@ namespace FlaxEditor.Windows
 
             return false;
         }
+        
+        /// <inheritdoc />
+        public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
+        {
+            if(button == MouseButton.Left)
+            {
+                switch (Editor.Options.Options.Input.DoubleClickSceneNode)
+                {
+                    case SceneNodeDoubleClick.Rename:
+                        Rename();
+                        return true;
+                    case SceneNodeDoubleClick.Focus:
+                        Editor.Windows.EditWin.Viewport.FocusSelection();
+                        return true;
+                    case SceneNodeDoubleClick.Open:
+                        return Editor.Prefabs.OpenPrefab();
+                    case SceneNodeDoubleClick.None:
+                    default:
+                        return base.OnMouseDoubleClick(location, button);
+                }
+            }
+            return base.OnMouseDoubleClick(location, button);
+        }
 
         /// <inheritdoc />
         public override void OnLostFocus()
@@ -458,5 +481,29 @@ namespace FlaxEditor.Windows
 
             base.OnDestroy();
         }
+    }
+
+    /// <summary>
+    /// Action to perform when a Scene Node receive a double mouse click (Left)
+    /// </summary>
+    [Serializable]
+    public enum SceneNodeDoubleClick
+    {
+        /// <summary>
+        /// No action is performed
+        /// </summary>
+        None, 
+        /// <summary>
+        /// Rename the Scene Node
+        /// </summary>
+        Rename,
+        /// <summary>
+        /// Focus the Scene Node object in the Scene View
+        /// </summary>
+        Focus,
+        /// <summary>
+        /// If possible, open the scene node in an associated Editor (e.g. Prefab Editor)
+        /// </summary>
+        Open
     }
 }


### PR DESCRIPTION
Customizable options to be called on DoubleClick on a Scene Nodes. It defaults to None. The options are:
- None (default, does nothing)
- Rename (double clicking boots the user into renaming the Scene Node)
- Focus (double clicking focuses the Actor in the Scene View)
- Open (double clicking a prefab in the scene view will open said prefab in a Prefab Editor)

Currently this setting is sitting in Options -> Input -> Interface. 

Additionally, I added the "Open Prefab"  button to the context menu for Actors that are linked to a prefab. This means users can right-click on a prefab actor and open the prefab editor from the context menu item. 

**Happy to discuss, didn't really have any comments on this on the Discord.**

[Example (link cuz of filesize limit)](https://media.discordapp.net/attachments/1153634661990420550/1154815999523176510/options.gif)