### PR TITLE
Animation Graph: Added animation asset input box to animation sample node

### DIFF
--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -34,6 +34,9 @@ namespace FlaxEditor.Surface.Archetypes
         /// <seealso cref="FlaxEditor.Surface.SurfaceNode" />
         public class Sample : SurfaceNode
         {
+            private AssetSelect _assetSelect;
+            private Box _assetBox;
+            
             /// <inheritdoc />
             public Sample(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
             : base(id, context, nodeArch, groupArch)
@@ -54,7 +57,12 @@ namespace FlaxEditor.Surface.Archetypes
                 base.OnSurfaceLoaded();
 
                 if (Surface != null)
+                {
+                    _assetSelect = GetChild<AssetSelect>();
+                    _assetBox = GetBox(8);
+                    _assetSelect.Visible = !_assetBox.HasAnyConnection;
                     UpdateTitle();
+                }
             }
 
             private void UpdateTitle()
@@ -63,6 +71,17 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = asset?.ShortName ?? "Animation";
                 var style = Style.Current;
                 Resize(Mathf.Max(230, style.FontLarge.MeasureText(Title).X + 30), 160);
+            }
+
+            /// <inheritdoc />
+            public override void ConnectionTick(Box box)
+            {
+                base.ConnectionTick(box);
+                
+                if(box.ID != _assetBox.ID)
+                    return;
+
+                _assetSelect.Visible = !box.HasAnyConnection;
             }
         }
 
@@ -305,7 +324,8 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, "Speed", true, typeof(float), 5, 1),
                     NodeElementArchetype.Factory.Input(1, "Loop", true, typeof(bool), 6, 2),
                     NodeElementArchetype.Factory.Input(2, "Start Position", true, typeof(float), 7, 3),
-                    NodeElementArchetype.Factory.Asset(0, Surface.Constants.LayoutOffsetY * 3, 0, typeof(FlaxEngine.Animation)),
+                    NodeElementArchetype.Factory.Input(3, "Animation Asset", true, typeof(FlaxEngine.Animation), 8),
+                    NodeElementArchetype.Factory.Asset(0, Surface.Constants.LayoutOffsetY * 4, 0, typeof(FlaxEngine.Animation)),
                 }
             },
             new NodeArchetype

--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -36,7 +36,7 @@ namespace FlaxEditor.Surface.Archetypes
         {
             private AssetSelect _assetSelect;
             private Box _assetBox;
-            
+
             /// <inheritdoc />
             public Sample(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
             : base(id, context, nodeArch, groupArch)
@@ -77,7 +77,7 @@ namespace FlaxEditor.Surface.Archetypes
             public override void ConnectionTick(Box box)
             {
                 base.ConnectionTick(box);
-                
+
                 if(box.ID != _assetBox.ID)
                     return;
 

--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -68,7 +68,7 @@ namespace FlaxEditor.Surface.Archetypes
             private void UpdateTitle()
             {
                 var asset = Editor.Instance.ContentDatabase.Find((Guid)Values[0]);
-                Title = asset?.ShortName ?? "Animation";
+                Title = _assetBox.HasAnyConnection || asset == null ? "Animation" : asset.ShortName;
                 var style = Style.Current;
                 Resize(Mathf.Max(230, style.FontLarge.MeasureText(Title).X + 30), 160);
             }
@@ -82,6 +82,7 @@ namespace FlaxEditor.Surface.Archetypes
                     return;
 
                 _assetSelect.Visible = !box.HasAnyConnection;
+                UpdateTitle();
             }
         }
 

--- a/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
+++ b/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
@@ -772,7 +772,7 @@ void AnimGraphExecutor::ProcessGroupAnimation(Box* boxBase, Node* nodeBase, Valu
                 else
                     anim = nullptr;
             }
-            
+
             const float length = anim ? anim->GetLength() : 0.0f;
 
             // Calculate new time position

--- a/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
+++ b/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
@@ -749,7 +749,7 @@ void AnimGraphExecutor::ProcessGroupAnimation(Box* boxBase, Node* nodeBase, Valu
     // Animation
     case 2:
     {
-        const auto anim = node->Assets[0].As<Animation>();
+        auto anim = node->Assets[0].As<Animation>();
         auto& bucket = context.Data->State[node->BucketIndex].Animation;
 
         switch (box->ID)
@@ -761,6 +761,18 @@ void AnimGraphExecutor::ProcessGroupAnimation(Box* boxBase, Node* nodeBase, Valu
             const float speed = (float)tryGetValue(node->GetBox(5), node->Values[1]);
             const bool loop = (bool)tryGetValue(node->GetBox(6), node->Values[2]);
             const float startTimePos = (float)tryGetValue(node->GetBox(7), node->Values[3]);
+
+            // Override animation when animation reference box is connected
+            auto animationAssetBox = node->GetBox(8);
+            if(animationAssetBox->HasConnection())
+            {
+                const Value assetBoxValue = tryGetValue(animationAssetBox, Value::Null);
+                if(assetBoxValue != Value::Null)
+                    anim = (Animation*)assetBoxValue.AsAsset;
+                else
+                    anim = nullptr;
+            }
+            
             const float length = anim ? anim->GetLength() : 0.0f;
 
             // Calculate new time position


### PR DESCRIPTION
As requested by @Tryibion, the animation sample node now has an animation asset reference input box, where the user can now alternatively connect an asset/animation reference to.
This allows to connect a parameter to the sample node and change the parameter via code at runtime.

Animation Graph:
![AnimationSampleInputPort](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/4e25a4c4-490d-40dc-8de6-5301a980f07e)

Ingame:
![SwitchAnimationsSmol](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/0c39badf-fbb5-4612-8cb3-6afbbb5bcf62)
(I made a simple visual script, where the parameter of the animated model gets changed with every LMB click)