### PR TITLE
Add showing only collision wireframe in `CollisionDataWindow`

### DIFF
--- a/Source/Editor/Windows/Assets/CollisionDataWindow.cs
+++ b/Source/Editor/Windows/Assets/CollisionDataWindow.cs
@@ -200,7 +200,7 @@ namespace FlaxEditor.Windows.Assets
                 ViewportCamera = new FPSCamera(),
                 Parent = _split.Panel1
             };
-            _preview.Task.ViewFlags = ViewFlags.Reflections | ViewFlags.DebugDraw | ViewFlags.AO | ViewFlags.DirectionalLights | ViewFlags.SkyLights | ViewFlags.Shadows | ViewFlags.SpecularLight | ViewFlags.AntiAliasing | ViewFlags.ToneMapping;
+            _preview.Task.ViewFlags &= ~ViewFlags.Sky & ~ViewFlags.Bloom;
 
             // Asset properties
             _propertiesPresenter = new CustomEditorPresenter(null);

--- a/Source/Editor/Windows/Assets/CollisionDataWindow.cs
+++ b/Source/Editor/Windows/Assets/CollisionDataWindow.cs
@@ -200,6 +200,7 @@ namespace FlaxEditor.Windows.Assets
                 ViewportCamera = new FPSCamera(),
                 Parent = _split.Panel1
             };
+            _preview.Task.ViewFlags = ViewFlags.Reflections | ViewFlags.DebugDraw | ViewFlags.AO | ViewFlags.DirectionalLights | ViewFlags.SkyLights | ViewFlags.Shadows | ViewFlags.SpecularLight | ViewFlags.AntiAliasing | ViewFlags.ToneMapping;
 
             // Asset properties
             _propertiesPresenter = new CustomEditorPresenter(null);


### PR DESCRIPTION
This Remove background Sky from Collision Data Window, this help a lot when you don't have a mesh because collision data wire have a too light color with background.

Remade of #1413