### PR TITLE
Fix build project generation under Arch linux

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -192,11 +192,9 @@ namespace Flax.Build
             case TargetPlatform.Linux:
             {
                 rid = $"linux-{arch}";
-                ridFallback = "";
+                ridFallback = Utilities.ReadProcessOutput("dotnet", "--info").Split('\n').FirstOrDefault(x => x.StartsWith(" RID:"), "").Replace("RID:", "").Trim();
                 if (string.IsNullOrEmpty(dotnetPath))
                     dotnetPath ??= SearchForDotnetLocationLinux();
-                if (dotnetPath == null)
-                    ridFallback = Utilities.ReadProcessOutput("dotnet", "--info").Split('\n').FirstOrDefault(x => x.StartsWith(" RID:"), "").Replace("RID:", "").Trim();
                 break;
             }
             case TargetPlatform.Mac:


### PR DESCRIPTION
Just a quick patch to stop the "Exception: Missing NET SDK 7.0" error while generating project files under a situation where the dotnet environment path exists and is defined, but the dotnet pack is named differently (such as Microsoft.NETCORE.App.Host.arch-x64 vs Microsoft.NETCORE.App.Host.linux-x64). In such case the ridFallback would never get filled and thus fail later on with the TryAddHostRuntime function call resulting in the missing sdk error.