### PR TITLE
Add color picker option to accept changes on dismissal

### DIFF
--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -362,7 +362,10 @@ namespace FlaxEditor.GUI.Dialogs
             _disableEvents = true;
 
             // Restore color if modified
-            if (_useDynamicEditing && _initialValue != _value)
+            var options = Editor.Instance.Options.Options;
+
+            if (!options.Interface.ColorPickerAlwaysChangesColor &&
+                _useDynamicEditing && _initialValue != _value)
             {
                 _onChanged?.Invoke(_initialValue, false);
             }

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -149,6 +149,13 @@ namespace FlaxEditor.Options
         public FlaxEngine.GUI.Orientation ContentWindowOrientation { get; set; } = FlaxEngine.GUI.Orientation.Horizontal;
 
         /// <summary>
+        /// Gets or sets the editor content window orientation.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Interface"), EditorOrder(300), Tooltip("If checked, color pickers will always modify the color unless 'Cancel' if pressed, otherwise color won't change unless 'Ok' is pressed (default)")]
+        public bool ColorPickerAlwaysChangesColor { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the timestamps prefix mode for output log messages.
         /// </summary>
         [DefaultValue(TimestampsFormats.TimeSinceStartup)]


### PR DESCRIPTION
I'm really used to the Unity (and maybe other creative tools) of color picker functionality, where you don't need to press "Ok" for the color to be accepted, just dismissing the dialog is enough.

This PR adds an option to be able to do that, and I'd be grateful if somebody has some feedback on the naming, category location and/or tooltip description, naming is difficult.