### PR TITLE
Fix string use-after-free while loading managed assemblies

### DIFF
--- a/Source/Engine/Scripting/Runtime/DotNet.cpp
+++ b/Source/Engine/Scripting/Runtime/DotNet.cpp
@@ -707,6 +707,8 @@ bool MAssembly::LoadImage(const String& assemblyPath, const StringView& nativePa
     const char* fullname = nullptr;
     static void* LoadAssemblyImagePtr = GetStaticMethodPointer(TEXT("LoadAssemblyImage"));
     _handle = CallStaticMethod<void*, const Char*, const char**, const char**>(LoadAssemblyImagePtr, assemblyPath.Get(), &name, &fullname);
+    _name = StringAnsi(name);
+    _fullname = StringAnsi(fullname);
     MCore::GC::FreeMemory((void*)name);
     MCore::GC::FreeMemory((void*)fullname);
     if (_handle == nullptr)
@@ -714,8 +716,6 @@ bool MAssembly::LoadImage(const String& assemblyPath, const StringView& nativePa
         Log::CLRInnerException(TEXT(".NET assembly image is invalid at ") + assemblyPath);
         return true;
     }
-    _name = name;
-    _fullname = fullname;
     CachedAssemblyHandles.Add(_handle, this);
 
     // Provide new path of hot-reloaded native library path for managed DllImport


### PR DESCRIPTION
Possibly fixes the recent crashes in GitHub Actions Linux workloads