### PR TITLE
Use a maximum distance between clicks, when detecting a double click, to prevent accidental double clicks.

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxWindow.cpp
+++ b/Source/Engine/Platform/Linux/LinuxWindow.cpp
@@ -41,8 +41,10 @@ extern Dictionary<StringAnsi, X11::KeyCode> KeyNameMap;
 extern Array<KeyboardKeys> KeyCodeMap;
 extern X11::Cursor Cursors[(int32)CursorType::MAX];
 
-static const uint32 MouseDoubleClickTime = 500;
+static constexpr uint32 MouseDoubleClickTime = 500;
+static constexpr uint32 MaxDoubleClickDistanceSquared = 10;
 static X11::Time MouseLastButtonPressTime = 0;
+static Float2 OldMouseClickPosition;
 
 LinuxWindow::LinuxWindow(const CreateWindowSettings& settings)
 	: WindowBase(settings)
@@ -597,15 +599,19 @@ void LinuxWindow::OnButtonPress(void* event)
 	// Handle double-click
 	if (buttonEvent->button == Button1)
 	{
-		if (buttonEvent->time < (MouseLastButtonPressTime + MouseDoubleClickTime))
+		if (
+			buttonEvent->time < (MouseLastButtonPressTime + MouseDoubleClickTime) &&
+			Float2::DistanceSquared(mousePos, OldMouseClickPosition) < MaxDoubleClickDistanceSquared)
 		{
 			Input::Mouse->OnMouseDoubleClick(ClientToScreen(mousePos), mouseButton, this);
 			MouseLastButtonPressTime = 0;
+			OldMouseClickPosition = mousePos;
 			return;
 		}
 		else
 		{
 			MouseLastButtonPressTime = buttonEvent->time;
+			OldMouseClickPosition = mousePos;
 		}
 	}
 


### PR DESCRIPTION
Double click detection on Linux doesn't use a maximum distance between clicks and only checks for time. As such, it is possible to trigger a double click while casually clicking around in the editor:

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/1d046323-a282-4e22-b9d9-b20bd0f11125

One solution is to reduce the time allowed between two clicks but that makes it harder to successfully double click, especially for people who can't click fast. This PR makes sure that clicks have to be really close before triggering a double click:

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/980266df-3bb5-4a7e-8bd4-6e9c33278e6c

