### PR TITLE
Always generate additional Visual Studio solution files for all platforms

### DIFF
--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -199,6 +199,9 @@ namespace Flax.Build
                 if (projectFormats.Count == 0)
                     projectFormats.Add(Platform.BuildPlatform.DefaultProjectFormat);
 
+                // Always generate VS solution files for project (needed for C# Intellisense support)
+                projectFormats.Add(ProjectFormat.VisualStudio2022);
+
                 foreach (ProjectFormat projectFormat in projectFormats)
                     GenerateProject(projectFormat);
             }

--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -228,6 +228,8 @@ namespace Flax.Build
                 var projectToModulesBuildOptions = new Dictionary<Project, Dictionary<Module, BuildOptions>>();
                 Project mainSolutionProject = null;
                 ProjectGenerator nativeProjectGenerator = ProjectGenerator.Create(projectFormat, TargetType.NativeCpp);
+                var solutionName = rootProject.Name;
+                var solutionPath = Path.Combine(workspaceRoot, solutionName + '.' + nativeProjectGenerator.SolutionFileExtension);
 
                 // Group targets by project name and sort groups based on the project (ensures that referenced plugin source projects are generated firstly before main source projects)
                 var targetGroups = new List<ProjectTargetsGroup>();
@@ -549,7 +551,7 @@ namespace Flax.Build
                     foreach (var project in projects)
                     {
                         Log.Verbose(project.Name + " -> " + project.Path);
-                        project.Generate();
+                        project.Generate(solutionPath);
                     }
                 }
 
@@ -628,7 +630,7 @@ namespace Flax.Build
                     using (new ProfileEventScope("GenerateProject"))
                     {
                         Log.Verbose("Project " + rulesProjectName + " -> " + project.Path);
-                        dotNetProjectGenerator.GenerateProject(project);
+                        dotNetProjectGenerator.GenerateProject(project, solutionPath);
                     }
 
                     projects.Add(project);
@@ -641,9 +643,9 @@ namespace Flax.Build
                     using (new ProfileEventScope("CreateSolution"))
                     {
                         solution = nativeProjectGenerator.CreateSolution();
-                        solution.Name = rootProject.Name;
+                        solution.Name = solutionName;
                         solution.WorkspaceRootPath = workspaceRoot;
-                        solution.Path = Path.Combine(workspaceRoot, solution.Name + '.' + nativeProjectGenerator.SolutionFileExtension);
+                        solution.Path = solutionPath;
                         solution.Projects = projects.ToArray();
                         solution.MainProject = mainSolutionProject;
                     }

--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -179,7 +179,7 @@ namespace Flax.Build
             using (new ProfileEventScope("GenerateProjects"))
             {
                 // Pick the project format
-                List<ProjectFormat> projectFormats = new List<ProjectFormat>();
+                HashSet<ProjectFormat> projectFormats = new HashSet<ProjectFormat>();
 
                 if (Configuration.ProjectFormatVS2022)
                     projectFormats.Add(ProjectFormat.VisualStudio2022);
@@ -191,6 +191,8 @@ namespace Flax.Build
                     projectFormats.Add(ProjectFormat.VisualStudio2015);
                 if (Configuration.ProjectFormatVSCode)
                     projectFormats.Add(ProjectFormat.VisualStudioCode);
+                if (Configuration.ProjectFormatRider)
+                    projectFormats.Add(ProjectFormat.VisualStudio2022);
                 if (!string.IsNullOrEmpty(Configuration.ProjectFormatCustom))
                     projectFormats.Add(ProjectFormat.Custom);
 

--- a/Source/Tools/Flax.Build/Configuration.cs
+++ b/Source/Tools/Flax.Build/Configuration.cs
@@ -214,6 +214,12 @@ namespace Flax.Build
         public static bool ProjectFormatVSCode = false;
 
         /// <summary>
+        /// Generates Visual Studio 2022 project format files for Rider. Valid only with -genproject option.
+        /// </summary>
+        [CommandLine("rider", "Generates Visual Studio 2022 project format files for Rider. Valid only with -genproject option.")]
+        public static bool ProjectFormatRider = false;
+
+        /// <summary>
         /// Generates code project files for a custom project format type. Valid only with -genproject option.
         /// </summary>
         [CommandLine("customProjectFormat", "<type>", "Generates code project files for a custom project format type. Valid only with -genproject option.")]

--- a/Source/Tools/Flax.Build/Projects/Project.cs
+++ b/Source/Tools/Flax.Build/Projects/Project.cs
@@ -253,9 +253,9 @@ namespace Flax.Build.Projects
         /// <summary>
         /// Generates the project.
         /// </summary>
-        public virtual void Generate()
+        public virtual void Generate(string solutionPath)
         {
-            Generator.GenerateProject(this);
+            Generator.GenerateProject(this, solutionPath);
         }
 
         /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Projects/ProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/ProjectGenerator.cs
@@ -52,7 +52,7 @@ namespace Flax.Build.Projects
         /// Generates the project.
         /// </summary>
         /// <param name="project">The project.</param>
-        public abstract void GenerateProject(Project project);
+        public abstract void GenerateProject(Project project, string solutionPath);
 
         /// <summary>
         /// Generates the solution.

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
@@ -26,7 +26,7 @@ namespace Flax.Build.Projects.VisualStudio
         public override TargetType? Type => TargetType.DotNet;
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project)
+        public override void GenerateProject(Project project, string solutionPath)
         {
             var csProjectFileContent = new StringBuilder();
 
@@ -48,6 +48,11 @@ namespace Flax.Build.Projects.VisualStudio
             var projectTypes = ProjectTypeGuids.ToOption(ProjectTypeGuids.WindowsCSharp);
             if (vsProject.CSharp.UseFlaxVS && VisualStudioInstance.HasFlaxVS)
                 projectTypes = ProjectTypeGuids.ToOption(ProjectTypeGuids.FlaxVS) + ';' + projectTypes;
+
+            // Try to reuse the existing project guid from solution file
+            vsProject.ProjectGuid = GetProjectGuid(solutionPath, vsProject.Name);
+            if (vsProject.ProjectGuid == Guid.Empty)
+                vsProject.ProjectGuid = Guid.NewGuid();
 
             // Header
 

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -26,7 +26,7 @@ namespace Flax.Build.Projects.VisualStudio
         public override TargetType? Type => TargetType.DotNetCore;
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project)
+        public override void GenerateProject(Project project, string solutionPath)
         {
             var csProjectFileContent = new StringBuilder();
 
@@ -52,6 +52,11 @@ namespace Flax.Build.Projects.VisualStudio
                     break;
                 }
             }
+
+            // Try to reuse the existing project guid from solution file
+            vsProject.ProjectGuid = GetProjectGuid(solutionPath, vsProject.Name);
+            if (vsProject.ProjectGuid == Guid.Empty)
+                vsProject.ProjectGuid = Guid.NewGuid();
 
             // Header
             csProjectFileContent.AppendLine("<Project Sdk=\"Microsoft.NET.Sdk\">");

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
@@ -55,7 +55,7 @@ namespace Flax.Build.Projects.VisualStudio
         }
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project)
+        public override void GenerateProject(Project project, string solutionPath)
         {
             var vcProjectFileContent = new StringBuilder();
             var vcFiltersFileContent = new StringBuilder();
@@ -66,6 +66,13 @@ namespace Flax.Build.Projects.VisualStudio
             var projectFilePlatformToolsetVersion = ProjectFilePlatformToolsetVersion;
             var projectDirectory = Path.GetDirectoryName(project.Path);
             var filtersDirectory = project.SourceFolderPath;
+
+            // Try to reuse the existing project guid from existing files
+            vsProject.ProjectGuid = GetProjectGuid(vsProject.Path, vsProject.Name);
+            if (vsProject.ProjectGuid == Guid.Empty)
+                vsProject.ProjectGuid = GetProjectGuid(solutionPath, vsProject.Name);
+            if (vsProject.ProjectGuid == Guid.Empty)
+                vsProject.ProjectGuid = Guid.NewGuid();
 
             // Header
             vcProjectFileContent.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProject.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProject.cs
@@ -36,20 +36,5 @@ namespace Flax.Build.Projects.VisualStudio
                 }
             }
         }
-
-        /// <inheritdoc />
-        public override string Path
-        {
-            get => base.Path;
-            set
-            {
-                base.Path = value;
-
-                if (ProjectGuid == Guid.Empty)
-                {
-                    ProjectGuid = VisualStudioProjectGenerator.GetProjectGuid(Path);
-                }
-            }
-        }
     }
 }

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -38,7 +38,7 @@ namespace Flax.Build.Projects.VisualStudioCode
         }
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project)
+        public override void GenerateProject(Project project, string solutionPath)
         {
             // Not used, solution contains all projects definitions
         }

--- a/Source/Tools/Flax.Build/Projects/XCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/XCodeProjectGenerator.cs
@@ -42,7 +42,7 @@ namespace Flax.Build.Projects
         }
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project)
+        public override void GenerateProject(Project project, string solutionPath)
         {
         }
 


### PR DESCRIPTION
Fixes ~~# 1537~~ (sorry wrong issue) and possibly other Intellisense issues regarding VSCode, especially in non-Windows platforms where VSCode workspace files are always generated with default `-genproject` options.