### PR TITLE
Fix bool editor when null.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/BooleanEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/BooleanEditor.cs
@@ -34,7 +34,9 @@ namespace FlaxEditor.CustomEditors.Editors
             }
             else
             {
-                element.CheckBox.Checked = (bool)Values[0];
+                var value = (bool?)Values[0];
+                if (value != null)
+                    element.CheckBox.Checked = value.Value;
             }
         }
     }


### PR DESCRIPTION
Fix for #1418. Not sure if there is a bigger issue were it is allowing null values through, but this does fix the issue.