### PR TITLE
Expose Main Window to c# through Screen class.

### DIFF
--- a/Source/Engine/Engine/Screen.cpp
+++ b/Source/Engine/Engine/Screen.cpp
@@ -181,6 +181,15 @@ void Screen::SetGameWindowMode(GameWindowMode windowMode)
 #endif
 }
 
+Window* Screen::GetMainWindow()
+{
+    Window* win = nullptr;
+#if !USE_EDITOR
+    win = Engine::MainWindow;
+#endif
+    return win;
+}
+
 void ScreenService::Update()
 {
 #if USE_EDITOR

--- a/Source/Engine/Engine/Screen.cpp
+++ b/Source/Engine/Engine/Screen.cpp
@@ -183,11 +183,7 @@ void Screen::SetGameWindowMode(GameWindowMode windowMode)
 
 Window* Screen::GetMainWindow()
 {
-    Window* win = nullptr;
-#if !USE_EDITOR
-    win = Engine::MainWindow;
-#endif
-    return win;
+    return Engine::MainWindow;
 }
 
 void ScreenService::Update()

--- a/Source/Engine/Engine/Screen.h
+++ b/Source/Engine/Engine/Screen.h
@@ -98,7 +98,7 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(Screen);
     API_PROPERTY() static void SetGameWindowMode(GameWindowMode windowMode);
 
     /// <summary>
-    /// Gets the main window. Only during built game.
+    /// Gets the main window.
     /// </summary>
     /// <returns>The current window. Will be null if fails.</returns>
     API_PROPERTY() static Window* GetMainWindow();

--- a/Source/Engine/Engine/Screen.h
+++ b/Source/Engine/Engine/Screen.h
@@ -96,4 +96,10 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(Screen);
     /// </remarks>
     /// <param name="windowMode">The window mode.</param>
     API_PROPERTY() static void SetGameWindowMode(GameWindowMode windowMode);
+
+    /// <summary>
+    /// Gets the main window. Only during built game.
+    /// </summary>
+    /// <returns>The current window. Will be null if fails.</returns>
+    API_PROPERTY() static Window* GetMainWindow();
 };


### PR DESCRIPTION
This is easier for users to find than using `RootControl.GameRoot.RootWindow.Window`.