### PR TITLE
Fix segfault: target can be null when font size is changed

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -989,7 +989,7 @@ namespace FlaxEditor.Windows
                 }
                 _view.ShowItems(items, _sortType, false, true);
             }
-            else
+            else if (target != null)
             {
                 // Show folder contents
                 var items = target.Folder.Children;


### PR DESCRIPTION
When changing the font size in the editor options a segfault occurs when you try to change it back or reset. This simple null check lets you save your options changes again.