### PR TITLE
Add button to position camera to editor viewport view.

### DIFF
--- a/Source/Editor/SceneGraph/Actors/AnimatedModelNode.cs
+++ b/Source/Editor/SceneGraph/Actors/AnimatedModelNode.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Windows;
 using FlaxEngine;
 
 namespace FlaxEditor.SceneGraph.Actors
@@ -22,9 +23,9 @@ namespace FlaxEditor.SceneGraph.Actors
         }
 
         /// <inheritdoc />
-        public override void OnContextMenu(ContextMenu contextMenu)
+        public override void OnContextMenu(ContextMenu contextMenu, EditorWindow window)
         {
-            base.OnContextMenu(contextMenu);
+            base.OnContextMenu(contextMenu, window);
 
             var actor = (AnimatedModel)Actor;
             if (actor && actor.SkinnedModel)

--- a/Source/Editor/SceneGraph/Actors/CameraNode.cs
+++ b/Source/Editor/SceneGraph/Actors/CameraNode.cs
@@ -6,6 +6,8 @@ using Real = System.Double;
 using Real = System.Single;
 #endif
 
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Windows;
 using FlaxEngine;
 
 namespace FlaxEditor.SceneGraph.Actors
@@ -21,6 +23,25 @@ namespace FlaxEditor.SceneGraph.Actors
         public CameraNode(Actor actor)
         : base(actor)
         {
+        }
+
+        /// <inheritdoc />
+        public override void OnContextMenu(ContextMenu contextMenu, EditorWindow window)
+        {
+            base.OnContextMenu(contextMenu,window);
+            if (window is not SceneTreeWindow win)
+                return;
+            var button = new ContextMenuButton(contextMenu, "Move Camera to View");
+            button.Parent = contextMenu.ItemsContainer;
+            contextMenu.ItemsContainer.Children.Remove(button);
+            contextMenu.ItemsContainer.Children.Insert(4, button);
+            button.Clicked += () =>
+            {
+                var c = Actor as Camera;
+                var viewport = Editor.Instance.Windows.EditWin.Viewport;
+                c.Position = viewport.ViewPosition;
+                c.Orientation = viewport.ViewOrientation;
+            };
         }
 
         /// <inheritdoc />

--- a/Source/Editor/SceneGraph/Actors/SceneNode.cs
+++ b/Source/Editor/SceneGraph/Actors/SceneNode.cs
@@ -3,6 +3,7 @@
 using System.IO;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.SceneGraph.GUI;
+using FlaxEditor.Windows;
 using FlaxEngine;
 
 namespace FlaxEditor.SceneGraph.Actors
@@ -65,7 +66,7 @@ namespace FlaxEditor.SceneGraph.Actors
         public override SceneNode ParentScene => this;
 
         /// <inheritdoc />
-        public override void OnContextMenu(ContextMenu contextMenu)
+        public override void OnContextMenu(ContextMenu contextMenu, EditorWindow window)
         {
             contextMenu.AddSeparator();
             var path = Scene.Path;
@@ -80,7 +81,7 @@ namespace FlaxEditor.SceneGraph.Actors
             if (Level.ScenesCount > 1)
                 contextMenu.AddButton("Unload all but this scene", OnUnloadAllButSelectedScene).LinkTooltip("Unloads all of the active scenes except for the selected scene.").Enabled = Editor.Instance.StateMachine.CurrentState.CanChangeScene;
 
-            base.OnContextMenu(contextMenu);
+            base.OnContextMenu(contextMenu, window);
         }
 
         private void OnSelect()

--- a/Source/Editor/SceneGraph/Actors/SplineNode.cs
+++ b/Source/Editor/SceneGraph/Actors/SplineNode.cs
@@ -9,6 +9,7 @@ using Real = System.Single;
 using System;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.Modules;
+using FlaxEditor.Windows;
 using FlaxEngine;
 using FlaxEngine.Json;
 using Object = FlaxEngine.Object;
@@ -203,9 +204,9 @@ namespace FlaxEditor.SceneGraph.Actors
                 }
             }
 
-            public override void OnContextMenu(ContextMenu contextMenu)
+            public override void OnContextMenu(ContextMenu contextMenu, EditorWindow window)
             {
-                ParentNode.OnContextMenu(contextMenu);
+                ParentNode.OnContextMenu(contextMenu, window);
             }
 
             public static SceneGraphNode Create(StateData state)
@@ -272,9 +273,9 @@ namespace FlaxEditor.SceneGraph.Actors
                 DebugDraw.DrawSphere(new BoundingSphere(pos, tangentSize), Color.YellowGreen, 0, false);
             }
 
-            public override void OnContextMenu(ContextMenu contextMenu)
+            public override void OnContextMenu(ContextMenu contextMenu, EditorWindow window)
             {
-                ParentNode.OnContextMenu(contextMenu);
+                ParentNode.OnContextMenu(contextMenu, window);
             }
 
             public override void OnDispose()
@@ -354,9 +355,9 @@ namespace FlaxEditor.SceneGraph.Actors
         }
 
         /// <inheritdoc />
-        public override void OnContextMenu(ContextMenu contextMenu)
+        public override void OnContextMenu(ContextMenu contextMenu, EditorWindow window)
         {
-            base.OnContextMenu(contextMenu);
+            base.OnContextMenu(contextMenu, window);
 
             contextMenu.AddButton("Add spline model", OnAddSplineModel);
             contextMenu.AddButton("Add spline collider", OnAddSplineCollider);

--- a/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
+++ b/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
@@ -3,6 +3,7 @@
 using System;
 using FlaxEditor.Content;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Windows;
 using FlaxEngine;
 
 namespace FlaxEditor.SceneGraph.Actors
@@ -21,9 +22,9 @@ namespace FlaxEditor.SceneGraph.Actors
         }
 
         /// <inheritdoc />
-        public override void OnContextMenu(ContextMenu contextMenu)
+        public override void OnContextMenu(ContextMenu contextMenu, EditorWindow window)
         {
-            base.OnContextMenu(contextMenu);
+            base.OnContextMenu(contextMenu, window);
 
             contextMenu.AddButton("Add collider", OnAddMeshCollider).Enabled = ((StaticModel)Actor).Model != null;
         }

--- a/Source/Editor/SceneGraph/SceneGraphNode.cs
+++ b/Source/Editor/SceneGraph/SceneGraphNode.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FlaxEditor.Modules;
 using FlaxEditor.SceneGraph.Actors;
+using FlaxEditor.Windows;
 using FlaxEngine;
 
 namespace FlaxEditor.SceneGraph
@@ -339,7 +340,7 @@ namespace FlaxEditor.SceneGraph
         /// <summary>
         /// Called when scene tree window wants to show the context menu. Allows to add custom options.
         /// </summary>
-        public virtual void OnContextMenu(FlaxEditor.GUI.ContextMenu.ContextMenu contextMenu)
+        public virtual void OnContextMenu(FlaxEditor.GUI.ContextMenu.ContextMenu contextMenu, EditorWindow window)
         {
         }
 

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -313,7 +313,7 @@ namespace FlaxEditor.Windows.Assets
             }
             if (showCustomNodeOptions)
             {
-                Selection[0].OnContextMenu(contextMenu);
+                Selection[0].OnContextMenu(contextMenu, this);
             }
             ContextMenuShow?.Invoke(contextMenu);
 

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -45,16 +45,6 @@ namespace FlaxEditor.Windows
             if (hasSthSelected)
             {
                 contextMenu.AddButton(Editor.Windows.EditWin.IsPilotActorActive ? "Stop piloting actor" : "Pilot actor", Editor.UI.PilotActor);
-                // Position camera to viewport view
-                if (Editor.SceneEditing.Selection[0] is ActorNode a && a.Actor is Camera c && isSingleActorSelected)
-                {
-                    contextMenu.AddButton("Position Camera to View", () =>
-                    {
-                        var viewport = Editor.Windows.EditWin.Viewport;
-                        c.Position = viewport.ViewPosition;
-                        c.Orientation = viewport.ViewOrientation;
-                    });
-                }
             }
 
             contextMenu.AddSeparator();
@@ -224,7 +214,7 @@ namespace FlaxEditor.Windows
             }
             if (showCustomNodeOptions)
             {
-                Editor.SceneEditing.Selection[0].OnContextMenu(contextMenu);
+                Editor.SceneEditing.Selection[0].OnContextMenu(contextMenu, this);
             }
 
             ContextMenuShow?.Invoke(contextMenu);

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -45,6 +45,15 @@ namespace FlaxEditor.Windows
             if (hasSthSelected)
             {
                 contextMenu.AddButton(Editor.Windows.EditWin.IsPilotActorActive ? "Stop piloting actor" : "Pilot actor", Editor.UI.PilotActor);
+                // Position camera to viewport view
+                if (Editor.SceneEditing.Selection[0] is ActorNode a && a.Actor is Camera c && isSingleActorSelected)
+                {
+                    contextMenu.AddButton("Position Camera to View", () =>
+                    {
+                        c.Position = Editor.Windows.EditWin.Viewport.ViewPosition;
+                        c.Orientation = Editor.Windows.EditWin.Viewport.ViewOrientation;
+                    });
+                }
             }
 
             contextMenu.AddSeparator();

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -50,8 +50,9 @@ namespace FlaxEditor.Windows
                 {
                     contextMenu.AddButton("Position Camera to View", () =>
                     {
-                        c.Position = Editor.Windows.EditWin.Viewport.ViewPosition;
-                        c.Orientation = Editor.Windows.EditWin.Viewport.ViewOrientation;
+                        var viewport = Editor.Windows.EditWin.Viewport;
+                        c.Position = viewport.ViewPosition;
+                        c.Orientation = viewport.ViewOrientation;
                     });
                 }
             }


### PR DESCRIPTION
This adds a button on the camera actor node context menu to quickly position the camera to the editor's viewport view.