### PR TITLE
Show full exception message in error message box for managed exceptions

### DIFF
--- a/Source/Engine/Core/Log.cpp
+++ b/Source/Engine/Core/Log.cpp
@@ -251,19 +251,13 @@ void Log::Logger::Write(LogType type, const StringView& msg)
         OnError(type, msg);
     }
 
-    // Check if need to show message box with that log message
-    if (type == LogType::Fatal)
-    {
+    // Ensure the error gets written to the disk
+    if (type == LogType::Fatal || type == LogType::Error)
         Flush();
 
-        // Process message further
-        if (type == LogType::Fatal)
-            Platform::Fatal(msg);
-        else if (type == LogType::Error)
-            Platform::Error(msg);
-        else
-            Platform::Info(msg);
-    }
+    // Check if need to show message box with that log message
+    if (type == LogType::Fatal)
+        Platform::Fatal(msg);
 }
 
 const Char* ToString(LogType e)

--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -30,6 +30,9 @@
 #endif
 #include "resource.h"
 
+#define CLR_EXCEPTION 0xE0434352
+#define VCPP_EXCEPTION 0xE06D7363
+
 const Char* WindowsPlatform::ApplicationWindowClass = TEXT("FlaxWindow");
 void* WindowsPlatform::Instance = nullptr;
 
@@ -272,6 +275,12 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 LONG CALLBACK SehExceptionHandler(EXCEPTION_POINTERS* ep)
 {
+    if (ep->ExceptionRecord->ExceptionCode == CLR_EXCEPTION)
+    {
+        // Pass CLR exceptions back to runtime
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+
     // Skip if engine already crashed
     if (Globals::FatalErrorOccurred)
         return EXCEPTION_CONTINUE_SEARCH;

--- a/Source/Engine/Scripting/Scripting.cs
+++ b/Source/Engine/Scripting/Scripting.cs
@@ -135,8 +135,13 @@ namespace FlaxEngine
         {
             if (e.ExceptionObject is Exception exception)
             {
-                Debug.LogError("Unhandled Exception: " + exception.Message);
-                Debug.LogException(exception);
+                if (e.IsTerminating && !System.Diagnostics.Debugger.IsAttached)
+                    Platform.Fatal($"Unhandled Exception: {exception}");
+                else
+                {
+                    Debug.LogError($"Unhandled Exception: {exception.Message}");
+                    Debug.LogException(exception);
+                }
             }
         }
 


### PR DESCRIPTION
In case of unhandled managed exceptions, the error dialog is populated with more information:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/4064397/8b14df7a-a8bc-4d95-89b0-4580c9d4b7d6)
