### PR TITLE
Visject: Minor visual fix to preview connection

### DIFF
--- a/Source/Editor/Surface/VisjectSurface.Draw.cs
+++ b/Source/Editor/Surface/VisjectSurface.Draw.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
+using FlaxEditor.Surface.Elements;
 using FlaxEngine;
 
 namespace FlaxEditor.Surface
@@ -135,8 +136,25 @@ namespace FlaxEditor.Surface
                 endPos = _lastInstigatorUnderMouse.ConnectionOrigin;
             }
 
+            Float2 actualStartPos = startPos;
+            Float2 actualEndPos = endPos;
+
+            if (_connectionInstigator is Archetypes.Tools.RerouteNode)
+            {
+                if (endPos.X < startPos.X && _lastInstigatorUnderMouse is null or Box { IsOutput: true})
+                {
+                    actualStartPos = endPos;
+                    actualEndPos = startPos;
+                }
+            }
+            else if (_connectionInstigator is Box { IsOutput: false })
+            {
+                actualStartPos = endPos;
+                actualEndPos = startPos;
+            }
+
             // Draw connection
-            _connectionInstigator.DrawConnectingLine(ref startPos, ref endPos, ref lineColor);
+            _connectionInstigator.DrawConnectingLine(ref actualStartPos, ref actualEndPos, ref lineColor);
         }
 
         /// <summary>


### PR DESCRIPTION
When pulling a connection out of a box or a reroute node, it always gets handled like a connection from an output. This causes preview connections from input boxes and reroute nodes too look wrong.

This PR just fixes the 2 cases.

Reroute node before:
![FalseBendingReroute](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/68a98dba-2d6c-42a9-88a0-6dca944fe8de)

Reroute node after:
![CorrectBendingReroute](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/356ce70f-5189-4e35-b629-59c7ef6880f6)

Input box before:
![FalseBendingInputBox](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/2e286517-eae8-418c-afba-005999de37c7)

Input box after:
![CorrectBendingInputBox](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/11f12dd2-45c1-4ea7-a37d-4d015cb03204)
