### PR TITLE
Improve Editor performance with multiple windows open

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -770,6 +770,10 @@ namespace FlaxEditor.Viewport
 
         private class FpsCounter : Control
         {
+            private int fps;
+            private int accumFrames;
+            private float lastUpdate;
+
             public FpsCounter(float x, float y)
             : base(x, y, 64, 32)
             {
@@ -779,7 +783,15 @@ namespace FlaxEditor.Viewport
             {
                 base.Draw();
 
-                int fps = Engine.FramesPerSecond;
+                accumFrames++;
+                float timeNow = Time.TimeSinceStartup;
+                if (timeNow - lastUpdate >= 1.0f)
+                {
+                    fps = accumFrames;
+                    lastUpdate = timeNow;
+                    accumFrames = 0;
+                }
+
                 Color color = Color.Green;
                 if (fps < 13)
                     color = Color.Red;

--- a/Source/Engine/Engine/Base/GameBase.cpp
+++ b/Source/Engine/Engine/Base/GameBase.cpp
@@ -176,6 +176,7 @@ Window* GameBase::CreateMainWindow()
     settings.AllowMinimize = true;
     settings.Size = Platform::GetDesktopSize();
     settings.Position = Float2::Zero;
+    settings.WindowFPSWhenNotFocused = 0;
 
     Game::InitMainWindowSettings(settings);
 

--- a/Source/Engine/Graphics/RenderTask.h
+++ b/Source/Engine/Graphics/RenderTask.h
@@ -51,6 +51,8 @@ API_CLASS() class FLAXENGINE_API RenderTask : public ScriptingObject
 
 private:
     RenderTask* _prevTask = nullptr;
+    
+    float _lastFrameTime = 0.0f;
 
 public:
     /// <summary>
@@ -68,6 +70,11 @@ public:
     /// The order of the task. Used for tasks rendering order. Lower first, higher later.
     /// </summary>
     API_FIELD() int32 Order = 0;
+
+    /// <summary>
+    /// The framerate of the task, or how often the task rendering is performed per second.
+    /// </summary>
+    API_FIELD() int32 RenderFPS = 0;
 
     /// <summary>
     /// The amount of frames rendered by this task. It is auto incremented on task drawing.

--- a/Source/Engine/Platform/Base/WindowBase.cpp
+++ b/Source/Engine/Platform/Base/WindowBase.cpp
@@ -14,6 +14,7 @@
 #include "Engine/Scripting/ManagedCLR/MUtils.h"
 #include "Engine/Scripting/ManagedCLR/MMethod.h"
 #include "Engine/Scripting/ManagedCLR/MClass.h"
+#include "Engine/Engine/Time.h"
 
 #if USE_CSHARP
 // Helper macros for calling C# events
@@ -439,6 +440,9 @@ void WindowBase::OnGotFocus()
         return;
     _focused = true;
 
+    if (RenderTask && _settings.WindowFPSWhenNotFocused > ZeroTolerance)
+        RenderTask->RenderFPS = 0;
+
     GotFocus();
     INVOKE_EVENT_PARAMS_0(OnGotFocus);
 }
@@ -448,6 +452,9 @@ void WindowBase::OnLostFocus()
     if (!_focused)
         return;
     _focused = false;
+
+    if (RenderTask && _settings.WindowFPSWhenNotFocused > ZeroTolerance)
+        RenderTask->RenderFPS = _settings.WindowFPSWhenNotFocused;
 
     LostFocus();
     INVOKE_EVENT_PARAMS_0(OnLostFocus);

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -298,7 +298,7 @@ public:
     /// <summary>
     /// The rendering task for that window.
     /// </summary>
-    RenderTask* RenderTask;
+    API_FIELD() RenderTask* RenderTask;
 
     /// <summary>
     /// Event fired when window gets shown.

--- a/Source/Engine/Platform/CreateWindowSettings.cs
+++ b/Source/Engine/Platform/CreateWindowSettings.cs
@@ -24,6 +24,7 @@ namespace FlaxEngine
             IsRegularWindow = true,
             HasSizingFrame = true,
             ShowAfterFirstPaint = true,
+            WindowFPSWhenNotFocused = 2,
         };
     }
 }

--- a/Source/Engine/Platform/CreateWindowSettings.h
+++ b/Source/Engine/Platform/CreateWindowSettings.h
@@ -134,6 +134,11 @@ DECLARE_SCRIPTING_TYPE_MINIMAL(CreateWindowSettings);
     API_FIELD() bool ShowAfterFirstPaint = true;
 
     /// <summary>
+    /// Custom framerate limit for window rendering when the window is not focused.
+    /// </summary>
+    API_FIELD() int WindowFPSWhenNotFocused = 2;
+
+    /// <summary>
     /// The custom data (platform dependant).
     /// </summary>
     API_FIELD() void* Data = nullptr;

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -1178,7 +1178,7 @@ LRESULT WindowsWindow::WndProc(UINT msg, WPARAM wParam, LPARAM lParam)
         }
         OnLostFocus();
         break;
-    case WM_ACTIVATEAPP:
+    case WM_ACTIVATE:
         if (wParam == TRUE && !_focused)
         {
             OnGotFocus();

--- a/Source/Engine/UI/GUI/Tooltip.cs
+++ b/Source/Engine/UI/GUI/Tooltip.cs
@@ -102,6 +102,9 @@ namespace FlaxEngine.GUI
             Visible = true;
             _window.Show();
             _showTarget.OnTooltipShown(this);
+
+            // Throttle tooltip rendering
+            _window.RenderTask.RenderFPS = 2;
         }
 
         /// <summary>


### PR DESCRIPTION
This should improve the overall framerate in editor when multiple windows, tooltips or menus are active at once by reducing the rendering framerate of inactive windows to 2fps.

There is some unexpected behavior with these changes however: `Editor.FramesPerSecond` used by the viewport widget does not show the effective framerate of that window anymore because the `RenderTask` might be running at reduced framerate. This however works accurately in games which does not use multiple windows.