### PR TITLE
Fix terrain painting.

### DIFF
--- a/Source/Editor/Tools/Terrain/Paint/Mode.cs
+++ b/Source/Editor/Tools/Terrain/Paint/Mode.cs
@@ -67,11 +67,13 @@ namespace FlaxEditor.Tools.Terrain.Paint
 
             // Prepare
             var splatmapIndex = ActiveSplatmapIndex;
+            var splatmapIndexOther = (splatmapIndex + 1) % 2;
             var chunkSize = terrain.ChunkSize;
             var heightmapSize = chunkSize * FlaxEngine.Terrain.PatchEdgeChunksCount + 1;
             var heightmapLength = heightmapSize * heightmapSize;
             var patchSize = chunkSize * FlaxEngine.Terrain.UnitsPerVertex * FlaxEngine.Terrain.PatchEdgeChunksCount;
-            var tempBuffer = (Color32*)gizmo.GetSplatmapTempBuffer(heightmapLength * Color32.SizeInBytes).ToPointer();
+            var tempBuffer = (Color32*)gizmo.GetSplatmapTempBuffer(heightmapLength * Color32.SizeInBytes, splatmapIndex).ToPointer();
+            var tempBufferOther = (Color32*)gizmo.GetSplatmapTempBuffer(heightmapLength * Color32.SizeInBytes, (splatmapIndex + 1) % 2).ToPointer();
             var unitsPerVertexInv = 1.0f / FlaxEngine.Terrain.UnitsPerVertex;
             ApplyParams p = new ApplyParams
             {
@@ -81,8 +83,10 @@ namespace FlaxEditor.Tools.Terrain.Paint
                 Options = options,
                 Strength = strength,
                 SplatmapIndex = splatmapIndex,
+                SplatmapIndexOther = splatmapIndexOther,
                 HeightmapSize = heightmapSize,
                 TempBuffer = tempBuffer,
+                TempBufferOther = tempBufferOther,
             };
 
             // Get brush bounds in terrain local space
@@ -131,11 +135,16 @@ namespace FlaxEditor.Tools.Terrain.Paint
                 var sourceData = TerrainTools.GetSplatMapData(terrain, ref patch.PatchCoord, splatmapIndex);
                 if (sourceData == null)
                     throw new Exception("Cannot modify terrain. Loading splatmap failed. See log for more info.");
+                
+                var sourceDataOther = TerrainTools.GetSplatMapData(terrain, ref patch.PatchCoord, splatmapIndexOther);
+                if (sourceDataOther == null)
+                    throw new Exception("Cannot modify terrain. Loading splatmap failed. See log for more info.");
 
                 // Record patch data before editing it
                 if (!gizmo.CurrentEditUndoAction.HashPatch(ref patch.PatchCoord))
                 {
                     gizmo.CurrentEditUndoAction.AddPatch(ref patch.PatchCoord, splatmapIndex);
+                    gizmo.CurrentEditUndoAction.AddPatch(ref patch.PatchCoord, splatmapIndexOther);
                 }
 
                 // Apply modification
@@ -144,6 +153,7 @@ namespace FlaxEditor.Tools.Terrain.Paint
                 p.PatchCoord = patch.PatchCoord;
                 p.PatchPositionLocal = patchPositionLocal;
                 p.SourceData = sourceData;
+                p.SourceDataOther = sourceDataOther;
                 Apply(ref p);
             }
         }
@@ -197,16 +207,34 @@ namespace FlaxEditor.Tools.Terrain.Paint
             /// The splatmap texture index.
             /// </summary>
             public int SplatmapIndex;
+            
+            /// <summary>
+            /// The splatmap texture index. If <see cref="SplatmapIndex"/> is 0, this will be 1.
+            /// If <see cref="SplatmapIndex"/> is 1, this will be 0.
+            /// </summary>
+            public int SplatmapIndexOther;
 
             /// <summary>
             /// The temporary data buffer (for modified data).
             /// </summary>
             public Color32* TempBuffer;
+            
+            /// <summary>
+            /// The 'other" temporary data buffer (for modified data). If <see cref="TempBuffer"/> refers
+            /// to the splatmap with index 0, this one will refer to the one with index 1.
+            /// </summary>
+            public Color32* TempBufferOther;
 
             /// <summary>
             /// The source data buffer.
             /// </summary>
             public Color32* SourceData;
+            
+            /// <summary>
+            /// The 'other' source data buffer. If <see cref="SourceData"/> refers
+            /// to the splatmap with index 0, this one will refer to the one with index 1.
+            /// </summary>
+            public Color32* SourceDataOther;
 
             /// <summary>
             /// The heightmap size (edge).

--- a/Source/Editor/Tools/Terrain/Paint/SingleLayerMode.cs
+++ b/Source/Editor/Tools/Terrain/Paint/SingleLayerMode.cs
@@ -72,7 +72,7 @@ namespace FlaxEditor.Tools.Terrain.Paint
             var strength = p.Strength;
             var layer = (int)Layer;
             var brushPosition = p.Gizmo.CursorPosition;
-            var layerComponent = layer % 4;
+            var c = layer % 4;
 
             // Apply brush modification
             Profiler.BeginEvent("Apply Brush");
@@ -82,26 +82,38 @@ namespace FlaxEditor.Tools.Terrain.Paint
                 for (int x = 0; x < p.ModifiedSize.X; x++)
                 {
                     var xx = x + p.ModifiedOffset.X;
-                    var src = p.SourceData[zz * p.HeightmapSize + xx];
+                    var src = (Color)p.SourceData[zz * p.HeightmapSize + xx];
 
                     var samplePositionLocal = p.PatchPositionLocal + new Vector3(xx * FlaxEngine.Terrain.UnitsPerVertex, 0, zz * FlaxEngine.Terrain.UnitsPerVertex);
                     Vector3.Transform(ref samplePositionLocal, ref p.TerrainWorld, out Vector3 samplePositionWorld);
-                    
-                    var sample = Mathf.Clamp(p.Brush.Sample(ref brushPosition, ref samplePositionWorld), 0f, 1f);
-                    var paintAmount = sample * strength * (1f - src[layerComponent] / 255f);
 
-                    src[layerComponent] = (byte)Mathf.Clamp(src[layerComponent] + paintAmount * 255, 0, 255);
-                    src[(layerComponent + 1) % 4] = (byte)Mathf.Clamp(src[(layerComponent + 1) % 4] - paintAmount * 255, 0, 255);
-                    src[(layerComponent + 2) % 4] = (byte)Mathf.Clamp(src[(layerComponent + 2) % 4] - paintAmount * 255, 0, 255);
-                    src[(layerComponent + 3) % 4] = (byte)Mathf.Clamp(src[(layerComponent + 3) % 4] - paintAmount * 255, 0, 255);
+                    var sample = Mathf.Clamp(p.Brush.Sample(ref brushPosition, ref samplePositionWorld), 0f, 1f);
+                    var paintAmount = sample * strength * (1f - src[c]);
                     
+                    // Paint on the active splatmap texture
+                    src[c] = Mathf.Clamp(src[c] + paintAmount, 0, 1f);
+                    src[(c + 1) % 4] = Mathf.Clamp(src[(c + 1) % 4] - paintAmount, 0, 1f);
+                    src[(c + 2) % 4] = Mathf.Clamp(src[(c + 2) % 4] - paintAmount, 0, 1f);
+                    src[(c + 3) % 4] = Mathf.Clamp(src[(c + 3) % 4] - paintAmount, 0, 1f);
+
                     p.TempBuffer[z * p.ModifiedSize.X + x] = src;
+
+                    // Remove 'paint' from the other splatmap texture
+                    var other = (Color)p.SourceDataOther[zz * p.HeightmapSize + xx];
+
+                    other[c] = Mathf.Clamp(other[c] - paintAmount, 0, 1f);
+                    other[(c + 1) % 4] = Mathf.Clamp(other[(c + 1) % 4] - paintAmount, 0, 1f);
+                    other[(c + 2) % 4] = Mathf.Clamp(other[(c + 2) % 4] - paintAmount, 0, 1f);
+                    other[(c + 3) % 4] = Mathf.Clamp(other[(c + 3) % 4] - paintAmount, 0, 1f);
+
+                    p.TempBufferOther[z * p.ModifiedSize.X + x] = other;
                 }
             }
             Profiler.EndEvent();
 
             // Update terrain patch
             TerrainTools.ModifySplatMap(p.Terrain, ref p.PatchCoord, p.SplatmapIndex, p.TempBuffer, ref p.ModifiedOffset, ref p.ModifiedSize);
+            TerrainTools.ModifySplatMap(p.Terrain, ref p.PatchCoord, p.SplatmapIndexOther, p.TempBufferOther, ref p.ModifiedOffset, ref p.ModifiedSize);
         }
     }
 }


### PR DESCRIPTION
Fixes #1654

This is an attempt to fix the issue with terrain painting by making sure the splatmap texture layers are correctly adjusted when one of them is updated by painting. I am a where of a small bug where keeping the mouse button down and painting on one area without moving, will cause the edges of the brush to create a few pixels with weird values.

Old:

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/42b732b6-8ab7-47e8-9139-821196f24c22

New:

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/5c7e059b-d234-46e8-be6b-a87c99365a10

I am also planning to add support for painting the other 4 layers.