### PR TITLE
Fix `Dictionary` iterator comparison

### DIFF
--- a/Source/Engine/Core/Collections/Dictionary.h
+++ b/Source/Engine/Core/Collections/Dictionary.h
@@ -309,7 +309,7 @@ public:
 
         FORCE_INLINE bool operator==(const Iterator& v) const
         {
-            return _index == v._index && &_collection == &v._collection;
+            return _index == v._index && _collection == v._collection;
         }
 
         FORCE_INLINE bool operator!=(const Iterator& v) const


### PR DESCRIPTION
Missing change from 9291295a4d9997e3257037db7135d3a5e52d3962

Fixes a crash when reloading changed shader files.