### PR TITLE
Evaluate animation graph transition data before executing the transition rule.

### DIFF
--- a/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
+++ b/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
@@ -512,18 +512,6 @@ void AnimGraphExecutor::UpdateStateTransitions(AnimGraphContext& context, const 
             transitionIndex++;
             continue;
         }
-        const bool useDefaultRule = EnumHasAnyFlags(transition.Flags, AnimGraphStateTransition::FlagTypes::UseDefaultRule);
-        if (transition.RuleGraph && !useDefaultRule)
-        {
-            // Execute transition rule
-            auto rootNode = transition.RuleGraph->GetRootNode();
-            ASSERT(rootNode);
-            if (!(bool)eatBox((Node*)rootNode, &rootNode->Boxes[0]))
-            {
-                transitionIndex++;
-                continue;
-            }
-        }
 
         // Evaluate source state transition data (position, length, etc.)
         const Value sourceStatePtr = SampleState(stateMachineBucket.CurrentState);
@@ -541,6 +529,19 @@ void AnimGraphExecutor::UpdateStateTransitions(AnimGraphContext& context, const 
             // Reset
             transitionData.Position = 0;
             transitionData.Length = ZeroTolerance;
+        }
+        
+        const bool useDefaultRule = EnumHasAnyFlags(transition.Flags, AnimGraphStateTransition::FlagTypes::UseDefaultRule);
+        if (transition.RuleGraph && !useDefaultRule)
+        {
+            // Execute transition rule
+            auto rootNode = transition.RuleGraph->GetRootNode();
+            ASSERT(rootNode);
+            if (!(bool)eatBox((Node*)rootNode, &rootNode->Boxes[0]))
+            {
+                transitionIndex++;
+                continue;
+            }
         }
 
         // Check if can trigger the transition


### PR DESCRIPTION
Some people in the discord encountered problems where the 'Transition Source State Anim' node wasn't working. After some digging, i found out that the Position and Length fields of the transition data were 0, while evaluating the node, so the remaining time output was always 1 and the rest were 0. This fixes that by making sure the transition data is evaluated and updated before executing the transition rule. I've tested this and it works but it's impossible to understand the whole animation graph execution flow without spending a lot of time, so i'm not sure if this change could cause problems elsewhere.