### PR TITLE
crash hacy fix when pasting get parameter node to other graph

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1079,7 +1079,7 @@ namespace FlaxEditor.Surface.Archetypes
 
             private void UpdateBoxes()
             {
-                if (Surface == null)
+                if (Surface == null || _input == null)
                     return;
 
                 var type = _input.CurrentType;


### PR DESCRIPTION
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/1bc61d04-1a54-4bc4-881a-098307abb603)
