### PR TITLE
Rename new actor after creating it

### DIFF
--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -173,6 +173,9 @@ namespace FlaxEditor.Windows
 
             // Spawn it
             Editor.SceneEditing.Spawn(actor, parentActor);
+
+            Editor.SceneEditing.Select(actor);
+            Rename();
         }
 
         /// <summary>


### PR DESCRIPTION
Very simple change that starts renaming a new actor just after it's been created. There are more instances where this should happen (IMHO) but they require many more changes, so starting with the low hanging fruit...