### PR TITLE
Improve viewport camera settings

### DIFF
--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -47,6 +47,13 @@ namespace FlaxEditor.Options
         public float MaxMovementSpeed { get; set; } = 64f;
 
         /// <summary>
+        /// Gets or sets the degree to which the camera will be eased when using camera flight in the editor window.
+        /// </summary>
+        [DefaultValue(3.0f), Limit(1.0f, 8.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default degree to which the camera will be eased when using camera flight in the editor window.")]
+        public float CameraEasingDegree { get; set; } = 3.0f;
+
+        /// <summary>
         /// Gets or sets the default near clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(10.0f), Limit(0.001f, 1000.0f)]

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -24,47 +24,89 @@ namespace FlaxEditor.Options
         [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
         [EditorDisplay("General"), EditorOrder(101), Tooltip("The mouse wheel sensitivity applied to zoom in orthographic mode.")]
         public float MouseWheelSensitivity { get; set; } = 1.0f;
-
+        
         /// <summary>
-        /// Gets or sets the default movement speed for the viewport camera (must match the dropdown menu values in the viewport).
+        /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
         /// </summary>
-        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(110), Tooltip("The default movement speed for the viewport camera (must match the dropdown menu values in the viewport).")]
+        [DefaultValue(1.0f), Limit(0.05f, 64.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(110), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
         public float DefaultMovementSpeed { get; set; } = 1.0f;
 
+        /// <summary>
+        /// Gets or sets the default minimum camera movement speed.
+        /// </summary>
+        [DefaultValue(0.05f), Limit(0.05f, 64.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(111), Tooltip("The default minimum movement speed for the viewport camera.")]
+        public float DefaultMinMovementSpeed { get; set; } = 0.05f;
+
+        /// <summary>
+        /// Gets or sets the default maximum camera movement speed.
+        /// </summary>
+        [DefaultValue(64.0f), Limit(32.0f, 1000.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(112), Tooltip("The default maximum movement speed for the viewport camera.")]
+        public float DefaultMaxMovementSpeed { get; set; } = 64f;
+        
         /// <summary>
         /// Gets or sets the default near clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(10.0f), Limit(0.001f, 1000.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default near clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(130), Tooltip("The default near clipping plane distance for the viewport camera.")]
         public float DefaultNearPlane { get; set; } = 10.0f;
 
         /// <summary>
         /// Gets or sets the default far clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(40000.0f), Limit(10.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(130), Tooltip("The default far clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(140), Tooltip("The default far clipping plane distance for the viewport camera.")]
         public float DefaultFarPlane { get; set; } = 40000.0f;
 
         /// <summary>
         /// Gets or sets the default field of view angle (in degrees) for the viewport camera.
         /// </summary>
         [DefaultValue(60.0f), Limit(35.0f, 160.0f, 0.1f)]
-        [EditorDisplay("Defaults", "Default Field Of View"), EditorOrder(140), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(150), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
         public float DefaultFieldOfView { get; set; } = 60.0f;
 
         /// <summary>
-        /// Gets or sets if the panning direction is inverted for the viewport camera.
+        /// Gets or sets the default camera orthographic mode.
         /// </summary>
         [DefaultValue(false)]
-        [EditorDisplay("Defaults"), EditorOrder(150), Tooltip("Invert the panning direction for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("The default camera orthographic mode.")]
+        public bool DefaultOrthographicProjection { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the default camera orthographic scale (if camera uses orthographic mode).
+        /// </summary>
+        [DefaultValue(5.0f), Limit(0.001f, 100000.0f, 0.1f)]
+        [EditorDisplay("Defaults"), EditorOrder(170), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
+        public float DefaultOrthographicScale { get; set; } = 5.0f;
+
+        /// <summary>
+        /// Gets or sets the default panning direction for the viewport camera.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Defaults"), EditorOrder(180), Tooltip("The default panning direction for the viewport camera.")]
         public bool DefaultInvertPanning { get; set; } = false;
 
         /// <summary>
-        /// Scales editor viewport grid.
+        /// Gets or sets the default relative panning mode.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Defaults"), EditorOrder(190), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
+        public bool DefaultRelativePanning { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).
+        /// </summary>
+        [DefaultValue(0.8f), Limit(0.01f, 128.0f, 0.1f)]
+        [EditorDisplay("Defaults"), EditorOrder(200), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
+        public float DefaultPanningSpeed { get; set; } = 0.8f;
+
+        /// <summary>
+        /// Gets or sets the default editor viewport grid scale.
         /// </summary>
         [DefaultValue(50.0f), Limit(25.0f, 500.0f, 5.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("Scales editor viewport grid.")]
+        [EditorDisplay("Defaults"), EditorOrder(210), Tooltip("The default editor viewport grid scale.")]
         public float ViewportGridScale { get; set; } = 50.0f;
     }
 }

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -47,10 +47,17 @@ namespace FlaxEditor.Options
         public float MaxMovementSpeed { get; set; } = 64f;
 
         /// <summary>
+        /// Gets or sets the default camera easing mode.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default camera easing mode.")]
+        public bool UseCameraEasing { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the degree to which the camera will be eased when using camera flight in the editor window.
         /// </summary>
         [DefaultValue(3.0f), Limit(1.0f, 8.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default degree to which the camera will be eased when using camera flight in the editor window.")]
+        [EditorDisplay("Defaults"), EditorOrder(121), Tooltip("The default degree to which the camera will be eased when using camera flight in the editor window (ignored if camera easing degree is enabled).")]
         public float CameraEasingDegree { get; set; } = 3.0f;
 
         /// <summary>
@@ -79,7 +86,7 @@ namespace FlaxEditor.Options
         /// </summary>
         [DefaultValue(false)]
         [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("The default camera orthographic mode.")]
-        public bool OrthographicProjection { get; set; } = false;
+        public bool UseOrthographicProjection { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the default camera orthographic scale (if camera uses orthographic mode).
@@ -100,7 +107,7 @@ namespace FlaxEditor.Options
         /// </summary>
         [DefaultValue(true)]
         [EditorDisplay("Defaults"), EditorOrder(190), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
-        public bool RelativePanning { get; set; } = true;
+        public bool UseRelativePanning { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -26,101 +26,108 @@ namespace FlaxEditor.Options
         public float MouseWheelSensitivity { get; set; } = 1.0f;
 
         /// <summary>
-        /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
+        /// Gets or sets the total amount of steps the camera needs to go from minimum to maximum speed.
         /// </summary>
-        [DefaultValue(1.0f), Limit(0.05f, 64.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(110), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
-        public float MovementSpeed { get; set; } = 1.0f;
-
-        /// <summary>
-        /// Gets or sets the default minimum camera movement speed.
-        /// </summary>
-        [DefaultValue(0.05f), Limit(0.05f, 64.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(111), Tooltip("The default minimum movement speed for the viewport camera.")]
-        public float MinMovementSpeed { get; set; } = 0.05f;
-
-        /// <summary>
-        /// Gets or sets the default maximum camera movement speed.
-        /// </summary>
-        [DefaultValue(64.0f), Limit(32.0f, 1000.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(112), Tooltip("The default maximum movement speed for the viewport camera.")]
-        public float MaxMovementSpeed { get; set; } = 64f;
-
-        /// <summary>
-        /// Gets or sets the default camera easing mode.
-        /// </summary>
-        [DefaultValue(true)]
-        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default camera easing mode.")]
-        public bool UseCameraEasing { get; set; } = true;
+        [DefaultValue(64), Limit(1, 128)]
+        [EditorDisplay("Camera"), EditorOrder(110), Tooltip("The total amount of steps the camera needs to go from minimum to maximum speed.")]
+        public int TotalCameraSpeedSteps { get; set; } = 64;
 
         /// <summary>
         /// Gets or sets the degree to which the camera will be eased when using camera flight in the editor window.
         /// </summary>
         [DefaultValue(3.0f), Limit(1.0f, 8.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(121), Tooltip("The default degree to which the camera will be eased when using camera flight in the editor window (ignored if camera easing degree is enabled).")]
+        [EditorDisplay("Camera"), EditorOrder(111), Tooltip("The degree to which the camera will be eased when using camera flight in the editor window (ignored if camera easing degree is enabled).")]
         public float CameraEasingDegree { get; set; } = 3.0f;
+
+        /// <summary>
+        /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
+        /// </summary>
+        [DefaultValue(1.0f), Limit(0.05f, 32.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
+        public float MovementSpeed { get; set; } = 1.0f;
+
+        /// <summary>
+        /// Gets or sets the default minimum camera movement speed.
+        /// </summary>
+        [DefaultValue(0.05f), Limit(0.05f, 32.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(121), Tooltip("The default minimum movement speed for the viewport camera.")]
+        public float MinMovementSpeed { get; set; } = 0.05f;
+
+        /// <summary>
+        /// Gets or sets the default maximum camera movement speed.
+        /// </summary>
+        [DefaultValue(32.0f), Limit(16.0f, 1000.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(122), Tooltip("The default maximum movement speed for the viewport camera.")]
+        public float MaxMovementSpeed { get; set; } = 32f;
+
+        /// <summary>
+        /// Gets or sets the default camera easing mode.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Defaults"), EditorOrder(130), Tooltip("The default camera easing mode.")]
+        public bool UseCameraEasing { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default near clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(10.0f), Limit(0.001f, 1000.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(130), Tooltip("The default near clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(140), Tooltip("The default near clipping plane distance for the viewport camera.")]
         public float NearPlane { get; set; } = 10.0f;
 
         /// <summary>
         /// Gets or sets the default far clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(40000.0f), Limit(10.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(140), Tooltip("The default far clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(150), Tooltip("The default far clipping plane distance for the viewport camera.")]
         public float FarPlane { get; set; } = 40000.0f;
 
         /// <summary>
         /// Gets or sets the default field of view angle (in degrees) for the viewport camera.
         /// </summary>
         [DefaultValue(60.0f), Limit(35.0f, 160.0f, 0.1f)]
-        [EditorDisplay("Defaults"), EditorOrder(150), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
         public float FieldOfView { get; set; } = 60.0f;
 
         /// <summary>
         /// Gets or sets the default camera orthographic mode.
         /// </summary>
         [DefaultValue(false)]
-        [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("The default camera orthographic mode.")]
+        [EditorDisplay("Defaults"), EditorOrder(170), Tooltip("The default camera orthographic mode.")]
         public bool UseOrthographicProjection { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the default camera orthographic scale (if camera uses orthographic mode).
         /// </summary>
         [DefaultValue(5.0f), Limit(0.001f, 100000.0f, 0.1f)]
-        [EditorDisplay("Defaults"), EditorOrder(170), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
+        [EditorDisplay("Defaults"), EditorOrder(180), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
         public float OrthographicScale { get; set; } = 5.0f;
 
         /// <summary>
         /// Gets or sets the default panning direction for the viewport camera.
         /// </summary>
         [DefaultValue(false)]
-        [EditorDisplay("Defaults"), EditorOrder(180), Tooltip("The default panning direction for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(190), Tooltip("The default panning direction for the viewport camera.")]
         public bool InvertPanning { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the default relative panning mode.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Defaults"), EditorOrder(190), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
+        [EditorDisplay("Defaults"), EditorOrder(200), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
         public bool UseRelativePanning { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).
         /// </summary>
         [DefaultValue(0.8f), Limit(0.01f, 128.0f, 0.1f)]
-        [EditorDisplay("Defaults"), EditorOrder(200), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
+        [EditorDisplay("Defaults"), EditorOrder(210), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
         public float PanningSpeed { get; set; } = 0.8f;
 
         /// <summary>
         /// Gets or sets the default editor viewport grid scale.
         /// </summary>
         [DefaultValue(50.0f), Limit(25.0f, 500.0f, 5.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(210), Tooltip("The default editor viewport grid scale.")]
+        [EditorDisplay("Defaults"), EditorOrder(220), Tooltip("The default editor viewport grid scale.")]
         public float ViewportGridScale { get; set; } = 50.0f;
     }
 }

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -24,83 +24,83 @@ namespace FlaxEditor.Options
         [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
         [EditorDisplay("General"), EditorOrder(101), Tooltip("The mouse wheel sensitivity applied to zoom in orthographic mode.")]
         public float MouseWheelSensitivity { get; set; } = 1.0f;
-        
+
         /// <summary>
         /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
         /// </summary>
         [DefaultValue(1.0f), Limit(0.05f, 64.0f)]
         [EditorDisplay("Defaults"), EditorOrder(110), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
-        public float DefaultMovementSpeed { get; set; } = 1.0f;
+        public float MovementSpeed { get; set; } = 1.0f;
 
         /// <summary>
         /// Gets or sets the default minimum camera movement speed.
         /// </summary>
         [DefaultValue(0.05f), Limit(0.05f, 64.0f)]
         [EditorDisplay("Defaults"), EditorOrder(111), Tooltip("The default minimum movement speed for the viewport camera.")]
-        public float DefaultMinMovementSpeed { get; set; } = 0.05f;
+        public float MinMovementSpeed { get; set; } = 0.05f;
 
         /// <summary>
         /// Gets or sets the default maximum camera movement speed.
         /// </summary>
         [DefaultValue(64.0f), Limit(32.0f, 1000.0f)]
         [EditorDisplay("Defaults"), EditorOrder(112), Tooltip("The default maximum movement speed for the viewport camera.")]
-        public float DefaultMaxMovementSpeed { get; set; } = 64f;
-        
+        public float MaxMovementSpeed { get; set; } = 64f;
+
         /// <summary>
         /// Gets or sets the default near clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(10.0f), Limit(0.001f, 1000.0f)]
         [EditorDisplay("Defaults"), EditorOrder(130), Tooltip("The default near clipping plane distance for the viewport camera.")]
-        public float DefaultNearPlane { get; set; } = 10.0f;
+        public float NearPlane { get; set; } = 10.0f;
 
         /// <summary>
         /// Gets or sets the default far clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(40000.0f), Limit(10.0f)]
         [EditorDisplay("Defaults"), EditorOrder(140), Tooltip("The default far clipping plane distance for the viewport camera.")]
-        public float DefaultFarPlane { get; set; } = 40000.0f;
+        public float FarPlane { get; set; } = 40000.0f;
 
         /// <summary>
         /// Gets or sets the default field of view angle (in degrees) for the viewport camera.
         /// </summary>
         [DefaultValue(60.0f), Limit(35.0f, 160.0f, 0.1f)]
         [EditorDisplay("Defaults"), EditorOrder(150), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
-        public float DefaultFieldOfView { get; set; } = 60.0f;
+        public float FieldOfView { get; set; } = 60.0f;
 
         /// <summary>
         /// Gets or sets the default camera orthographic mode.
         /// </summary>
         [DefaultValue(false)]
         [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("The default camera orthographic mode.")]
-        public bool DefaultOrthographicProjection { get; set; } = false;
+        public bool OrthographicProjection { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the default camera orthographic scale (if camera uses orthographic mode).
         /// </summary>
         [DefaultValue(5.0f), Limit(0.001f, 100000.0f, 0.1f)]
         [EditorDisplay("Defaults"), EditorOrder(170), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
-        public float DefaultOrthographicScale { get; set; } = 5.0f;
+        public float OrthographicScale { get; set; } = 5.0f;
 
         /// <summary>
         /// Gets or sets the default panning direction for the viewport camera.
         /// </summary>
         [DefaultValue(false)]
         [EditorDisplay("Defaults"), EditorOrder(180), Tooltip("The default panning direction for the viewport camera.")]
-        public bool DefaultInvertPanning { get; set; } = false;
+        public bool InvertPanning { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the default relative panning mode.
         /// </summary>
         [DefaultValue(true)]
         [EditorDisplay("Defaults"), EditorOrder(190), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
-        public bool DefaultRelativePanning { get; set; } = true;
+        public bool RelativePanning { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).
         /// </summary>
         [DefaultValue(0.8f), Limit(0.01f, 128.0f, 0.1f)]
         [EditorDisplay("Defaults"), EditorOrder(200), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
-        public float DefaultPanningSpeed { get; set; } = 0.8f;
+        public float PanningSpeed { get; set; } = 0.8f;
 
         /// <summary>
         /// Gets or sets the default editor viewport grid scale.

--- a/Source/Editor/Viewport/Cameras/FPSCamera.cs
+++ b/Source/Editor/Viewport/Cameras/FPSCamera.cs
@@ -259,7 +259,10 @@ namespace FlaxEditor.Viewport.Cameras
             // Pan
             if (input.IsPanning)
             {
-                var panningSpeed = 0.8f;
+                var panningSpeed = (Viewport.RelativePanning)
+                    ? Mathf.Abs((position - TargetPoint).Length) * 0.005f
+                    : Viewport.PanningSpeed;
+
                 if (Viewport.InvertPanning)
                 {
                     position += up * (mouseDelta.Y * panningSpeed);

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -467,15 +467,8 @@ namespace FlaxEditor.Viewport
 
             // Setup options
             {
-                var options = Editor.Instance.Options.Options;
-                _movementSpeed = options.Viewport.DefaultMovementSpeed;
-                _nearPlane = options.Viewport.DefaultNearPlane;
-                _farPlane = options.Viewport.DefaultFarPlane;
-                _fieldOfView = options.Viewport.DefaultFieldOfView;
-                _invertPanning = options.Viewport.DefaultInvertPanning;
-
                 Editor.Instance.Options.OptionsChanged += OnEditorOptionsChanged;
-                OnEditorOptionsChanged(options);
+                SetupViewportOptions();
             }
 
             if (useWidgets)
@@ -807,6 +800,28 @@ namespace FlaxEditor.Viewport
 
             // Link for task event
             task.Begin += OnRenderBegin;
+        }
+
+        /// <summary>
+        /// Sets the viewport options to the default values.
+        /// </summary>
+        private void SetupViewportOptions()
+        {
+            var options = Editor.Instance.Options.Options;
+            _minMovementSpeed = options.Viewport.DefaultMinMovementSpeed;
+            _movementSpeed = options.Viewport.DefaultMovementSpeed;
+            _maxMovementSpeed = options.Viewport.DefaultMaxMovementSpeed;
+            _panningSpeed = options.Viewport.DefaultPanningSpeed;
+            _invertPanning = options.Viewport.DefaultInvertPanning;
+            _relativePanning = options.Viewport.DefaultRelativePanning;
+
+            _isOrtho = options.Viewport.DefaultOrthographicProjection;
+            _orthoSize = options.Viewport.DefaultOrthographicScale;
+            _fieldOfView = options.Viewport.DefaultFieldOfView;
+            _nearPlane = options.Viewport.DefaultNearPlane;
+            _farPlane = options.Viewport.DefaultFarPlane;
+
+            OnEditorOptionsChanged(options);
         }
         
         private void OnMovementSpeedChanged(FloatValueBox control)

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -546,10 +546,10 @@ namespace FlaxEditor.Viewport
                 var xLocationForExtras = textSize.X + 5;
                 var cameraSpeedTextWidth = Style.Current.FontMedium.MeasureText("0.00").X;
 
-                // Camera settings widget
+                // Camera Settings Widget
                 _cameraWidget = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
 
-                // Camera settings menu
+                // Camera Settings Menu
                 var cameraCM = new ContextMenu();
                 _cameraButton = new ViewportWidgetButton(string.Format(MovementSpeedTextFormat, _movementSpeed), Editor.Instance.Icons.Camera64, cameraCM, false, cameraSpeedTextWidth)
                 {
@@ -559,7 +559,7 @@ namespace FlaxEditor.Viewport
                 };
                 _cameraWidget.Parent = this;
 
-                // Toggle orthographic mode widget
+                // Orthographic/Perspective Mode Widget
                 _orthographicModeButton = new ViewportWidgetButton(string.Empty, Editor.Instance.Icons.CamSpeed32, null, true)
                 {
                     Checked = !_isOrtho,
@@ -568,7 +568,7 @@ namespace FlaxEditor.Viewport
                 };
                 _orthographicModeButton.Toggled += OnOrthographicModeToggled;
 
-                // Camera speed
+                // Camera Speed
                 var camSpeedButton = cameraCM.AddButton("Camera Speed");
                 camSpeedButton.CloseMenuOnClick = false;
                 var camSpeedValue = new FloatValueBox(_movementSpeed, xLocationForExtras, 2, 70.0f, _minMovementSpeed, _maxMovementSpeed, 0.5f)
@@ -579,7 +579,7 @@ namespace FlaxEditor.Viewport
                 camSpeedValue.ValueChanged += () => OnMovementSpeedChanged(camSpeedValue);
                 cameraCM.VisibleChanged += control => camSpeedValue.Value = _movementSpeed;
 
-                // Minimum & maximum camera speed
+                // Minimum & Maximum Camera Speed
                 var minCamSpeedButton = cameraCM.AddButton("Min Cam Speed");
                 minCamSpeedButton.CloseMenuOnClick = false;
                 var minCamSpeedValue = new FloatValueBox(_minMovementSpeed, xLocationForExtras, 2, 70.0f, 0.05f, _maxMovementSpeed, 0.5f)
@@ -614,7 +614,7 @@ namespace FlaxEditor.Viewport
                 };
                 cameraCM.VisibleChanged += control => maxCamSpeedValue.Value = _maxMovementSpeed;
 
-                // Camera easing
+                // Camera Easing
                 {
                     var useCameraEasing = cameraCM.AddButton("Camera Easing");
                     useCameraEasing.CloseMenuOnClick = false;
@@ -627,7 +627,7 @@ namespace FlaxEditor.Viewport
                     cameraCM.VisibleChanged += control => useCameraEasingValue.Checked = _useCameraEasing;
                 }
 
-                // Panning speed
+                // Panning Speed
                 {
                     var panningSpeed = cameraCM.AddButton("Panning Speed");
                     panningSpeed.CloseMenuOnClick = false;
@@ -644,7 +644,7 @@ namespace FlaxEditor.Viewport
                     };
                 }
 
-                // Relative panning
+                // Relative Panning
                 {
                     var relativePanning = cameraCM.AddButton("Relative Panning");
                     relativePanning.CloseMenuOnClick = false;
@@ -664,7 +664,7 @@ namespace FlaxEditor.Viewport
                     cameraCM.VisibleChanged += control => relativePanningValue.Checked = _relativePanning;
                 }
 
-                // Invert panning
+                // Invert Panning
                 {
                     var invertPanning = cameraCM.AddButton("Invert Panning");
                     invertPanning.CloseMenuOnClick = false;
@@ -679,7 +679,7 @@ namespace FlaxEditor.Viewport
 
                 cameraCM.AddSeparator();
 
-                // Camera viewpoints
+                // Camera Viewpoints
                 {
                     var cameraView = cameraCM.AddChildMenu("Viewpoints").ContextMenu;
                     for (int i = 0; i < EditorViewportCameraViewpointValues.Length; i++)
@@ -692,7 +692,7 @@ namespace FlaxEditor.Viewport
                     cameraView.ButtonClicked += OnViewpointChanged;
                 }
 
-                // Orthographic mode
+                // Orthographic Mode
                 {
                     var ortho = cameraCM.AddButton("Orthographic");
                     ortho.CloseMenuOnClick = false;
@@ -712,7 +712,7 @@ namespace FlaxEditor.Viewport
                     cameraCM.VisibleChanged += control => orthoValue.Checked = _isOrtho;
                 }
 
-                // Field of view
+                // Field of View
                 {
                     var fov = cameraCM.AddButton("Field Of View");
                     fov.CloseMenuOnClick = false;
@@ -729,7 +729,7 @@ namespace FlaxEditor.Viewport
                     };
                 }
 
-                // Orthographic scale
+                // Orthographic Scale
                 {
                     var orthoSize = cameraCM.AddButton("Ortho Scale");
                     orthoSize.CloseMenuOnClick = false;
@@ -746,7 +746,7 @@ namespace FlaxEditor.Viewport
                     };
                 }
 
-                // Near plane
+                // Near Plane
                 {
                     var nearPlane = cameraCM.AddButton("Near Plane");
                     nearPlane.CloseMenuOnClick = false;
@@ -759,7 +759,7 @@ namespace FlaxEditor.Viewport
                     cameraCM.VisibleChanged += control => nearPlaneValue.Value = _nearPlane;
                 }
 
-                // Far plane
+                // Far Plane
                 {
                     var farPlane = cameraCM.AddButton("Far Plane");
                     farPlane.CloseMenuOnClick = false;
@@ -774,14 +774,16 @@ namespace FlaxEditor.Viewport
 
                 cameraCM.AddSeparator();
 
-                // Reset button
+                // Reset Button
                 {
                     var reset = cameraCM.AddButton("Reset to default");
                     reset.ButtonClicked += button =>
                     {
                         SetupViewportOptions();
 
-                        // trigger UI update
+                        // if the context menu is opened without triggering the value changes beforehand,
+                        // the movement speed will not be correctly reset to its default value in certain cases
+                        // therefore, a UI update needs to be triggered here
                         minCamSpeedValue.Value = _minMovementSpeed;
                         camSpeedValue.Value = _movementSpeed;
                         maxCamSpeedValue.Value = _maxMovementSpeed;
@@ -815,7 +817,7 @@ namespace FlaxEditor.Viewport
                     }
                 }
 
-                // View flags
+                // View Flags
                 {
                     var viewFlags = ViewWidgetButtonMenu.AddChildMenu("View Flags").ContextMenu;
                     viewFlags.AddButton("Reset flags", () => Task.ViewFlags = ViewFlags.DefaultEditor).Icon = Editor.Instance.Icons.Rotate32;
@@ -839,7 +841,7 @@ namespace FlaxEditor.Viewport
                     viewFlags.VisibleChanged += WidgetViewFlagsShowHide;
                 }
 
-                // Debug view
+                // Debug View
                 {
                     var debugView = ViewWidgetButtonMenu.AddChildMenu("Debug View").ContextMenu;
                     for (int i = 0; i < EditorViewportViewModeValues.Length; i++)

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -680,6 +680,22 @@ namespace FlaxEditor.Viewport
                     farPlaneValue.ValueChanged += () => OnFarPlaneChanged(farPlaneValue);
                     cameraCM.VisibleChanged += control => farPlaneValue.Value = _farPlane;
                 }
+
+                cameraCM.AddSeparator();
+
+                //Reset Button
+                {
+                    var reset = cameraCM.AddButton("Reset to default");
+                    reset.ButtonClicked += button =>
+                    {
+                        SetupViewportOptions();
+
+                        // trigger UI update
+                        minCamSpeedValue.Value = _minMovementSpeed;
+                        camSpeedValue.Value = _movementSpeed;
+                        maxCamSpeedValue.Value = _maxMovementSpeed;
+                    };
+                }
                 #endregion Camera settings widget
 
                 #region View mode widget

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -217,7 +217,7 @@ namespace FlaxEditor.Viewport
                 _movementSpeed = value;
 
                 if (_cameraButton != null)
-                    _cameraButton.Text = _movementSpeed.ToString();
+                    _cameraButton.Text = string.Format("{0:0.##}", _movementSpeed);
             }
         }
 
@@ -495,7 +495,7 @@ namespace FlaxEditor.Viewport
 
             // Initialize camera values from cache
             if (_editor.ProjectCache.TryGetCustomData("CameraMovementSpeedValue", out var cachedState))
-                _movementSpeed = float.Parse(cachedState);
+                MovementSpeed = float.Parse(cachedState);
             if (_editor.ProjectCache.TryGetCustomData("CameraMinMovementSpeedValue", out cachedState))
                 _minMovementSpeed = float.Parse(cachedState);
             if (_editor.ProjectCache.TryGetCustomData("CameraMaxMovementSpeedValue", out cachedState))
@@ -533,7 +533,7 @@ namespace FlaxEditor.Viewport
 
                 // Camera settings menu
                 var cameraCM = new ContextMenu();
-                _cameraButton = new ViewportWidgetButton(_movementSpeed.ToString(), Editor.Instance.Icons.Camera64, cameraCM)
+                _cameraButton = new ViewportWidgetButton(string.Format("{0:0.##}", _movementSpeed), Editor.Instance.Icons.Camera64, cameraCM, false, Style.Current.FontMedium.MeasureText("000.00").X)
                 {
                     Tag = this,
                     TooltipText = "Camera Settings",
@@ -546,7 +546,7 @@ namespace FlaxEditor.Viewport
                 {
                     Checked = !_isOrtho,
                     TooltipText = "Toggle Orthographic/Perspective Mode",
-                    Parent = _cameraWidget,
+                    Parent = _cameraWidget
                 };
                 _orthographicModeButton.Toggled += OnOrthographicModeToggled;
 
@@ -555,7 +555,7 @@ namespace FlaxEditor.Viewport
                 camSpeedButton.CloseMenuOnClick = false;
                 var camSpeedValue = new FloatValueBox(_movementSpeed, xLocationForExtras, 2, 70.0f, _minMovementSpeed, _maxMovementSpeed, 0.5f)
                 {
-                    Parent = camSpeedButton,
+                    Parent = camSpeedButton
                 };
 
                 camSpeedValue.ValueChanged += () => OnMovementSpeedChanged(camSpeedValue);
@@ -566,13 +566,13 @@ namespace FlaxEditor.Viewport
                 minCamSpeedButton.CloseMenuOnClick = false;
                 var minCamSpeedValue = new FloatValueBox(_minMovementSpeed, xLocationForExtras, 2, 70.0f, 0.05f, _maxMovementSpeed, 0.5f)
                 {
-                    Parent = minCamSpeedButton,
+                    Parent = minCamSpeedButton
                 };
                 var maxCamSpeedButton = cameraCM.AddButton("Max Cam Speed");
                 maxCamSpeedButton.CloseMenuOnClick = false;
                 var maxCamSpeedValue = new FloatValueBox(_maxMovementSpeed, xLocationForExtras, 2, 70.0f, _minMovementSpeed, 1000.0f, 0.5f)
                 {
-                    Parent = maxCamSpeedButton,
+                    Parent = maxCamSpeedButton
                 };
 
                 minCamSpeedValue.ValueChanged += () =>
@@ -898,7 +898,7 @@ namespace FlaxEditor.Viewport
         {
             var options = Editor.Instance.Options.Options;
             _minMovementSpeed = options.Viewport.MinMovementSpeed;
-            _movementSpeed = options.Viewport.MovementSpeed;
+            MovementSpeed = options.Viewport.MovementSpeed;
             _maxMovementSpeed = options.Viewport.MaxMovementSpeed;
             _useCameraEasing = options.Viewport.UseCameraEasing;
             _panningSpeed = options.Viewport.PanningSpeed;
@@ -929,7 +929,7 @@ namespace FlaxEditor.Viewport
             _minMovementSpeed = value;
 
             if (_movementSpeed < value)
-                _movementSpeed = value;
+                MovementSpeed = value;
 
             OnCameraMovementProgressChanged();
             _editor.ProjectCache.SetCustomData("CameraMinMovementSpeedValue", _minMovementSpeed.ToString());
@@ -941,7 +941,7 @@ namespace FlaxEditor.Viewport
             _maxMovementSpeed = value;
 
             if (_movementSpeed > value)
-                _movementSpeed = value;
+                MovementSpeed = value;
 
             OnCameraMovementProgressChanged();
             _editor.ProjectCache.SetCustomData("CameraMaxMovementSpeedValue", _maxMovementSpeed.ToString());
@@ -1105,16 +1105,16 @@ namespace FlaxEditor.Viewport
 
             if (_useCameraEasing)
             {
-                _easedMovementProgress = Mathf.Clamp(_easedMovementProgress + speedDelta, 0.0f, 1.0f);
+                _easedMovementProgress = Mathf.Saturate(_easedMovementProgress + speedDelta);
                 speed = Mathf.InterpEaseInOut(_minMovementSpeed, _maxMovementSpeed, _easedMovementProgress, _cameraEasingDegree);
             }
             else
             {
-                _linearMovementProgress = Mathf.Clamp(_linearMovementProgress + speedDelta, 0.0f, 1.0f);
+                _linearMovementProgress = Mathf.Saturate(_linearMovementProgress + speedDelta);
                 speed = Mathf.Lerp(_minMovementSpeed, _maxMovementSpeed, _linearMovementProgress);
             }
 
-            MovementSpeed = Mathf.Round(speed * 100) / 100;
+            MovementSpeed = speed;
         }
 
         private void OnEditorOptionsChanged(EditorOptions options)

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -134,6 +134,11 @@ namespace FlaxEditor.Viewport
         /// </summary>
         protected ViewportWidgetButton _cameraButton;
 
+        /// <summary>
+        /// The orthographic mode widget button.
+        /// </summary>
+        protected ViewportWidgetButton _orthographicModeButton;
+
         private readonly Editor _editor;
 
         private float _mouseSensitivity;
@@ -523,6 +528,15 @@ namespace FlaxEditor.Viewport
                     Parent = _cameraWidget
                 };
                 _cameraWidget.Parent = this;
+
+                // Toggle orthographic mode widget
+                _orthographicModeButton = new ViewportWidgetButton(string.Empty, Editor.Instance.Icons.CamSpeed32, null, true)
+                {
+                    Checked = !_isOrtho,
+                    TooltipText = "Toggle Orthographic/Perspective Mode",
+                    Parent = _cameraWidget,
+                };
+                _orthographicModeButton.Toggled += OnOrthographicModeToggled;
 
                 // Camera speed
                 var camSpeedButton = cameraCM.AddButton("Camera Speed");
@@ -941,6 +955,9 @@ namespace FlaxEditor.Viewport
         private void OnOrthographicModeToggled(Control control)
         {
             _isOrtho = !_isOrtho;
+
+            if (_orthographicModeButton != null)
+                _orthographicModeButton.Checked = !_isOrtho;
 
             if (_isOrtho)
             {

--- a/Source/Editor/Viewport/Widgets/ViewportWidgetButton.cs
+++ b/Source/Editor/Viewport/Widgets/ViewportWidgetButton.cs
@@ -19,6 +19,7 @@ namespace FlaxEditor.Viewport.Widgets
         private bool _checked;
         private bool _autoCheck;
         private bool _isMosueDown;
+        private float _forcedTextWidth;
 
         /// <summary>
         /// Event fired when user toggles checked state.
@@ -63,14 +64,16 @@ namespace FlaxEditor.Viewport.Widgets
         /// <param name="text">The text.</param>
         /// <param name="icon">The icon.</param>
         /// <param name="contextMenu">The context menu.</param>
-        /// <param name="autoCheck">if set to <c>true</c> will be automatic checked on mouse click.</param>
-        public ViewportWidgetButton(string text, SpriteHandle icon, ContextMenu contextMenu = null, bool autoCheck = false)
-        : base(0, 0, CalculateButtonWidth(0, icon.IsValid), ViewportWidgetsContainer.WidgetsHeight)
+        /// <param name="autoCheck">If set to <c>true</c> will be automatic checked on mouse click.</param>
+        /// <param name="textWidth">Forces the text to be drawn with the specified width.</param>
+        public ViewportWidgetButton(string text, SpriteHandle icon, ContextMenu contextMenu = null, bool autoCheck = false, float textWidth = 0.0f)
+        : base(0, 0, CalculateButtonWidth(textWidth, icon.IsValid), ViewportWidgetsContainer.WidgetsHeight)
         {
             _text = text;
             Icon = icon;
             _cm = contextMenu;
             _autoCheck = autoCheck;
+            _forcedTextWidth = textWidth;
 
             if (_cm != null)
                 _cm.VisibleChanged += CmOnVisibleChanged;
@@ -160,7 +163,7 @@ namespace FlaxEditor.Viewport.Widgets
             var style = Style.Current;
 
             if (style != null && style.FontMedium)
-                Width = CalculateButtonWidth(style.FontMedium.MeasureText(_text).X, Icon.IsValid);
+                Width = CalculateButtonWidth(_forcedTextWidth > 0.0f ? _forcedTextWidth : style.FontMedium.MeasureText(_text).X, Icon.IsValid);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR is trying to improve the camera settings widget and related camera settings in `EditorViewport`.

Based on my search, at this time, it does not seem to fix any open issues.

The PR contains:
- [x] Gathering all camera settings into one camera widget with context menu
- [x] Improved panning, including the ability to manually set the panning speed and have panning based on distance to the focused/target object (aka relative panning, thanks @stefnotch!)
- [x] Additional default settings in the Flax Engine options
- [x] Ability to reset all camera settings to default through a button in the context menu of the camera settings widget
- [x] Saving and loading of cached camera settings values (similar to how it is in `MainEditorGizmoViewport`)
- [x] Camera speed easing during camera flight and when using `EditorViewport.AdjustCameraMoveSpeed` using `Mathf.Pow`
- [x] Possibility to disable camera easing completely
- [x] Toggle button to quickly switch between orthographic and perspective mode (still missing dedicated icon, feel free to add one)

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Refactoring
- [x] Requires documentation update

## Motivation

### Grouping of related settings
The camera settings were spread across the view widget and the camera speed scale widget. With this change, they are all combined into one camera settings widget.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/d3e01994-0899-4abd-b631-758ce655c9a4)

### Camera panning
When panning the camera, the panning speed would always be locked at a certain value. These changes add the possibility to manually set the panning speed or use a relative panning mode, which automatically calculates the panning speed based on the camera target/focused object.

Before:
![FlaxEditor_2023-10-05_00-07-25](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/7c9cc839-cd98-4f9f-874d-12b163826dfb)
After:
![FlaxEditor_2023-10-05_00-09-36](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/56318bd5-47b1-4df5-95fb-cf034268af51)

### Adjustable camera speed and camera speed easing
Previously, the camera speed setting was limited to only a few options. Now, from the context menu, the camera settings widget allows you to set the minimum, maximum and current speed of the camera.

![FlaxEditor_2023-10-05_00-12-40](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/67d9447d-04ba-4f84-acd4-959efdb45212)

In addition to that, when using the camera flight mode (holding RMB or using `CameraToggleRotation`), the camera speed is now adjusted based on `Mathf.Pow` to slow down the camera speed in the beginning (min speed).

![FlaxEditor_2023-10-05_00-45-34](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/e3304390-8703-43b4-8760-39ca34824c7f)

The possibility to fully disable camera speed easing was added to the camera settings widget.
![image](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/1cc5b990-2166-4cf0-b84d-1516382dc8a4)

The camera settings widget now uses a fixed size to prevent being resized whenever the string length of the speed value changes. On top of that, the string gets formatted using `string.Format`. In the `FloatValueBox` inside the context menu, the movement speed will show up rounded up to the third decimal to make it look more appealing to the user.

Before:
![FlaxEditor_2023-10-05_20-08-43](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/246d2119-80d7-4d82-99fb-1f5dc76ff464)
After:
![2023-10-08_02-44-26](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/89b0502b-2302-46ef-b466-9166cbbdf6a0)

### New default settings based on changes
In the options of Flax Engine, additional settings have been added based on the changes that were made to the possible camera settings. These changes get synced with the editor viewport and are also the ones that are used when the reset button is pressed.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/20548409/b671c66d-d62a-4a9c-bb73-61e9a90e6507)

The new settings described:
| Setting | Description |
| - | - |
|**Total Camera Speed Steps** | Changes the amount of steps it requires for the camera speed to go from minimum to maximum (1-128).|
|**Camera Easing Degree**| When using camera easing, the camera easing degree will determine how slow/fast the camera speed increases/decreases across steps (1.0-8.0).|
|**Min Movement Speed**| The default minimum speed of the camera (0.05-32).|
|**Max Movement Speed**| The default maximum speed of the camera (32-1000).|
|**Use Camera Easing**| Enable/disable camera easing.|
|**Use Relative Panning**| Enable/disable whether the panning speed of the camera should be affected by the distance to the target/focused object or not. |

## Potential changes
### Easing value calculation
This was simplified to use `Mathf.Pow` [here](https://github.com/FlaxEngine/FlaxEngine/pull/1611/commits/00aa54cde82da867b2a861cd1b6bf307dafc0a7f), should be fine now.

### ~Additional easing curve setting~
~There doesn't necessarily have to be an ease out on the camera speed. However, a possible change to the camera easing could be to allow changing the easing degree between 0% and 50% and the one between 50% and 100% separately.~

### Orthographic/perspective toggle button
This button is currently missing the correct icon. I had one that I made myself, but I was not too happy with it. Best case, it is an icon that represents the perspective mode, as that one is more easily identifiable.