### PR TITLE
fix color picker (signal handler + alpha channel)

### DIFF
--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -218,7 +218,6 @@ namespace FlaxEditor.GUI.Dialogs
 
         private void OnColorPicked(Color32 colorPicked)
         {
-            Editor.Log("OnColorPicked " + colorPicked + ", _active eye dropper=" + _activeEyedropper);
             if (_activeEyedropper)
             {
                 _activeEyedropper = false;

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -218,6 +218,7 @@ namespace FlaxEditor.GUI.Dialogs
 
         private void OnColorPicked(Color32 colorPicked)
         {
+            Editor.Log("OnColorPicked " + colorPicked + ", _active eye dropper=" + _activeEyedropper);
             if (_activeEyedropper)
             {
                 _activeEyedropper = false;
@@ -319,7 +320,7 @@ namespace FlaxEditor.GUI.Dialogs
         protected override void OnShow()
         {
             // Auto cancel on lost focus
-            ((WindowRootControl)Root).Window.LostFocus += OnCancel;
+            //((WindowRootControl)Root).Window.LostFocus += OnCancel;
 
             base.OnShow();
         }

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -319,7 +319,9 @@ namespace FlaxEditor.GUI.Dialogs
         protected override void OnShow()
         {
             // Auto cancel on lost focus
-            //((WindowRootControl)Root).Window.LostFocus += OnCancel;
+#if !PLATFORM_LINUX
+            ((WindowRootControl)Root).Window.LostFocus += OnCancel;
+#endif
 
             base.OnShow();
         }

--- a/Source/Editor/Utilities/ScreenUtilities.cpp
+++ b/Source/Editor/Utilities/ScreenUtilities.cpp
@@ -73,6 +73,7 @@ Color32 ScreenUtilities::GetColorAt(const Float2& pos)
     outputColor.R = color.red / 256;
     outputColor.G = color.green / 256;
     outputColor.B = color.blue / 256;
+    outputColor.A = 255;
     return outputColor;
 }
 


### PR DESCRIPTION
This fixes the signal handling problem on Linux which closes the dialog before the color under the mouse cursor is accepted and the alpha channel of the picked color was always 0.