### PR TITLE
Holiday splash

### DIFF
--- a/Source/Editor/Windows/SplashScreen.cpp
+++ b/Source/Editor/Windows/SplashScreen.cpp
@@ -138,6 +138,16 @@ const Char* SplashScreenQuotes[] =
     TEXT("Slava Ukraini!"),
 };
 
+const Char* ChristmasSplashScreenQuotes[] =
+{
+    //Use these if the month is December
+    //TODO: More flexible system for specific holidays or special events
+    TEXT("All I want for Christmas... is $USER_FNAME"), 
+    TEXT("Entering '; DROP TABLE into the Nice List..."),
+    TEXT("Checking PearTree.Partridge!=null... OK")
+
+};
+
 SplashScreen::~SplashScreen()
 {
     // Ensure to be closed
@@ -198,7 +208,11 @@ void SplashScreen::Show()
     str.Replace('\\', '/');
 #endif
     _infoText = String::Format(TEXT("Flax Editor {0}\n{1}\nProject: {2}"), TEXT(FLAXENGINE_VERSION_TEXT), TEXT(FLAXENGINE_COPYRIGHT), str);
-    _quote = SplashScreenQuotes[rand() % ARRAY_COUNT(SplashScreenQuotes)];
+    //Check for special occasion; only December/holiday season supported for now
+    SplashScreen::HolidayStatus _splashScreenHolidayStatus = GetHolidayStatus(_startTime);
+    const bool _useHolidayQuote = _splashScreenHolidayStatus!=None;
+    
+    _quote = _useHolidayQuote ? ChristmasSplashScreenQuotes[rand() % ARRAY_COUNT(ChristmasSplashScreenQuotes)] : SplashScreenQuotes[rand() % ARRAY_COUNT(SplashScreenQuotes)];
 
     // Load font
     auto font = Content::LoadAsyncInternal<FontAsset>(TEXT("Editor/Fonts/Roboto-Regular"));
@@ -217,6 +231,14 @@ void SplashScreen::Show()
     _window->Show();
 }
 
+SplashScreen::HolidayStatus SplashScreen::GetHolidayStatus(DateTime CurrentDate)
+{
+    //Simple function that checks the current Date/Time to see if it crosses any holidays.  
+    //Could affect splash screen text and possibly bg image in the future
+    if (CurrentDate.GetMonth() == 12) return Christmas;
+
+    return None;
+}
 void SplashScreen::Close()
 {
     if (!IsVisible())

--- a/Source/Editor/Windows/SplashScreen.h
+++ b/Source/Editor/Windows/SplashScreen.h
@@ -63,6 +63,16 @@ public:
 public:
 
     /// <summary>
+    /// The current holiday present as determined based on startup date.
+    /// </summary>
+    enum HolidayStatus {None,Christmas};//Add more conditions as needed and use GetHolidayStatus function to incorporate logic
+    /// <summary>
+    /// Function that returns the current holiday based on date.
+    /// </summary>
+    /// <param name="CurrentDate"></param>
+    /// <returns></returns>
+    HolidayStatus GetHolidayStatus(DateTime CurrentDate);
+    /// <summary>
     /// Shows popup.
     /// </summary>
     void Show();


### PR DESCRIPTION
As part of a larger conversation #1499, this splash screen addition cuts the holiday themed quotes into its own dedicated function that only triggers at the appropriate time of year.  For now this is just Winter holiday/Christmas themed, however this code could be modified in the future to check for other date ranges.