### PR TITLE
Input event improvements

### DIFF
--- a/Source/Editor/CustomEditors/Editors/InputEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/InputEditor.cs
@@ -64,6 +64,63 @@ namespace FlaxEditor.CustomEditors.Editors
     }
 
     /// <summary>
+    /// Default implementation of the inspector used to edit input event properties.
+    /// </summary>
+    [CustomEditor(typeof(InputEventState)), DefaultEditor]
+    public class InputEventStateEditor : CustomEditor
+    {
+        private Dropdown _dropdown;
+
+        /// <inheritdoc />
+        public override DisplayStyle Style => DisplayStyle.Inline;
+
+        /// <inheritdoc />
+        public override void Initialize(LayoutElementsContainer layout)
+        {
+            var dropdownElement = layout.Custom<Dropdown>();
+            _dropdown = dropdownElement.CustomControl;
+            var names = new List<LocalizedString>();
+            foreach (var mapping in Input.ActionMappings)
+            {
+                if (!names.Contains(mapping.Name))
+                    names.Add(mapping.Name);
+            }
+            _dropdown.Items = names;
+            if (Values[0] is InputEventState inputEvent && names.Contains(inputEvent.Name))
+                _dropdown.SelectedItem = inputEvent.Name;
+            _dropdown.SelectedIndexChanged += OnSelectedIndexChanged;
+        }
+
+        private void OnSelectedIndexChanged(Dropdown dropdown)
+        {
+            SetValue(new InputEventState(dropdown.SelectedItem));
+        }
+
+        /// <inheritdoc />
+        public override void Refresh()
+        {
+            base.Refresh();
+
+            if (HasDifferentValues)
+            {
+            }
+            else
+            {
+                if (Values[0] is InputEventState inputEvent && _dropdown.Items.Contains(inputEvent.Name))
+                    _dropdown.SelectedItem = inputEvent.Name;
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Deinitialize()
+        {
+            if (_dropdown != null)
+                _dropdown.SelectedIndexChanged -= OnSelectedIndexChanged;
+            _dropdown = null;
+        }
+    }
+
+    /// <summary>
     /// Default implementation of the inspector used to edit input axis properties.
     /// </summary>
     [CustomEditor(typeof(InputAxis)), DefaultEditor]

--- a/Source/Engine/Engine/InputEventState.cs
+++ b/Source/Engine/Engine/InputEventState.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
+
+using System;
+
+namespace FlaxEngine
+{
+    /// <summary>
+    /// Virtual input action binding. Helps with listening for a selected input event.
+    /// </summary>
+    public class InputEventState
+    {
+        /// <summary>
+        /// The name of the action to use. See <see cref="Input.ActionMappings"/>.
+        /// </summary>
+        [Tooltip("The name of the action to use.")]
+        public string Name;
+
+        /// <summary>
+        /// Returns true if the event has been triggered during the current frame (e.g. user pressed a key). Use <see cref="Triggered"/> to catch events without active waiting.
+        /// </summary>
+        public bool Active => Input.GetAction(Name);
+
+        /// <summary>
+        /// Occurs when event is triggered (e.g. user pressed a key). Called before scripts update.
+        /// Has an additional parameter to read the input state.
+        /// </summary>
+        public event Action<InputActionState> Triggered;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InputEvent"/> class.
+        /// </summary>
+        public InputEventState()
+        {
+            Input.ActionStateChanged += Handler;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InputEvent"/> class.
+        /// </summary>
+        /// <param name="name">The action name.</param>
+        public InputEventState(string name)
+        {
+            Input.ActionStateChanged += Handler;
+            Name = name;
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="InputEvent"/> class.
+        /// </summary>
+        ~InputEventState()
+        {
+            Input.ActionStateChanged -= Handler;
+        }
+
+        private void Handler(string name, InputActionState state)
+        {
+            if (string.Equals(name, Name, StringComparison.OrdinalIgnoreCase))
+                Triggered?.Invoke(state);
+        }
+
+        /// <summary>
+        /// Releases this object.
+        /// </summary>
+        public void Dispose()
+        {
+            Input.ActionStateChanged -= Handler;
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -98,6 +98,7 @@ Delegate<const Float2&, int32> Input::TouchDown;
 Delegate<const Float2&, int32> Input::TouchMove;
 Delegate<const Float2&, int32> Input::TouchUp;
 Delegate<StringView> Input::ActionTriggered;
+Delegate<StringView, const InputActionState&> Input::ActionStateChanged;
 Array<ActionConfig> Input::ActionMappings;
 Array<AxisConfig> Input::AxisMappings;
 
@@ -1022,6 +1023,7 @@ void InputService::Update()
     {
         for (auto i = Actions.Begin(); i.IsNotEnd(); ++i)
         {
+            Input::ActionStateChanged(i->Key, i->Value.State);
             if (i->Value.Active)
             {
                 Input::ActionTriggered(i->Key);

--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -1023,7 +1023,11 @@ void InputService::Update()
     {
         for (auto i = Actions.Begin(); i.IsNotEnd(); ++i)
         {
-            Input::ActionStateChanged(i->Key, i->Value.State);
+            if (i->Value.State != InputActionState::Waiting) 
+            {
+                Input::ActionStateChanged(i->Key, i->Value.State);
+            }
+
             if (i->Value.Active)
             {
                 Input::ActionTriggered(i->Key);

--- a/Source/Engine/Input/Input.h
+++ b/Source/Engine/Input/Input.h
@@ -296,6 +296,12 @@ public:
     API_EVENT() static Delegate<StringView> ActionTriggered;
 
     /// <summary>
+    /// Event fired when virtual input action state is changed. Called before scripts update. See <see cref="ActionMappings"/> to edit configuration.
+    /// </summary>
+    /// <seealso cref="InputEventState"/>
+    API_EVENT() static Delegate<StringView, const InputActionState&> ActionStateChanged;
+
+    /// <summary>
     /// Gets the value of the virtual action identified by name. Use <see cref="ActionMappings"/> to get the current config.
     /// </summary>
     /// <param name="name">The action name.</param>


### PR DESCRIPTION
This PR will allow developers to use a new InputEventState class to subscribe to input events which pass in the state of the input, where they can then handle what happens per-state, rather than having to make multiple input actions, and then creating multiple InputEvents.

This is pretty similar to my last input PR but just adds the functionality to InputEvent (through a new class).

Decided on making it a new C# class as I didn't want to break current functionality with InputEvents but open to suggestions.

Example usage:
```csharp
public InputEventState inputEvent = new InputEventState("Jump");

public override void OnEnable()
{
    // Here you can add code that needs to be called when script is enabled (eg. register for events)
    inputEvent.Triggered += OnTriggeredState;
}

private void OnTriggeredState(InputActionState state)
{
    if (state == InputActionState.Press) Debug.Log("Press");
    if (state == InputActionState.Release) Debug.Log("Release");
}

public override void OnDisable()
{
    // Here you can add code that needs to be called when script is disabled (eg. unregister from events)
    inputEvent.Triggered -= OnTriggeredState;
}
```