### PR TITLE
Improved mousewheel scrolling behavior

### DIFF
--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -671,9 +671,7 @@ namespace FlaxEditor.Surface.ContextMenu
                     SelectedItem = previousSelectedItem;
 
                     // Scroll into view (without smoothing)
-                    _panel1.VScrollBar.SmoothingScale = 0;
-                    _panel1.ScrollViewTo(SelectedItem);
-                    _panel1.VScrollBar.SmoothingScale = 1;
+                    _panel1.ScrollViewTo(SelectedItem, true);
                 }
                 return true;
             }

--- a/Source/Editor/Windows/Search/ContentFinder.cs
+++ b/Source/Editor/Windows/Search/ContentFinder.cs
@@ -54,9 +54,7 @@ namespace FlaxEditor.Windows.Search
                     _selectedItem.BackgroundColor = Style.Current.BackgroundSelected;
                     if (_matchedItems.Count > VisibleItemCount)
                     {
-                        _resultPanel.VScrollBar.SmoothingScale = 0;
-                        _resultPanel.ScrollViewTo(_selectedItem);
-                        _resultPanel.VScrollBar.SmoothingScale = 1;
+                        _resultPanel.ScrollViewTo(_selectedItem, true);
                     }
                 }
             }

--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -425,7 +425,7 @@ namespace FlaxEngine.GUI
                 float mousePosition = _orientation == Orientation.Vertical ? slidePosition.Y : slidePosition.X;
 
                 float percentage = (mousePosition - _mouseOffset - _thumbSize / 2) / (TrackSize - _thumbSize);
-                Value = _minimum + percentage * (_maximum - _minimum);
+                TargetValue = _minimum + percentage * (_maximum - _minimum);
             }
         }
 

--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -325,7 +325,7 @@ namespace FlaxEngine.GUI
                     var progress = _scrollAnimationProgress;
                     progress = Mathf.Clamp(progress + step, 0, 1);
                             
-                    // https://easings.net/#easeInOutQuad
+                    // https://easings.net/#easeOutSine
                     var easedProgress = Mathf.Sin((progress * Mathf.Pi) / 2);
                     value = Mathf.Lerp(_startValue, _targetValue, easedProgress);
 

--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -23,9 +23,9 @@ namespace FlaxEngine.GUI
 
         // Scrolling
 
-        private float _clickChange = 20, _scrollChange = 100;
+        private float _clickChange = 20, _scrollChange = 50;
         private float _minimum, _maximum = 100;
-        private float _value, _targetValue;
+        private float _startValue, _value, _targetValue;
         private readonly Orientation _orientation;
         private RootControl.UpdateDelegate _update;
 
@@ -42,6 +42,7 @@ namespace FlaxEngine.GUI
         // Smoothing
 
         private float _thumbOpacity = DefaultMinimumOpacity;
+        private float _scrollAnimationProgress = 0f;
 
         /// <summary>
         /// Gets the orientation.
@@ -60,13 +61,35 @@ namespace FlaxEngine.GUI
 
         /// <summary>
         /// Gets or sets the value smoothing scale (0 to not use it).
+        /// [Deprecated on 26.09.2023, expires on 26.09.2025]
+        /// This property is deprecated, use <see cref="ScrollAnimationDuration"/> instead
+        /// Set this to >= 0 to use legacy behavior
         /// </summary>
-        public float SmoothingScale { get; set; } = 0.6f;
+        [Obsolete("Deprecated in 1.7")]
+        public float SmoothingScale { get; set; } = -1f;
+
+        /// <summary>
+        /// The maximum time it takes to animate from current to target scroll position 
+        /// </summary>
+        public float ScrollAnimationDuration { get; set; } = 0.18f;
 
         /// <summary>
         /// Gets a value indicating whether use scroll value smoothing.
         /// </summary>
-        public bool UseSmoothing => !Mathf.IsZero(SmoothingScale);
+        public bool UseSmoothing
+        {
+            get
+            {
+                if (!EnableSmoothing || Mathf.IsZero(SmoothingScale)) { return false; }
+                
+                return SmoothingScale > 0 || SmoothingScale < 0 && !Mathf.IsZero(ScrollAnimationDuration);
+            }
+        }
+
+        /// <summary>
+        /// Enables scroll smoothing
+        /// </summary>
+        public bool EnableSmoothing { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the minimum value.
@@ -112,11 +135,15 @@ namespace FlaxEngine.GUI
                 if (!Mathf.NearEqual(value, _targetValue))
                 {
                     _targetValue = value;
+                    _startValue = _value;
+                    _scrollAnimationProgress = 0f;
 
                     // Check if skip smoothing
                     if (!UseSmoothing)
                     {
                         _value = value;
+                        _startValue = value;
+                        _scrollAnimationProgress = 1f;
                         OnValueChanged();
                     }
                     else
@@ -208,7 +235,8 @@ namespace FlaxEngine.GUI
         {
             if (!Mathf.NearEqual(_value, _targetValue))
             {
-                _value = _targetValue;
+                _value = _targetValue = _startValue;
+                _scrollAnimationProgress = 0f;
                 SetUpdate(ref _update, null);
                 OnValueChanged();
             }
@@ -274,7 +302,8 @@ namespace FlaxEngine.GUI
 
         internal void Reset()
         {
-            _value = _targetValue = 0;
+            _value = _targetValue = _startValue = 0;
+            _scrollAnimationProgress = 0f;
         }
 
         /// <summary>
@@ -296,22 +325,49 @@ namespace FlaxEngine.GUI
             _thumbOpacity = isDeltaSlow ? targetOpacity : Mathf.Lerp(_thumbOpacity, targetOpacity, deltaTime * 10.0f);
             bool needUpdate = Mathf.Abs(_thumbOpacity - targetOpacity) > 0.001f;
 
-            // Ensure scroll bar is visible
-            if (Visible)
+            // Ensure scroll bar is visible and smoothing is required
+            if (Visible && Mathf.Abs(_targetValue - _value) > 0.01f)
             {
-                // Value smoothing
-                if (Mathf.Abs(_targetValue - _value) > 0.01f)
+                // Interpolate or not if running slow
+                float value;
+                if (!isDeltaSlow && UseSmoothing)
                 {
-                    // Interpolate or not if running slow
-                    float value;
-                    if (!isDeltaSlow && UseSmoothing)
+                    // use legacy behavior
+                    if (SmoothingScale >= 0)
+                    {
                         value = Mathf.Lerp(_value, _targetValue, deltaTime * 20.0f * SmoothingScale);
+                    }
                     else
-                        value = _targetValue;
-                    _value = value;
-                    OnValueChanged();
-                    needUpdate = true;
+                    {
+                        // percentage of scroll from 0 to _scrollChange, ex. 0.5 at _scrollChange / 2
+                        var minScrollChangeRatio = Mathf.Clamp(Mathf.Abs(_targetValue - _startValue) / _scrollChange, 0, 1);
+                        
+                        // shorten the duration if we scrolled less than _scrollChange
+                        var actualDuration = ScrollAnimationDuration * minScrollChangeRatio;
+                        var step = deltaTime / actualDuration;
+
+                        var progress = _scrollAnimationProgress;
+                        progress = Mathf.Clamp(progress + step, 0, 1);
+                            
+                        Debug.Log($"why {progress} {step} {minScrollChangeRatio}");
+                            
+                        // https://easings.net/#easeInOutQuad
+                        var easedProgress = Mathf.Sin((progress * Mathf.Pi) / 2);
+                        value = Mathf.Lerp(_startValue, _targetValue, easedProgress);
+
+                        _scrollAnimationProgress = progress;
+                    }
                 }
+                else
+                {
+                    value = _targetValue;
+                    _startValue = _targetValue;
+                    _scrollAnimationProgress = 0f;
+                }
+                
+                _value = value;
+                OnValueChanged();
+                needUpdate = true;
             }
 
             // End updating if all animations are done
@@ -381,7 +437,7 @@ namespace FlaxEngine.GUI
             if (ThumbEnabled)
             {
                 // Scroll
-                Value = _value - delta * _scrollChange;
+                Value = _targetValue - delta * _scrollChange;
             }
             return true;
         }

--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -60,15 +60,6 @@ namespace FlaxEngine.GUI
         public float TrackThickness { get; set; } = 2.0f;
 
         /// <summary>
-        /// Gets or sets the value smoothing scale (0 to not use it).
-        /// [Deprecated on 26.09.2023, expires on 26.09.2025]
-        /// This property is deprecated, use <see cref="ScrollAnimationDuration"/> instead
-        /// Set this to >= 0 to use legacy behavior
-        /// </summary>
-        [Obsolete("Deprecated in 1.7")]
-        public float SmoothingScale { get; set; } = -1f;
-
-        /// <summary>
         /// The maximum time it takes to animate from current to target scroll position 
         /// </summary>
         public float ScrollAnimationDuration { get; set; } = 0.18f;
@@ -76,15 +67,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets a value indicating whether use scroll value smoothing.
         /// </summary>
-        public bool UseSmoothing
-        {
-            get
-            {
-                if (!EnableSmoothing || Mathf.IsZero(SmoothingScale)) { return false; }
-                
-                return SmoothingScale > 0 || SmoothingScale < 0 && !Mathf.IsZero(ScrollAnimationDuration);
-            }
-        }
+        public bool UseSmoothing => EnableSmoothing && !Mathf.IsZero(ScrollAnimationDuration);
 
         /// <summary>
         /// Enables scroll smoothing
@@ -332,29 +315,21 @@ namespace FlaxEngine.GUI
                 float value;
                 if (!isDeltaSlow && UseSmoothing)
                 {
-                    // use legacy behavior
-                    if (SmoothingScale >= 0)
-                    {
-                        value = Mathf.Lerp(_value, _targetValue, deltaTime * 20.0f * SmoothingScale);
-                    }
-                    else
-                    {
-                        // percentage of scroll from 0 to _scrollChange, ex. 0.5 at _scrollChange / 2
-                        var minScrollChangeRatio = Mathf.Clamp(Mathf.Abs(_targetValue - _startValue) / _scrollChange, 0, 1);
+                    // percentage of scroll from 0 to _scrollChange, ex. 0.5 at _scrollChange / 2
+                    var minScrollChangeRatio = Mathf.Clamp(Mathf.Abs(_targetValue - _startValue) / _scrollChange, 0, 1);
                         
-                        // shorten the duration if we scrolled less than _scrollChange
-                        var actualDuration = ScrollAnimationDuration * minScrollChangeRatio;
-                        var step = deltaTime / actualDuration;
+                    // shorten the duration if we scrolled less than _scrollChange
+                    var actualDuration = ScrollAnimationDuration * minScrollChangeRatio;
+                    var step = deltaTime / actualDuration;
 
-                        var progress = _scrollAnimationProgress;
-                        progress = Mathf.Clamp(progress + step, 0, 1);
+                    var progress = _scrollAnimationProgress;
+                    progress = Mathf.Clamp(progress + step, 0, 1);
                             
-                        // https://easings.net/#easeInOutQuad
-                        var easedProgress = Mathf.Sin((progress * Mathf.Pi) / 2);
-                        value = Mathf.Lerp(_startValue, _targetValue, easedProgress);
+                    // https://easings.net/#easeInOutQuad
+                    var easedProgress = Mathf.Sin((progress * Mathf.Pi) / 2);
+                    value = Mathf.Lerp(_startValue, _targetValue, easedProgress);
 
-                        _scrollAnimationProgress = progress;
-                    }
+                    _scrollAnimationProgress = progress;
                 }
                 else
                 {

--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -349,8 +349,6 @@ namespace FlaxEngine.GUI
                         var progress = _scrollAnimationProgress;
                         progress = Mathf.Clamp(progress + step, 0, 1);
                             
-                        Debug.Log($"why {progress} {step} {minScrollChangeRatio}");
-                            
                         // https://easings.net/#easeInOutQuad
                         var easedProgress = Mathf.Sin((progress * Mathf.Pi) / 2);
                         value = Mathf.Lerp(_startValue, _targetValue, easedProgress);


### PR DESCRIPTION
Scrolling with the mouse in Flax feels awful. There are 2 reasons for this:

1. The scrolling calculation is bugged, making it impossible to scroll to the top of a long window in a single stroke
2. The scrolling animation doesn't *feel* right. 

This pr addresses this by fixing the bug and changing the scroll behavior to be 1:1 to the way the browser does it.

Here's how it was before:

https://github.com/FlaxEngine/FlaxEngine/assets/8556074/ef643f67-6d65-4e92-a8a0-58fc50d4e247

No matter how hard I scroll up, I just can't get to the top in one scroll stoke

Here's after:

https://github.com/FlaxEngine/FlaxEngine/assets/8556074/545e54b6-08cb-4572-a11f-321db5e4b361

A comparison between browser and Flax scrolling before this pr:

https://github.com/FlaxEngine/FlaxEngine/assets/8556074/59925dc5-264d-47b6-852d-5eb1ceb1358e

Flax scrolls way too much and the animation is different

And here's after:

https://github.com/FlaxEngine/FlaxEngine/assets/8556074/303a5dd3-4d35-4d1b-b990-396e186763a8

Now the scroll distance and the animation is similar to the browser

This pr changes the following:

- Fixes scrolling distance calculation
- Makes scrolling duration-based by introducing a ScrollAnimationDuration property. ~~This means that SmoothingScale is now deprecated and quite a bit of logic had to be added in order to replace the old behavior and still allow using SmoothingScale for old code~~
- Completely removed SmoothingScale and its usages
- Remove scroll smoothing when dragging the slider thumb

The amount of changes I had to do in order to add the new behavior and still be compatible with the old one is quite a lot unfortunately. Is it worth it doing all of this for an improved animation?

