### PR TITLE
Use PrefabObjectID when setting/getting the actor expanded value for prefabs.

### DIFF
--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -776,11 +776,20 @@ namespace FlaxEditor.GUI.Tree
                 // Check if mouse hits arrow
                 if (_mouseOverArrow && HasAnyVisibleChild)
                 {
-                    // Toggle open state
-                    if (_opened)
-                        Collapse();
+                    if (ParentTree.Root.GetKey(KeyboardKeys.Alt))
+                    {
+                        if (_opened)
+                            CollapseAll();
+                        else
+                            ExpandAll();
+                    }
                     else
-                        Expand();
+                    {
+                        if (_opened)
+                            Collapse();
+                        else
+                            Expand();
+                    }
                 }
 
                 // Check if mouse hits bar

--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -66,7 +66,8 @@ namespace FlaxEditor.SceneGraph.GUI
                 _orderInParent = actor.OrderInParent;
                 Visible = (actor.HideFlags & HideFlags.HideInHierarchy) == 0;
 
-                var id = actor.ID;
+                // Pick the correct id when inside a prefab window.
+                var id = actor.HasPrefabLink && actor.Scene == null ? actor.PrefabObjectID : actor.ID;
                 if (Editor.Instance.ProjectCache.IsExpandedActor(ref id))
                 {
                     Expand(true);
@@ -171,7 +172,8 @@ namespace FlaxEditor.SceneGraph.GUI
             // Restore cached state on query filter clear
             if (noFilter && actor != null)
             {
-                var id = actor.ID;
+                // Pick the correct id when inside a prefab window.
+                var id = actor.HasPrefabLink && actor.Scene.Scene == null ? actor.PrefabObjectID : actor.ID;
                 isExpanded = Editor.Instance.ProjectCache.IsExpandedActor(ref id);
             }
 
@@ -301,10 +303,12 @@ namespace FlaxEditor.SceneGraph.GUI
         protected override void OnExpandedChanged()
         {
             base.OnExpandedChanged();
+            var actor = Actor;
 
-            if (!IsLayoutLocked && Actor)
+            if (!IsLayoutLocked && actor)
             {
-                var id = Actor.ID;
+                // Pick the correct id when inside a prefab window.
+                var id = actor.HasPrefabLink && actor.Scene == null ? actor.PrefabObjectID : actor.ID;
                 Editor.Instance.ProjectCache.SetExpandedActor(ref id, IsExpanded);
             }
         }

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -149,6 +149,7 @@ namespace FlaxEditor.Windows.Assets
 
             // Prefab structure tree
             Graph = new LocalSceneGraph(new CustomRootNode(this));
+            Graph.Root.TreeNode.Expand(true);
             _tree = new PrefabTree
             {
                 Margin = new Margin(0.0f, 0.0f, -16.0f, _treePanel.ScrollBarsSize), // Hide root node
@@ -317,7 +318,7 @@ namespace FlaxEditor.Windows.Assets
             Graph.MainActor = _viewport.Instance;
             Selection.Clear();
             Select(Graph.Main);
-            Graph.Root.TreeNode.ExpandAll(true);
+            Graph.Root.TreeNode.Expand(true);
             _undo.Clear();
             ClearEditedFlag();
         }
@@ -413,7 +414,7 @@ namespace FlaxEditor.Windows.Assets
             _focusCamera = true;
             Selection.Clear();
             Select(Graph.Main);
-            Graph.Root.TreeNode.ExpandAll(true);
+            Graph.Root.TreeNode.Expand(true);
 
             _undo.Clear();
             ClearEditedFlag();


### PR DESCRIPTION
Fixes #1742.

The ActorTreeNode node now uses the PrefabObjectID when saving to the project cache if the Actor has a prefab link and is not in a scene, indicating that it is in a prefab window. We need to check for the scene explicitly because otherwise, PrefabObjectID will be used inside a scene too and the actors of the prefab will overwrite the project cache and as such collapsing/expanding nodes in the scene will affect the nodes in the prefab window and vice versa.

Also implements the Alt key functionality requested from that issue. 