### PR TITLE
Add Game Settings open button to Edit menu.

### DIFF
--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -553,6 +553,13 @@ namespace FlaxEditor.Modules
             cm.AddSeparator();
             _menuEditSelectAll = cm.AddButton("Select all", inputOptions.SelectAll, Editor.SceneEditing.SelectAllScenes);
             _menuEditFind = cm.AddButton("Find", inputOptions.Search, Editor.Windows.SceneWin.Search);
+            cm.AddSeparator();
+            cm.AddButton("Game Settings", () =>
+            {
+                var item = Editor.ContentDatabase.Find(GameSettings.GameSettingsAssetPath);
+                if(item != null)
+                    Editor.ContentEditing.Open(item);
+            });
 
             // Scene
             MenuScene = MainMenu.AddButton("Scene");


### PR DESCRIPTION
This adds a button to open the game settings under the `Edit` menu. This is a nice QoL feature for others coming from other engines who are used to finding settings in that location. (this way no one will ever know of its location :P)