### PR TITLE
Build C# bindings after generating engine project files

### DIFF
--- a/GenerateProjectFiles.bat
+++ b/GenerateProjectFiles.bat
@@ -1,14 +1,21 @@
 @echo off
-
-rem Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
+:: Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 setlocal
 pushd
+
 echo Generating Flax Engine project files...
 
-rem Run Flax.Build to generate Visual Studio solution and project files (also pass the arguments)
-call "Development\Scripts\Windows\CallBuildTool.bat" -genproject %*
+:: Change the path to the script root
+cd /D "%~dp0"
+
+:: Run Flax.Build to generate Visual Studio solution and project files (also pass the arguments)
+call "Development\Scripts\Windows\CallBuildTool.bat" -genproject  %*
 if errorlevel 1 goto BuildToolFailed
+
+:: Build bindings for all editor configurations
+echo Building C# bindings...
+Binaries\Tools\Flax.Build.exe -build -BuildBindingsOnly -arch=x64 -platform=Windows --buildTargets=FlaxEditor,FlaxGame
 
 popd
 echo Done!

--- a/GenerateProjectFiles.command
+++ b/GenerateProjectFiles.command
@@ -10,3 +10,8 @@ cd "`dirname "$0"`"
 
 # Run Flax.Build to generate project files (also pass the arguments)
 bash ./Development/Scripts/Mac/CallBuildTool.sh --genproject "$@"
+
+# Build bindings for all editor configurations
+echo Building C# bindings...
+# TODO: Detect the correct architecture here
+Binaries/Tools/Flax.Build -build -BuildBindingsOnly -arch=ARM64 -platform=Mac --buildTargets=FlaxEditor,FlaxGame

--- a/GenerateProjectFiles.sh
+++ b/GenerateProjectFiles.sh
@@ -10,3 +10,8 @@ cd "`dirname "$0"`"
 
 # Run Flax.Build to generate project files (also pass the arguments)
 bash ./Development/Scripts/Linux/CallBuildTool.sh --genproject "$@"
+
+# Build bindings for all editor configurations
+echo Building C# bindings...
+# TODO: Detect the correct architecture here
+Binaries/Tools/Flax.Build -build -BuildBindingsOnly -arch=x64 -platform=Linux --buildTargets=FlaxEditor,FlaxGame


### PR DESCRIPTION
Ensures the needed C# bindings are generated for all configurations when engine project files are generated. This should fix Intellisense issues in non-deployed engine builds.