### PR TITLE
Fix loading shared managed assemblies multiple times

### DIFF
--- a/Source/Engine/Scripting/Scripting.cpp
+++ b/Source/Engine/Scripting/Scripting.cpp
@@ -104,7 +104,7 @@ namespace
     MMethod* _method_LateFixedUpdate = nullptr;
     MMethod* _method_Draw = nullptr;
     MMethod* _method_Exit = nullptr;
-    Array<BinaryModule*, InlinedAllocation<64>> _nonNativeModules;
+    Dictionary<StringAnsi, BinaryModule*, InlinedAllocation<64>> _nonNativeModules;
 #if USE_EDITOR
     bool LastBinariesLoadTriggeredCompilation = false;
 #endif
@@ -335,6 +335,8 @@ bool Scripting::LoadBinaryModules(const String& path, const String& projectFolde
             // Check if that module has been already registered
             BinaryModule* module = BinaryModule::GetModule(nameAnsi);
             if (!module)
+                _nonNativeModules.TryGet(nameAnsi, module);
+            if (!module)
             {
                 // C++
                 if (nativePath.HasChars())
@@ -403,7 +405,7 @@ bool Scripting::LoadBinaryModules(const String& path, const String& projectFolde
                 {
                     // Create module if native library is not used
                     module = New<ManagedBinaryModule>(nameAnsi);
-                    _nonNativeModules.Add(module);
+                    _nonNativeModules.Add(nameAnsi, module);
                 }
             }
 


### PR DESCRIPTION
Fixes a case where multiple plugin projects having dependencies to the same project fails to load with managed assemblies.