### PR TITLE
Visject: Context sensitive node search

### DIFF
--- a/Source/Editor/Scripting/ScriptType.cs
+++ b/Source/Editor/Scripting/ScriptType.cs
@@ -1393,5 +1393,32 @@ namespace FlaxEditor.Scripting
                 return _custom.GetMembers(name, MemberTypes.Method, bindingAttr).FirstOrDefault();
             return ScriptMemberInfo.Null;
         }
+        
+        /// <summary>
+        /// Basic check to see if a type could be casted to another type
+        /// </summary>
+        /// <param name="from">Source type</param>
+        /// <param name="to">Target type</param>
+        /// <returns>True if the type can be casted</returns>
+        public static bool CanCast(ScriptType from, ScriptType to)
+        {
+            if (from == to)
+                return true;
+            if (from == Null || to == Null)
+                return false;
+            return (from.Type != typeof(void) && from.Type != typeof(FlaxEngine.Object)) &&
+                   (to.Type != typeof(void) && to.Type != typeof(FlaxEngine.Object)) &&
+                   from.IsAssignableFrom(to);
+        }
+
+        /// <summary>
+        /// Basic check to see if this type could be casted to another type
+        /// </summary>
+        /// <param name="to">Target type</param>
+        /// <returns>True if the type can be casted</returns>
+        public bool CanCastTo(ScriptType to)
+        {
+            return CanCast(this, to);
+        }
     }
 }

--- a/Source/Editor/Surface/Archetypes/Function.cs
+++ b/Source/Editor/Surface/Archetypes/Function.cs
@@ -773,7 +773,7 @@ namespace FlaxEditor.Surface.Archetypes
                     Values[4] = GetSignatureData(memberInfo, memberInfo.GetParameters());
                 }
             }
-
+            
             private SignatureInfo LoadSignature()
             {
                 var signature = new SignatureInfo();
@@ -1150,6 +1150,45 @@ namespace FlaxEditor.Surface.Archetypes
                 }
 
                 base.OnDestroy();
+            }
+            
+            internal static bool IsInputCompatible(NodeArchetype nodeArch, ScriptType outputType, ConnectionsHint hint)
+            {
+                if (nodeArch.Tag is not ScriptMemberInfo memberInfo)
+                    return false;
+                if(memberInfo.ValueType.IsVoid && outputType.IsVoid)
+                    return true;
+                if (!memberInfo.IsStatic)
+                {
+                    if (VisjectSurface.FullCastCheck(memberInfo.DeclaringType, outputType, hint))
+                        return true;
+                }
+                foreach (var param in memberInfo.GetParameters())
+                {
+                    if(param.IsOut)
+                        continue;
+                    if (VisjectSurface.FullCastCheck(param.Type, outputType, hint))
+                        return true;
+                }
+                return false;
+            }
+            
+            internal static bool IsOutputCompatible(NodeArchetype nodeArch, ScriptType inputType, ConnectionsHint hint)
+            {
+                if (nodeArch.Tag is not ScriptMemberInfo memberInfo)
+                    return false;
+                if(memberInfo.ValueType.IsVoid && inputType.IsVoid)
+                    return true;
+                if (VisjectSurface.FullCastCheck(memberInfo.ValueType, inputType, hint))
+                    return true;
+                foreach (var param in memberInfo.GetParameters())
+                {
+                    if(!param.IsOut)
+                        continue;
+                    if (VisjectSurface.FullCastCheck(param.Type, inputType, hint))
+                        return true;
+                }
+                return false;
             }
         }
 
@@ -2228,7 +2267,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Function Input",
                 Description = "The graph function input data",
                 Flags = NodeFlags.MaterialGraph | NodeFlags.ParticleEmitterGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaPaste,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2248,7 +2286,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Function Output",
                 Description = "The graph function output data",
                 Flags = NodeFlags.MaterialGraph | NodeFlags.ParticleEmitterGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaPaste,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2267,7 +2304,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = string.Empty,
                 Description = "Overrides the base class method with custom implementation",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI | NodeFlags.NoSpawnViaPaste,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2280,9 +2316,10 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 4,
                 Create = (id, context, arch, groupArch) => new InvokeMethodNode(id, context, arch, groupArch),
+                IsInputCompatible = InvokeMethodNode.IsInputCompatible,
+                IsOutputCompatible = InvokeMethodNode.IsOutputCompatible,
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2306,7 +2343,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new ReturnNode(id, context, arch, groupArch),
                 Title = "Return",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(100, 40),
                 DefaultValues = new object[]
                 {
@@ -2325,7 +2361,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "New Function",
                 Description = "Adds a new function to the script",
                 Flags = NodeFlags.VisualScriptGraph,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 20),
                 DefaultValues = new object[]
                 {
@@ -2338,7 +2373,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new GetFieldNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2354,7 +2388,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new SetFieldNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2371,7 +2404,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new BindEventNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(260, 60),
                 DefaultValues = new object[]
                 {
@@ -2394,7 +2426,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new UnbindEventNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(260, 60),
                 DefaultValues = new object[]
                 {

--- a/Source/Editor/Surface/Archetypes/Function.cs
+++ b/Source/Editor/Surface/Archetypes/Function.cs
@@ -2223,6 +2223,43 @@ namespace FlaxEditor.Surface.Archetypes
 
                 base.OnDestroy();
             }
+            
+            internal static bool IsInputCompatible(NodeArchetype nodeArch, ScriptType outputType, ConnectionsHint hint)
+            {
+                // Event based nodes always have a pulse input, so it's always compatible with void
+                if (outputType.IsVoid)
+                    return true;
+                
+                var eventName = (string)nodeArch.DefaultValues[1];
+                var eventType = TypeUtils.GetType((string)nodeArch.DefaultValues[0]);
+                var member = eventType.GetMember(eventName, MemberTypes.Event, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+                if (member && SurfaceUtils.IsValidVisualScriptEvent(member))
+                {
+                    if (!member.IsStatic)
+                    {
+                        if (VisjectSurface.FullCastCheck(eventType, outputType, hint))
+                            return true;
+                    }
+                }
+                return false;
+            }
+            
+            internal static bool IsOutputCompatible(NodeArchetype nodeArch, ScriptType inputType, ConnectionsHint hint)
+            {
+                // Event based nodes always have a pulse output, so it's always compatible with void
+                if (inputType.IsVoid)
+                    return true;
+                
+                var eventName = (string)nodeArch.DefaultValues[1];
+                var eventType = TypeUtils.GetType((string)nodeArch.DefaultValues[0]);
+                var member = eventType.GetMember(eventName, MemberTypes.Event, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+                if (member && SurfaceUtils.IsValidVisualScriptEvent(member))
+                {
+                    if (VisjectSurface.FullCastCheck(member.ValueType, inputType, hint))
+                        return true;
+                }
+                return false;
+            }
         }
 
         private sealed class BindEventNode : EventBaseNode
@@ -2402,6 +2439,8 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 9,
                 Create = (id, context, arch, groupArch) => new BindEventNode(id, context, arch, groupArch),
+                IsInputCompatible = EventBaseNode.IsInputCompatible,
+                IsOutputCompatible = EventBaseNode.IsOutputCompatible,
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
                 Size = new Float2(260, 60),
@@ -2424,6 +2463,8 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 10,
                 Create = (id, context, arch, groupArch) => new UnbindEventNode(id, context, arch, groupArch),
+                IsInputCompatible = EventBaseNode.IsInputCompatible,
+                IsOutputCompatible = EventBaseNode.IsOutputCompatible,
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
                 Size = new Float2(260, 60),

--- a/Source/Editor/Surface/Archetypes/Function.cs
+++ b/Source/Editor/Surface/Archetypes/Function.cs
@@ -2228,6 +2228,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Function Input",
                 Description = "The graph function input data",
                 Flags = NodeFlags.MaterialGraph | NodeFlags.ParticleEmitterGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaPaste,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2247,6 +2248,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Function Output",
                 Description = "The graph function output data",
                 Flags = NodeFlags.MaterialGraph | NodeFlags.ParticleEmitterGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaPaste,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2265,6 +2267,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = string.Empty,
                 Description = "Overrides the base class method with custom implementation",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI | NodeFlags.NoSpawnViaPaste,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2279,6 +2282,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new InvokeMethodNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2302,6 +2306,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new ReturnNode(id, context, arch, groupArch),
                 Title = "Return",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(100, 40),
                 DefaultValues = new object[]
                 {
@@ -2320,6 +2325,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "New Function",
                 Description = "Adds a new function to the script",
                 Flags = NodeFlags.VisualScriptGraph,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 20),
                 DefaultValues = new object[]
                 {
@@ -2332,6 +2338,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new GetFieldNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2347,6 +2354,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new SetFieldNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {
@@ -2363,6 +2371,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new BindEventNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(260, 60),
                 DefaultValues = new object[]
                 {
@@ -2385,6 +2394,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new UnbindEventNode(id, context, arch, groupArch),
                 Title = string.Empty,
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.FunctionNode,
                 Size = new Float2(260, 60),
                 DefaultValues = new object[]
                 {

--- a/Source/Editor/Surface/Archetypes/Function.cs
+++ b/Source/Editor/Surface/Archetypes/Function.cs
@@ -744,6 +744,16 @@ namespace FlaxEditor.Surface.Archetypes
 
                 base.OnDestroy();
             }
+            
+            internal static bool IsInputCompatible(NodeArchetype nodeArch, ScriptType outputType, ConnectionsHint hint)
+            {
+                return false;
+            }
+            
+            internal static bool IsOutputCompatible(NodeArchetype nodeArch, ScriptType inputType, ConnectionsHint hint)
+            {
+                return inputType.IsVoid;
+            }
         }
 
         private sealed class InvokeMethodNode : SurfaceNode
@@ -2460,6 +2470,8 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = string.Empty,
                 Description = "Overrides the base class method with custom implementation",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.NoSpawnViaGUI | NodeFlags.NoSpawnViaPaste,
+                IsInputCompatible = MethodOverrideNode.IsInputCompatible,
+                IsOutputCompatible = MethodOverrideNode.IsOutputCompatible,
                 Size = new Float2(240, 60),
                 DefaultValues = new object[]
                 {

--- a/Source/Editor/Surface/Archetypes/Function.cs
+++ b/Source/Editor/Surface/Archetypes/Function.cs
@@ -773,7 +773,7 @@ namespace FlaxEditor.Surface.Archetypes
                     Values[4] = GetSignatureData(memberInfo, memberInfo.GetParameters());
                 }
             }
-            
+
             private SignatureInfo LoadSignature()
             {
                 var signature = new SignatureInfo();

--- a/Source/Editor/Surface/Archetypes/Packing.cs
+++ b/Source/Editor/Surface/Archetypes/Packing.cs
@@ -353,7 +353,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new PackStructureNode(id, context, arch, groupArch),
                 Description = "Makes the structure data to from the components.",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.PackingNode,
                 Size = new Float2(180, 20),
                 DefaultValues = new object[]
                 {
@@ -464,7 +463,6 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new UnpackStructureNode(id, context, arch, groupArch),
                 Description = "Breaks the structure data to allow extracting components from it.",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaGUI,
-                NodeTypeHint = NodeTypeHint.PackingNode,
                 Size = new Float2(180, 20),
                 DefaultValues = new object[]
                 {

--- a/Source/Editor/Surface/Archetypes/Packing.cs
+++ b/Source/Editor/Surface/Archetypes/Packing.cs
@@ -207,6 +207,26 @@ namespace FlaxEditor.Surface.Archetypes
                     AddElement(box);
                 }
             }
+            
+            protected static bool IsInputCompatible(NodeArchetype nodeArch, ScriptType outputType, ConnectionsHint hint)
+            {
+                // Event based nodes always have a pulse input, so it's always compatible with void
+                if (outputType.IsVoid)
+                    return true;
+                
+                var eventName = (string)nodeArch.DefaultValues[1];
+                var eventType = TypeUtils.GetType((string)nodeArch.DefaultValues[0]);
+                var member = eventType.GetMember(eventName, MemberTypes.Event, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+                if (member && SurfaceUtils.IsValidVisualScriptEvent(member))
+                {
+                    if (!member.IsStatic)
+                    {
+                        if (VisjectSurface.FullCastCheck(eventType, outputType, hint))
+                            return true;
+                    }
+                }
+                return false;
+            }
         }
 
         private sealed class PackStructureNode : StructureNode
@@ -216,6 +236,35 @@ namespace FlaxEditor.Surface.Archetypes
             : base(id, context, nodeArch, groupArch, false)
             {
             }
+            
+            internal static bool IsInputCompatible(NodeArchetype nodeArch, ScriptType outputType, ConnectionsHint hint)
+            {
+                var typeName = (string)nodeArch.DefaultValues[0];
+                var type = TypeUtils.GetType(typeName);
+                if (type)
+                {
+                    var fields = type.GetMembers(BindingFlags.Public | BindingFlags.Instance).Where(x => x.IsField).ToArray();
+                    var fieldsLength = fields.Length;
+                    for (var i = 0; i < fieldsLength; i++)
+                    {
+                        if (VisjectSurface.FullCastCheck(fields[i].ValueType, outputType, hint))
+                            return true;
+                    }
+                }
+                return false;
+            }
+            
+            internal static bool IsOutputCompatible(NodeArchetype nodeArch, ScriptType inputType, ConnectionsHint hint)
+            {
+                var typeName = (string)nodeArch.DefaultValues[0];
+                var type = TypeUtils.GetType(typeName);
+                if (type)
+                {
+                    if (VisjectSurface.FullCastCheck(type, inputType, hint))
+                        return true;
+                }
+                return false;
+            }
         }
 
         private sealed class UnpackStructureNode : StructureNode
@@ -224,6 +273,35 @@ namespace FlaxEditor.Surface.Archetypes
             public UnpackStructureNode(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
             : base(id, context, nodeArch, groupArch, true)
             {
+            }
+
+            internal static bool IsInputCompatible(NodeArchetype nodeArch, ScriptType outputType, ConnectionsHint hint)
+            {
+                var typeName = (string)nodeArch.DefaultValues[0];
+                var type = TypeUtils.GetType(typeName);
+                if (type)
+                {
+                    if (VisjectSurface.FullCastCheck(type, outputType, hint))
+                        return true;
+                }
+                return false;
+            }
+            
+            internal static bool IsOutputCompatible(NodeArchetype nodeArch, ScriptType inputType, ConnectionsHint hint)
+            {
+                var typeName = (string)nodeArch.DefaultValues[0];
+                var type = TypeUtils.GetType(typeName);
+                if (type)
+                {
+                    var fields = type.GetMembers(BindingFlags.Public | BindingFlags.Instance).Where(x => x.IsField).ToArray();
+                    var fieldsLength = fields.Length;
+                    for (var i = 0; i < fieldsLength; i++)
+                    {
+                        if (VisjectSurface.FullCastCheck(fields[i].ValueType, inputType, hint))
+                            return true;
+                    }
+                }
+                return false;
             }
         }
 
@@ -351,6 +429,8 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 26,
                 Title = "Pack Structure",
                 Create = (id, context, arch, groupArch) => new PackStructureNode(id, context, arch, groupArch),
+                IsInputCompatible = PackStructureNode.IsInputCompatible,
+                IsOutputCompatible = PackStructureNode.IsOutputCompatible,
                 Description = "Makes the structure data to from the components.",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaGUI,
                 Size = new Float2(180, 20),
@@ -461,6 +541,8 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 36,
                 Title = "Unpack Structure",
                 Create = (id, context, arch, groupArch) => new UnpackStructureNode(id, context, arch, groupArch),
+                IsInputCompatible = UnpackStructureNode.IsInputCompatible,
+                IsOutputCompatible = UnpackStructureNode.IsOutputCompatible,
                 Description = "Breaks the structure data to allow extracting components from it.",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaGUI,
                 Size = new Float2(180, 20),

--- a/Source/Editor/Surface/Archetypes/Packing.cs
+++ b/Source/Editor/Surface/Archetypes/Packing.cs
@@ -353,6 +353,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new PackStructureNode(id, context, arch, groupArch),
                 Description = "Makes the structure data to from the components.",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.PackingNode,
                 Size = new Float2(180, 20),
                 DefaultValues = new object[]
                 {
@@ -463,6 +464,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Create = (id, context, arch, groupArch) => new UnpackStructureNode(id, context, arch, groupArch),
                 Description = "Breaks the structure data to allow extracting components from it.",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaGUI,
+                NodeTypeHint = NodeTypeHint.PackingNode,
                 Size = new Float2(180, 20),
                 DefaultValues = new object[]
                 {

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -419,7 +419,7 @@ namespace FlaxEditor.Surface.ContextMenu
 
             Profiler.BeginEvent("VisjectCM.OnSearchFilterChanged");
             
-            if (string.IsNullOrEmpty(_searchBox.Text))
+            if (string.IsNullOrEmpty(_searchBox.Text) && _selectedBox == null)
             {
                 ResetView();
                 Profiler.EndEvent();
@@ -430,7 +430,7 @@ namespace FlaxEditor.Surface.ContextMenu
             LockChildrenRecursive();
             for (int i = 0; i < _groups.Count; i++)
             {
-                _groups[i].UpdateFilter(_searchBox.Text);
+                _groups[i].UpdateFilter(_searchBox.Text, _selectedBox);
                 _groups[i].UpdateItemSort(_selectedBox);
             }
             SortGroups();
@@ -503,12 +503,19 @@ namespace FlaxEditor.Surface.ContextMenu
             _searchBox.Clear();
             SelectedItem = null;
             for (int i = 0; i < _groups.Count; i++)
+            {
                 _groups[i].ResetView();
+            }
             UnlockChildrenRecursive();
 
             SortGroups();
             PerformLayout();
 
+            for (int i = 0; i < _groups.Count; i++)
+            {
+                _groups[i].EvaluateVisibilityWithBox(_selectedBox);
+            }
+            
             Profiler.EndEvent();
         }
 
@@ -626,10 +633,11 @@ namespace FlaxEditor.Surface.ContextMenu
             // Prepare
             UpdateSurfaceParametersGroup();
             ResetView();
+            
             _panel1.VScrollBar.TargetValue = 0;
             Focus();
             _waitingForInput = true;
-
+            
             base.OnShow();
         }
 

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -505,9 +505,6 @@ namespace FlaxEditor.Surface.ContextMenu
             for (int i = 0; i < _groups.Count; i++)
             {
                 _groups[i].ResetView();
-            }
-            for (int i = 0; i < _groups.Count; i++)
-            {
                 _groups[i].EvaluateVisibilityWithBox(_selectedBox);
             }
             UnlockChildrenRecursive();

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -506,15 +506,14 @@ namespace FlaxEditor.Surface.ContextMenu
             {
                 _groups[i].ResetView();
             }
-            UnlockChildrenRecursive();
-
-            SortGroups();
-            PerformLayout();
-
             for (int i = 0; i < _groups.Count; i++)
             {
                 _groups[i].EvaluateVisibilityWithBox(_selectedBox);
             }
+            UnlockChildrenRecursive();
+
+            SortGroups();
+            PerformLayout();
             
             Profiler.EndEvent();
         }

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Input;
-using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Utilities;

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -450,7 +450,25 @@ namespace FlaxEditor.Surface.ContextMenu
                 return;
 
             Profiler.BeginEvent("VisjectCM.OnSearchFilterChanged");
+            UpdateFilters();
+            _searchBox.Focus();
+            Profiler.EndEvent();
+        }
+
+        private void OnContextSensitiveToggleStateChanged(CheckBox checkBox)
+        {
+            // Skip events during setup or init stuff
+            if (IsLayoutLocked)
+                return;
             
+            Profiler.BeginEvent("VisjectCM.OnContextSensitiveToggleStateChanged");
+            _contextSensitiveSearchEnabled = checkBox.Checked;
+            UpdateFilters();
+            Profiler.EndEvent();
+        }
+
+        private void UpdateFilters()
+        {
             if (string.IsNullOrEmpty(_searchBox.Text) && _selectedBox == null)
             {
                 ResetView();
@@ -475,33 +493,6 @@ namespace FlaxEditor.Surface.ContextMenu
             PerformLayout();
             if (SelectedItem != null)
                 _panel1.ScrollViewTo(SelectedItem);
-            _searchBox.Focus();
-            Profiler.EndEvent();
-
-            Profiler.EndEvent();
-        }
-
-        private void OnContextSensitiveToggleStateChanged(CheckBox checkBox)
-        {
-            Profiler.BeginEvent("VisjectCM.OnContextSensitiveToggleStateChanged");
-            _contextSensitiveSearchEnabled = checkBox.Checked;
-            
-            LockChildrenRecursive();
-            for (int i = 0; i < _groups.Count; i++)
-            {
-                _groups[i].UpdateFilter(_searchBox.Text, _contextSensitiveSearchEnabled ? _selectedBox : null);
-            }
-            SortGroups();
-            UnlockChildrenRecursive();
-            
-            Profiler.BeginEvent("VisjectCM.Layout");
-            if (SelectedItem == null || !SelectedItem.VisibleInHierarchy)
-                SelectedItem = _groups.Find(g => g.Visible)?.Children.Find(c => c.Visible && c is VisjectCMItem) as VisjectCMItem;
-            PerformLayout();
-            if (SelectedItem != null)
-                _panel1.ScrollViewTo(SelectedItem);
-            Profiler.EndEvent();
-            
             Profiler.EndEvent();
         }
         

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -494,7 +494,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 _panel1.ScrollViewTo(SelectedItem);
             Profiler.EndEvent();
         }
-        
+
         /// <summary>
         /// Sort the groups and keeps <see cref="_groups"/> in sync
         /// </summary>
@@ -558,7 +558,7 @@ namespace FlaxEditor.Surface.ContextMenu
 
             SortGroups();
             PerformLayout();
-            
+
             Profiler.EndEvent();
         }
 
@@ -676,11 +676,10 @@ namespace FlaxEditor.Surface.ContextMenu
             // Prepare
             UpdateSurfaceParametersGroup();
             ResetView();
-            
             _panel1.VScrollBar.TargetValue = 0;
             Focus();
             _waitingForInput = true;
-            
+
             base.OnShow();
         }
 

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -288,6 +288,10 @@ namespace FlaxEditor.Surface.ContextMenu
                         OnSearchFilterChanged();
                     }
                 }
+                else
+                {
+                    group.EvaluateVisibilityWithBox(_selectedBox);
+                }
 
                 Profiler.EndEvent();
             }
@@ -321,6 +325,7 @@ namespace FlaxEditor.Surface.ContextMenu
                             Parent = group
                         };
                     }
+                    group.EvaluateVisibilityWithBox(_selectedBox); 
                     group.SortChildren();
                     group.Parent = _groupsPanel;
                     _groups.Add(group);

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -40,6 +40,8 @@ namespace FlaxEditor.Surface.ContextMenu
         public delegate List<SurfaceParameter> ParameterGetterDelegate();
 
         private readonly List<VisjectCMGroup> _groups = new List<VisjectCMGroup>(16);
+        private CheckBox _contextSensitiveToggle;
+        private bool _contextSensitiveSearchEnabled = true;
         private readonly TextBox _searchBox;
         private bool _waitingForInput;
         private VisjectCMGroup _surfaceParametersGroup;
@@ -127,7 +129,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 _parameterSetNodeArchetype = info.ParameterSetNodeArchetype ?? Archetypes.Parameters.Nodes[3];
 
             // Context menu dimensions
-            Size = new Float2(320, 248);
+            Size = new Float2(300, 400);
 
             var headerPanel = new Panel(ScrollBars.None)
             {
@@ -139,17 +141,40 @@ namespace FlaxEditor.Surface.ContextMenu
             };
 
             // Title bar
+            var titleFontReference = new FontReference(Style.Current.FontLarge.Asset, 10);
             var titleLabel = new Label
             {
-                Width = Width - 8,
+                Width = Width * 0.5f - 8f,
                 Height = 20,
                 X = 4,
                 Parent = headerPanel,
                 Text = "Select Node",
-                HorizontalAlignment = TextAlignment.Center,
-                Font = new FontReference(Style.Current.FontLarge.Asset, 10),
+                HorizontalAlignment = TextAlignment.Near,
+                Font = titleFontReference,
             };
 
+            // Context sensitive toggle
+            var contextSensitiveLabel = new Label
+            {
+                Width = Width * 0.5f - 28,
+                Height = 20,
+                X = Width * 0.5f,
+                Parent = headerPanel,
+                Text = "Context Sensitive",
+                HorizontalAlignment = TextAlignment.Far,
+                Font = titleFontReference,
+            };
+            
+            _contextSensitiveToggle = new CheckBox
+            {
+                Width = 20,
+                Height = 20,
+                X = Width - 24,
+                Parent = headerPanel,
+                Checked = _contextSensitiveSearchEnabled,
+            };
+            _contextSensitiveToggle.StateChanged += OnContextSensitiveToggleStateChanged;
+            
             // Search box
             _searchBox = new SearchBox(false, 2, 22)
             {
@@ -249,6 +274,11 @@ namespace FlaxEditor.Surface.ContextMenu
                     group.SortChildren();
                 }
             }
+        }
+
+        private void OnContextSensitiveToggleStateChanged(CheckBox checkBox)
+        {
+            _contextSensitiveSearchEnabled = checkBox.Checked;
         }
 
         /// <summary>
@@ -767,6 +797,13 @@ namespace FlaxEditor.Surface.ContextMenu
         private IEnumerable<T> GetPreviousSiblings<T>(Control item) where T : Control
         {
             return GetPreviousSiblings(item).OfType<T>();
+        }
+
+        /// <inheritdoc />
+        public override void OnDestroy()
+        {
+            _contextSensitiveToggle.StateChanged -= OnContextSensitiveToggleStateChanged;
+            base.OnDestroy();
         }
     }
 }

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -90,25 +90,13 @@ namespace FlaxEditor.Surface.ContextMenu
 
             // Update items
             bool isAnyVisible = false;
+            bool groupHeaderMatches = QueryFilterHelper.Match(filterText, HeaderText);
             for (int i = 0; i < _children.Count; i++)
             {
                 if (_children[i] is VisjectCMItem item)
                 {
-                    item.UpdateFilter(filterText, selectedBox);
+                    item.UpdateFilter(filterText, selectedBox, groupHeaderMatches);
                     isAnyVisible |= item.Visible;
-                }
-            }
-
-            // Update header title
-            if (QueryFilterHelper.Match(filterText, HeaderText))
-            {
-                for (int i = 0; i < _children.Count; i++)
-                {
-                    if (_children[i] is VisjectCMItem item)
-                    {
-                        item.UpdateFilter(null, selectedBox);
-                        isAnyVisible |= item.Visible;
-                    }
                 }
             }
 
@@ -136,7 +124,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 {
                     if (_children[i] is VisjectCMItem item)
                     {
-                        item.CanConnectTo(null);
+                        item.Visible = true;
                     }
                 }
                 Visible = true;
@@ -150,7 +138,8 @@ namespace FlaxEditor.Surface.ContextMenu
             {
                 if (_children[i] is VisjectCMItem item)
                 {
-                    isAnyVisible |= item.CanConnectTo(selectedBox);
+                    item.Visible = item.CanConnectTo(selectedBox);
+                    isAnyVisible |= item.Visible;
                 }
             }
             

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -153,10 +153,10 @@ namespace FlaxEditor.Surface.ContextMenu
                 // Hide group if none of the items matched the filter
                 Visible = false;
             }
-            
+
             Profiler.EndEvent();
         }
-        
+
         /// <summary>
         /// Updates the sorting of the <see cref="VisjectCMItem"/>s of this <see cref="VisjectCMGroup"/>
         /// Also updates the <see cref="SortScore"/>

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -66,7 +66,7 @@ namespace FlaxEditor.Surface.ContextMenu
             {
                 if (_children[i] is VisjectCMItem item)
                 {
-                    item.UpdateFilter(null);
+                    item.UpdateFilter(null, null);
                     item.UpdateScore(null);
                 }
             }
@@ -84,7 +84,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// Updates the filter.
         /// </summary>
         /// <param name="filterText">The filter text.</param>
-        public void UpdateFilter(string filterText)
+        public void UpdateFilter(string filterText, Box selectedBox)
         {
             Profiler.BeginEvent("VisjectCMGroup.UpdateFilter");
 
@@ -94,13 +94,13 @@ namespace FlaxEditor.Surface.ContextMenu
             {
                 if (_children[i] is VisjectCMItem item)
                 {
-                    item.UpdateFilter(filterText);
+                    item.UpdateFilter(filterText, selectedBox);
                     isAnyVisible |= item.Visible;
                 }
             }
 
             // Update header title
-            if (QueryFilterHelper.Match(filterText, HeaderText))
+            /*if (QueryFilterHelper.Match(filterText, HeaderText))
             {
                 for (int i = 0; i < _children.Count; i++)
                 {
@@ -110,7 +110,7 @@ namespace FlaxEditor.Surface.ContextMenu
                     }
                 }
                 isAnyVisible = true;
-            }
+            }*/
 
             // Update itself
             if (isAnyVisible)
@@ -128,6 +128,35 @@ namespace FlaxEditor.Surface.ContextMenu
             Profiler.EndEvent();
         }
 
+        public void EvaluateVisibilityWithBox(Box selectedBox)
+        {
+            if (selectedBox == null)
+            {
+                Visible = true;
+                return;
+            }
+
+            bool isAnyVisible = false;
+            for (int i = 0; i < _children.Count; i++)
+            {
+                if (_children[i] is VisjectCMItem item)
+                {
+                    isAnyVisible |= item.IsCompatibleWithBox(selectedBox);
+                }
+            }
+            
+            // Update itself
+            if (isAnyVisible)
+            {
+                Visible = true;
+            }
+            else
+            {
+                // Hide group if none of the items matched the filter
+                Visible = false;
+            }
+        }
+        
         /// <summary>
         /// Updates the sorting of the <see cref="VisjectCMItem"/>s of this <see cref="VisjectCMGroup"/>
         /// Also updates the <see cref="SortScore"/>

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -132,6 +132,13 @@ namespace FlaxEditor.Surface.ContextMenu
         {
             if (selectedBox == null)
             {
+                for (int i = 0; i < _children.Count; i++)
+                {
+                    if (_children[i] is VisjectCMItem item)
+                    {
+                        item.CanConnectTo(null);
+                    }
+                }
                 Visible = true;
                 return;
             }

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -136,6 +136,8 @@ namespace FlaxEditor.Surface.ContextMenu
                 return;
             }
 
+            Profiler.BeginEvent("VisjectCMGroup.EvaluateVisibilityWithBox");
+            
             bool isAnyVisible = false;
             for (int i = 0; i < _children.Count; i++)
             {
@@ -155,6 +157,8 @@ namespace FlaxEditor.Surface.ContextMenu
                 // Hide group if none of the items matched the filter
                 Visible = false;
             }
+            
+            Profiler.EndEvent();
         }
         
         /// <summary>

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -143,7 +143,7 @@ namespace FlaxEditor.Surface.ContextMenu
             {
                 if (_children[i] is VisjectCMItem item)
                 {
-                    isAnyVisible |= item.IsCompatibleWithBox(selectedBox);
+                    isAnyVisible |= item.CanConnectTo(selectedBox);
                 }
             }
             

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -100,17 +100,17 @@ namespace FlaxEditor.Surface.ContextMenu
             }
 
             // Update header title
-            /*if (QueryFilterHelper.Match(filterText, HeaderText))
+            if (QueryFilterHelper.Match(filterText, HeaderText))
             {
                 for (int i = 0; i < _children.Count; i++)
                 {
                     if (_children[i] is VisjectCMItem item)
                     {
-                        item.Visible = true;
+                        item.UpdateFilter(null, selectedBox);
+                        isAnyVisible |= item.Visible;
                     }
                 }
-                isAnyVisible = true;
-            }*/
+            }
 
             // Update itself
             if (isAnyVisible)

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -121,13 +121,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 Visible = true;
                 return true;   
             }
-
-            if (_archetype.Title == "GetChild")
-            {
-                Debug.Log("");
-                Debug.Log(_archetype.Create == null);
-                Debug.Log(_archetype.Create.GetType() == typeof(FlaxEditor.Surface.Archetypes.Function.MethodOverrideNode));
-            }
             
             if (_archetype?.Elements == null)
             {
@@ -161,15 +154,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 }
                 
                 bool checkCompatibility = CanCastToType(inType, outType, hint);
-                /*if (!checkCompatibility)
-                {
-                    /*checkCompatibility = element.ConnectionsType == null && startBox.CurrentType != ScriptType.Object;#1#
-                    checkCompatibility = 
-                }*/
                 isCompatible |= checkCompatibility;
-                
-                /*if(!isCompatible)
-                    Debug.Log($"Is {_archetype.Title} cant connect type {element.ConnectionsType}");*/
             }
             
             Visible = isCompatible;

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -121,6 +121,8 @@ namespace FlaxEditor.Surface.ContextMenu
             if(_archetype?.Elements == null)
                 return false;
             
+            Profiler.BeginEvent("VisjectCMItem.IsCompatibleWithBox");
+            
             bool isCompatible = false;
             foreach (NodeElementArchetype element in _archetype.Elements)
             {
@@ -129,11 +131,11 @@ namespace FlaxEditor.Surface.ContextMenu
                 
                 if ((box.IsOutput && element.Type == NodeElementType.Output) || (!box.IsOutput && element.Type == NodeElementType.Input))
                     continue;
-                
-                bool checkCompatibility = box.CanUseType(element.ConnectionsType);;
+
+                bool checkCompatibility = ((element.ConnectionsType == null || element.ConnectionsType == typeof(void)) && box.CurrentType != typeof(FlaxEngine.Object));
                 if (!checkCompatibility)
                 {
-                    if ((element.ConnectionsType == null || element.ConnectionsType == typeof(void)) && box.CurrentType != typeof(FlaxEngine.Object))
+                    if (box.CanUseType(element.ConnectionsType))
                         checkCompatibility = true;
                 }
                 isCompatible |= checkCompatibility;
@@ -143,6 +145,8 @@ namespace FlaxEditor.Surface.ContextMenu
             }
             
             Visible = isCompatible;
+            
+            Profiler.EndEvent();
             return isCompatible;
         }
         

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -156,32 +156,37 @@ namespace FlaxEditor.Surface.ContextMenu
                     if(memberInfo.IsEvent)
                         isCompatible = false;
                     
-                    if (startBox.IsOutput)
-                    {
-                        var parameters = memberInfo.GetParameters();
-                        ScriptType outType = startBox.CurrentType;
-
-                        if (startBox.CurrentType.IsVoid && memberInfo.ValueType.IsVoid)
-                            isCompatible = true;
-                        
-                        if (!memberInfo.IsStatic)
-                        {
-                            var scriptType = TypeUtils.GetType((string)_archetype.DefaultValues[0]);
-                            isCompatible |= CanCastToType(scriptType, outType, _archetype.ConnectionsHints);
-                        }
-
-                        if (!memberInfo.IsEvent)
-                        {
-                            for (int i = 0; i < parameters.Length; i++)
-                            {
-                                ScriptType inType = parameters[i].Type;
-                                isCompatible |= CanCastToType(inType, outType, _archetype.ConnectionsHints);
-                            }
-                        }
-                    }
+                    if (startBox.CurrentType.IsVoid && memberInfo.ValueType.IsVoid)
+                        isCompatible = true;
                     else
                     {
+                        if (startBox.IsOutput)
+                        {
+                            var parameters = memberInfo.GetParameters();
+                            ScriptType outType = startBox.CurrentType;
 
+                            if (!memberInfo.IsStatic)
+                            {
+                                var scriptType = memberInfo.DeclaringType;
+                                isCompatible |= CanCastToType(scriptType, outType, _archetype.ConnectionsHints);
+                            }
+
+                            if (!memberInfo.IsEvent)
+                            {
+                                for (int i = 0; i < parameters.Length; i++)
+                                {
+                                    ScriptType inType = parameters[i].Type;
+                                    isCompatible |= CanCastToType(inType, outType, _archetype.ConnectionsHints);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            ScriptType inType = startBox.CurrentType;
+                            ScriptType outType = memberInfo.ValueType;
+
+                            isCompatible |= CanCastToType(inType, outType, _archetype.ConnectionsHints);
+                        }
                     }
                 }
             }

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -58,7 +58,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <param name="groupArchetype">The group archetype.</param>
         /// <param name="archetype">The archetype.</param>
         public VisjectCMItem(VisjectCMGroup group, GroupArchetype groupArchetype, NodeArchetype archetype)
-        : base(0, 0, 120, 12)
+        : base(0, 0, 120, 14)
         {
             Group = group;
             _groupArchetype = groupArchetype;

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -113,12 +113,51 @@ namespace FlaxEditor.Surface.ContextMenu
             return false;
         }
 
+        public bool IsCompatibleWithBox(Box box)
+        {
+            if (box == null)
+                return true;
+            
+            if(_archetype?.Elements == null)
+                return false;
+            
+            bool isCompatible = false;
+            foreach (NodeElementArchetype element in _archetype.Elements)
+            {
+                if(element.Type != NodeElementType.Output && element.Type != NodeElementType.Input)
+                    continue;
+                
+                if ((box.IsOutput && element.Type == NodeElementType.Output) || (!box.IsOutput && element.Type == NodeElementType.Input))
+                    continue;
+                
+                bool checkCompatibility = box.CanUseType(element.ConnectionsType);;
+                if (!checkCompatibility)
+                {
+                    if ((element.ConnectionsType == null || element.ConnectionsType == typeof(void)) && box.CurrentType != typeof(FlaxEngine.Object))
+                        checkCompatibility = true;
+                }
+                isCompatible |= checkCompatibility;
+                
+                /*if(!isCompatible)
+                    Debug.Log($"Is {_archetype.Title} cant connect type {element.ConnectionsType}");*/
+            }
+            
+            Visible = isCompatible;
+            return isCompatible;
+        }
+        
         /// <summary>
         /// Updates the filter.
         /// </summary>
         /// <param name="filterText">The filter text.</param>
-        public void UpdateFilter(string filterText)
+        public void UpdateFilter(string filterText, Box selectedBox)
         {
+            if (selectedBox != null)
+            {
+                if (!IsCompatibleWithBox(selectedBox))
+                    return;
+            }
+            
             _isStartsWithMatch = _isFullMatch = false;
             if (filterText == null)
             {
@@ -192,7 +231,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 }
             }
         }
-
+        
         /// <inheritdoc />
         public override void Draw()
         {

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -109,7 +109,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 return false;
 
             bool isCompatible = false;
-
             if (startBox.IsOutput && _archetype.IsInputCompatible != null)
             {
                 isCompatible |= _archetype.IsInputCompatible.Invoke(_archetype, startBox.CurrentType, _archetype.ConnectionsHints);
@@ -124,79 +123,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 isCompatible = CheckElementsCompatibility(startBox);
             }
             
-            // Check compatibility based on the archetype tag or name. This handles custom groups and items, mainly function nodes for visual scripting
-            /*if (_archetype.NodeTypeHint is NodeTypeHint.FunctionNode)
-            {
-                ScriptMemberInfo memberInfo = ScriptMemberInfo.Null;
-
-                // Check if the archetype tag already has a member info otherwise try to fetch it via the archetype type and name
-                // Only really the InvokeMethod Nodes have a member info in their tag
-                if (_archetype.Tag is ScriptMemberInfo tagInfo)
-                {
-                    memberInfo = tagInfo;
-                }
-                else if(_archetype.DefaultValues is { Length: > 1 }) // We have to check since VisualScriptFunctionNode and ReturnNode don't have a name and type
-                {
-                    var eventName = (string)_archetype.DefaultValues[1];
-                    var eventType = TypeUtils.GetType((string)_archetype.DefaultValues[0]);
-                    memberInfo = eventType.GetMember(eventName, System.Reflection.MemberTypes.Event, 
-                                                     System.Reflection.BindingFlags.Public | 
-                                                     System.Reflection.BindingFlags.Static | 
-                                                     System.Reflection.BindingFlags.Instance);
-                }
-
-                if (memberInfo != ScriptMemberInfo.Null)
-                {
-                    isCompatible |= CheckMemberInfoCompatibility(startBox, memberInfo);
-                }
-            }*/
-            /*else */
-            
-            return isCompatible;
-        }
-
-        private bool CheckMemberInfoCompatibility(Box startBox, ScriptMemberInfo info)
-        {
-            bool isCompatible = false;
-            // Box was dragged from an impulse port and the member info can be invoked so it is compatible
-            if (startBox.CurrentType.IsVoid && info.ValueType.IsVoid)
-            {
-                isCompatible = true;   
-            }
-            else
-            {
-                // When the startBox is output we only need to check the input parameters
-                if (startBox.IsOutput && !info.IsField)
-                {
-                    var parameters = info.GetParameters();
-                    ScriptType outType = startBox.CurrentType;
-                    
-                    // non static members have an instance input parameter
-                    if (!info.IsStatic)
-                    {
-                        var scriptType = info.DeclaringType;
-                        isCompatible |= VisjectSurface.FullCastCheck(scriptType, outType, _archetype.ConnectionsHints);
-                    }
-
-                    // We ignore event members here since they only have output parameters, which are currently not declared as such
-                    if (!info.IsEvent)
-                    {
-                        for (int i = 0; i < parameters.Length; i++)
-                        {
-                            ScriptType inType = parameters[i].Type;
-                            isCompatible |= VisjectSurface.FullCastCheck(inType, outType, _archetype.ConnectionsHints);
-                        }
-                    }
-                }
-                else
-                {
-                    // When the startBox is input we only have to check the output type of the method
-                    ScriptType inType = startBox.CurrentType;
-                    ScriptType outType = info.ValueType;
-
-                    isCompatible |= VisjectSurface.FullCastCheck(inType, outType, _archetype.ConnectionsHints);
-                }
-            }
             return isCompatible;
         }
         

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -309,11 +309,14 @@ namespace FlaxEditor.Surface.ContextMenu
             if (selectedBox != null)
             {
                 if (!CanConnectTo(selectedBox))
+                {
+                    _highlights?.Clear();
                     return;
+                }
             }
             
             _isStartsWithMatch = _isFullMatch = false;
-            if (filterText == null)
+            if (string.IsNullOrEmpty(filterText))
             {
                 // Clear filter
                 _highlights?.Clear();

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -117,10 +117,23 @@ namespace FlaxEditor.Surface.ContextMenu
         public bool CanConnectTo(Box startBox)
         {
             if (startBox == null)
-                return true;
+            {
+                Visible = true;
+                return true;   
+            }
+
+            if (_archetype.Title == "GetChild")
+            {
+                Debug.Log("");
+                Debug.Log(_archetype.Create == null);
+                Debug.Log(_archetype.Create.GetType() == typeof(FlaxEditor.Surface.Archetypes.Function.MethodOverrideNode));
+            }
             
-            if(_archetype?.Elements == null)
+            if (_archetype?.Elements == null)
+            {
+                Visible = false;
                 return false;
+            }
             
             bool isCompatible = false;
             foreach (NodeElementArchetype element in _archetype.Elements)

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -336,7 +336,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 }
             }
         }
-        
+
         /// <inheritdoc />
         public override void Draw()
         {

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -138,7 +138,6 @@ namespace FlaxEditor.Surface.ContextMenu
 
             if (_archetype.NodeTypeHint == NodeTypeHint.FunctionNode)
             {
-                isCompatible = false;
                 ScriptMemberInfo memberInfo = ScriptMemberInfo.Null;
 
                 if (_archetype.Tag is ScriptMemberInfo info)
@@ -154,11 +153,17 @@ namespace FlaxEditor.Surface.ContextMenu
 
                 if (memberInfo != ScriptMemberInfo.Null)
                 {
+                    if(memberInfo.IsEvent)
+                        isCompatible = false;
+                    
                     if (startBox.IsOutput)
                     {
                         var parameters = memberInfo.GetParameters();
                         ScriptType outType = startBox.CurrentType;
 
+                        if (startBox.CurrentType.IsVoid && memberInfo.ValueType.IsVoid)
+                            isCompatible = true;
+                        
                         if (!memberInfo.IsStatic)
                         {
                             var scriptType = TypeUtils.GetType((string)_archetype.DefaultValues[0]);

--- a/Source/Editor/Surface/Elements/Box.cs
+++ b/Source/Editor/Surface/Elements/Box.cs
@@ -231,58 +231,8 @@ namespace FlaxEditor.Surface.Elements
             }
 
             // Check using connection hints
-            var connectionsHints = ParentNode.Archetype.ConnectionsHints;
-            if (Archetype.ConnectionsType == ScriptType.Null && connectionsHints != ConnectionsHint.None)
-            {
-                if ((connectionsHints & ConnectionsHint.Anything) == ConnectionsHint.Anything)
-                    return true;
-                if ((connectionsHints & ConnectionsHint.Value) == ConnectionsHint.Value && type.Type != typeof(void))
-                    return true;
-                if ((connectionsHints & ConnectionsHint.Enum) == ConnectionsHint.Enum && type.IsEnum)
-                    return true;
-                if ((connectionsHints & ConnectionsHint.Array) == ConnectionsHint.Array && type.IsArray)
-                    return true;
-                if ((connectionsHints & ConnectionsHint.Dictionary) == ConnectionsHint.Dictionary && type.IsDictionary)
-                    return true;
-                if ((connectionsHints & ConnectionsHint.Vector) == ConnectionsHint.Vector)
-                {
-                    var t = type.Type;
-                    if (t == typeof(Vector2) ||
-                        t == typeof(Vector3) ||
-                        t == typeof(Vector4) ||
-                        t == typeof(Float2) ||
-                        t == typeof(Float3) ||
-                        t == typeof(Float4) ||
-                        t == typeof(Double2) ||
-                        t == typeof(Double3) ||
-                        t == typeof(Double4) ||
-                        t == typeof(Int2) ||
-                        t == typeof(Int3) ||
-                        t == typeof(Int4) ||
-                        t == typeof(Color))
-                    {
-                        return true;
-                    }
-                }
-                if ((connectionsHints & ConnectionsHint.Scalar) == ConnectionsHint.Scalar)
-                {
-                    var t = type.Type;
-                    if (t == typeof(bool) ||
-                        t == typeof(char) ||
-                        t == typeof(byte) ||
-                        t == typeof(short) ||
-                        t == typeof(ushort) ||
-                        t == typeof(int) ||
-                        t == typeof(uint) ||
-                        t == typeof(long) ||
-                        t == typeof(ulong) ||
-                        t == typeof(float) ||
-                        t == typeof(double))
-                    {
-                        return true;
-                    }
-                }
-            }
+            if(VisjectSurface.IsTypeCompatible(Archetype.ConnectionsType, type, ParentNode.Archetype.ConnectionsHints))
+                return true;
 
             // Check independent and if there is box with bigger potential because it may block current one from changing type
             var parentArch = ParentNode.Archetype;

--- a/Source/Editor/Surface/Elements/Box.cs
+++ b/Source/Editor/Surface/Elements/Box.cs
@@ -91,7 +91,7 @@ namespace FlaxEditor.Surface.Elements
                     _currentType = value;
 
                     // Check if will need to update box connections due to type change
-                    if ((Surface == null || Surface._isUpdatingBoxTypes == 0) && HasAnyConnection && !CanCast(prev, _currentType))
+                    if ((Surface == null || Surface._isUpdatingBoxTypes == 0) && HasAnyConnection && !prev.CanCastTo(_currentType))
                     {
                         // Remove all invalid connections and update those which still can be valid
                         var connections = Connections.ToArray();
@@ -246,7 +246,7 @@ namespace FlaxEditor.Surface.Elements
                     var b = ParentNode.GetBox(boxes[i]);
 
                     // Check if its the same and tested type matches the default value type
-                    if (b == this && CanCast(parentArch.DefaultType, type))
+                    if (b == this && parentArch.DefaultType.CanCastTo(type))
                     {
                         // Can
                         return true;
@@ -668,17 +668,6 @@ namespace FlaxEditor.Surface.Elements
             }
         }
 
-        private static bool CanCast(ScriptType oB, ScriptType iB)
-        {
-            if (oB == iB)
-                return true;
-            if (oB == ScriptType.Null || iB == ScriptType.Null)
-                return false;
-            return (oB.Type != typeof(void) && oB.Type != typeof(FlaxEngine.Object)) &&
-                   (iB.Type != typeof(void) && iB.Type != typeof(FlaxEngine.Object)) &&
-                   oB.IsAssignableFrom(iB);
-        }
-
         /// <inheritdoc />
         public bool AreConnected(IConnectionInstigator other)
         {
@@ -737,7 +726,7 @@ namespace FlaxEditor.Surface.Elements
             {
                 if (!iB.CanUseType(oB.CurrentType))
                 {
-                    if (!CanCast(oB.CurrentType, iB.CurrentType))
+                    if (!oB.CurrentType.CanCastTo(iB.CurrentType))
                     {
                         // Cannot
                         return false;
@@ -748,7 +737,7 @@ namespace FlaxEditor.Surface.Elements
             {
                 if (!oB.CanUseType(iB.CurrentType))
                 {
-                    if (!CanCast(oB.CurrentType, iB.CurrentType))
+                    if (!oB.CurrentType.CanCastTo(iB.CurrentType))
                     {
                         // Cannot
                         return false;
@@ -821,7 +810,7 @@ namespace FlaxEditor.Surface.Elements
             bool useCaster = false;
             if (!iB.CanUseType(oB.CurrentType))
             {
-                if (CanCast(oB.CurrentType, iB.CurrentType))
+                if (oB.CurrentType.CanCastTo(iB.CurrentType))
                     useCaster = true;
                 else
                     return;

--- a/Source/Editor/Surface/NodeArchetype.cs
+++ b/Source/Editor/Surface/NodeArchetype.cs
@@ -72,7 +72,7 @@ namespace FlaxEditor.Surface
         /// </summary>
         All = Scalar | Vector | Enum | Anything | Value | Array | Dictionary,
     }
-    
+
     /// <summary>
     /// Surface node archetype description.
     /// </summary>
@@ -123,7 +123,7 @@ namespace FlaxEditor.Surface
         /// Custom set of flags.
         /// </summary>
         public NodeFlags Flags;
-        
+
         /// <summary>
         /// Title text.
         /// </summary>
@@ -166,7 +166,7 @@ namespace FlaxEditor.Surface
         /// Connections hints.
         /// </summary>
         public ConnectionsHint ConnectionsHints;
-        
+
         /// <summary>
         /// Array with independent boxes IDs.
         /// </summary>

--- a/Source/Editor/Surface/NodeArchetype.cs
+++ b/Source/Editor/Surface/NodeArchetype.cs
@@ -72,28 +72,6 @@ namespace FlaxEditor.Surface
         /// </summary>
         All = Scalar | Vector | Enum | Anything | Value | Array | Dictionary,
     }
-
-    /// <summary>
-    /// Node type hint. Helps to distinguish special archetypes
-    /// </summary>
-    [HideInEditor]
-    public enum NodeTypeHint
-    {
-        /// <summary>
-        /// Is Node.
-        /// </summary>
-        Default = 0,
-        
-        /// <summary>
-        /// Is Function Node.
-        /// </summary>
-        FunctionNode = 1,
-        
-        /// <summary>
-        /// Is custom Packing Node.
-        /// </summary>
-        PackingNode = 2,
-    }
     
     /// <summary>
     /// Surface node archetype description.
@@ -112,6 +90,11 @@ namespace FlaxEditor.Surface
         public delegate SurfaceNode CreateCustomNodeFunc(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch);
 
         /// <summary>
+        /// Checks if the given type is compatible with the given node archetype. Used for custom nodes
+        /// </summary>
+        public delegate bool IsCompatible(NodeArchetype nodeArch, ScriptType portType, ConnectionsHint hint);
+        
+        /// <summary>
         /// Unique node type ID within a single group.
         /// </summary>
         public ushort TypeID;
@@ -122,6 +105,16 @@ namespace FlaxEditor.Surface
         public CreateCustomNodeFunc Create;
 
         /// <summary>
+        /// Function for asynchronously loaded nodes to check if input ports are compatible, for filtering.
+        /// </summary>
+        public IsCompatible IsInputCompatible;
+        
+        /// <summary>
+        /// Function for asynchronously loaded nodes to check if output ports are compatible, for filtering.
+        /// </summary>
+        public IsCompatible IsOutputCompatible;
+        
+        /// <summary>
         /// Default initial size of the node.
         /// </summary>
         public Float2 Size;
@@ -130,7 +123,7 @@ namespace FlaxEditor.Surface
         /// Custom set of flags.
         /// </summary>
         public NodeFlags Flags;
-
+        
         /// <summary>
         /// Title text.
         /// </summary>
@@ -173,11 +166,6 @@ namespace FlaxEditor.Surface
         /// Connections hints.
         /// </summary>
         public ConnectionsHint ConnectionsHints;
-
-        /// <summary>
-        /// Node Type hints.
-        /// </summary>
-        public NodeTypeHint NodeTypeHint;
         
         /// <summary>
         /// Array with independent boxes IDs.
@@ -211,6 +199,8 @@ namespace FlaxEditor.Surface
             {
                 TypeID = TypeID,
                 Create = Create,
+                IsInputCompatible = IsInputCompatible,
+                IsOutputCompatible = IsOutputCompatible,
                 Size = Size,
                 Flags = Flags,
                 Title = Title,
@@ -220,7 +210,6 @@ namespace FlaxEditor.Surface
                 DefaultValues = (object[])DefaultValues?.Clone(),
                 DefaultType = DefaultType,
                 ConnectionsHints = ConnectionsHints,
-                NodeTypeHint = NodeTypeHint,
                 IndependentBoxes = (int[])IndependentBoxes?.Clone(),
                 DependentBoxes = (int[])DependentBoxes?.Clone(),
                 Elements = (NodeElementArchetype[])Elements?.Clone(),

--- a/Source/Editor/Surface/NodeArchetype.cs
+++ b/Source/Editor/Surface/NodeArchetype.cs
@@ -73,6 +73,9 @@ namespace FlaxEditor.Surface
         All = Scalar | Vector | Enum | Anything | Value | Array | Dictionary,
     }
 
+    /// <summary>
+    /// Node type hint. Helps to distinguish special archetypes
+    /// </summary>
     [HideInEditor]
     public enum NodeTypeHint
     {

--- a/Source/Editor/Surface/NodeArchetype.cs
+++ b/Source/Editor/Surface/NodeArchetype.cs
@@ -88,6 +88,11 @@ namespace FlaxEditor.Surface
         /// Is Function Node.
         /// </summary>
         FunctionNode = 1,
+        
+        /// <summary>
+        /// Is custom Packing Node.
+        /// </summary>
+        PackingNode = 2,
     }
     
     /// <summary>

--- a/Source/Editor/Surface/NodeArchetype.cs
+++ b/Source/Editor/Surface/NodeArchetype.cs
@@ -73,6 +73,20 @@ namespace FlaxEditor.Surface
         All = Scalar | Vector | Enum | Anything | Value | Array | Dictionary,
     }
 
+    [HideInEditor]
+    public enum NodeTypeHint
+    {
+        /// <summary>
+        /// Is Node.
+        /// </summary>
+        Default = 0,
+        
+        /// <summary>
+        /// Is Function Node.
+        /// </summary>
+        FunctionNode = 1,
+    }
+    
     /// <summary>
     /// Surface node archetype description.
     /// </summary>
@@ -153,6 +167,11 @@ namespace FlaxEditor.Surface
         public ConnectionsHint ConnectionsHints;
 
         /// <summary>
+        /// Node Type hints.
+        /// </summary>
+        public NodeTypeHint NodeTypeHint;
+        
+        /// <summary>
         /// Array with independent boxes IDs.
         /// </summary>
         public int[] IndependentBoxes;
@@ -193,6 +212,7 @@ namespace FlaxEditor.Surface
                 DefaultValues = (object[])DefaultValues?.Clone(),
                 DefaultType = DefaultType,
                 ConnectionsHints = ConnectionsHints,
+                NodeTypeHint = NodeTypeHint,
                 IndependentBoxes = (int[])IndependentBoxes?.Clone(),
                 DependentBoxes = (int[])DependentBoxes?.Clone(),
                 Elements = (NodeElementArchetype[])Elements?.Clone(),

--- a/Source/Editor/Surface/VisjectSurface.Connecting.cs
+++ b/Source/Editor/Surface/VisjectSurface.Connecting.cs
@@ -137,6 +137,70 @@ namespace FlaxEditor.Surface
         }
 
         /// <summary>
+        /// Checks if a type is compatible with another type and can be casted by using a connection hint
+        /// </summary>
+        /// <param name="from">Source type</param>
+        /// <param name="to">Type to check compatibility with</param>
+        /// <param name="hint">Hint to check if casting is possible</param>
+        /// <returns>True if the source type is compatible with the target type</returns>
+        public static bool IsTypeCompatible(ScriptType from, ScriptType to, ConnectionsHint hint)
+        {
+            if (from == ScriptType.Null && hint != ConnectionsHint.None)
+            {
+                if ((hint & ConnectionsHint.Anything) == ConnectionsHint.Anything)
+                    return true;
+                if ((hint & ConnectionsHint.Value) == ConnectionsHint.Value && to.Type != typeof(void))
+                    return true;
+                if ((hint & ConnectionsHint.Enum) == ConnectionsHint.Enum && to.IsEnum)
+                    return true;
+                if ((hint & ConnectionsHint.Array) == ConnectionsHint.Array && to.IsArray)
+                    return true;
+                if ((hint & ConnectionsHint.Dictionary) == ConnectionsHint.Dictionary && to.IsDictionary)
+                    return true;
+                if ((hint & ConnectionsHint.Vector) == ConnectionsHint.Vector)
+                {
+                    var t = to.Type;
+                    if (t == typeof(Vector2) ||
+                        t == typeof(Vector3) ||
+                        t == typeof(Vector4) ||
+                        t == typeof(Float2) ||
+                        t == typeof(Float3) ||
+                        t == typeof(Float4) ||
+                        t == typeof(Double2) ||
+                        t == typeof(Double3) ||
+                        t == typeof(Double4) ||
+                        t == typeof(Int2) ||
+                        t == typeof(Int3) ||
+                        t == typeof(Int4) ||
+                        t == typeof(Color))
+                    {
+                        return true;
+                    }
+                }
+                if ((hint & ConnectionsHint.Scalar) == ConnectionsHint.Scalar)
+                {
+                    var t = to.Type;
+                    if (t == typeof(bool) ||
+                        t == typeof(char) ||
+                        t == typeof(byte) ||
+                        t == typeof(short) ||
+                        t == typeof(ushort) ||
+                        t == typeof(int) ||
+                        t == typeof(uint) ||
+                        t == typeof(long) ||
+                        t == typeof(ulong) ||
+                        t == typeof(float) ||
+                        t == typeof(double))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+        
+        /// <summary>
         /// Checks if can use direct conversion from one type to another.
         /// </summary>
         /// <param name="from">Source type.</param>

--- a/Source/Editor/Surface/VisjectSurface.Connecting.cs
+++ b/Source/Editor/Surface/VisjectSurface.Connecting.cs
@@ -200,6 +200,13 @@ namespace FlaxEditor.Surface
             return false;
         }
 
+        /// <summary>
+        /// Checks if a type is compatible with another type and can be casted by using a connection hint
+        /// </summary>
+        /// <param name="from">Source type</param>
+        /// <param name="to">Target type</param>
+        /// <param name="hint">Connection hint</param>
+        /// <returns>True if any method of casting or compatibility check succeeds</returns>
         public static bool FullCastCheck(ScriptType from, ScriptType to, ConnectionsHint hint)
         {
             // Yes, from and to are switched on purpose

--- a/Source/Editor/Surface/VisjectSurface.Connecting.cs
+++ b/Source/Editor/Surface/VisjectSurface.Connecting.cs
@@ -199,6 +199,17 @@ namespace FlaxEditor.Surface
 
             return false;
         }
+
+        public static bool FullCastCheck(ScriptType from, ScriptType to, ConnectionsHint hint)
+        {
+            // Yes, from and to are switched on purpose
+            if (CanUseDirectCastStatic(to, from, false))
+                return true;
+            if(IsTypeCompatible(from, to, hint))
+                return true;
+            // Same here
+            return to.CanCastTo(from);
+        }
         
         /// <summary>
         /// Checks if can use direct conversion from one type to another.

--- a/Source/Editor/Surface/VisualScriptSurface.cs
+++ b/Source/Editor/Surface/VisualScriptSurface.cs
@@ -370,7 +370,7 @@ namespace FlaxEditor.Surface
                                 bindNode.Description = SurfaceUtils.GetVisualScriptMemberInfoDescription(member);
                                 bindNode.SubTitle = string.Format(" (in {0})", scriptTypeName);
                                 ((IList<NodeArchetype>)group.Archetypes).Add(bindNode);
-                                
+
                                 // Add Unbind event node
                                 var unbindNode = (NodeArchetype)Archetypes.Function.Nodes[9].Clone();
                                 unbindNode.DefaultValues[0] = scriptTypeTypeName;

--- a/Source/Editor/Surface/VisualScriptSurface.cs
+++ b/Source/Editor/Surface/VisualScriptSurface.cs
@@ -370,7 +370,7 @@ namespace FlaxEditor.Surface
                                 bindNode.Description = SurfaceUtils.GetVisualScriptMemberInfoDescription(member);
                                 bindNode.SubTitle = string.Format(" (in {0})", scriptTypeName);
                                 ((IList<NodeArchetype>)group.Archetypes).Add(bindNode);
-
+                                
                                 // Add Unbind event node
                                 var unbindNode = (NodeArchetype)Archetypes.Function.Nodes[9].Clone();
                                 unbindNode.DefaultValues[0] = scriptTypeTypeName;
@@ -589,6 +589,7 @@ namespace FlaxEditor.Surface
                         node.DefaultValues[0] = name;
                         node.DefaultValues[1] = parameters.Length;
                         node.Title = "Override " + name;
+                        node.Tag = member;
                         nodes.Add(node);
                     }
                 }

--- a/Source/Editor/Surface/VisualScriptSurface.cs
+++ b/Source/Editor/Surface/VisualScriptSurface.cs
@@ -589,7 +589,6 @@ namespace FlaxEditor.Surface
                         node.DefaultValues[0] = name;
                         node.DefaultValues[1] = parameters.Length;
                         node.Title = "Override " + name;
-                        node.Tag = member;
                         nodes.Add(node);
                     }
                 }


### PR DESCRIPTION
When dragging a connection out of a node port into the void, the context menu to add nodes gets shown.
Context sensitive node search makes it so that only nodes with compatible ports get shown in the context menu. This mimics the behaviour of visual editors from other engines, e.g. Unreal.


### Tasks
- [x] Implement context menu item filtering by type
- [x] Implement context menu group filtering by type
- [x] Support default archetypes and groups
- [x] Support particle emitter graph specific archetypes and groups
- [x] Support visual scripting specific archetypes and groups 
- [x] Support animation graph specific archetypes and groups
- [x] Add "context sensitive" toggle to context menu
- [x] Cleanup
- [x] Add XML comments
- [x] A lot of testing 
- [x] New tasks ahead
- [x] Rewrite input/output compatibility check for custom nodes
- [x] Cleanup 2
- [x] Testing 2
- [x] Profiling (against master)
- [x] Done 🥳
- [x] #1114 

**Known Bugs**
- [x] 'Comment' archetype shows up when typing in the search bar
- [x] Filtering by group name activates all items (turned off at the moment)
- [x] Asynchronously loaded nodes that aren't InvokeMethodNodes currently get filtered out even when compatible

**Optional**
- [x] Make context menu taller and less wide
- [x] Make item entries a tiny bit taller

**Didn't do**
- [x] Change entry score based on the port type (e.g. when dragging out of a vector3 port, options that have Vector3 as input should have a higher score than Float3, Vector2, int etc) -> Will probably be its own PR

### Profiling Results
I didn't do craaaazzy profiling and testing. But enough to get an idea what the costs of this feature are.
I used the in engine profiler to check how much longer in time the opening and fetching of the items take, and how much more memory is getting used. Also these times are just the spikes visible in the profiler, since custom nodes get fetched asynchronously, so the time for all items to appear varies.

First of all, when right clicking into the void, so when no context is really needed, the speeds are rather identical. 
Opening the CM took in both cases around **85ms** on average while taking up **~4MB of memory**

Now, the more interesting part: dragging a connection out of a port. Since here context sensitivity really just starts doing work.

On master with no context sensitivity it took around **85ms** on average while taking up **~4MB of memory**, what a surprise
And on my branch with context sensitivity enabled it took around **116ms** while taking up **~7MB of memory**

I think it comes to no surprise that filtering through all archetypes does take some more time. With an average of around 30ms more, which means it's effectively ~35% slower now and takes up 3MB of memory more.

Like i said, i didn't do crazy profiling here, i just read numbers from the in engine profiler. Let's just say i was a bit lazy to open dotTrace now and do in depth profiling.
Also the whole filtering process could probably be a lot more optimized and faster, but would need some refactoring.
I think sacrificing a couple of milliseconds more for such a QoL feature is okay, when opening a context menu. Especially since it can still be optimized.

Just keep in mind that my PC is on the stronger side, with an Ryzen 9 3900X, 32GB RAM etc. But i think even weaker PCs won't have a problem with that.

### Feature preview

Material Editor
![ContextualNodes](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/2680cc8f-a996-49ca-a541-79befe9a1db7)

Visual Scripting Editor
![ContextSensitiveVisualScripting](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/3218aa5c-042e-49bc-b89d-b8103596bc42)

Context Menu Toggle
![ContextSensitiveToggle](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/3dc6bc2d-f39f-407f-ba3e-e472629761c6)
