### PR TITLE
Fix menu misalignment and window placement on Linux

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxPlatform.cpp
+++ b/Source/Engine/Platform/Linux/LinuxPlatform.cpp
@@ -2707,8 +2707,34 @@ Float2 LinuxPlatform::GetDesktopSize()
 
 Rectangle LinuxPlatform::GetMonitorBounds(const Float2& screenPos)
 {
-	// TODO: do it in a proper way
-	return Rectangle(Float2::Zero, GetDesktopSize());
+    if (!xDisplay)
+        return Rectangle::Empty;
+
+    int event, err;
+    const bool ok = X11::XineramaQueryExtension(xDisplay, &event, &err);
+    if (!ok)
+        return Rectangle::Empty;
+
+    int count;
+    int screenIdx = 0;
+    X11::XineramaScreenInfo* xsi = X11::XineramaQueryScreens(xDisplay, &count);
+    if (screenIdx >= count)
+        return Rectangle::Empty;
+    // find the screen for this screenPos
+    for (int i = 0; i < count; i++)
+    {
+        if (screenPos.X >= xsi[i].x_org && screenPos.X < xsi[i].x_org+xsi[i].width
+            && screenPos.Y >= xsi[i].y_org && screenPos.Y < xsi[i].y_org+xsi[i].height)
+        {
+            screenIdx = i;
+            break;
+        }
+    }
+
+    Float2 org((float)xsi[screenIdx].x_org, (float)xsi[screenIdx].y_org);
+    Float2 size((float)xsi[screenIdx].width, (float)xsi[screenIdx].height);
+    X11::XFree(xsi);
+	return Rectangle(org, size);
 }
 
 Rectangle LinuxPlatform::GetVirtualDesktopBounds()

--- a/Source/Engine/Platform/Linux/LinuxWindow.cpp
+++ b/Source/Engine/Platform/Linux/LinuxWindow.cpp
@@ -153,7 +153,11 @@ LinuxWindow::LinuxWindow(const CreateWindowSettings& settings)
 		hints.max_height = (int)settings.MaximumSize.Y;
 		hints.flags |= USSize;
 	}
-	X11::XSetNormalHints(display, window, &hints);
+    // honor the WM placement except for manual (overriding) placements
+    if (settings.StartPosition == WindowStartPosition::Manual)
+    {
+        X11::XSetNormalHints(display, window, &hints);
+    }
 
 	// Ensures the child window is always on top of the parent window
 	if (settings.Parent)


### PR DESCRIPTION
This fixes the LinuxPlatform::GetMonitorBounds which caused the menu misalignment problems in multi-screen environments and the ignored placement hints of the window manager.