### PR TITLE
Fix Editor viewport camera transformation getting corrupted when focused

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1119,7 +1119,12 @@ namespace FlaxEditor.Viewport
             var win = (WindowRootControl)Root;
 
             // Get current mouse position in the view
-            _viewMousePos = PointFromWindow(win.MousePosition);
+            {
+                // When the window is not focused, the position in window does not return sane values
+                Float2 pos = PointFromWindow(win.MousePosition);
+                if (!float.IsInfinity(pos.LengthSquared))
+                    _viewMousePos = pos;
+            }
 
             // Update input
             var window = win.Window;


### PR DESCRIPTION
In some rare occasions, when the Editor viewport camera is activated, the returned point in window area lands outside of the window area, returning invalid value and causing the camera to render black.