### PR TITLE
Build C# projects in VS/Rider solution configurations

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -628,7 +628,10 @@ namespace Flax.Build
                         }
                     }
                     if (failed)
+                    {
+                        Globals.BuildErrors = true;
                         throw new Exception($"Failed to build target {target.Name}. See log.");
+                    }
                 }
                 else
                 {
@@ -689,7 +692,10 @@ namespace Flax.Build
                         }
                     }
                     if (failed)
+                    {
+                        Globals.BuildErrors = true;
                         throw new Exception($"Failed to build target {target.Name}. See log.");
+                    }
                 }
                 else
                 {

--- a/Source/Tools/Flax.Build/Globals.cs
+++ b/Source/Tools/Flax.Build/Globals.cs
@@ -23,6 +23,11 @@ namespace Flax.Build
         public static ProjectInfo Project;
 
         /// <summary>
+        /// Set when any build related errors were raised.
+        /// </summary>
+        public static bool BuildErrors = false;
+
+        /// <summary>
         /// All platforms array.
         /// </summary>
         public static readonly TargetPlatform[] AllPlatforms =

--- a/Source/Tools/Flax.Build/Program.cs
+++ b/Source/Tools/Flax.Build/Program.cs
@@ -171,7 +171,9 @@ namespace Flax.Build
             }
             catch (Exception ex)
             {
-                Log.Exception(ex);
+                // Ignore exception logging for build errors
+                if (!Globals.BuildErrors)
+                    Log.Exception(ex);
                 failed = true;
             }
             finally

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -91,7 +91,7 @@ namespace Flax.Build.Projects.VisualStudio
             var baseOutputDir = Utilities.MakePathRelativeTo(project.CSharp.OutputPath ?? baseConfiguration.TargetBuildOptions.OutputFolder, projectDirectory);
             var baseIntermediateOutputPath = Utilities.MakePathRelativeTo(project.CSharp.IntermediateOutputPath ?? Path.Combine(baseConfiguration.TargetBuildOptions.IntermediateFolder, "CSharp"), projectDirectory);
             
-            bool isMainProject = Globals.Project.ProjectFolderPath == project.WorkspaceRootPath && project.Name != "BuildScripts";
+            bool isMainProject = Globals.Project.ProjectFolderPath == project.WorkspaceRootPath && project.Name != "BuildScripts" && (Globals.Project.Name != "Flax" || project.Name != "FlaxEngine");
             var flaxBuildTargetsFilename = isMainProject ? "Flax.Build.CSharp.targets" : "Flax.Build.CSharp.SkipBuild.targets";
             var cacheProjectsPath = Utilities.MakePathRelativeTo(Path.Combine(Globals.Root, "Cache", "Projects"), projectDirectory);
             var flaxBuildTargetsPath = !string.IsNullOrEmpty(cacheProjectsPath) ? Path.Combine(cacheProjectsPath, flaxBuildTargetsFilename) : flaxBuildTargetsFilename;

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -90,6 +90,11 @@ namespace Flax.Build.Projects.VisualStudio
             var baseConfiguration = project.Configurations.First();
             var baseOutputDir = Utilities.MakePathRelativeTo(project.CSharp.OutputPath ?? baseConfiguration.TargetBuildOptions.OutputFolder, projectDirectory);
             var baseIntermediateOutputPath = Utilities.MakePathRelativeTo(project.CSharp.IntermediateOutputPath ?? Path.Combine(baseConfiguration.TargetBuildOptions.IntermediateFolder, "CSharp"), projectDirectory);
+            
+            bool isMainProject = Globals.Project.ProjectFolderPath == project.WorkspaceRootPath && project.Name != "BuildScripts";
+            var flaxBuildTargetsFilename = isMainProject ? "Flax.Build.CSharp.targets" : "Flax.Build.CSharp.SkipBuild.targets";
+            var cacheProjectsPath = Utilities.MakePathRelativeTo(Path.Combine(Globals.Root, "Cache", "Projects"), projectDirectory);
+            var flaxBuildTargetsPath = !string.IsNullOrEmpty(cacheProjectsPath) ? Path.Combine(cacheProjectsPath, flaxBuildTargetsFilename) : flaxBuildTargetsFilename;
 
             csProjectFileContent.AppendLine("    <TargetFramework>net7.0</TargetFramework>");
             csProjectFileContent.AppendLine("    <ImplicitUsings>disable</ImplicitUsings>");
@@ -106,14 +111,14 @@ namespace Flax.Build.Projects.VisualStudio
             csProjectFileContent.AppendLine("    <LangVersion>11.0</LangVersion>");
             csProjectFileContent.AppendLine("    <FileAlignment>512</FileAlignment>");
 
-            // Needed for Hostfxr
-            csProjectFileContent.AppendLine("    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>");
-            csProjectFileContent.AppendLine("    <EnableDynamicLoading>true</EnableDynamicLoading>");
             //csProjectFileContent.AppendLine("    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>"); // TODO: use it to reduce burden of framework libs
 
-            // This needs to be set here to fix errors in VS
-            csProjectFileContent.AppendLine(string.Format("    <OutDir>{0}</OutDir>", baseOutputDir));
-            csProjectFileContent.AppendLine(string.Format("    <IntermediateOutputPath>{0}</IntermediateOutputPath>", baseIntermediateOutputPath));
+            // Custom .targets file for overriding MSBuild build tasks
+            csProjectFileContent.AppendLine(string.Format("    <CustomAfterMicrosoftCommonTargets>$(MSBuildThisFileDirectory){0}</CustomAfterMicrosoftCommonTargets>", flaxBuildTargetsPath));
+
+            // Hide annoying warnings during build
+            csProjectFileContent.AppendLine("    <RestorePackages>false</RestorePackages>");
+            csProjectFileContent.AppendLine("    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>");
 
             csProjectFileContent.AppendLine("  </PropertyGroup>");
             csProjectFileContent.AppendLine("");

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
@@ -679,6 +679,57 @@ namespace Flax.Build.Projects.VisualStudio
 
                 Utilities.WriteFileIfChanged(dotSettingsUserFilePath, dotSettingsFileContent.ToString());
             }
+
+            // Custom MSBuild .targets file to prevent building Flax C#-projects directly with MSBuild
+            {
+                var targetsFileContent = new StringBuilder();
+                targetsFileContent.AppendLine("<Project>");
+                targetsFileContent.AppendLine("  <!-- Prevent building projects with MSBuild, let Flax.Build handle the building process -->");
+                targetsFileContent.AppendLine("  <Target Name=\"Build\" Condition=\"'false' == 'true'\" />");
+                targetsFileContent.AppendLine("</Project>");
+
+                Utilities.WriteFileIfChanged(Path.Combine(Globals.Root, "Cache", "Projects", "Flax.Build.CSharp.SkipBuild.targets"), targetsFileContent.ToString());
+            }
+
+            // Override MSBuild build tasks to run Flax.Build in C#-only projects
+            {
+                // Build command for the build tool
+                var buildToolPath = Path.ChangeExtension(Utilities.MakePathRelativeTo(typeof(Builder).Assembly.Location, Path.GetDirectoryName(solution.MainProject.Path)), null);
+                
+                var targetsFileContent = new StringBuilder();
+                targetsFileContent.AppendLine("<Project>");
+                targetsFileContent.AppendLine("  <!-- Custom Flax.Build scripts for C# projects. -->");
+                targetsFileContent.AppendLine("  <Target Name=\"Build\">");
+                AppendBuildToolCommands(targetsFileContent, "-build");
+                targetsFileContent.AppendLine("  </Target>");
+                targetsFileContent.AppendLine("  <Target Name=\"Rebuild\">");
+                AppendBuildToolCommands(targetsFileContent, "-rebuild");
+                targetsFileContent.AppendLine("  </Target>");
+                targetsFileContent.AppendLine("  <Target Name=\"Clean\">");
+                AppendBuildToolCommands(targetsFileContent, "-clean");
+                targetsFileContent.AppendLine("  </Target>");
+                targetsFileContent.AppendLine("</Project>");
+
+                Utilities.WriteFileIfChanged(Path.Combine(Globals.Root, "Cache", "Projects", "Flax.Build.CSharp.targets"), targetsFileContent.ToString());
+
+                void AppendBuildToolCommands(StringBuilder str, string extraArgs)
+                {
+                    foreach (var configuration in solution.MainProject.Configurations)
+                    {
+                        var cmdLine = string.Format("{0} -log -mutex -workspace={1} -arch={2} -configuration={3} -platform={4} -buildTargets={5}",
+                                                FixPath(buildToolPath),
+                                                FixPath(solution.MainProject.WorkspaceRootPath),
+                                                configuration.Architecture,
+                                                configuration.Configuration,
+                                                configuration.Platform,
+                                                configuration.Target);
+                        if (!string.IsNullOrEmpty(Configuration.Compiler))
+                            cmdLine += " -compiler=" + Configuration.Compiler;
+
+                        str.AppendLine(string.Format("    <Exec Command=\"{0} {1}\" Condition=\"'$(Configuration)|$(Platform)'=='{2}'\"/>", cmdLine, extraArgs, configuration.Name));
+                    }
+                }
+            }
         }
 
         /// <inheritdoc />
@@ -715,6 +766,15 @@ namespace Flax.Build.Projects.VisualStudio
                 };
                 projects.Add(project);
             }
+        }
+
+        private static string FixPath(string path)
+        {
+            if (path.Contains(' '))
+            {
+                path = "\"" + path + "\"";
+            }
+            return path;
         }
     }
 }

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
@@ -518,7 +518,15 @@ namespace Flax.Build.Projects.VisualStudio
                             else if (firstFullMatch != -1)
                             {
                                 projectConfiguration = configuration;
-                                build = solution.MainProject == project || (solution.MainProject == null && project.Name == solution.Name);
+
+                                // Always build the main project
+                                build = solution.MainProject == project;
+
+                                // Build C# projects (needed for Rider solution wide analysis)
+                                build |= project.Type == TargetType.DotNetCore;
+
+                                // 
+                                build |= solution.MainProject == null && project.Name == solution.Name;
                             }
                             else if (firstPlatformMatch != -1 && !configuration.Name.StartsWith("Editor."))
                             {


### PR DESCRIPTION
Rider's solution wide analysis does not work properly when projects are not included in the active configuration for build.

Also implements experimental MSBuild .targets files for running Flax.Build when building the solution in IDEs, the same way VC++ projects use custom build commands to invoke Flax.Build.