### PR TITLE
Fix error when hitting escape in read-only textboxes

### DIFF
--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1399,6 +1399,12 @@ namespace FlaxEngine.GUI
             }
             case KeyboardKeys.Escape:
             {
+                if (IsReadOnly)
+                {
+                    SetSelection(_selectionEnd);
+                    return true;
+                }
+
                 RestoreTextFromStart();
 
                 if (!IsNavFocused)


### PR DESCRIPTION
Fixes a crash/empty Debug Log view in Editor after pressing Escape.