### PR TITLE
Automatically set SpriteRender size when changing either its Texture or Sprite

### DIFF
--- a/Source/Engine/UI/SpriteRender.cpp
+++ b/Source/Engine/UI/SpriteRender.cpp
@@ -87,12 +87,20 @@ void SpriteRender::SetImage()
 {
     TextureBase* image = Image.Get();
     Vector4 imageMAD(Vector2::One, Vector2::Zero);
+    Float2 newSize = _size;
     if (!image && _sprite.IsValid())
     {
         image = _sprite.Atlas.Get();
         Sprite* sprite = &_sprite.Atlas->Sprites.At(_sprite.Index);
         imageMAD = Vector4(sprite->Area.Size, sprite->Area.Location);
+        newSize = sprite->Area.Size * image->Size();
     }
+    else if (image != nullptr)
+    {
+        newSize = image->Size();
+    }
+
+    SetSize(newSize);
     if (_paramImage)
         _paramImage->SetValue(image);
     if (_paramImageMAD)


### PR DESCRIPTION
When assigning a new texture or sprite to a `SpriteRender` element, the size needs to be set by hand, which is really annoying. This PR simply sets the right size after a change of Texture/Sprite has been made.