### PR TITLE
Change base editor window size to 75% of desktop size when restored for the first time

### DIFF
--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -721,7 +721,7 @@ namespace FlaxEditor.Modules
             // Create main window
             var settings = CreateWindowSettings.Default;
             settings.Title = "Flax Editor";
-            //settings.Size = Platform.DesktopSize;
+            settings.Size = Platform.DesktopSize * 0.75f;
             settings.StartPosition = WindowStartPosition.CenterScreen;
             settings.ShowAfterFirstPaint = true;
 


### PR DESCRIPTION
This is a better value than the default that is set for the window as it is not a set value for larger screens.