### PR TITLE
Add VisibleIfValue attribute

### DIFF
--- a/Source/Engine/Scripting/Attributes/Editor/VisibleIfAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/VisibleIfAttribute.cs
@@ -5,12 +5,11 @@ using System;
 namespace FlaxEngine
 {
     /// <summary>
-    /// Shows property/field in the editor only if the specified member has a given value. Can be used to hide properties based on other properties (also private properties). The given member has to be bool type.
+    /// Base class for VisibleIf attributes
     /// </summary>
-    /// <seealso cref="System.Attribute" />
     [Serializable]
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class VisibleIfAttribute : Attribute
+    public abstract class VisibleIfBaseAttribute : Attribute
     {
         /// <summary>
         /// The member name.
@@ -22,7 +21,34 @@ namespace FlaxEngine
         /// </summary>
         public bool Invert;
 
-        private VisibleIfAttribute()
+        /// <summary>
+        /// The type this VisibleIf attribute checks for.
+        /// </summary>
+        public abstract Type MemberType { get; }
+
+        /// <summary>
+        /// Initializes a new instance of a VisibleIf attribute class.
+        /// </summary>
+        /// <param name="memberName">The name of the field or property of the object. Must be a type matching <see cref="MemberType"/>.</param>
+        /// <param name="invert">True if invert member value when computing the visibility value.</param>
+        protected VisibleIfBaseAttribute(string memberName, bool invert) {
+            MemberName = memberName;
+            Invert = invert;
+        }
+    }
+
+    /// <summary>
+    /// Shows property/field in the editor only if the specified member has a given value. Can be used to hide properties based on other properties (also private properties). The given member has to be bool type.
+    /// </summary>
+    /// <seealso cref="System.Attribute" />
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class VisibleIfAttribute : VisibleIfBaseAttribute
+    {
+        /// <inheritdoc />
+        public override Type MemberType => typeof(bool);
+
+        private VisibleIfAttribute() : base(null, false)
         {
         }
 
@@ -31,9 +57,40 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="memberName">The name of the field or property of the object. Must be a bool type.</param>
         /// <param name="invert">True if invert member value when computing the visibility value.</param>
-        public VisibleIfAttribute(string memberName, bool invert = false)
+        public VisibleIfAttribute(string memberName, bool invert = false) : base(memberName, invert)
         {
-            MemberName = memberName;
+        }
+    }
+
+    /// <summary>
+    /// Shows property/field in the editor only if the specified member has a given value. Can be used to hide properties based on other properties (also private properties).
+    /// </summary>
+    /// <seealso cref="System.Attribute" />
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class VisibleIfValueAttribute : VisibleIfBaseAttribute
+    {
+        /// <summary>
+        /// Value to compare when computing the visibility value.
+        /// </summary>
+        public object Value;
+
+        /// <inheritdoc />
+        public override Type MemberType => Value?.GetType();
+
+        private VisibleIfValueAttribute() : base(null, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisibleIfValueAttribute"/> class.
+        /// </summary>
+        /// <param name="memberName">The name of the field or property of the object.</param>
+        /// <param name="value">Value to compare when computing the visibility value.</param>
+        /// <param name="invert">True if invert member value when computing the visibility value.</param>
+        public VisibleIfValueAttribute(string memberName, object value, bool invert = false) : base(memberName, invert)
+        {
+            Value = value;
             Invert = invert;
         }
     }


### PR DESCRIPTION
The `VisibleIf` attribute allows you to hide fields in the editor for your type based on another `bool` field without having to create a custom editor.

I've expanded support and added attributes for `Enum` and `int`. This can be generalized more, for example, having a single `VisibleIfValue` attribute where you pass the type of the field you're depending on, or even ignoring the type of the field altogether, just comparing its value, instead of having `VisibleIfEnum`, `VisibleIfInt`, etc... I've just followed the existing pattern for now but will be nice hearing some feedback about it.