### PR TITLE
Fix editor window closing when using camera flight

### DIFF
--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -192,6 +192,13 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {
+            // Prevent closing the editor window when using RMB + Ctrl + W to slow down the camera flight
+            if (Editor.Options.Options.Input.CloseTab.Process(this, key))
+            {
+                if (Root.GetMouseButton(MouseButton.Right))
+                    return true;
+            }
+
             if (base.OnKeyDown(key))
                 return true;
 


### PR DESCRIPTION
## Summary
This fixes an issue where an editor window would close if you were to press RMB + Ctrl + W in that order.

While pressing and holding RMB + W would engage a forward camera flight, additionally holding Ctrl would slow the flight. If pressed in the "wrong" order, it would cause the editor window to close instead.