### PR TITLE
Use Guids for sprite identification instead of indexing

### DIFF
--- a/Source/Editor/Content/PreviewsCache.cpp
+++ b/Source/Editor/Content/PreviewsCache.cpp
@@ -121,9 +121,10 @@ Asset::LoadResult PreviewsCache::load()
     const float positionOffset = static_cast<float>(ASSETS_ICONS_ATLAS_MARGIN) / ASSETS_ICONS_ATLAS_SIZE;
     for (int32 i = 0; i < ASSETS_ICONS_PER_ATLAS; i++)
     {
+        sprite.Id = Guid::New();
         sprite.Area.Location = Float2(static_cast<float>(i % ASSETS_ICONS_PER_ROW), static_cast<float>(i / ASSETS_ICONS_PER_ROW)) * positionScale + positionOffset;
         sprite.Name = StringUtils::ToString(i);
-        Sprites.Add(sprite);
+        Sprites[sprite.Id] = sprite;
     }
 
     _isDirty = false;

--- a/Source/Editor/GUI/Timeline/Tracks/CameraCutTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/CameraCutTrack.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using FlaxEditor.Utilities;
 using FlaxEngine;
+using FlaxEngine.Assertions;
 using FlaxEngine.GUI;
 using Object = FlaxEngine.Object;
 
@@ -436,6 +437,7 @@ namespace FlaxEditor.GUI.Timeline.Tracks
         private SceneRenderTask _task;
         private GPUTexture _output;
         private List<Atlas> _atlases;
+        private Dictionary<Guid, int> _guid2index;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CameraCutThumbnailRenderer"/> class.
@@ -484,7 +486,10 @@ namespace FlaxEditor.GUI.Timeline.Tracks
                 if (atlas.Texture == sprite.Atlas)
                 {
                     atlas.Count--;
-                    atlas.SlotsUsage[sprite.Index] = false;
+
+                    Assert.IsTrue(_guid2index.ContainsKey(sprite.Id));
+                    atlas.SlotsUsage[_guid2index[sprite.Id]] = false;
+                    _guid2index.Remove(sprite.Id);
 
                     _atlases[i] = atlas;
                     break;
@@ -498,6 +503,8 @@ namespace FlaxEditor.GUI.Timeline.Tracks
         public void Dispose()
         {
             FlaxEngine.Scripting.Update -= OnUpdate;
+            _guid2index.Clear();
+            _guid2index = null;
             _queue.Clear();
             _queue = null;
             Object.Destroy(ref _task);
@@ -630,11 +637,16 @@ namespace FlaxEditor.GUI.Timeline.Tracks
                     break;
                 }
             }
+
+            _guid2index ??= new Dictionary<Guid, int>();
+            var id = Guid.NewGuid();
+            _guid2index[id] = spriteIndex;
+
             if (spriteIndex == -1)
                 throw new Exception();
             atlas.Count++;
             _atlases[atlasIndex] = atlas;
-            var sprite = new SpriteHandle(atlas.Texture, spriteIndex);
+            var sprite = new SpriteHandle(atlas.Texture, id);
 
             // Copy output frame to the sprite atlas slot
             var spriteLocation = sprite.Location;

--- a/Source/Engine/Render2D/Render2D.cpp
+++ b/Source/Engine/Render2D/Render2D.cpp
@@ -1596,16 +1596,18 @@ void Render2D::DrawTexture(TextureBase* t, const Rectangle& rect, const Color& c
 void Render2D::DrawSprite(const SpriteHandle& spriteHandle, const Rectangle& rect, const Color& color)
 {
     RENDER2D_CHECK_RENDERING_STATE;
-    if (spriteHandle.Index == INVALID_INDEX || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
+    if (spriteHandle.Id == Guid::Empty || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
         return;
 
-    Sprite* sprite = &spriteHandle.Atlas->Sprites.At(spriteHandle.Index);
+    Sprite sprite{};
+    if (!spriteHandle.Atlas->Sprites.TryGet(spriteHandle.Id, sprite)) return;
+
     Render2DDrawCall& drawCall = DrawCalls.AddOne();
     drawCall.Type = DrawCallType::FillTexture;
     drawCall.StartIB = IBIndex;
     drawCall.CountIB = 6;
     drawCall.AsTexture.Ptr = spriteHandle.Atlas->GetTexture();
-    WriteRect(rect, color, sprite->Area.GetUpperLeft(), sprite->Area.GetBottomRight());
+    WriteRect(rect, color, sprite.Area.GetUpperLeft(), sprite.Area.GetBottomRight());
 }
 
 void Render2D::DrawTexturePoint(GPUTexture* t, const Rectangle& rect, const Color& color)
@@ -1623,16 +1625,18 @@ void Render2D::DrawTexturePoint(GPUTexture* t, const Rectangle& rect, const Colo
 void Render2D::DrawSpritePoint(const SpriteHandle& spriteHandle, const Rectangle& rect, const Color& color)
 {
     RENDER2D_CHECK_RENDERING_STATE;
-    if (spriteHandle.Index == INVALID_INDEX || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
+    if (spriteHandle.Id == Guid::Empty || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
         return;
 
-    Sprite* sprite = &spriteHandle.Atlas->Sprites.At(spriteHandle.Index);
+    Sprite sprite{};
+    if (!spriteHandle.Atlas->Sprites.TryGet(spriteHandle.Id, sprite)) return;
+
     Render2DDrawCall& drawCall = DrawCalls.AddOne();
     drawCall.Type = DrawCallType::FillTexturePoint;
     drawCall.StartIB = IBIndex;
     drawCall.CountIB = 6;
     drawCall.AsTexture.Ptr = spriteHandle.Atlas->GetTexture();
-    WriteRect(rect, color, sprite->Area.GetUpperLeft(), sprite->Area.GetBottomRight());
+    WriteRect(rect, color, sprite.Area.GetUpperLeft(), sprite.Area.GetBottomRight());
 }
 
 void Render2D::Draw9SlicingTexture(TextureBase* t, const Rectangle& rect, const Float4& border, const Float4& borderUVs, const Color& color)
@@ -1664,31 +1668,35 @@ void Render2D::Draw9SlicingTexturePoint(TextureBase* t, const Rectangle& rect, c
 void Render2D::Draw9SlicingSprite(const SpriteHandle& spriteHandle, const Rectangle& rect, const Float4& border, const Float4& borderUVs, const Color& color)
 {
     RENDER2D_CHECK_RENDERING_STATE;
-    if (spriteHandle.Index == INVALID_INDEX || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
+    if (spriteHandle.Id == Guid::Empty || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
         return;
 
-    Sprite* sprite = &spriteHandle.Atlas->Sprites.At(spriteHandle.Index);
+    Sprite sprite{};
+    if (!spriteHandle.Atlas->Sprites.TryGet(spriteHandle.Id, sprite)) return;
+
     Render2DDrawCall& drawCall = DrawCalls.AddOne();
     drawCall.Type = DrawCallType::FillTexture;
     drawCall.StartIB = IBIndex;
     drawCall.CountIB = 6 * 9;
     drawCall.AsTexture.Ptr = spriteHandle.Atlas->GetTexture();
-    Write9SlicingRect(rect, color, border, borderUVs, sprite->Area.Location, sprite->Area.Size);
+    Write9SlicingRect(rect, color, border, borderUVs, sprite.Area.Location, sprite.Area.Size);
 }
 
 void Render2D::Draw9SlicingSpritePoint(const SpriteHandle& spriteHandle, const Rectangle& rect, const Float4& border, const Float4& borderUVs, const Color& color)
 {
     RENDER2D_CHECK_RENDERING_STATE;
-    if (spriteHandle.Index == INVALID_INDEX || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
+    if (spriteHandle.Id == Guid::Empty || !spriteHandle.Atlas || !spriteHandle.Atlas->GetTexture()->HasResidentMip())
         return;
 
-    Sprite* sprite = &spriteHandle.Atlas->Sprites.At(spriteHandle.Index);
+    Sprite sprite{};
+    if (!spriteHandle.Atlas->Sprites.TryGet(spriteHandle.Id, sprite)) return;
+
     Render2DDrawCall& drawCall = DrawCalls.AddOne();
     drawCall.Type = DrawCallType::FillTexturePoint;
     drawCall.StartIB = IBIndex;
     drawCall.CountIB = 6 * 9;
     drawCall.AsTexture.Ptr = spriteHandle.Atlas->GetTexture();
-    Write9SlicingRect(rect, color, border, borderUVs, sprite->Area.Location, sprite->Area.Size);
+    Write9SlicingRect(rect, color, border, borderUVs, sprite.Area.Location, sprite.Area.Size);
 }
 
 void Render2D::DrawCustom(GPUTexture* t, const Rectangle& rect, GPUPipelineState* ps, const Color& color)

--- a/Source/Engine/Render2D/SpriteAtlas.cs
+++ b/Source/Engine/Render2D/SpriteAtlas.cs
@@ -16,16 +16,16 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="atlas">The atlas.</param>
         /// <param name="index">The index.</param>
-        public SpriteHandle(SpriteAtlas atlas, int index)
+        public SpriteHandle(SpriteAtlas atlas, Guid id)
         {
             Atlas = atlas;
-            Index = index;
+            Id = id;
         }
 
         /// <summary>
         /// Returns true if sprite is valid.
         /// </summary>
-        public bool IsValid => Atlas != null && Index != -1;
+        public bool IsValid => Atlas != null && Id != Guid.Empty;
 
         /// <summary>
         /// Gets or sets the sprite name.
@@ -37,15 +37,15 @@ namespace FlaxEngine
             {
                 if (Atlas == null)
                     throw new InvalidOperationException("Cannot use invalid sprite.");
-                return Atlas.GetSprite(Index).Name;
+                return Atlas.GetSprite(Id).Name;
             }
             set
             {
                 if (Atlas == null)
                     throw new InvalidOperationException("Cannot use invalid sprite.");
-                var sprite = Atlas.GetSprite(Index);
+                var sprite = Atlas.GetSprite(Id);
                 sprite.Name = value;
-                Atlas.SetSprite(Index, ref sprite);
+                Atlas.SetSprite(Id, ref sprite);
             }
         }
 
@@ -89,15 +89,15 @@ namespace FlaxEngine
             {
                 if (Atlas == null)
                     throw new InvalidOperationException("Cannot use invalid sprite.");
-                return Atlas.GetSprite(Index).Area;
+                return Atlas.GetSprite(Id).Area;
             }
             set
             {
                 if (Atlas == null)
                     throw new InvalidOperationException("Cannot use invalid sprite.");
-                var sprite = Atlas.GetSprite(Index);
+                var sprite = Atlas.GetSprite(Id);
                 sprite.Area = value;
-                Atlas.SetSprite(Index, ref sprite);
+                Atlas.SetSprite(Id, ref sprite);
             }
         }
     }

--- a/Source/Engine/Render2D/SpriteAtlas.h
+++ b/Source/Engine/Render2D/SpriteAtlas.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Engine/Core/Collections/Dictionary.h"
 #include "Engine/Core/ISerializable.h"
 #include "Engine/Core/Types/String.h"
 #include "Engine/Core/Math/Rectangle.h"
@@ -28,6 +29,11 @@ DECLARE_SCRIPTING_TYPE_MINIMAL(Sprite);
     /// The sprite name.
     /// </summary>
     API_FIELD() String Name;
+
+    /// <summary>
+    /// The sprite id.
+    /// </summary>
+    API_FIELD() Guid Id;
 };
 
 /// <summary>
@@ -51,25 +57,25 @@ DECLARE_SCRIPTING_TYPE_MINIMAL(SpriteHandle);
     /// <summary>
     /// The atlas sprites array index.
     /// </summary>
-    API_FIELD() int32 Index;
+    API_FIELD() Guid Id;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SpriteHandle"/> struct.
     /// </summary>
     SpriteHandle()
     {
-        Index = -1;
+        Id = Guid::Empty;
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SpriteHandle"/> struct.
     /// </summary>
     /// <param name="atlas">The sprite atlas.</param>
-    /// <param name="index">The sprite slot index.</param>
-    SpriteHandle(SpriteAtlas* atlas, int32 index)
+    /// <param name="id">The sprite id.</param>
+    SpriteHandle(SpriteAtlas* atlas, Guid id)
         : Atlas(atlas)
     {
-        Index = index;
+        Id = id;
     }
 
     /// <summary>
@@ -104,7 +110,7 @@ public:
     /// <summary>
     /// List with all tiles in the sprite atlas.
     /// </summary>
-    API_FIELD() Array<Sprite> Sprites;
+    API_FIELD() Dictionary<Guid, Sprite> Sprites;
 
 public:
 
@@ -116,16 +122,17 @@ public:
     /// <summary>
     /// Gets the sprite data.
     /// </summary>
-    /// <param name="index">The index.</param>
+    /// <param name="id">The id.</param>
     /// <returns>The sprite data.</returns>
-    API_FUNCTION() Sprite GetSprite(int32 index) const;
+    // FIXME: This should probably be Optional, or pointer so nullptr is "not existing"
+    API_FUNCTION() Sprite GetSprite(Guid id) const;
 
     /// <summary>
     /// Sets the sprite data.
     /// </summary>
-    /// <param name="index">The index.</param>
+    /// <param name="id">The id.</param>
     /// <param name="value">The sprite data.</param>
-    API_FUNCTION() void SetSprite(int32 index, API_PARAM(Ref) const Sprite& value);
+    API_FUNCTION() void SetSprite(Guid id, API_PARAM(Ref) const Sprite& value);
 
     /// <summary>
     /// Finds the sprite by the name.
@@ -145,7 +152,7 @@ public:
     /// Removes the sprite.
     /// </summary>
     /// <param name="index">The sprite index.</param>
-    API_FUNCTION() void RemoveSprite(int32 index);
+    API_FUNCTION() void RemoveSprite(Guid id);
 
 #if USE_EDITOR
 

--- a/Source/Engine/UI/SpriteRender.cpp
+++ b/Source/Engine/UI/SpriteRender.cpp
@@ -87,10 +87,10 @@ void SpriteRender::SetImage()
 {
     TextureBase* image = Image.Get();
     Vector4 imageMAD(Vector2::One, Vector2::Zero);
-    if (!image && _sprite.IsValid())
+    if (!image && _sprite.IsValid() && _sprite.Atlas->Sprites.ContainsKey(_sprite.Id))
     {
         image = _sprite.Atlas.Get();
-        Sprite* sprite = &_sprite.Atlas->Sprites.At(_sprite.Index);
+        const Sprite* sprite = &_sprite.Atlas->Sprites.At(_sprite.Id);
         imageMAD = Vector4(sprite->Area.Size, sprite->Area.Location);
     }
     if (_paramImage)


### PR DESCRIPTION
Atlas sprites are currently being identified using an index. Problem is, modifying the atlas list of sprites can invalidate all used sprites, or use the wrong ones, etc. Worse still, this happens without any error or warning, and the user won't even notice until they save and load their project again (because `SpriteHandle` instances are cached, so the editor will still show the correct Sprites even when their index has changed).

This PR makes Sprites use a `Guid` for identification instead.

Various things:
1. Missing is a way of processing existing projects so indices can be replaced with generated `Guid`s. There is a warning that shows up when a project is opened with a newer version of the editor, and I'm assuming something runs to update the project. I'm assuming that mechanism can be used to do this. Otherwise this will be a breaking change...
2. The `Array<Sprite> Sprites` inside `SpriteAtlas` has been replaced with a `Dictionary<Guid, Sprite> Sprites` instead. This has obvious performance implications when `Draw`ing (at least), but the tradeoff of possibly using the wrong index is worse in my opinion. Caching layers or passing `Sprite` references instead might improve this, but benchmarking should probably be applied before fixing what might not be a real issue.