### PR TITLE
Fix Vulkan shader compilation with source files missing the last newline

### DIFF
--- a/Source/Engine/ContentImporters/ImportShader.cpp
+++ b/Source/Engine/ContentImporters/ImportShader.cpp
@@ -32,14 +32,21 @@ CreateAssetResult ImportShader::Import(CreateAssetContext& context)
         LOG(Warning, "Empty shader source file.");
         return CreateAssetResult::Error;
     }
+
+    // Ensure the source code has an empty line at the end (expected by glslang)
+    auto sourceCodeChunkSize = sourceCodeSize + 1;
+    if (sourceCodeText[sourceCodeSize - 1] != '\n')
+        sourceCodeChunkSize++;
+
     const auto& sourceCodeChunk = context.Data.Header.Chunks[SourceCodeChunk];
-    sourceCodeChunk->Data.Allocate(sourceCodeSize + 1);
+    sourceCodeChunk->Data.Allocate(sourceCodeChunkSize);
     const auto sourceCode = sourceCodeChunk->Get();
     Platform::MemoryCopy(sourceCode, sourceCodeText.Get(), sourceCodeSize);
+    sourceCode[sourceCodeChunkSize - 2] = '\n';
 
     // Encrypt source code
-    Encryption::EncryptBytes(sourceCode, sourceCodeSize);
-    sourceCode[sourceCodeSize] = 0;
+    Encryption::EncryptBytes(sourceCode, sourceCodeChunkSize - 1);
+    sourceCode[sourceCodeChunkSize - 1] = 0;
 
     // Set Custom Data with Header
     ShaderStorage::Header20 shaderHeader;


### PR DESCRIPTION
glslang seems to expect the shader source files to terminate with a newline, failing to compile with a undescriptive error like `error at column 0, HLSL parsing failed`. This fix will insert a newline to the imported chunk data in case it's not present.