### PR TITLE
Fix Editor viewport camera drifting with odd viewport sizes

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1022,7 +1022,7 @@ namespace FlaxEditor.Viewport
 
             // Center mouse position if it's too close to the edge
             var size = Size;
-            var center = size * 0.5f;
+            var center = Float2.Round(size * 0.5f);
             if (Mathf.Abs(_viewMousePos.X - center.X) > center.X * 0.8f || Mathf.Abs(_viewMousePos.Y - center.Y) > center.Y * 0.8f)
             {
                 _viewMousePos = center;


### PR DESCRIPTION
Occurs when right-clicking at the edges of the viewport when the viewport size is not even in either dimension.