### PR TITLE
Use and store restored window position after minimizing the window

### DIFF
--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -472,19 +472,13 @@ namespace FlaxEditor.Modules
         {
             writer.WriteStartElement("Bounds");
             {
-                var isMaximized = win.IsMaximized;
-                var isMinimized = win.IsMinimized;
-                if (isMinimized)
-                    win.Restore(); // Restore window back to desktop to get proper client bounds
                 var bounds = win.ClientBounds;
-                if (isMinimized)
-                    win.Minimize();
                 writer.WriteAttributeString("X", bounds.X.ToString(CultureInfo.InvariantCulture));
                 writer.WriteAttributeString("Y", bounds.Y.ToString(CultureInfo.InvariantCulture));
                 writer.WriteAttributeString("Width", bounds.Width.ToString(CultureInfo.InvariantCulture));
                 writer.WriteAttributeString("Height", bounds.Height.ToString(CultureInfo.InvariantCulture));
-                writer.WriteAttributeString("IsMaximized", isMaximized.ToString());
-                writer.WriteAttributeString("IsMinimized", isMinimized.ToString());
+                writer.WriteAttributeString("IsMaximized", win.IsMaximized.ToString());
+                writer.WriteAttributeString("IsMinimized", win.IsMinimized.ToString());
             }
             writer.WriteEndElement();
         }

--- a/Source/Engine/Platform/Windows/WindowsWindow.h
+++ b/Source/Engine/Platform/Windows/WindowsWindow.h
@@ -32,6 +32,7 @@ private:
     Windows::HANDLE _monitor = nullptr;
     Windows::LONG _clipCursorRect[4];
     int32 _regionWidth = 0, _regionHeight = 0;
+    Float2 _minimizedScreenPosition = Float2::Zero;
 
 public:
 


### PR DESCRIPTION
The window layout saving process restores and minimizes the minimized window, causing the window to flash briefly on screen.

Fixes #1707.