### PR TITLE
Use latest supported C# version for building rules assemblies

### DIFF
--- a/Source/Tools/Flax.Build/Build/Assembler.cs
+++ b/Source/Tools/Flax.Build/Build/Assembler.cs
@@ -154,7 +154,7 @@ namespace Flax.Build
 
             // Run the compilation
             using var memoryStream = new MemoryStream();
-            CSharpParseOptions parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp9).WithPreprocessorSymbols(PreprocessorSymbols);
+            CSharpParseOptions parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest).WithPreprocessorSymbols(PreprocessorSymbols);
             var syntaxTrees = new List<SyntaxTree>();
             foreach (var sourceFile in SourceFiles)
             {


### PR DESCRIPTION
The module C# template does not work with module build files as the assemblies are built with older C# version.