### PR TITLE
Fix edit TextBox

### DIFF
--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1302,7 +1302,7 @@ namespace FlaxEngine.GUI
                 MoveRight(shiftDown, ctrDown);
                 return true;
             case KeyboardKeys.ArrowLeft:
-                    MoveLeft(shiftDown, ctrDown);
+                MoveLeft(shiftDown, ctrDown);
                 return true;
             case KeyboardKeys.ArrowUp:
                 MoveUp(shiftDown, ctrDown);

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -769,13 +769,13 @@ namespace FlaxEngine.GUI
             {
                 SetSelection(SelectionLeft);
             }
-            else if (SelectionLeft > 0)
+            else if (SelectionLeft >= 0)
             {
                 int position;
                 if (ctrl)
                     position = FindPrevWordBegin();
                 else
-                    position = _selectionEnd - 1;
+                    position = Mathf.Max(_selectionEnd - 1, 0);
 
                 if (shift)
                 {
@@ -1302,7 +1302,7 @@ namespace FlaxEngine.GUI
                 MoveRight(shiftDown, ctrDown);
                 return true;
             case KeyboardKeys.ArrowLeft:
-                MoveLeft(shiftDown, ctrDown);
+                    MoveLeft(shiftDown, ctrDown);
                 return true;
             case KeyboardKeys.ArrowUp:
                 MoveUp(shiftDown, ctrDown);


### PR DESCRIPTION
This is a small correction in editing the text box, before I couldn't edit a text if I start selecting the characters at the beginning of the text with Shift