### PR TITLE
Added support for in parameters to the csharp binding generator

### DIFF
--- a/Source/Editor/CustomEditors/CustomEditor.cs
+++ b/Source/Editor/CustomEditors/CustomEditor.cs
@@ -637,7 +637,7 @@ namespace FlaxEditor.CustomEditors
                 if (text.Length != 32)
                     return false;
                 JsonSerializer.ParseID(text, out var id);
-                obj = FlaxEngine.Object.Find<FlaxEngine.Object>(ref id);
+                obj = FlaxEngine.Object.Find<FlaxEngine.Object>(in id);
             }
             else if (Color.TryParseHex(text, out var color))
             {

--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -58,7 +58,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 if (prefab && !prefab.WaitForLoaded())
                 {
                     var prefabObjectId = actor.PrefabObjectID;
-                    var prefabInstance = prefab.GetDefaultInstance(ref prefabObjectId);
+                    var prefabInstance = prefab.GetDefaultInstance(in prefabObjectId);
                     if (prefabInstance != null)
                     {
                         // Use default prefab instance as a reference for the editor
@@ -168,7 +168,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 {
                     var actor = (Actor)Values[0];
                     var prefabObjectId = actor.PrefabObjectID;
-                    var prefabInstance = prefab.GetDefaultInstance(ref prefabObjectId);
+                    var prefabInstance = prefab.GetDefaultInstance(in prefabObjectId);
                     if (prefabInstance != null)
                     {
                         Values.SetReferenceValue(prefabInstance);

--- a/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
@@ -114,7 +114,7 @@ namespace FlaxEditor.CustomEditors.Editors
         public Guid ValueID
         {
             get => _value ? _value.ID : Guid.Empty;
-            set => Value = Object.Find<Object>(ref value);
+            set => Value = Object.Find<Object>(in value);
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace FlaxEditor.CustomEditors.Editors
 
             // Load or get asset
             var id = assetItem.ID;
-            var obj = Object.Find<Asset>(ref id);
+            var obj = Object.Find<Asset>(in id);
             if (obj == null)
                 return false;
 

--- a/Source/Editor/GUI/Drag/DragScripts.cs
+++ b/Source/Editor/GUI/Drag/DragScripts.cs
@@ -100,7 +100,7 @@ namespace FlaxEditor.GUI.Drag
                         // Find element
                         if (Guid.TryParse(ids[i], out Guid id))
                         {
-                            var obj = FlaxEngine.Object.Find<Script>(ref id);
+                            var obj = FlaxEngine.Object.Find<Script>(in id);
 
                             // Check it
                             if (obj != null)
@@ -130,7 +130,7 @@ namespace FlaxEditor.GUI.Drag
                     // Find element
                     if (Guid.TryParse(ids[i], out Guid id))
                     {
-                        var obj = FlaxEngine.Object.Find<Script>(ref id);
+                        var obj = FlaxEngine.Object.Find<Script>(in id);
 
                         // Check it
                         if (obj != null)

--- a/Source/Editor/GUI/Timeline/Tracks/ActorTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/ActorTrack.cs
@@ -78,7 +78,7 @@ namespace FlaxEditor.GUI.Timeline.Tracks
                     }
                     return null;
                 }
-                return FlaxEngine.Object.TryFind<Actor>(ref ActorID);
+                return FlaxEngine.Object.TryFind<Actor>(in ActorID);
             }
             set
             {

--- a/Source/Editor/GUI/Timeline/Tracks/ScriptTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/ScriptTrack.cs
@@ -52,7 +52,7 @@ namespace FlaxEditor.GUI.Timeline.Tracks
         /// </summary>
         public Script Script
         {
-            get => FlaxEngine.Object.TryFind<Script>(ref ScriptID);
+            get => FlaxEngine.Object.TryFind<Script>(in ScriptID);
             set => ScriptID = value?.ID ?? Guid.Empty;
         }
 

--- a/Source/Editor/Gizmo/TransformGizmoBase.Draw.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.Draw.cs
@@ -89,37 +89,37 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationY(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                transAxisMesh.Draw(ref renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, ref m3);
+                transAxisMesh.Draw(in renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, in m3);
 
                 // Y axis
                 Matrix.RotationX(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                transAxisMesh.Draw(ref renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, ref m3);
+                transAxisMesh.Draw(in renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, in m3);
 
                 // Z axis
                 Matrix.RotationX(Mathf.Pi, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                transAxisMesh.Draw(ref renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, ref m3);
+                transAxisMesh.Draw(in renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, in m3);
 
                 // XY plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationX(Mathf.PiOverTwo), new Vector3(boxSize * boxScale, boxSize * boxScale, 0.0f));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX, ref m3);
+                cubeMesh.Draw(in renderContext, _activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX, in m3);
 
                 // ZX plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.Identity, new Vector3(boxSize * boxScale, 0.0f, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ, ref m3);
+                cubeMesh.Draw(in renderContext, _activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ, in m3);
 
                 // YZ plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationZ(Mathf.PiOverTwo), new Vector3(0.0f, boxSize * boxScale, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY, ref m3);
+                cubeMesh.Draw(in renderContext, _activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY, in m3);
 
                 // Center sphere
                 Matrix.Scaling(gizmoModelsScale2RealGizmoSize, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                sphereMesh.Draw(ref renderContext, isCenter ? _materialAxisFocus : _materialSphere, ref m3);
+                sphereMesh.Draw(in renderContext, isCenter ? _materialAxisFocus : _materialSphere, in m3);
 
                 break;
             }
@@ -138,20 +138,20 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationZ(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                rotationAxisMesh.Draw(ref renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, ref m3);
+                rotationAxisMesh.Draw(in renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, in m3);
 
                 // Y axis
-                rotationAxisMesh.Draw(ref renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, ref m1);
+                rotationAxisMesh.Draw(in renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, in m1);
 
                 // Z axis
                 Matrix.RotationX(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                rotationAxisMesh.Draw(ref renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, ref m3);
+                rotationAxisMesh.Draw(in renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, in m3);
 
                 // Center box
                 Matrix.Scaling(gizmoModelsScale2RealGizmoSize, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                sphereMesh.Draw(ref renderContext, isCenter ? _materialAxisFocus : _materialSphere, ref m3);
+                sphereMesh.Draw(in renderContext, isCenter ? _materialAxisFocus : _materialSphere, in m3);
 
                 break;
             }
@@ -171,37 +171,37 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationY(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref mx1, out m3);
-                scaleAxisMesh.Draw(ref renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, ref m3);
+                scaleAxisMesh.Draw(in renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, in m3);
 
                 // Y axis
                 Matrix.RotationX(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                scaleAxisMesh.Draw(ref renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, ref m3);
+                scaleAxisMesh.Draw(in renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, in m3);
 
                 // Z axis
                 Matrix.RotationX(Mathf.Pi, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                scaleAxisMesh.Draw(ref renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, ref m3);
+                scaleAxisMesh.Draw(in renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, in m3);
 
                 // XY plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationX(Mathf.PiOverTwo), new Vector3(boxSize * boxScale, boxSize * boxScale, 0.0f));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX, ref m3);
+                cubeMesh.Draw(in renderContext, _activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX, in m3);
 
                 // ZX plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.Identity, new Vector3(boxSize * boxScale, 0.0f, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ, ref m3);
+                cubeMesh.Draw(in renderContext, _activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ, in m3);
 
                 // YZ plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationZ(Mathf.PiOverTwo), new Vector3(0.0f, boxSize * boxScale, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY, ref m3);
+                cubeMesh.Draw(in renderContext, _activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY, in m3);
 
                 // Center box
                 Matrix.Scaling(gizmoModelsScale2RealGizmoSize, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                sphereMesh.Draw(ref renderContext, isCenter ? _materialAxisFocus : _materialSphere, ref m3);
+                sphereMesh.Draw(in renderContext, isCenter ? _materialAxisFocus : _materialSphere, in m3);
 
                 break;
             }

--- a/Source/Editor/Modules/ContentFindingModule.cs
+++ b/Source/Editor/Modules/ContentFindingModule.cs
@@ -228,7 +228,7 @@ namespace FlaxEditor.Modules
                         new SearchResult { Name = item.ShortName, Type = assetItem.TypeName, Item = item }
                     };
                 }
-                var actor = FlaxEngine.Object.Find<Actor>(ref id);
+                var actor = FlaxEngine.Object.Find<Actor>(in id);
                 if (actor != null)
                 {
                     return new List<SearchResult>

--- a/Source/Editor/SceneGraph/Actors/CameraNode.cs
+++ b/Source/Editor/SceneGraph/Actors/CameraNode.cs
@@ -35,7 +35,7 @@ namespace FlaxEditor.SceneGraph.Actors
                 return false;
             }
 
-            return Camera.Internal_IntersectsItselfEditor(FlaxEngine.Object.GetUnmanagedPtr(_actor), ref ray.Ray, out distance);
+            return Camera.Internal_IntersectsItselfEditor(FlaxEngine.Object.GetUnmanagedPtr(_actor), in ray.Ray, out distance);
         }
     }
 }

--- a/Source/Editor/SceneGraph/Actors/SplineNode.cs
+++ b/Source/Editor/SceneGraph/Actors/SplineNode.cs
@@ -104,19 +104,19 @@ namespace FlaxEditor.SceneGraph.Actors
 
                 public void Do()
                 {
-                    var spline = Object.Find<Spline>(ref SplineId);
+                    var spline = Object.Find<Spline>(in SplineId);
                     spline.InsertSplineLocalPoint(Index, Time, Value);
                 }
 
                 public void Undo()
                 {
-                    var spline = Object.Find<Spline>(ref SplineId);
+                    var spline = Object.Find<Spline>(in SplineId);
                     spline.RemoveSplinePoint(Index);
                 }
 
                 public void MarkSceneEdited(SceneModule sceneModule)
                 {
-                    var spline = Object.Find<Spline>(ref SplineId);
+                    var spline = Object.Find<Spline>(in SplineId);
                     sceneModule.MarkSceneEdited(spline.Scene);
                     OnSplineEdited(spline);
                 }
@@ -211,7 +211,7 @@ namespace FlaxEditor.SceneGraph.Actors
             public static SceneGraphNode Create(StateData state)
             {
                 var data = JsonSerializer.Deserialize<Data>(state.State);
-                var spline = Object.Find<Spline>(ref data.Spline);
+                var spline = Object.Find<Spline>(in data.Spline);
                 spline.InsertSplineLocalPoint(data.Index, data.Keyframe.Time, data.Keyframe.Value, false);
                 spline.SetSplineKeyframe(data.Index, data.Keyframe);
                 var splineNode = (SplineNode)SceneGraphFactory.FindNode(data.Spline);

--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -496,7 +496,7 @@ namespace FlaxEditor.SceneGraph.GUI
                 // Restore links
                 for (int i = 0; i < _actorsCount; i++)
                 {
-                    var actor = Object.Find<Actor>(ref _ids[i]);
+                    var actor = Object.Find<Actor>(in _ids[i]);
                     if (actor != null && _prefabIds[i] != Guid.Empty)
                     {
                         Actor.Internal_LinkPrefab(Object.GetUnmanagedPtr(actor), ref _prefabIds[i], ref _prefabObjectIds[i]);
@@ -504,7 +504,7 @@ namespace FlaxEditor.SceneGraph.GUI
                 }
                 for (int i = _actorsCount; i < _ids.Length; i++)
                 {
-                    var script = Object.Find<Script>(ref _ids[i]);
+                    var script = Object.Find<Script>(in _ids[i]);
                     if (script != null && _prefabIds[i] != Guid.Empty)
                     {
                         Script.Internal_LinkPrefab(Object.GetUnmanagedPtr(script), ref _prefabIds[i], ref _prefabObjectIds[i]);

--- a/Source/Editor/SceneGraph/SceneGraphFactory.cs
+++ b/Source/Editor/SceneGraph/SceneGraphFactory.cs
@@ -99,7 +99,7 @@ namespace FlaxEditor.SceneGraph
             Nodes.TryGetValue(id, out SceneGraphNode result);
             if (result == null)
             {
-                var actor = Object.TryFind<Actor>(ref id);
+                var actor = Object.TryFind<Actor>(in id);
                 if (actor != null)
                 {
                     result = BuildActorNode(actor);

--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -773,7 +773,7 @@ namespace FlaxEditor.Surface.Archetypes
             private void UpdateOutputBox()
             {
                 var id = (Guid)Values[0];
-                var actor = FlaxEngine.Object.Find<Actor>(ref id);
+                var actor = FlaxEngine.Object.Find<Actor>(in id);
                 var box = (OutputBox)GetBox(0);
                 box.CurrentType = new ScriptType(actor != null ? actor.GetType() : typeof(Actor));
             }

--- a/Source/Editor/Surface/Elements/InputBox.cs
+++ b/Source/Editor/Surface/Elements/InputBox.cs
@@ -1550,7 +1550,7 @@ namespace FlaxEditor.Surface.Elements
                 if (text.Length != 32)
                     return false;
                 JsonSerializer.ParseID(text, out var id);
-                obj = FlaxEngine.Object.Find<FlaxEngine.Object>(ref id);
+                obj = FlaxEngine.Object.Find<FlaxEngine.Object>(in id);
             }
             else
             {

--- a/Source/Editor/Tools/Foliage/EditFoliageGizmo.cs
+++ b/Source/Editor/Tools/Foliage/EditFoliageGizmo.cs
@@ -218,7 +218,7 @@ namespace FlaxEditor.Tools.Foliage
             {
                 var transform = foliage.Transform.LocalToWorld(instance.Transform);
                 renderContext.View.GetWorldMatrix(ref transform, out var world);
-                model.Draw(ref renderContext, _highlightMaterial, ref world, StaticFlags.None, false);
+                model.Draw(in renderContext, _highlightMaterial, in world, StaticFlags.None, false);
             }
         }
 

--- a/Source/Editor/Tools/Foliage/PaintFoliageGizmo.cs
+++ b/Source/Editor/Tools/Foliage/PaintFoliageGizmo.cs
@@ -94,7 +94,7 @@ namespace FlaxEditor.Tools.Foliage
                     else
                         rotation = Quaternion.LookRotation(Vector3.Cross(Vector3.Cross(brushNormal, Vector3.Forward), brushNormal), brushNormal);
                     Matrix transform = Matrix.Scaling(Mode.CurrentBrush.Size * 0.01f) * Matrix.RotationQuaternion(rotation) * Matrix.Translation(brushPosition - renderContext.View.Origin);
-                    _brushModel.Draw(ref renderContext, brushMaterial, ref transform);
+                    _brushModel.Draw(in renderContext, brushMaterial, in transform);
                 }
             }
         }

--- a/Source/Editor/Tools/Foliage/Undo/DeleteInstanceAction.cs
+++ b/Source/Editor/Tools/Foliage/Undo/DeleteInstanceAction.cs
@@ -39,7 +39,7 @@ namespace FlaxEditor.Tools.Foliage.Undo
         public void Do()
         {
             var foliageId = _foliageId;
-            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(ref foliageId);
+            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(in foliageId);
 
             _instance = foliage.GetInstance(_index);
             foliage.RemoveInstance(_index);
@@ -52,7 +52,7 @@ namespace FlaxEditor.Tools.Foliage.Undo
         public void Undo()
         {
             var foliageId = _foliageId;
-            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(ref foliageId);
+            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(in foliageId);
 
             _index = foliage.InstancesCount;
             foliage.AddInstance(ref _instance);

--- a/Source/Editor/Tools/Foliage/Undo/EditFoliageAction.cs
+++ b/Source/Editor/Tools/Foliage/Undo/EditFoliageAction.cs
@@ -38,7 +38,7 @@ namespace FlaxEditor.Tools.Foliage.Undo
         public void RecordEnd()
         {
             var foliageId = _foliageId;
-            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(ref foliageId);
+            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(in foliageId);
 
             _after = foliage.ToJson();
 
@@ -70,7 +70,7 @@ namespace FlaxEditor.Tools.Foliage.Undo
         private void Set(string data)
         {
             var foliageId = _foliageId;
-            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(ref foliageId);
+            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(in foliageId);
 
             foliage.FromJson(data);
 

--- a/Source/Editor/Tools/Foliage/Undo/EditInstanceAction.cs
+++ b/Source/Editor/Tools/Foliage/Undo/EditInstanceAction.cs
@@ -42,7 +42,7 @@ namespace FlaxEditor.Tools.Foliage.Undo
         public void RecordEnd()
         {
             var foliageId = _foliageId;
-            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(ref foliageId);
+            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(in foliageId);
             _after = foliage.GetInstance(_index).Transform;
             Editor.Instance.Scene.MarkSceneEdited(foliage.Scene);
         }
@@ -54,7 +54,7 @@ namespace FlaxEditor.Tools.Foliage.Undo
         public void Do()
         {
             var foliageId = _foliageId;
-            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(ref foliageId);
+            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(in foliageId);
             foliage.SetInstanceTransform(_index, ref _after);
             foliage.RebuildClusters();
             Editor.Instance.Scene.MarkSceneEdited(foliage.Scene);
@@ -64,7 +64,7 @@ namespace FlaxEditor.Tools.Foliage.Undo
         public void Undo()
         {
             var foliageId = _foliageId;
-            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(ref foliageId);
+            var foliage = FlaxEngine.Object.Find<FlaxEngine.Foliage>(in foliageId);
             foliage.SetInstanceTransform(_index, ref _before);
             foliage.RebuildClusters();
             Editor.Instance.Scene.MarkSceneEdited(foliage.Scene);

--- a/Source/Editor/Tools/Terrain/EditTab.cs
+++ b/Source/Editor/Tools/Terrain/EditTab.cs
@@ -152,7 +152,7 @@ namespace FlaxEditor.Tools.Terrain
             /// <inheritdoc />
             public void Do()
             {
-                var terrain = Object.Find<FlaxEngine.Terrain>(ref _terrainId);
+                var terrain = Object.Find<FlaxEngine.Terrain>(in _terrainId);
                 if (terrain == null)
                 {
                     Editor.LogError("Missing terrain actor.");
@@ -167,7 +167,7 @@ namespace FlaxEditor.Tools.Terrain
             /// <inheritdoc />
             public void Undo()
             {
-                var terrain = Object.Find<FlaxEngine.Terrain>(ref _terrainId);
+                var terrain = Object.Find<FlaxEngine.Terrain>(in _terrainId);
                 if (terrain == null)
                 {
                     Editor.LogError("Missing terrain actor.");
@@ -270,7 +270,7 @@ namespace FlaxEditor.Tools.Terrain
 
             private void Set(ref Guid id)
             {
-                var terrain = Object.Find<FlaxEngine.Terrain>(ref _terrainId);
+                var terrain = Object.Find<FlaxEngine.Terrain>(in _terrainId);
                 if (terrain == null)
                 {
                     Editor.LogError("Missing terrain actor.");

--- a/Source/Editor/Tools/Terrain/EditTerrainGizmo.cs
+++ b/Source/Editor/Tools/Terrain/EditTerrainGizmo.cs
@@ -166,7 +166,7 @@ namespace FlaxEditor.Tools.Terrain
             /// <inheritdoc />
             public void Do()
             {
-                var terrain = Object.Find<FlaxEngine.Terrain>(ref _terrainId);
+                var terrain = Object.Find<FlaxEngine.Terrain>(in _terrainId);
                 if (terrain == null)
                 {
                     Editor.LogError("Missing terrain actor.");
@@ -185,7 +185,7 @@ namespace FlaxEditor.Tools.Terrain
             /// <inheritdoc />
             public void Undo()
             {
-                var terrain = Object.Find<FlaxEngine.Terrain>(ref _terrainId);
+                var terrain = Object.Find<FlaxEngine.Terrain>(in _terrainId);
                 if (terrain == null)
                 {
                     Editor.LogError("Missing terrain actor.");

--- a/Source/Editor/Tools/Terrain/EditTerrainGizmo.cs
+++ b/Source/Editor/Tools/Terrain/EditTerrainGizmo.cs
@@ -96,7 +96,7 @@ namespace FlaxEditor.Tools.Terrain
                                    Matrix.Scaling(terrain.Scale) *
                                    Matrix.RotationQuaternion(terrain.Orientation) *
                                    Matrix.Translation(terrain.Position - renderContext.View.Origin);
-                    _planeModel.Draw(ref renderContext, _highlightMaterial, ref world);
+                    _planeModel.Draw(in renderContext, _highlightMaterial, in world);
                 }
 
                 break;

--- a/Source/Editor/Tools/Terrain/Undo/EditTerrainMapAction.cs
+++ b/Source/Editor/Tools/Terrain/Undo/EditTerrainMapAction.cs
@@ -71,7 +71,7 @@ namespace FlaxEditor.Tools.Terrain.Undo
             get
             {
                 var terrainId = _terrain;
-                return FlaxEngine.Object.Find<FlaxEngine.Terrain>(ref terrainId);
+                return FlaxEngine.Object.Find<FlaxEngine.Terrain>(in terrainId);
             }
         }
 

--- a/Source/Editor/Tools/VertexPainting.cs
+++ b/Source/Editor/Tools/VertexPainting.cs
@@ -638,7 +638,7 @@ namespace FlaxEditor.Tools
                     _brushMaterial.SetParameterValue("DepthBuffer", Owner.RenderTask.Buffers.DepthBuffer);
                     Quaternion rotation = RootNode.RaycastNormalRotation(ref _hitNormal);
                     Matrix transform = Matrix.Scaling(_gizmoMode.BrushSize * 0.01f) * Matrix.RotationQuaternion(rotation) * Matrix.Translation(_hitLocation - viewOrigin);
-                    _brushModel.Draw(ref renderContext, _brushMaterial, ref transform);
+                    _brushModel.Draw(in renderContext, _brushMaterial, in transform);
                 }
 
                 // Draw intersecting vertices
@@ -669,7 +669,7 @@ namespace FlaxEditor.Tools
                                 if (brushSphere.Contains(ref pos) == ContainmentType.Disjoint)
                                     continue;
                                 Matrix transform = modelScaleMatrix * Matrix.Translation(pos - viewOrigin);
-                                _brushModel.Draw(ref renderContext, _verticesPreviewMaterial, ref transform);
+                                _brushModel.Draw(in renderContext, _verticesPreviewMaterial, in transform);
                             }
                         }
                     }

--- a/Source/Editor/Tools/VertexPainting.cs
+++ b/Source/Editor/Tools/VertexPainting.cs
@@ -772,14 +772,14 @@ namespace FlaxEditor.Tools
 
         public void RecordEnd()
         {
-            var model = Object.Find<StaticModel>(ref _actorId);
+            var model = Object.Find<StaticModel>(in _actorId);
             _after = GetState(model);
             Editor.Instance.Scene.MarkSceneEdited(model.Scene);
         }
 
         private void Set(string state)
         {
-            var model = Object.Find<StaticModel>(ref _actorId);
+            var model = Object.Find<StaticModel>(in _actorId);
             SetState(model, state);
             Editor.Instance.Scene.MarkSceneEdited(model.Scene);
         }

--- a/Source/Editor/Undo/Actions/AddRemoveScriptAction.cs
+++ b/Source/Editor/Undo/Actions/AddRemoveScriptAction.cs
@@ -136,7 +136,7 @@ namespace FlaxEditor.Actions
         private void DoRemove()
         {
             // Remove script (it could be removed by sth else, just check it)
-            var script = Object.Find<Script>(ref _scriptId);
+            var script = Object.Find<Script>(in _scriptId);
             if (!script)
             {
                 Editor.LogWarning("Missing script.");
@@ -150,7 +150,7 @@ namespace FlaxEditor.Actions
         private void DoAdd()
         {
             // Restore script
-            var parentActor = Object.Find<Actor>(ref _parentId);
+            var parentActor = Object.Find<Actor>(in _parentId);
             if (parentActor == null)
             {
                 Editor.LogWarning("Missing parent actor.");
@@ -168,7 +168,7 @@ namespace FlaxEditor.Actions
                 Editor.LogWarning("Cannot create script of type " + _scriptTypeName);
                 return;
             }
-            Object.Internal_ChangeID(Object.GetUnmanagedPtr(script), ref _scriptId);
+            Object.Internal_ChangeID(Object.GetUnmanagedPtr(script), in _scriptId);
             if (_scriptData != null)
                 FlaxEngine.Json.JsonSerializer.Deserialize(script, _scriptData);
             script.Enabled = _enabled;

--- a/Source/Editor/Undo/Actions/BreakPrefabLinkAction.cs
+++ b/Source/Editor/Undo/Actions/BreakPrefabLinkAction.cs
@@ -104,7 +104,7 @@ namespace FlaxEditor.Actions
             if (_prefabObjectIds == null)
                 throw new Exception("Cannot link prefab. Missing objects Ids mapping.");
 
-            var actor = Object.Find<Actor>(ref _actorId);
+            var actor = Object.Find<Actor>(in _actorId);
             if (actor == null)
                 throw new Exception("Cannot link prefab. Missing actor.");
 
@@ -114,7 +114,7 @@ namespace FlaxEditor.Actions
                 var objId = e.Key;
                 var prefabObjId = e.Value;
 
-                var obj = Object.Find<Object>(ref objId);
+                var obj = Object.Find<Object>(in objId);
                 if (obj is Actor)
                 {
                     Actor.Internal_LinkPrefab(Object.GetUnmanagedPtr(obj), ref _prefabId, ref prefabObjId);
@@ -147,7 +147,7 @@ namespace FlaxEditor.Actions
 
         private void DoBreak()
         {
-            var actor = Object.Find<Actor>(ref _actorId);
+            var actor = Object.Find<Actor>(in _actorId);
             if (actor == null)
                 throw new Exception("Cannot break prefab link. Missing actor.");
             if (!actor.HasPrefabLink)

--- a/Source/Editor/Undo/Actions/ChangeScriptAction.cs
+++ b/Source/Editor/Undo/Actions/ChangeScriptAction.cs
@@ -66,7 +66,7 @@ namespace FlaxEditor.Actions
         /// <inheritdoc />
         public void Do()
         {
-            var script = FlaxEngine.Object.Find<Script>(ref _scriptId);
+            var script = FlaxEngine.Object.Find<Script>(in _scriptId);
             if (script == null)
                 return;
             script.Enabled = _enableB;
@@ -76,7 +76,7 @@ namespace FlaxEditor.Actions
         /// <inheritdoc />
         public void Undo()
         {
-            var script = FlaxEngine.Object.Find<Script>(ref _scriptId);
+            var script = FlaxEngine.Object.Find<Script>(in _scriptId);
             if (script == null)
                 return;
             script.Enabled = _enableA;
@@ -91,7 +91,7 @@ namespace FlaxEditor.Actions
         /// <inheritdoc />
         public void MarkSceneEdited(SceneModule sceneModule)
         {
-            var script = FlaxEngine.Object.Find<Script>(ref _scriptId);
+            var script = FlaxEngine.Object.Find<Script>(in _scriptId);
             if (script != null)
                 sceneModule.MarkSceneEdited(script.Scene);
         }

--- a/Source/Editor/Undo/Actions/EditSplineAction.cs
+++ b/Source/Editor/Undo/Actions/EditSplineAction.cs
@@ -42,7 +42,7 @@ namespace FlaxEditor.Actions
         /// <inheritdoc />
         public void Do()
         {
-            var spline = FlaxEngine.Object.Find<Spline>(ref _splineId);
+            var spline = FlaxEngine.Object.Find<Spline>(in _splineId);
             if (spline == null)
                 return;
             spline.SplineKeyframes = _after;
@@ -52,7 +52,7 @@ namespace FlaxEditor.Actions
         /// <inheritdoc />
         public void Undo()
         {
-            var spline = FlaxEngine.Object.Find<Spline>(ref _splineId);
+            var spline = FlaxEngine.Object.Find<Spline>(in _splineId);
             if (spline == null)
                 return;
             spline.SplineKeyframes = _before;
@@ -68,7 +68,7 @@ namespace FlaxEditor.Actions
         /// <inheritdoc />
         public void MarkSceneEdited(SceneModule sceneModule)
         {
-            var spline = FlaxEngine.Object.Find<Spline>(ref _splineId);
+            var spline = FlaxEngine.Object.Find<Spline>(in _splineId);
             if (spline != null)
                 sceneModule.MarkSceneEdited(spline.Scene);
         }

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -945,7 +945,7 @@ namespace FlaxEditor.Viewport
                 {
                     _previewStaticModel = (StaticModel)staticModelNode.Actor;
                     var ray = ConvertMouseToRay(ref location);
-                    _previewStaticModel.IntersectsEntry(ref ray, out _, out _, out _previewModelEntryIndex);
+                    _previewStaticModel.IntersectsEntry(in ray, out _, out _, out _previewModelEntryIndex);
                 }
                 else if (hit is BoxBrushNode.SideLinkNode brushSurfaceNode)
                 {
@@ -1078,7 +1078,7 @@ namespace FlaxEditor.Viewport
                 {
                     var staticModel = (StaticModel)staticModelNode.Actor;
                     var ray = ConvertMouseToRay(ref location);
-                    if (staticModel.IntersectsEntry(ref ray, out _, out _, out var entryIndex))
+                    if (staticModel.IntersectsEntry(in ray, out _, out _, out var entryIndex))
                     {
                         using (new UndoBlock(Undo, staticModel, "Change material"))
                             staticModel.SetMaterial(entryIndex, material);

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -735,7 +735,7 @@ namespace FlaxEditor.Viewport
                     {
                         var staticModel = (StaticModel)staticModelNode.Actor;
                         var ray = ConvertMouseToRay(ref location);
-                        if (staticModel.IntersectsEntry(ref ray, out _, out _, out var entryIndex))
+                        if (staticModel.IntersectsEntry(in ray, out _, out _, out var entryIndex))
                         {
                             var material = FlaxEngine.Content.LoadAsync<MaterialBase>(item.ID);
                             using (new UndoBlock(Undo, staticModel, "Change material"))

--- a/Source/Editor/ViewportDebugDrawData.cs
+++ b/Source/Editor/ViewportDebugDrawData.cs
@@ -126,7 +126,7 @@ namespace FlaxEditor
                     {
                         if (lod.Meshes[meshIndex].MaterialSlotIndex == highlight.EntryIndex)
                         {
-                            lod.Meshes[meshIndex].Draw(ref renderContext, _highlightMaterial, ref world);
+                            lod.Meshes[meshIndex].Draw(in renderContext, _highlightMaterial, in world);
                         }
                     }
                 }
@@ -145,7 +145,7 @@ namespace FlaxEditor
                 }
 
                 world = Matrix.Identity;
-                mesh.Draw(ref renderContext, _highlightMaterial, ref world);
+                mesh.Draw(in renderContext, _highlightMaterial, in world);
             }
 
             Profiler.EndEvent();

--- a/Source/Editor/Windows/AssetReferencesGraphWindow.cs
+++ b/Source/Editor/Windows/AssetReferencesGraphWindow.cs
@@ -204,7 +204,7 @@ namespace FlaxEditor.Windows
 
             // Load asset (with cancel support)
             //Debug.Log("Searching refs for " + assetInfo.Path);
-            var obj = FlaxEngine.Object.TryFind<FlaxEngine.Object>(ref assetId);
+            var obj = FlaxEngine.Object.TryFind<FlaxEngine.Object>(in assetId);
             if (obj is Scene scene)
             {
                 // Special case for scene assets that are also loaded
@@ -260,7 +260,7 @@ namespace FlaxEditor.Windows
                 var assetRef = assetRefs[i];
 
                 // Check if asset exists
-                var obj = FlaxEngine.Object.TryFind<FlaxEngine.Object>(ref assetRef);
+                var obj = FlaxEngine.Object.TryFind<FlaxEngine.Object>(in assetRef);
                 if (!(obj is Asset) && !(obj is Scene))
                 {
                     var asset = FlaxEngine.Content.LoadAsync<Asset>(assetRef);

--- a/Source/Editor/Windows/Assets/PrefabWindow.Actions.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Actions.cs
@@ -37,8 +37,8 @@ namespace FlaxEditor.Windows.Assets
 
             private void Set(Guid oldRootId, Guid newRootId)
             {
-                var oldRoot = Object.Find<Actor>(ref oldRootId);
-                var newRoot = Object.Find<Actor>(ref newRootId);
+                var oldRoot = Object.Find<Actor>(in oldRootId);
+                var newRoot = Object.Find<Actor>(in newRootId);
 
                 _window.Graph.MainActor = null;
                 _window.Viewport.Instance = null;

--- a/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
@@ -952,7 +952,7 @@ namespace FlaxEditor.Windows.Assets
             // Try to reassign the player
             if (_timeline.Player == null && _cachedPlayerId != Guid.Empty)
             {
-                var obj = Object.TryFind<SceneAnimationPlayer>(ref _cachedPlayerId);
+                var obj = Object.TryFind<SceneAnimationPlayer>(in _cachedPlayerId);
                 if (obj)
                 {
                     _cachedPlayerId = Guid.Empty;

--- a/Source/Engine/Content/Assets/Model.h
+++ b/Source/Engine/Content/Assets/Model.h
@@ -182,7 +182,7 @@ public:
     /// <param name="flags">The object static flags.</param>
     /// <param name="receiveDecals">True if rendered geometry can receive decals, otherwise false.</param>
     /// <param name="sortOrder">Object sorting key.</param>
-    API_FUNCTION() void Draw(API_PARAM(Ref) const RenderContext& renderContext, MaterialBase* material, API_PARAM(Ref) const Matrix& world, StaticFlags flags = StaticFlags::None, bool receiveDecals = true, int16 sortOrder = 0) const;
+    API_FUNCTION() void Draw(API_PARAM(In) const RenderContext& renderContext, MaterialBase* material, API_PARAM(In) const Matrix& world, StaticFlags flags = StaticFlags::None, bool receiveDecals = true, int16 sortOrder = 0) const;
 
     /// <summary>
     /// Draws the model.

--- a/Source/Engine/Graphics/Models/Mesh.h
+++ b/Source/Engine/Graphics/Models/Mesh.h
@@ -287,7 +287,7 @@ public:
     /// <param name="drawModes">The draw passes to use for rendering this object.</param>
     /// <param name="perInstanceRandom">The random per-instance value (normalized to range 0-1).</param>
     /// <param name="sortOrder">Object sorting key.</param>
-    API_FUNCTION() void Draw(API_PARAM(Ref) const RenderContext& renderContext, MaterialBase* material, API_PARAM(Ref) const Matrix& world, StaticFlags flags = StaticFlags::None, bool receiveDecals = true, DrawPass drawModes = DrawPass::Default, float perInstanceRandom = 0.0f, int16 sortOrder = 0) const;
+    API_FUNCTION() void Draw(API_PARAM(In) const RenderContext& renderContext, MaterialBase* material, API_PARAM(In) const Matrix& world, StaticFlags flags = StaticFlags::None, bool receiveDecals = true, DrawPass drawModes = DrawPass::Default, float perInstanceRandom = 0.0f, int16 sortOrder = 0) const;
 
     /// <summary>
     /// Draws the mesh.

--- a/Source/Engine/Graphics/Models/ModelLOD.h
+++ b/Source/Engine/Graphics/Models/ModelLOD.h
@@ -138,7 +138,7 @@ public:
     /// <param name="drawModes">The draw passes to use for rendering this object.</param>
     /// <param name="perInstanceRandom">The random per-instance value (normalized to range 0-1).</param>
     /// <param name="sortOrder">Object sorting key.</param>
-    API_FUNCTION() void Draw(API_PARAM(Ref) const RenderContext& renderContext, MaterialBase* material, API_PARAM(Ref) const Matrix& world, StaticFlags flags = StaticFlags::None, bool receiveDecals = true, DrawPass drawModes = DrawPass::Default, float perInstanceRandom = 0.0f, int16 sortOrder = 0) const
+    API_FUNCTION() void Draw(API_PARAM(In) const RenderContext& renderContext, MaterialBase* material, API_PARAM(In) const Matrix& world, StaticFlags flags = StaticFlags::None, bool receiveDecals = true, DrawPass drawModes = DrawPass::Default, float perInstanceRandom = 0.0f, int16 sortOrder = 0) const
     {
         for (int32 i = 0; i < Meshes.Count(); i++)
             Meshes.Get()[i].Draw(renderContext, material, world, flags, receiveDecals, drawModes, perInstanceRandom, sortOrder);

--- a/Source/Engine/Graphics/RenderView.cs
+++ b/Source/Engine/Graphics/RenderView.cs
@@ -98,7 +98,7 @@ namespace FlaxEngine
             Direction = camera.Direction;
             Near = camera.NearPlane;
             Far = camera.FarPlane;
-            camera.GetMatrices(out View, out Projection, ref viewport, ref Origin);
+            camera.GetMatrices(out View, out Projection, in viewport, in Origin);
             NonJitteredProjection = Projection;
             TemporalAAJitter = Float4.Zero;
             RenderLayersMask = camera.RenderLayersMask;

--- a/Source/Engine/Level/Actors/Camera.h
+++ b/Source/Engine/Level/Actors/Camera.h
@@ -148,7 +148,7 @@ public:
     /// <param name="worldSpaceLocation">The input world-space location (XYZ in world).</param>
     /// <param name="cameraViewportSpaceLocation">The output camera viewport-space location (XY in screen pixels).</param>
     /// <param name="viewport">The viewport.</param>
-    API_FUNCTION() void ProjectPoint(const Vector3& worldSpaceLocation, API_PARAM(Out) Float2& cameraViewportSpaceLocation, API_PARAM(Ref) const Viewport& viewport) const;
+    API_FUNCTION() void ProjectPoint(const Vector3& worldSpaceLocation, API_PARAM(Out) Float2& cameraViewportSpaceLocation, API_PARAM(In) const Viewport& viewport) const;
 
     /// <summary>
     /// Converts a game window-space point into a corresponding point in world space.
@@ -165,7 +165,7 @@ public:
     /// <param name="depth">The input camera-relative depth position (eg. clipping plane).</param>
     /// <param name="worldSpaceLocation">The output world-space location (XYZ in world).</param>
     /// <param name="viewport">The viewport.</param>
-    API_FUNCTION() void UnprojectPoint(const Float2& cameraViewportSpaceLocation, float depth, API_PARAM(Out) Vector3& worldSpaceLocation, API_PARAM(Ref) const Viewport& viewport) const;
+    API_FUNCTION() void UnprojectPoint(const Float2& cameraViewportSpaceLocation, float depth, API_PARAM(Out) Vector3& worldSpaceLocation, API_PARAM(In) const Viewport& viewport) const;
 
     /// <summary>
     /// Checks if the 3d point of the world is in the camera's field of view.
@@ -187,7 +187,7 @@ public:
     /// <param name="mousePosition">The mouse position.</param>
     /// <param name="viewport">The viewport.</param>
     /// <returns>Mouse ray</returns>
-    API_FUNCTION() Ray ConvertMouseToRay(const Float2& mousePosition, API_PARAM(Ref) const Viewport& viewport) const;
+    API_FUNCTION() Ray ConvertMouseToRay(const Float2& mousePosition, API_PARAM(In) const Viewport& viewport) const;
 
     /// <summary>
     /// Gets the camera viewport.
@@ -207,7 +207,7 @@ public:
     /// <param name="view">The result camera view matrix.</param>
     /// <param name="projection">The result camera projection matrix.</param>
     /// <param name="viewport">The custom output viewport.</param>
-    API_FUNCTION() void GetMatrices(API_PARAM(Out) Matrix& view, API_PARAM(Out) Matrix& projection, API_PARAM(Ref) const Viewport& viewport) const;
+    API_FUNCTION() void GetMatrices(API_PARAM(Out) Matrix& view, API_PARAM(Out) Matrix& projection, API_PARAM(In) const Viewport& viewport) const;
 
     /// <summary>
     /// Calculates the view and the projection matrices for the camera. Support using custom viewport and view origin.
@@ -216,11 +216,11 @@ public:
     /// <param name="projection">The result camera projection matrix.</param>
     /// <param name="viewport">The custom output viewport.</param>
     /// <param name="origin">The rendering view origin (for relative-to-camera rendering).</param>
-    API_FUNCTION() void GetMatrices(API_PARAM(Out) Matrix& view, API_PARAM(Out) Matrix& projection, API_PARAM(Ref) const Viewport& viewport, API_PARAM(Ref) const Vector3& origin) const;
+    API_FUNCTION() void GetMatrices(API_PARAM(Out) Matrix& view, API_PARAM(Out) Matrix& projection, API_PARAM(In) const Viewport& viewport, API_PARAM(In) const Vector3& origin) const;
 
 #if USE_EDITOR
     // Intersection check for editor picking the camera
-    API_FUNCTION() bool IntersectsItselfEditor(API_PARAM(Ref) const Ray& ray, API_PARAM(Out) Real& distance);
+    API_FUNCTION() bool IntersectsItselfEditor(API_PARAM(In) const Ray& ray, API_PARAM(Out) Real& distance);
 #endif
 
 private:

--- a/Source/Engine/Level/Actors/ModelInstanceActor.h
+++ b/Source/Engine/Level/Actors/ModelInstanceActor.h
@@ -71,7 +71,7 @@ public:
     /// <param name="distance">When the method completes and returns true, contains the distance of the intersection (if any valid).</param>
     /// <param name="normal">When the method completes, contains the intersection surface normal vector (if any valid).</param>
     /// <returns>True if the actor is intersected by the ray, otherwise false.</returns>
-    API_FUNCTION() virtual bool IntersectsEntry(int32 entryIndex, API_PARAM(Ref) const Ray& ray, API_PARAM(Out) Real& distance, API_PARAM(Out) Vector3& normal)
+    API_FUNCTION() virtual bool IntersectsEntry(int32 entryIndex, API_PARAM(In) const Ray& ray, API_PARAM(Out) Real& distance, API_PARAM(Out) Vector3& normal)
     {
         return false;
     }
@@ -87,7 +87,7 @@ public:
     /// <param name="normal">When the method completes, contains the intersection surface normal vector (if any valid).</param>
     /// <param name="entryIndex">When the method completes, contains the intersection entry index (if any valid).</param>
     /// <returns>True if the actor is intersected by the ray, otherwise false.</returns>
-    API_FUNCTION() virtual bool IntersectsEntry(API_PARAM(Ref) const Ray& ray, API_PARAM(Out) Real& distance, API_PARAM(Out) Vector3& normal, API_PARAM(Out) int32& entryIndex)
+    API_FUNCTION() virtual bool IntersectsEntry(API_PARAM(In) const Ray& ray, API_PARAM(Out) Real& distance, API_PARAM(Out) Vector3& normal, API_PARAM(Out) int32& entryIndex)
     {
         return false;
     }

--- a/Source/Engine/Level/Prefabs/Prefab.h
+++ b/Source/Engine/Level/Prefabs/Prefab.h
@@ -63,7 +63,7 @@ public:
     /// </summary>
     /// <param name="objectId">The ID of the object to get from prefab default object. It can be one of the child-actors or any script that exists in the prefab. Methods returns root if id is empty.</param>
     /// <returns>The object of the prefab loaded from the prefab. Contains the default values. It's not added to gameplay but deserialized with postLoad and init event fired.</returns>
-    API_FUNCTION() SceneObject* GetDefaultInstance(API_PARAM(Ref) const Guid& objectId);
+    API_FUNCTION() SceneObject* GetDefaultInstance(API_PARAM(In) const Guid& objectId);
 
 #if USE_EDITOR
     /// <summary>

--- a/Source/Engine/Scripting/Object.cs
+++ b/Source/Engine/Scripting/Object.cs
@@ -127,9 +127,9 @@ namespace FlaxEngine
         /// <param name="id">Unique ID of the object.</param>
         /// <typeparam name="T">Type of the object.</typeparam>
         /// <returns>Found object or null if missing.</returns>
-        public static T Find<T>(ref Guid id) where T : Object
+        public static T Find<T>(in Guid id) where T : Object
         {
-            return Internal_FindObject(ref id, typeof(T)) as T;
+            return Internal_FindObject(in id, typeof(T)) as T;
         }
 
         /// <summary>
@@ -138,9 +138,9 @@ namespace FlaxEngine
         /// <param name="id">Unique ID of the object.</param>
         /// <param name="type">Type of the object.</param>
         /// <returns>Found object or null if missing.</returns>
-        public static Object Find(ref Guid id, Type type)
+        public static Object Find(in Guid id, Type type)
         {
-            return Internal_FindObject(ref id, type);
+            return Internal_FindObject(in id, type);
         }
 
         /// <summary>
@@ -149,9 +149,9 @@ namespace FlaxEngine
         /// <param name="id">Unique ID of the object.</param>
         /// <typeparam name="T">Type of the object.</typeparam>
         /// <returns>Found object or null if missing.</returns>
-        public static T TryFind<T>(ref Guid id) where T : Object
+        public static T TryFind<T>(in Guid id) where T : Object
         {
-            return Internal_TryFindObject(ref id, typeof(T)) as T;
+            return Internal_TryFindObject(in id, typeof(T)) as T;
         }
 
         /// <summary>
@@ -160,9 +160,9 @@ namespace FlaxEngine
         /// <param name="id">Unique ID of the object.</param>
         /// <param name="type">Type of the object.</param>
         /// <returns>Found object or null if missing.</returns>
-        public static Object TryFind(ref Guid id, Type type)
+        public static Object TryFind(in Guid id, Type type)
         {
-            return Internal_TryFindObject(ref id, type);
+            return Internal_TryFindObject(in id, type);
         }
 
         /// <summary>
@@ -335,13 +335,13 @@ namespace FlaxEngine
         internal static partial string Internal_GetTypeName(IntPtr obj);
 
         [LibraryImport("FlaxEngine", EntryPoint = "ObjectInternal_FindObject", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Interop.StringMarshaller))]
-        internal static partial Object Internal_FindObject(ref Guid id, [MarshalUsing(typeof(Interop.SystemTypeMarshaller))] Type type);
+        internal static partial Object Internal_FindObject(in Guid id, [MarshalUsing(typeof(Interop.SystemTypeMarshaller))] Type type);
 
         [LibraryImport("FlaxEngine", EntryPoint = "ObjectInternal_TryFindObject", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Interop.StringMarshaller))]
-        internal static partial Object Internal_TryFindObject(ref Guid id, [MarshalUsing(typeof(Interop.SystemTypeMarshaller))] Type type);
+        internal static partial Object Internal_TryFindObject(in Guid id, [MarshalUsing(typeof(Interop.SystemTypeMarshaller))] Type type);
 
         [LibraryImport("FlaxEngine", EntryPoint = "ObjectInternal_ChangeID", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Interop.StringMarshaller))]
-        internal static partial void Internal_ChangeID(IntPtr obj, ref Guid id);
+        internal static partial void Internal_ChangeID(IntPtr obj, in Guid id);
 
         [LibraryImport("FlaxEngine", EntryPoint = "ObjectInternal_GetUnmanagedInterface", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Interop.StringMarshaller))]
         internal static partial IntPtr Internal_GetUnmanagedInterface(IntPtr obj, [MarshalUsing(typeof(Interop.SystemTypeMarshaller))] Type type);

--- a/Source/Engine/Scripting/SoftObjectReference.cs
+++ b/Source/Engine/Scripting/SoftObjectReference.cs
@@ -35,7 +35,7 @@ namespace FlaxEngine
         public T Get<T>() where T : Object
         {
             if (!_object)
-                _object = Object.Find(ref _id, typeof(T));
+                _object = Object.Find(in _id, typeof(T));
             return _object as T;
         }
 

--- a/Source/Engine/Serialization/JsonConverters.cs
+++ b/Source/Engine/Serialization/JsonConverters.cs
@@ -27,7 +27,7 @@ namespace FlaxEngine.Json
             if (reader.TokenType == JsonToken.String)
             {
                 JsonSerializer.ParseID((string)reader.Value, out var id);
-                return Object.Find(ref id, objectType);
+                return Object.Find(in id, objectType);
             }
             return null;
         }

--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -446,7 +446,7 @@ namespace FlaxEngine
                 var viewport = camera.Viewport;
                 if (camera.UsePerspective)
                 {
-                    camera.GetMatrices(out tmp1, out var tmp3, ref viewport);
+                    camera.GetMatrices(out tmp1, out var tmp3, in viewport);
                     Matrix.Multiply(ref tmp1, ref tmp3, out tmp2);
                     var frustum = new BoundingFrustum(tmp2);
                     _guiRoot.Size = new Float2(frustum.GetWidthAtDepth(Distance), frustum.GetHeightAtDepth(Distance));

--- a/Source/Engine/Utilities/VariantUtils.cs
+++ b/Source/Engine/Utilities/VariantUtils.cs
@@ -472,12 +472,12 @@ namespace FlaxEngine.Utilities
             case VariantType.Object:
             {
                 var id = stream.ReadGuid();
-                return FlaxEngine.Object.Find(ref id, type ?? typeof(FlaxEngine.Object));
+                return FlaxEngine.Object.Find(in id, type ?? typeof(FlaxEngine.Object));
             }
             case VariantType.Asset:
             {
                 var id = stream.ReadGuid();
-                return FlaxEngine.Object.Find(ref id, type ?? typeof(Asset));
+                return FlaxEngine.Object.Find(in id, type ?? typeof(Asset));
             }
             case VariantType.Blob: return stream.ReadBytes(stream.ReadInt32());
             case VariantType.Enum:

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -601,6 +601,8 @@ namespace Flax.Build.Bindings
 #endif
                 if (parameterInfo.IsOut)
                     contents.Append("out ");
+                else if (parameterInfo.IsIn)
+                    contents.Append("in ");
                 else if (parameterInfo.IsRef || UsePassByReference(buildData, parameterInfo.Type, caller))
                     contents.Append("ref ");
 
@@ -639,6 +641,8 @@ namespace Flax.Build.Bindings
 #endif
                 if (parameterInfo.IsOut)
                     contents.Append("out ");
+                else if (parameterInfo.IsIn)
+                    contents.Append("in ");
                 else if (parameterInfo.IsRef || UsePassByReference(buildData, parameterInfo.Type, caller))
                     contents.Append("ref ");
                 contents.Append(nativeType);
@@ -687,6 +691,8 @@ namespace Flax.Build.Bindings
 
                 if (parameterInfo.IsOut)
                     contents.Append("out ");
+                else if (parameterInfo.IsIn)
+                    contents.Append("in ");
                 else if (parameterInfo.IsRef || UsePassByReference(buildData, parameterInfo.Type, caller))
                     contents.Append("ref ");
 
@@ -721,6 +727,8 @@ namespace Flax.Build.Bindings
                 {
                     if (parameterInfo.IsOut)
                         contents.Append("out ");
+                    else if (parameterInfo.IsIn)
+                        contents.Append("in ");
                     else if (parameterInfo.IsRef || UsePassByReference(buildData, parameterInfo.Type, caller))
                         contents.Append("ref ");
 
@@ -1203,6 +1211,8 @@ namespace Flax.Build.Bindings
                         var managedType = GenerateCSharpNativeToManaged(buildData, parameterInfo.Type, classInfo);
                         if (parameterInfo.IsOut)
                             contents.Append("out ");
+                        else if (parameterInfo.IsIn)
+                            contents.Append("in ");
                         else if (parameterInfo.IsRef)
                             contents.Append("ref ");
                         else if (parameterInfo.IsThis)
@@ -1265,6 +1275,8 @@ namespace Flax.Build.Bindings
                             var managedType = GenerateCSharpNativeToManaged(buildData, parameterInfo.Type, classInfo);
                             if (parameterInfo.IsOut)
                                 contents.Append("out ");
+                            else if (parameterInfo.IsIn)
+                                contents.Append("in ");
                             else if (parameterInfo.IsRef)
                                 contents.Append("ref ");
                             else if (parameterInfo.IsThis)
@@ -2005,6 +2017,8 @@ namespace Flax.Build.Bindings
                     var managedType = GenerateCSharpNativeToManaged(buildData, parameterInfo.Type, interfaceInfo);
                     if (parameterInfo.IsOut)
                         contents.Append("out ");
+                    else if (parameterInfo.IsIn)
+                        contents.Append("in ");
                     else if (parameterInfo.IsRef)
                         contents.Append("ref ");
                     else if (parameterInfo.IsThis)

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cache.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cache.cs
@@ -19,7 +19,7 @@ namespace Flax.Build.Bindings
     partial class BindingsGenerator
     {
         private static readonly Dictionary<string, Type> TypeCache = new Dictionary<string, Type>();
-        private const int CacheVersion = 20;
+        private const int CacheVersion = 22;
 
         internal static void Write(BinaryWriter writer, string e)
         {

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cache.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cache.cs
@@ -19,7 +19,7 @@ namespace Flax.Build.Bindings
     partial class BindingsGenerator
     {
         private static readonly Dictionary<string, Type> TypeCache = new Dictionary<string, Type>();
-        private const int CacheVersion = 19;
+        private const int CacheVersion = 20;
 
         internal static void Write(BinaryWriter writer, string e)
         {

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -920,7 +920,7 @@ namespace Flax.Build.Bindings
             for (int i = 0; i < functionInfo.Parameters.Count; i++)
             {
                 var parameterInfo = functionInfo.Parameters[i];
-                if (parameterInfo.IsOut || parameterInfo.IsRef || !GenerateCppWrapperFunctionImplicitBinding(buildData, parameterInfo.Type, caller))
+                if (parameterInfo.IsByRef || !GenerateCppWrapperFunctionImplicitBinding(buildData, parameterInfo.Type, caller))
                     return false;
             }
             return true;
@@ -1042,7 +1042,7 @@ namespace Flax.Build.Bindings
                     managedType = "MObject*";
 
                 contents.Append(managedType);
-                if (parameterInfo.IsRef || parameterInfo.IsOut || UsePassByReference(buildData, parameterInfo.Type, caller))
+                if (parameterInfo.IsByRef || UsePassByReference(buildData, parameterInfo.Type, caller))
                     contents.Append('*');
                 contents.Append(' ');
                 contents.Append(parameterInfo.Name);
@@ -1106,7 +1106,7 @@ namespace Flax.Build.Bindings
 
                 GenerateCppWrapperManagedToNative(buildData, parameterInfo.Type, caller, out var managedType, out _, functionInfo, out _);
                 contents.Append(managedType);
-                if (parameterInfo.IsRef || parameterInfo.IsOut || UsePassByReference(buildData, parameterInfo.Type, caller))
+                if (parameterInfo.IsByRef || UsePassByReference(buildData, parameterInfo.Type, caller))
                     contents.Append('*');
                 contents.Append(' ');
                 contents.Append(parameterInfo.Name);
@@ -1464,10 +1464,10 @@ namespace Flax.Build.Bindings
                     for (var i = 0; i < functionInfo.Parameters.Count; i++)
                     {
                         var parameterInfo = functionInfo.Parameters[i];
-                        var paramIsRef = parameterInfo.IsRef || parameterInfo.IsOut;
+                        var paramIsByRef = parameterInfo.IsByRef;
                         var paramValue = GenerateCppWrapperNativeToBox(buildData, parameterInfo.Type, classInfo, out var apiType, parameterInfo.Name);
                         var useLocalVar = false;
-                        if (paramIsRef)
+                        if (paramIsByRef)
                         {
                             // Pass as pointer to value when using ref/out parameter
                             contents.Append($"        auto __param_{parameterInfo.Name} = {paramValue};").AppendLine();
@@ -1505,8 +1505,8 @@ namespace Flax.Build.Bindings
                 for (var i = 0; i < functionInfo.Parameters.Count; i++)
                 {
                     var parameterInfo = functionInfo.Parameters[i];
-                    var paramIsRef = parameterInfo.IsRef || parameterInfo.IsOut;
-                    if (paramIsRef && !parameterInfo.Type.IsConst)
+                    var paramIsByRef = parameterInfo.IsByRef;
+                    if (paramIsByRef && !parameterInfo.Type.IsConst)
                     {
                         // Unbox from MObject*
                         parameterInfo.Type.IsRef = false;
@@ -1523,8 +1523,8 @@ namespace Flax.Build.Bindings
                     for (var i = 0; i < functionInfo.Parameters.Count; i++)
                     {
                         var parameterInfo = functionInfo.Parameters[i];
-                        var paramIsRef = parameterInfo.IsRef || parameterInfo.IsOut;
-                        var paramValue = GenerateCppWrapperNativeToManagedParam(buildData, contents, parameterInfo.Type, parameterInfo.Name, classInfo, paramIsRef, out CppParamsThatNeedLocalVariable[i]);
+                        var paramIsByRef = parameterInfo.IsByRef;
+                        var paramValue = GenerateCppWrapperNativeToManagedParam(buildData, contents, parameterInfo.Type, parameterInfo.Name, classInfo, paramIsByRef, out CppParamsThatNeedLocalVariable[i]);
                         contents.Append($"        params[{i}] = {paramValue};").AppendLine();
                     }
                 }
@@ -1536,8 +1536,8 @@ namespace Flax.Build.Bindings
                 for (var i = 0; i < functionInfo.Parameters.Count; i++)
                 {
                     var parameterInfo = functionInfo.Parameters[i];
-                    var paramIsRef = parameterInfo.IsRef || parameterInfo.IsOut;
-                    if (paramIsRef && !parameterInfo.Type.IsConst)
+                    var paramIsByRef = parameterInfo.IsByRef;
+                    if (paramIsByRef && !parameterInfo.Type.IsConst)
                     {
                         // Direct value convert
                         var managedToNative = GenerateCppWrapperManagedToNative(buildData, parameterInfo.Type, classInfo, out var managedType, out var apiType, null, out _);

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
@@ -331,6 +331,9 @@ namespace Flax.Build.Bindings
                         case "ref":
                             currentParam.IsRef = true;
                             break;
+                        case "in":
+                            currentParam.IsIn = true;
+                            break;
                         case "out":
                             currentParam.IsOut = true;
                             break;

--- a/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
@@ -16,10 +16,27 @@ namespace Flax.Build.Bindings
             public TypeInfo Type;
             public string DefaultValue;
             public string Attributes;
+            /// <summary>The parameter is passed by ref</summary>
             public bool IsRef;
+            /// <summary>The parameter is passed by in-ref</summary>
+            public bool IsIn;
+            /// <summary>The parameter is passed by out-ref</summary>
             public bool IsOut;
+            /// <summary>The parameter is the this-parameter of an extension method</summary>
             public bool IsThis;
+            /// <summary>The parameter is a param array</summary>
             public bool IsParams;
+
+
+            /// <summary>The parameter is passed by-ref</summary>
+            public bool IsByRef => IsRef || IsOut || IsIn;
+
+            /// <summary>The parameter is passed by-ref through ref or in</summary>
+            public bool IsByRefIn => IsRef || IsIn;
+
+            /// <summary>The parameter is passed by-ref through ref or out</summary>
+            public bool IsByRefOut => IsRef || IsOut;
+
 
             public bool HasDefaultValue => !string.IsNullOrEmpty(DefaultValue);
 
@@ -36,6 +53,7 @@ namespace Flax.Build.Bindings
                 BindingsGenerator.Write(writer, Attributes);
                 // TODO: convert into flags
                 writer.Write(IsRef);
+                writer.Write(IsIn);
                 writer.Write(IsOut);
                 writer.Write(IsThis);
                 writer.Write(IsParams);
@@ -49,6 +67,7 @@ namespace Flax.Build.Bindings
                 Attributes = BindingsGenerator.Read(reader, Attributes);
                 // TODO: convert into flags
                 IsRef = reader.ReadBoolean();
+                IsIn = reader.ReadBoolean();
                 IsOut = reader.ReadBoolean();
                 IsThis = reader.ReadBoolean();
                 IsParams = reader.ReadBoolean();

--- a/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
@@ -1,46 +1,88 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
 namespace Flax.Build.Bindings
 {
     /// <summary>
-    /// The native method information for bindings generator.
+    /// The native method information for the bindings generator.
     /// </summary>
     public class FunctionInfo : MemberInfo
     {
+        /// <summary>Decorators which are allowed on parameters</summary>
+        [Flags]
+        public enum ParameterDecoration : int
+        {
+            Ref = 0x1,
+            In = 0x2,
+            Out = 0x4,
+            This = 0x8,
+            Params = 0x10,
+        }
+
+        /// <summary>Decorators which are allowed on functions</summary>
+        [Flags]
+        public enum FunctionDecoration : int
+        {
+            Virtual = 0x1,
+            Const = 0x2,
+            NoProxy = 0x4,
+        }
+
+        /// <summary>
+        /// The native parameter information for the bindings generator.
+        /// </summary>
         public struct ParameterInfo : IBindingsCache
         {
             public string Name;
             public TypeInfo Type;
             public string DefaultValue;
             public string Attributes;
+            public ParameterDecoration Decoration;
+
+
             /// <summary>The parameter is passed by ref</summary>
-            public bool IsRef;
+            public bool IsRef {
+                readonly get => (Decoration & ParameterDecoration.Ref) is not 0;
+                set => Decoration = (Decoration & ~ParameterDecoration.Ref) | (value ? ParameterDecoration.Ref : 0);
+            }
             /// <summary>The parameter is passed by in-ref</summary>
-            public bool IsIn;
+            public bool IsIn {
+                readonly get => (Decoration & ParameterDecoration.In) is not 0;
+                set => Decoration = (Decoration & ~ParameterDecoration.In) | (value ? ParameterDecoration.In : 0);
+            }
             /// <summary>The parameter is passed by out-ref</summary>
-            public bool IsOut;
+            public bool IsOut {
+                readonly get => (Decoration & ParameterDecoration.Out) is not 0;
+                set => Decoration = (Decoration & ~ParameterDecoration.Out) | (value ? ParameterDecoration.Out : 0);
+            }
             /// <summary>The parameter is the this-parameter of an extension method</summary>
-            public bool IsThis;
+            public bool IsThis {
+                readonly get => (Decoration & ParameterDecoration.This) is not 0;
+                set => Decoration = (Decoration & ~ParameterDecoration.This) | (value ? ParameterDecoration.This : 0);
+            }
             /// <summary>The parameter is a param array</summary>
-            public bool IsParams;
+            public bool IsParams {
+                readonly get => (Decoration & ParameterDecoration.Params) is not 0;
+                set => Decoration = (Decoration & ~ParameterDecoration.Params) | (value ? ParameterDecoration.Params : 0);
+            }
 
 
             /// <summary>The parameter is passed by-ref</summary>
-            public bool IsByRef => IsRef || IsOut || IsIn;
+            public readonly bool IsByRef => IsRef || IsOut || IsIn;
 
             /// <summary>The parameter is passed by-ref through ref or in</summary>
-            public bool IsByRefIn => IsRef || IsIn;
+            public readonly bool IsByRefIn => IsRef || IsIn;
 
             /// <summary>The parameter is passed by-ref through ref or out</summary>
-            public bool IsByRefOut => IsRef || IsOut;
+            public readonly bool IsByRefOut => IsRef || IsOut;
 
 
-            public bool HasDefaultValue => !string.IsNullOrEmpty(DefaultValue);
+            public readonly bool HasDefaultValue => !string.IsNullOrEmpty(DefaultValue);
 
-            public bool HasAttribute(string name)
+            public readonly bool HasAttribute(string name)
             {
                 return Attributes != null && Attributes.Contains(name);
             }
@@ -51,12 +93,7 @@ namespace Flax.Build.Bindings
                 BindingsGenerator.Write(writer, Type);
                 BindingsGenerator.Write(writer, DefaultValue);
                 BindingsGenerator.Write(writer, Attributes);
-                // TODO: convert into flags
-                writer.Write(IsRef);
-                writer.Write(IsIn);
-                writer.Write(IsOut);
-                writer.Write(IsThis);
-                writer.Write(IsParams);
+                writer.Write((int)Decoration);
             }
 
             public void Read(BinaryReader reader)
@@ -65,12 +102,7 @@ namespace Flax.Build.Bindings
                 Type = BindingsGenerator.Read(reader, Type);
                 DefaultValue = BindingsGenerator.Read(reader, DefaultValue);
                 Attributes = BindingsGenerator.Read(reader, Attributes);
-                // TODO: convert into flags
-                IsRef = reader.ReadBoolean();
-                IsIn = reader.ReadBoolean();
-                IsOut = reader.ReadBoolean();
-                IsThis = reader.ReadBoolean();
-                IsParams = reader.ReadBoolean();
+                Decoration = (ParameterDecoration)reader.ReadInt32();
             }
 
             public override string ToString()
@@ -92,19 +124,27 @@ namespace Flax.Build.Bindings
         public string UniqueName;
         public TypeInfo ReturnType;
         public List<ParameterInfo> Parameters = new List<ParameterInfo>();
-        public bool IsVirtual;
-        public bool IsConst;
-        public bool NoProxy;
+        public FunctionDecoration Decoration;
         public GlueInfo Glue;
+
+        public bool IsVirtual {
+            get => (Decoration & FunctionDecoration.Virtual) is not 0;
+            set => Decoration = (Decoration & ~FunctionDecoration.Virtual) | (value ? FunctionDecoration.Virtual : 0);
+        }
+        public bool IsConst {
+            get => (Decoration & FunctionDecoration.Const) is not 0;
+            set => Decoration = (Decoration & ~FunctionDecoration.Const) | (value ? FunctionDecoration.Const : 0);
+        }
+        public bool NoProxy {
+            get => (Decoration & FunctionDecoration.NoProxy) is not 0;
+            set => Decoration = (Decoration & ~FunctionDecoration.NoProxy) | (value ? FunctionDecoration.NoProxy : 0);
+        }
 
         public override void Write(BinaryWriter writer)
         {
             BindingsGenerator.Write(writer, ReturnType);
             BindingsGenerator.Write(writer, Parameters);
-            // TODO: convert into flags
-            writer.Write(IsVirtual);
-            writer.Write(IsConst);
-            writer.Write(NoProxy);
+            writer.Write((int)Decoration);
 
             base.Write(writer);
         }
@@ -113,10 +153,7 @@ namespace Flax.Build.Bindings
         {
             ReturnType = BindingsGenerator.Read(reader, ReturnType);
             Parameters = BindingsGenerator.Read(reader, Parameters);
-            // TODO: convert into flags
-            IsVirtual = reader.ReadBoolean();
-            IsConst = reader.ReadBoolean();
-            NoProxy = reader.ReadBoolean();
+            Decoration = (FunctionDecoration)reader.ReadInt32();
 
             base.Read(reader);
         }


### PR DESCRIPTION
`in` parameters allow for large value type objects to be passed by reference with semantics very similar to `const &`, such that `r-values` can be passed seamlessly as well without needing to create a variable for the value. Functions such as [Camera.GetMatrices](https://github.com/FlaxEngine/FlaxEngine/blob/fd3f10864b8c09289971d8cb2cfd64090d0cd026/Source/Engine/Level/Actors/Camera.h#L219) or [Camera.Project](https://github.com/FlaxEngine/FlaxEngine/blob/fd3f10864b8c09289971d8cb2cfd64090d0cd026/Source/Engine/Level/Actors/Camera.h#L151) currently receive certain arguments by-ref, which in many cases requires the caller to explicitly create an `l-value` variable for the argument in order to pass it in by `ref`. If these functions instead used `in` values they could enjoy all of the advantages of passing by-ref without needing an explicit `l-value` to reference.


I have run some light tests of this change in a small project, and it appears to work correctly. As yet I haven't added any uses of `API_PARAM(In)` to the engine, but I will attempt to hit some of these obvious cases tomorrow,