### PR TITLE
Visual Scripting CM: Fixed surface parameter item duplication bug

### DIFF
--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -618,7 +618,7 @@ namespace FlaxEditor.Surface.ContextMenu
                     Archetypes = archetypes
                 };
 
-                var group = CreateGroup(groupArchetype);
+                var group = CreateGroup(groupArchetype, false);
                 group.ArrowImageOpened = new SpriteBrush(Style.Current.ArrowDown);
                 group.ArrowImageClosed = new SpriteBrush(Style.Current.ArrowRight);
                 group.Close(false);


### PR DESCRIPTION
Small bugfix with big benefits. This bug only appears in the visual scripting graph.

### The Bug
When opening the context menu in the visual scripting graph, all default groups get loaded, then all custom nodes get asynchronously fetched, then the surface parameter group gets created.
This currently causes items in the surface parameter group to be duplicated indefinitely every time the context menu gets openend

Bug:
![BrokenParameterGroup](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/da9bc33d-0b24-4a42-9178-f26257734a97)
![TestoPesto](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/9d8a2b99-9828-4984-9c2c-1f4c7001906e)

This has the potential to have big implications in terms of filtering, rendering and memory performance.

### The Fix
My theory to why this happens is, because the asynchronous loading of the custom nodes locks the context menu groups in another thread, which is why the surface parameter group cannot dispose and create itself again properly.
Putting the `base.OnShowPrimaryMenu` before the `NodesCache.Get`, makes the bug appear less, but doesn't eliminate it
![image](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/ffd9a04f-a013-492d-bf38-50f1f5c66601)

This bug can be eliminated by disabling group merging for the Surface Parameter group, as i did for this PR.
So yeah, a bugfix in a way...

Fixed:
![FixedParamaterGroup](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/317d93e2-e2f7-4026-a732-638f6d30dde6)
