### PR TITLE
Ensure WS_CAPTION style is set only for regular windows.

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -108,8 +108,7 @@ WindowsWindow::WindowsWindow(const CreateWindowSettings& settings)
             style |= WS_BORDER | WS_CAPTION | WS_DLGFRAME | WS_SYSMENU | WS_THICKFRAME | WS_GROUP;
 #elif WINDOWS_USE_NEWER_BORDER_LESS
         if (settings.IsRegularWindow)
-            style |= WS_THICKFRAME | WS_SYSMENU;
-        style |= WS_CAPTION;
+            style |= WS_THICKFRAME | WS_SYSMENU | WS_CAPTION;
 #endif
         exStyle |= WS_EX_WINDOWEDGE;
     }


### PR DESCRIPTION
This just makes sure that context menus will not be created with a titlebar, which caused this to happen for one frame:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/30367251/bd627de1-d4e2-402e-a1a0-1b892b108c04)

It does reset after one frame but it is annoying.