### PR TITLE
Fix incorrect mapping of Alt key on linux

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxPlatform.cpp
+++ b/Source/Engine/Platform/Linux/LinuxPlatform.cpp
@@ -945,7 +945,7 @@ const char* ButtonCodeToKeyName(KeyboardKeys code)
 		// Row #6
 	case KeyboardKeys::Control:	return "LCTL"; // Left Control
 	case KeyboardKeys::LeftWindows: return "LWIN";
-	case KeyboardKeys::LeftMenu: return "LALT";
+	case KeyboardKeys::Alt: return "LALT";
 	case KeyboardKeys::Spacebar: return "SPCE";
 	case KeyboardKeys::RightMenu: return "RALT";
 	case KeyboardKeys::RightWindows: return "RWIN";


### PR DESCRIPTION
For some reason the left alt key was mapped to `KeyboardKeys::LeftMenu` which prevented using the alt key in the editor. This changes it to `KeyboardKeys::Alt` and allows to orbit around objects again.