### PR TITLE
ContainerControl: Implemented shift + tab support

### DIFF
--- a/Source/Editor/GUI/Dialogs/Dialog.cs
+++ b/Source/Editor/GUI/Dialogs/Dialog.cs
@@ -290,7 +290,11 @@ namespace FlaxEditor.GUI.Dialogs
                 OnCancel();
                 return true;
             case KeyboardKeys.Tab:
-                Root?.Navigate(NavDirection.Next);
+                if (Root != null)
+                {
+                    bool shiftDown = Root.GetKey(KeyboardKeys.Shift);
+                    Root?.Navigate(shiftDown ? NavDirection.Previous : NavDirection.Next);   
+                }
                 return true;
             }
             return false;

--- a/Source/Editor/GUI/Dialogs/Dialog.cs
+++ b/Source/Editor/GUI/Dialogs/Dialog.cs
@@ -293,7 +293,7 @@ namespace FlaxEditor.GUI.Dialogs
                 if (Root != null)
                 {
                     bool shiftDown = Root.GetKey(KeyboardKeys.Shift);
-                    Root?.Navigate(shiftDown ? NavDirection.Previous : NavDirection.Next);   
+                    Root.Navigate(shiftDown ? NavDirection.Previous : NavDirection.Next);   
                 }
                 return true;
             }

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -207,7 +207,8 @@ namespace FlaxEditor.Windows
             case KeyboardKeys.Tab:
                 if (CanUseNavigation && Root != null)
                 {
-                    Root.Navigate(NavDirection.Next);
+                    bool shiftDown = Root.GetKey(KeyboardKeys.Shift);
+                    Root.Navigate(shiftDown ? NavDirection.Previous : NavDirection.Next);
                     return true;
                 }
                 break;

--- a/Source/Engine/UI/GUI/ContainerControl.cs
+++ b/Source/Engine/UI/GUI/ContainerControl.cs
@@ -507,15 +507,19 @@ namespace FlaxEngine.GUI
 
                 // Perform automatic navigation based on the layout
                 var result = NavigationRaycast(direction, location, visited);
-                if (result == null && direction == NavDirection.Next)
+                var rightMostLocation = location;
+                if (result == null && (direction == NavDirection.Next || direction == NavDirection.Previous))
                 {
                     // Try wrap the navigation over the layout based on the direction
                     var visitedWrap = new List<Control>(visited);
-                    result = NavigationWrap(direction, location, visitedWrap);
+                    result = NavigationWrap(direction, location, visitedWrap, out rightMostLocation);
                 }
                 if (result != null)
                 {
-                    result = result.OnNavigate(direction, result.PointFromParent(location), this, visited);
+                    // HACK: only the 'previous' direction needs the rightMostLocation so i used a ternary conditional operator.
+                    // The rightMostLocation can probably become a 'desired raycast origin' that gets calculated correctly in the NavigationWrap method.
+                    var useLocation = direction == NavDirection.Previous ? rightMostLocation : location;
+                    result = result.OnNavigate(direction, result.PointFromParent(useLocation), this, visited);
                     if (result != null)
                         return result;
                 }
@@ -551,8 +555,9 @@ namespace FlaxEngine.GUI
         /// <param name="direction">The navigation direction.</param>
         /// <param name="location">The navigation start location (in the control-space).</param>
         /// <param name="visited">The list with visited controls. Used to skip recursive navigation calls when doing traversal across the UI hierarchy.</param>
+        /// <param name="rightMostLocation">Returns the rightmost location of the parent container for the raycast used by the child container</param>
         /// <returns>The target navigation control or null if didn't performed any navigation.</returns>
-        protected virtual Control NavigationWrap(NavDirection direction, Float2 location, List<Control> visited)
+        protected virtual Control NavigationWrap(NavDirection direction, Float2 location, List<Control> visited, out Float2 rightMostLocation)
         {
             // This searches form a child that calls this navigation event (see Control.OnNavigate) to determinate the layout wrapping size based on that child size
             var currentChild = RootWindow?.FocusedControl;
@@ -566,15 +571,22 @@ namespace FlaxEngine.GUI
                 case NavDirection.Next:
                     predictedLocation = new Float2(0, location.Y + layoutSize.Y);
                     break;
+                case NavDirection.Previous:
+                    predictedLocation = new Float2(Size.X, location.Y - layoutSize.Y);
+                    break;
                 }
                 if (new Rectangle(Float2.Zero, Size).Contains(ref predictedLocation))
                 {
                     var result = NavigationRaycast(direction, predictedLocation, visited);
                     if (result != null)
-                        return result;
+                    {
+                        rightMostLocation = predictedLocation;
+                        return result;   
+                    }
                 }
             }
-            return Parent?.NavigationWrap(direction, PointToParent(ref location), visited);
+            rightMostLocation = location;
+            return Parent?.NavigationWrap(direction, PointToParent(ref location), visited, out rightMostLocation);
         }
 
         private static bool CanGetAutoFocus(Control c)
@@ -612,6 +624,10 @@ namespace FlaxEngine.GUI
             case NavDirection.Next:
                 uiDir1 = new Float2(1, 0);
                 uiDir2 = new Float2(0, 1);
+                break;
+            case NavDirection.Previous:
+                uiDir1 = new Float2(-1, 0);
+                uiDir2 = new Float2(0, -1);
                 break;
             }
             Control result = null;

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -634,6 +634,7 @@ namespace FlaxEngine.GUI
             case NavDirection.Left: return new Float2(0, size.Y * 0.5f);
             case NavDirection.Right: return new Float2(size.X, size.Y * 0.5f);
             case NavDirection.Next: return Float2.Zero;
+            case NavDirection.Previous: return new Float2(Size.X, Size.Y);
             default: return size * 0.5f;
             }
         }

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -634,7 +634,7 @@ namespace FlaxEngine.GUI
             case NavDirection.Left: return new Float2(0, size.Y * 0.5f);
             case NavDirection.Right: return new Float2(size.X, size.Y * 0.5f);
             case NavDirection.Next: return Float2.Zero;
-            case NavDirection.Previous: return new Float2(Size.X, Size.Y);
+            case NavDirection.Previous: return size;
             default: return size * 0.5f;
             }
         }

--- a/Source/Engine/UI/GUI/Enums.cs
+++ b/Source/Engine/UI/GUI/Enums.cs
@@ -202,5 +202,10 @@ namespace FlaxEngine.GUI
         /// The next item (right with layout wrapping).
         /// </summary>
         Next,
+        
+        /// <summary>
+        /// The previous item (left with layout wrapping).
+        /// </summary>
+        Previous,
     }
 }


### PR DESCRIPTION
This was a tough one 😅

It is common that the Tab key focuses the the input field on the right of the currently focused field and wraps to the next best leftmost field downwards, if there is no field to the right. This works as intended in Flax.

In a lot of cases Shift+Tab does the exact opposite, where it tries to focus the field to the left or wraps to the next best rightmost field upwards. This doesn't work as intended in Flax, instead it mimics the the usual Tab behavior.

This PR adds Shift+Tab support (see gifs) and fixes the Issue: #1431 
![ShiftTab](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/e36672c4-f8d9-4e9f-96cd-169f3bd92b3e)
![ShiftTab2](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/8df9e707-6434-4be0-83da-5f6f7509c7f7)

Note: There is a very minor hack in place, where i ask for the NavDirection one more time to determine which raycast origin point to use. This can probably be fixed via the NavigationWrap() method, but i didn't manage to accomplish that yet. As of now this code does work. And if needed i can look deeper into this and try to get rid of the additional conditional operator.