### PR TITLE
Prevent project file regeneration running while compiling scripts

### DIFF
--- a/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
@@ -410,7 +410,7 @@ namespace FlaxEditor.Modules.SourceCodeEditing
             base.OnUpdate();
 
             // Automatic project files generation after workspace modifications
-            if (_autoGenerateScriptsProjectFiles && ScriptsBuilder.IsSourceWorkspaceDirty)
+            if (_autoGenerateScriptsProjectFiles && ScriptsBuilder.IsSourceWorkspaceDirty && !ScriptsBuilder.IsCompiling)
             {
                 Editor.ProgressReporting.GenerateScriptsProjectFiles.RunAsync();
             }

--- a/Source/Editor/Scripting/ScriptsBuilder.cpp
+++ b/Source/Editor/Scripting/ScriptsBuilder.cpp
@@ -266,7 +266,7 @@ bool ScriptsBuilder::RunBuildTool(const StringView& args, const StringView& work
 
 bool ScriptsBuilder::GenerateProject(const StringView& customArgs)
 {
-    String args(TEXT("-log -genproject "));
+    String args(TEXT("-log -mutex -genproject "));
     args += customArgs;
     _wasProjectStructureChanged = false;
     return RunBuildTool(args);


### PR DESCRIPTION
Probably helps with #1706 but no idea if it fixes the freezing issue.