### PR TITLE
Disable inheriting C# optimization level from dependency modules

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -225,7 +225,7 @@ namespace Flax.Build.NativeCpp
             public CSharpNullableReferences CSharpNullableReferences = CSharpNullableReferences.Disable;
 
             /// <summary>
-            /// Enable code optimization.
+            /// Enable code optimizations for the managed module assembly.
             /// </summary>
             public bool? Optimization;
 
@@ -237,19 +237,13 @@ namespace Flax.Build.NativeCpp
             /// Adds the other options into this.
             /// </summary>
             /// <param name="other">The other.</param>
-            public void Add(ScriptingAPIOptions other, bool addBuildOptions = true)
+            public void Add(ScriptingAPIOptions other)
             {
                 Defines.AddRange(other.Defines);
                 SystemReferences.AddRange(other.SystemReferences);
                 FileReferences.AddRange(other.FileReferences);
                 Analyzers.AddRange(other.Analyzers);
                 IgnoreMissingDocumentationWarnings |= other.IgnoreMissingDocumentationWarnings;
-
-                if (addBuildOptions)
-                {
-                    if (other.Optimization.HasValue)
-                        Optimization |= other.Optimization;
-                }
             }
         }
 

--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -403,7 +403,7 @@ namespace Flax.Build
                     moduleOptions.PrivateIncludePaths.AddRange(dependencyOptions.PublicIncludePaths);
                     moduleOptions.Libraries.AddRange(dependencyOptions.Libraries);
                     moduleOptions.DelayLoadLibraries.AddRange(dependencyOptions.DelayLoadLibraries);
-                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI, false);
+                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI);
                     moduleOptions.ExternalModules.AddRange(dependencyOptions.ExternalModules);
                 }
             }
@@ -418,7 +418,7 @@ namespace Flax.Build
                     moduleOptions.PublicIncludePaths.AddRange(dependencyOptions.PublicIncludePaths);
                     moduleOptions.Libraries.AddRange(dependencyOptions.Libraries);
                     moduleOptions.DelayLoadLibraries.AddRange(dependencyOptions.DelayLoadLibraries);
-                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI, false);
+                    moduleOptions.ScriptingAPI.Add(dependencyOptions.ScriptingAPI);
                     moduleOptions.ExternalModules.AddRange(dependencyOptions.ExternalModules);
                 }
             }


### PR DESCRIPTION
Allows C# modules to independently set their optimization levels and not inherit from other dependencies. This also fixes a case where `GameEditorModule` optimization level gets overridden by `GameModule` dependencies.