### PR TITLE
Visject: Automatic casting

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -787,7 +787,7 @@ namespace FlaxEditor.Surface.Archetypes
             }
         }
 
-        private class AsNode : SurfaceNode
+        internal class AsNode : SurfaceNode
         {
             private TypePickerControl _picker;
 
@@ -838,6 +838,11 @@ namespace FlaxEditor.Surface.Archetypes
                 box.CurrentType = type ? type : ScriptType.FlaxObject;
             }
 
+            public void SetPickerValue(ScriptType type)
+            {
+                _picker.Value = type;
+            }
+            
             /// <inheritdoc />
             public override void OnDestroy()
             {
@@ -999,6 +1004,11 @@ namespace FlaxEditor.Surface.Archetypes
                 GetBox(4).CurrentType = type ? type : _picker.Type;
             }
 
+            public void SetPickerValue(ScriptType type)
+            {
+                _picker.Value = type;
+            }
+            
             /// <inheritdoc />
             public override void OnDestroy()
             {

--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -838,6 +838,10 @@ namespace FlaxEditor.Surface.Archetypes
                 box.CurrentType = type ? type : ScriptType.FlaxObject;
             }
 
+            /// <summary>
+            /// Sets the type of the picker and the type of the output box
+            /// </summary>
+            /// <param name="type">Target Type</param>
             public void SetPickerValue(ScriptType type)
             {
                 _picker.Value = type;
@@ -1004,6 +1008,10 @@ namespace FlaxEditor.Surface.Archetypes
                 GetBox(4).CurrentType = type ? type : _picker.Type;
             }
 
+            /// <summary>
+            /// Sets the type of the picker and the type of the output box
+            /// </summary>
+            /// <param name="type">Target Type</param>
             public void SetPickerValue(ScriptType type)
             {
                 _picker.Value = type;

--- a/Source/Editor/Surface/Elements/Box.cs
+++ b/Source/Editor/Surface/Elements/Box.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FlaxEditor.Scripting;
 using FlaxEditor.Surface.Undo;
 using FlaxEngine;
@@ -843,6 +842,7 @@ namespace FlaxEditor.Surface.Elements
                         throw new NullReferenceException("Casting failed. Cast node is invalid!");
                     }
                     
+                    // We set the position of the cast node here to set it relative to the target nodes input box
                     undoEnabled = castNode.Surface.Undo.Enabled;
                     castNode.Surface.Undo.Enabled = false;
                     var wantedOffset = iB.ParentNode.Location - new Float2(casterXOffset, -(iB.LocalY - castOutputBox.LocalY));
@@ -876,6 +876,7 @@ namespace FlaxEditor.Surface.Elements
                         throw new NullReferenceException("Casting failed. Cast node is invalid!");
                     }
                     
+                    // We set the position of the cast node here to set it relative to the target nodes input box
                     var wantedOffset = iB.ParentNode.Location - new Float2(casterXOffset, -(iB.LocalY - castOutputBox.LocalY));
                     castNode.Location = Surface.Root.PointFromParent(ref wantedOffset);
                     


### PR DESCRIPTION
When trying to connect two node ports, which types are theoretically compatible via casting, a casting node should be added automatically in front of the target port. This mimics the behavior of Unreal for example.
![image](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/a5d7a326-2905-4d60-bf78-7dbefa860576)


Currently when trying to connect two ports which are compatible via casting, nothing happens. Instead a NotImplementedException gets thrown. (See before gif)

This PR implements automatically spawning a casting node when needed, setting it's type and positioning it accordingly.
This functionality enhances this PR: #1522 but is not depending on it.

Before:
![BeforeCasting](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/868139e9-4907-4607-8a5b-5bd13b46105e)

After:
![AfterCasting](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/feb17eed-91ff-4157-8b91-ec21284d703b)

I already did a bit of testing including Undo/Redo functionality etc.