### PR TITLE
Change terrain brush size with scroll

### DIFF
--- a/Source/Editor/Tools/Terrain/PaintTerrainGizmo.cs
+++ b/Source/Editor/Tools/Terrain/PaintTerrainGizmo.cs
@@ -150,6 +150,14 @@ namespace FlaxEditor.Tools.Terrain
                 return;
             }
 
+            // Increase or decrease brush size with scroll
+            if (Input.GetKey(KeyboardKeys.Shift))
+            {
+                var currentBrush = Mode.CurrentBrush;
+                currentBrush.Size += dt * currentBrush.Size * Input.Mouse.ScrollDelta * 5f;
+                Mode.CurrentBrush = currentBrush;
+            }
+
             // Check if no terrain is selected
             var terrain = SelectedTerrain;
             if (!terrain)

--- a/Source/Editor/Tools/Terrain/PaintTerrainGizmoMode.cs
+++ b/Source/Editor/Tools/Terrain/PaintTerrainGizmoMode.cs
@@ -139,9 +139,9 @@ namespace FlaxEditor.Tools.Terrain
         }
 
         /// <summary>
-        /// Gets the current brush.
+        /// Gets or set the current brush.
         /// </summary>
-        public Brush CurrentBrush => _brushes[(int)_brushType];
+        public Brush CurrentBrush { get => _brushes[(int)_brushType]; set => _brushes[(int)_brushType] = value; }
 
         /// <summary>
         /// Gets the circle brush instance.

--- a/Source/Editor/Tools/Terrain/SculptTerrainGizmo.cs
+++ b/Source/Editor/Tools/Terrain/SculptTerrainGizmo.cs
@@ -158,6 +158,14 @@ namespace FlaxEditor.Tools.Terrain
                 return;
             }
 
+            // Increase or decrease brush size with scroll
+            if (Input.GetKey(KeyboardKeys.Shift))
+            {
+                var currentBrush = Mode.CurrentBrush;
+                currentBrush.Size += dt * currentBrush.Size * Input.Mouse.ScrollDelta * 5f;
+                Mode.CurrentBrush = currentBrush;
+            }
+
             // Check if selected terrain was changed during painting
             if (terrain != _paintTerrain && IsPainting)
             {

--- a/Source/Editor/Tools/Terrain/SculptTerrainGizmoMode.cs
+++ b/Source/Editor/Tools/Terrain/SculptTerrainGizmoMode.cs
@@ -158,9 +158,9 @@ namespace FlaxEditor.Tools.Terrain
         }
 
         /// <summary>
-        /// Gets the current brush.
+        /// Gets or set the current brush.
         /// </summary>
-        public Brush CurrentBrush => _brushes[(int)_brushType];
+        public Brush CurrentBrush { get => _brushes[(int)_brushType]; set => _brushes[(int)_brushType] = value; }
 
         /// <summary>
         /// Gets the circle brush instance.


### PR DESCRIPTION
This adds a way to change terrain brush size with mouse scroll pressing shift.

[Debug 2023.10.10 - 10.49.05.01.webm](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/da9a2ab2-b93b-44f4-8d3c-a448f744edce)
