### PR TITLE
Fix potential incorrect null checks in FlaxEngine.Objects

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -576,8 +576,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     return;
                 for (int j = 0; j < e.Length; j++)
                 {
-                    var t1 = scripts[j]?.TypeName;
-                    var t2 = e[j]?.TypeName;
+                    var t1 = scripts[j] != null ? scripts[j].TypeName : null;
+                    var t2 = e[j] != null ? e[j].TypeName : null;
                     if (t1 != t2)
                         return;
                 }

--- a/Source/Editor/EditorAssets.cs
+++ b/Source/Editor/EditorAssets.cs
@@ -36,7 +36,9 @@ namespace FlaxEditor
 
             public static void OnEditorOptionsChanged(Options.EditorOptions options)
             {
-                var param = _highlightMaterial?.GetParameter("Color");
+                if (!_highlightMaterial)
+                    return;
+                var param = _highlightMaterial.GetParameter("Color");
                 if (param != null)
                     param.Value = options.Visual.HighlightColor;
             }

--- a/Source/Editor/GUI/Timeline/SceneAnimationTimeline.cs
+++ b/Source/Editor/GUI/Timeline/SceneAnimationTimeline.cs
@@ -33,7 +33,7 @@ namespace FlaxEditor.GUI.Timeline
         /// </summary>
         public SceneAnimationPlayer Player
         {
-            get => _player;
+            get => _player != null ? _player : null;
             set
             {
                 if (_player == value)
@@ -268,7 +268,7 @@ namespace FlaxEditor.GUI.Timeline
         /// <inheritdoc />
         public override void OnSeek(int frame)
         {
-            if (_player?.Animation)
+            if (_player != null && _player.Animation)
             {
                 _player.Animation.WaitForLoaded();
                 _player.Time = frame / _player.Animation.FramesPerSecond;

--- a/Source/Editor/Tools/Foliage/FoliageTypesTab.cs
+++ b/Source/Editor/Tools/Foliage/FoliageTypesTab.cs
@@ -375,7 +375,7 @@ namespace FlaxEditor.Tools.Foliage
 
         private void OnModified()
         {
-            Editor.Instance.Scene.MarkSceneEdited(_proxy.Foliage?.Scene);
+            Editor.Instance.Scene.MarkSceneEdited(_proxy.Foliage != null ? _proxy.Foliage.Scene : null);
         }
 
         private void OnSelectedFoliageChanged()

--- a/Source/Editor/Tools/Foliage/PaintTab.cs
+++ b/Source/Editor/Tools/Foliage/PaintTab.cs
@@ -218,7 +218,7 @@ namespace FlaxEditor.Tools.Foliage
 
         private void OnModified()
         {
-            Editor.Instance.Scene.MarkSceneEdited(_proxy.Foliage?.Scene);
+            Editor.Instance.Scene.MarkSceneEdited(_proxy.Foliage != null ? _proxy.Foliage.Scene : null);
         }
 
         private void OnSelectedFoliageChanged()

--- a/Source/Editor/Tools/VertexPainting.cs
+++ b/Source/Editor/Tools/VertexPainting.cs
@@ -544,7 +544,7 @@ namespace FlaxEditor.Tools
         public override bool IsControllingMouse => IsPainting;
 
         /// <inheritdoc />
-        public override BoundingSphere FocusBounds => _selectedModel?.Sphere ?? base.FocusBounds;
+        public override BoundingSphere FocusBounds => _selectedModel != null ? _selectedModel.Sphere : base.FocusBounds;
 
         /// <inheritdoc />
         public override void Update(float dt)

--- a/Source/Editor/Undo/Actions/PasteActorsAction.cs
+++ b/Source/Editor/Undo/Actions/PasteActorsAction.cs
@@ -144,7 +144,7 @@ namespace FlaxEditor.Actions
             {
                 var node = nodeParents[i];
                 var actor = node.Actor;
-                var parent = actor?.Parent;
+                var parent = actor != null ? actor.Parent : null;
                 if (parent != null)
                 {
                     bool IsNameValid(string name)

--- a/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
@@ -68,7 +68,7 @@ namespace FlaxEditor.Viewport.Previews
         /// </summary>
         public bool ShowBounds
         {
-            get => _boundsModel?.IsActive ?? false;
+            get => _boundsModel != null ? _boundsModel.IsActive : false;
             set
             {
                 if (value == ShowBounds)
@@ -110,7 +110,7 @@ namespace FlaxEditor.Viewport.Previews
         /// </summary>
         public bool ShowOrigin
         {
-            get => _originModel?.IsActive ?? false;
+            get => _originModel != null ? _originModel.IsActive : false;
             set
             {
                 if (value == ShowOrigin)

--- a/Source/Editor/Viewport/Previews/TexturePreview.cs
+++ b/Source/Editor/Viewport/Previews/TexturePreview.cs
@@ -500,7 +500,7 @@ namespace FlaxEditor.Viewport.Previews
         /// <inheritdoc />
         protected override void CalculateTextureRect(out Rectangle rect)
         {
-            CalculateTextureRect(_asset?.Size ?? new Float2(100), Size, out rect);
+            CalculateTextureRect(_asset != null ? _asset.Size : new Float2(100), Size, out rect);
         }
 
         /// <inheritdoc />
@@ -549,7 +549,7 @@ namespace FlaxEditor.Viewport.Previews
         /// <inheritdoc />
         protected override void CalculateTextureRect(out Rectangle rect)
         {
-            CalculateTextureRect(_asset?.Size ?? new Float2(100), Size, out rect);
+            CalculateTextureRect(_asset != null ? _asset.Size : new Float2(100), Size, out rect);
         }
 
         /// <inheritdoc />
@@ -604,7 +604,7 @@ namespace FlaxEditor.Viewport.Previews
         /// <inheritdoc />
         protected override void CalculateTextureRect(out Rectangle rect)
         {
-            CalculateTextureRect(_asset?.Size ?? new Float2(100), Size, out rect);
+            CalculateTextureRect(_asset != null ? _asset.Size : new Float2(100), Size, out rect);
         }
 
         /// <inheritdoc />
@@ -659,7 +659,7 @@ namespace FlaxEditor.Viewport.Previews
         /// <inheritdoc />
         protected override void CalculateTextureRect(out Rectangle rect)
         {
-            CalculateTextureRect(_asset?.Size ?? new Float2(100), Size, out rect);
+            CalculateTextureRect(_asset != null ? _asset.Size : new Float2(100), Size, out rect);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -69,7 +69,7 @@ namespace FlaxEditor.Windows.Assets
             [EditorDisplay("General"), Tooltip("The base material used to override it's properties")]
             public MaterialBase BaseMaterial
             {
-                get => Window?.Asset?.BaseMaterial;
+                get => Window?.Asset != null ? Window?.Asset.BaseMaterial : null;
                 set
                 {
                     var asset = Window?.Asset;
@@ -101,10 +101,12 @@ namespace FlaxEditor.Windows.Assets
             [HideInEditor]
             public object[] Values
             {
-                get => Window?.Asset?.Parameters.Select(x => x.Value).ToArray();
+                get => Window?.Asset != null ? Window?.Asset.Parameters.Select(x => x.Value).ToArray() : null;
                 set
                 {
-                    var parameters = Window?.Asset?.Parameters;
+                    if (Window?.Asset == null)
+                        return;
+                    var parameters = Window?.Asset.Parameters;
                     if (value != null && parameters != null)
                     {
                         if (value.Length != parameters.Length)
@@ -131,9 +133,11 @@ namespace FlaxEditor.Windows.Assets
             [HideInEditor]
             public FlaxEngine.Object[] ValuesRef
             {
-                get => Window?.Asset?.Parameters.Select(x => x.Value as FlaxEngine.Object).ToArray();
+                get => Window?.Asset != null ? Window?.Asset.Parameters.Select(x => x.Value as FlaxEngine.Object).ToArray() : null;
                 set
                 {
+                    if (Window?.Asset == null)
+                        return;
                     var parameters = Window?.Asset?.Parameters;
                     if (value != null && parameters != null)
                     {
@@ -293,7 +297,7 @@ namespace FlaxEditor.Windows.Assets
                                                         var p = (MaterialParameter)e.Tag;
 
                                                         // Try to get default value (from the base material)
-                                                        var pBase = baseMaterial?.GetParameter(p.Name);
+                                                        var pBase = baseMaterial != null ? baseMaterial.GetParameter(p.Name) : null;
                                                         if (pBase != null && pBase.ParameterType == p.ParameterType)
                                                         {
                                                             valueContainer.SetDefaultValue(pBase.Value);

--- a/Source/Editor/Windows/Assets/ModelWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelWindow.cs
@@ -134,7 +134,7 @@ namespace FlaxEditor.Windows.Assets
                 if (Window._skipEffectsGuiEvents)
                     return;
 
-                Window._isolateIndex = mesh?.MaterialSlotIndex ?? -1;
+                Window._isolateIndex = mesh != null ? mesh.MaterialSlotIndex : -1;
                 Window.UpdateEffectsOnAsset();
                 UpdateEffectsOnUI();
             }
@@ -144,7 +144,7 @@ namespace FlaxEditor.Windows.Assets
                 if (Window._skipEffectsGuiEvents)
                     return;
 
-                Window._highlightIndex = mesh?.MaterialSlotIndex ?? -1;
+                Window._highlightIndex = mesh != null ? mesh.MaterialSlotIndex : -1;
                 Window.UpdateEffectsOnAsset();
                 UpdateEffectsOnUI();
             }
@@ -326,7 +326,7 @@ namespace FlaxEditor.Windows.Assets
             [EditorOrder(10), EditorDisplay("Materials", EditorDisplayAttribute.InlineStyle)]
             public MaterialSlot[] MaterialSlots
             {
-                get => Asset?.MaterialSlots;
+                get => Asset != null ? Asset.MaterialSlots : null;
                 set
                 {
                     if (Asset != null)

--- a/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
+++ b/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
@@ -187,7 +187,7 @@ namespace FlaxEditor.Windows.Assets
                     base.Initialize(layout);
 
                     var emitterTrack = Values[0] as EmitterTrackProxy;
-                    if (emitterTrack?._effect?.Parameters == null)
+                    if (emitterTrack?._effect == null || emitterTrack?._effect.Parameters == null)
                         return;
 
                     var group = layout.Group("Parameters");

--- a/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
@@ -821,7 +821,7 @@ namespace FlaxEditor.Windows.Assets
             if (_timeline.IsModified)
             {
                 var time = _timeline.CurrentTime;
-                var isPlaying = _previewPlayer?.IsPlaying ?? false;
+                var isPlaying = _previewPlayer != null ? _previewPlayer.IsPlaying : false;
                 _timeline.Save(_asset);
                 if (_previewButton.Checked && _previewPlayer != null)
                 {

--- a/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
@@ -792,7 +792,7 @@ namespace FlaxEditor.Windows.Assets
         {
             if (_previewButton.Checked)
                 return;
-            _previewPlayerPicker.Value = _timeline.Player;
+            _previewPlayerPicker.Value = _timeline.Player != null ? _timeline.Player : null;
             _cachedPlayerId = _timeline.Player?.ID ?? Guid.Empty;
         }
 

--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -151,7 +151,7 @@ namespace FlaxEditor.Windows.Assets
                 if (Window._skipEffectsGuiEvents)
                     return;
 
-                Window._isolateIndex = mesh?.MaterialSlotIndex ?? -1;
+                Window._isolateIndex = mesh != null ? mesh.MaterialSlotIndex : -1;
                 Window.UpdateEffectsOnAsset();
                 UpdateEffectsOnUI();
             }
@@ -165,7 +165,7 @@ namespace FlaxEditor.Windows.Assets
                 if (Window._skipEffectsGuiEvents)
                     return;
 
-                Window._highlightIndex = mesh?.MaterialSlotIndex ?? -1;
+                Window._highlightIndex = mesh != null ? mesh.MaterialSlotIndex : -1;
                 Window.UpdateEffectsOnAsset();
                 UpdateEffectsOnUI();
             }
@@ -415,7 +415,7 @@ namespace FlaxEditor.Windows.Assets
             [EditorOrder(10), EditorDisplay("Materials", EditorDisplayAttribute.InlineStyle)]
             public MaterialSlot[] MaterialSlots
             {
-                get => Asset?.MaterialSlots;
+                get => Asset != null ? Asset.MaterialSlots : null;
                 set
                 {
                     if (Asset != null)

--- a/Source/Engine/Animations/SceneAnimations/SceneAnimationPlayer.cpp
+++ b/Source/Engine/Animations/SceneAnimations/SceneAnimationPlayer.cpp
@@ -905,7 +905,7 @@ void SceneAnimationPlayer::Tick(SceneAnimation* anim, float time, float dt, int3
                         MException ex(exception);
                         ex.Log(LogType::Error, TEXT("Property"));
                     }
-                    else if (!MCore::Type::IsPointer(valueType))
+                    else if (!MCore::Type::IsPointer(valueType) && !MCore::Type::IsReference(valueType))
                     {
                         if (boxed)
                             Platform::MemoryCopy(value, MCore::Object::Unbox(boxed), valueSize);

--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -1230,7 +1230,7 @@ namespace FlaxEngine.Interop
         internal static bool GetTypeIsReference(ManagedHandle typeHandle)
         {
             Type type = Unsafe.As<TypeHolder>(typeHandle.Target);
-            return type.IsByRef;
+            return !type.IsValueType; // Maybe also type.IsByRef?
         }
 
         [UnmanagedCallersOnly]

--- a/Source/Engine/UI/GUI/Brushes/GPUTextureBrush.cs
+++ b/Source/Engine/UI/GUI/Brushes/GPUTextureBrush.cs
@@ -37,7 +37,7 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public Float2 Size => Texture?.Size ?? Float2.Zero;
+        public Float2 Size => Texture != null ? Texture.Size : Float2.Zero;
 
         /// <inheritdoc />
         public void Draw(Rectangle rect, Color color)

--- a/Source/Engine/UI/GUI/Brushes/TextureBrush.cs
+++ b/Source/Engine/UI/GUI/Brushes/TextureBrush.cs
@@ -104,7 +104,7 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
-        public Float2 Size => Texture?.Size ?? Float2.Zero;
+        public Float2 Size => Texture != null ? Texture.Size : Float2.Zero;
 
         /// <inheritdoc />
         public unsafe void Draw(Rectangle rect, Color color)

--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -493,7 +493,8 @@ namespace FlaxEngine
                 if (_renderer)
                 {
 #if FLAX_EDITOR
-                    _editorTask?.RemoveCustomPostFx(_renderer);
+                    if (_editorTask != null)
+                        _editorTask.RemoveCustomPostFx(_renderer);
 #endif
                     SceneRenderTask.RemoveGlobalCustomPostFx(_renderer);
                     _renderer.Canvas = null;

--- a/Source/Engine/UI/UIControl.cs
+++ b/Source/Engine/UI/UIControl.cs
@@ -204,7 +204,7 @@ namespace FlaxEngine
                 up = value;
                 Internal_SetNavTargets(__unmanagedPtr, GetUnmanagedPtr(up), GetUnmanagedPtr(down), GetUnmanagedPtr(left), GetUnmanagedPtr(right));
                 if (_control != null)
-                    _control.NavTargetUp = value?.Control;
+                    _control.NavTargetUp = value != null ? value.Control : null;
             }
         }
 
@@ -228,7 +228,7 @@ namespace FlaxEngine
                 down = value;
                 Internal_SetNavTargets(__unmanagedPtr, GetUnmanagedPtr(up), GetUnmanagedPtr(down), GetUnmanagedPtr(left), GetUnmanagedPtr(right));
                 if (_control != null)
-                    _control.NavTargetDown = value?.Control;
+                    _control.NavTargetDown = value != null ? value.Control : null;
             }
         }
 
@@ -252,7 +252,7 @@ namespace FlaxEngine
                 left = value;
                 Internal_SetNavTargets(__unmanagedPtr, GetUnmanagedPtr(up), GetUnmanagedPtr(down), GetUnmanagedPtr(left), GetUnmanagedPtr(right));
                 if (_control != null)
-                    _control.NavTargetLeft = value?.Control;
+                    _control.NavTargetLeft = value != null ? value.Control : null;
             }
         }
 
@@ -276,7 +276,7 @@ namespace FlaxEngine
                 right = value;
                 Internal_SetNavTargets(__unmanagedPtr, GetUnmanagedPtr(up), GetUnmanagedPtr(down), GetUnmanagedPtr(left), GetUnmanagedPtr(right));
                 if (_control != null)
-                    _control.NavTargetRight = value?.Control;
+                    _control.NavTargetRight = value != null ? value.Control : null;
             }
         }
 


### PR DESCRIPTION
The null-conditional operator checks for reference equality of the `FlaxEngine.Object`, but doesn't check the validity of the unmanaged pointer. This check is corrected in cases where the object was not immediately returned from the bindings layer and may have been destroyed earlier.

Fixes https://github.com/FlaxEngine/FlaxEngine/issues/1328