### PR TITLE
Delay compiler and project generation after large file operations

### DIFF
--- a/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
@@ -412,7 +412,9 @@ namespace FlaxEditor.Modules.SourceCodeEditing
             // Automatic project files generation after workspace modifications
             if (_autoGenerateScriptsProjectFiles && ScriptsBuilder.IsSourceWorkspaceDirty)
             {
-                Editor.ProgressReporting.GenerateScriptsProjectFiles.RunAsync();
+                // Try to delay generation when a lot of files are added at once
+                if (ScriptsBuilder.IsSourceDirtyFor(TimeSpan.FromMilliseconds(150)))
+                    Editor.ProgressReporting.GenerateScriptsProjectFiles.RunAsync();
             }
         }
 

--- a/Source/Editor/Scripting/ScriptsBuilder.cpp
+++ b/Source/Editor/Scripting/ScriptsBuilder.cpp
@@ -170,7 +170,7 @@ bool ScriptsBuilder::IsSourceWorkspaceDirty()
 bool ScriptsBuilder::IsSourceDirtyFor(const TimeSpan& timeout)
 {
     ScopeLock scopeLock(_locker);
-    return _lastSourceCodeEdited > (_lastCompileAction + timeout);
+    return _lastSourceCodeEdited > _lastCompileAction && DateTime::Now() > _lastSourceCodeEdited + timeout;
 }
 
 bool ScriptsBuilder::IsCompiling()
@@ -669,7 +669,7 @@ void ScriptsBuilderService::Update()
     }
 
     // Check if compile code (if has been edited)
-    const TimeSpan timeToCallCompileIfDirty = TimeSpan::FromMilliseconds(50);
+    const TimeSpan timeToCallCompileIfDirty = TimeSpan::FromMilliseconds(150);
     auto mainWindow = Engine::MainWindow;
     if (ScriptsBuilder::IsSourceDirtyFor(timeToCallCompileIfDirty) && mainWindow && mainWindow->IsFocused())
     {

--- a/Source/Editor/Scripting/ScriptsBuilder.h
+++ b/Source/Editor/Scripting/ScriptsBuilder.h
@@ -68,7 +68,7 @@ public:
     /// </summary>
     /// <param name="timeout">Time to use for checking.</param>
     /// <returns>True if source code is dirty, otherwise false.</returns>
-    static bool IsSourceDirtyFor(const TimeSpan& timeout);
+    API_FUNCTION() static bool IsSourceDirtyFor(const TimeSpan& timeout);
 
     /// <summary>
     /// Returns true if scripts are being now compiled/reloaded.


### PR DESCRIPTION
Fixes #1706 by delaying the automatic build tool calls by 150ms after recent file changes to not cause an avalanche of rebuilds/project regenerations when files are added one by one during long file copy operations.