### PR TITLE
Handle double clicking in CheckBox, Button, Dropdown and DropPanel.

### DIFF
--- a/Source/Engine/UI/GUI/Common/Button.cs
+++ b/Source/Engine/UI/GUI/Common/Button.cs
@@ -315,6 +315,28 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
+        {
+            if (base.OnMouseDoubleClick(location, button))
+                return true;
+
+            if (button == MouseButton.Left && _isPressed)
+            {
+                OnPressEnd();
+                OnClick();
+                return true;
+            }
+            
+            if (button == MouseButton.Left && !_isPressed)
+            {
+                OnPressBegin();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
         public override bool OnTouchDown(Float2 location, int pointerId)
         {
             if (base.OnTouchDown(location, pointerId))

--- a/Source/Engine/UI/GUI/Common/CheckBox.cs
+++ b/Source/Engine/UI/GUI/Common/CheckBox.cs
@@ -278,6 +278,27 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
+        {
+            if (button == MouseButton.Left && !_isPressed)
+            {
+                OnPressBegin();
+                return true;
+            }
+            
+            if (button == MouseButton.Left && _isPressed)
+            {
+                OnPressEnd();
+                if (_box.Contains(ref location))
+                {
+                    OnClick();
+                    return true;
+                }
+            }
+            return base.OnMouseDoubleClick(location, button);
+        }
+
+        /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
             if (button == MouseButton.Left && _isPressed)

--- a/Source/Engine/UI/GUI/Common/Dropdown.cs
+++ b/Source/Engine/UI/GUI/Common/Dropdown.cs
@@ -667,6 +667,30 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
+        {
+            if (base.OnMouseDoubleClick(location, button))
+                return true;
+            
+            if (_touchDown && button == MouseButton.Left)
+            {
+                _touchDown = false;
+                ShowPopup();
+                return true;
+            }
+            
+            if (button == MouseButton.Left)
+            {
+                _touchDown = true;
+                if (!IsPopupOpened)
+                    Focus();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
         public override bool OnTouchDown(Float2 location, int pointerId)
         {
             if (base.OnTouchDown(location, pointerId))

--- a/Source/Engine/UI/GUI/Panels/DropPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/DropPanel.cs
@@ -502,6 +502,29 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
+        {
+            if (base.OnMouseDoubleClick(location, button))
+                return true;
+            
+            _mouseOverHeader = HeaderRectangle.Contains(location);
+            if (button == MouseButton.Left && _mouseOverHeader)
+            {
+                _mouseButtonLeftDown = true;
+                return true;
+            }
+
+            if (button == MouseButton.Left && _mouseButtonLeftDown)
+            {
+                _mouseButtonLeftDown = false;
+                if (_mouseOverHeader)
+                    Toggle();
+                return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc />
         public override void OnMouseLeave()
         {
             _mouseButtonLeftDown = false;


### PR DESCRIPTION
The aforementioned UI controls don't handle double clicks, which means every second(depends how fast the user is clicking) mouse down event gets swallowed by the `OnMouseDoubleClick` method. This is not *really* a problem per se but it's kind of annoying when you want to spam-click a button or a checkbox and makes the UI feel a bit more responsive.
Below are two videos showcasing the change. In both videos i click as fast as i can:

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/a2465073-781a-4d45-b0be-6f68af071b56


https://github.com/FlaxEngine/FlaxEngine/assets/30367251/333b5800-f077-4795-aa16-d778e19487d2

