### PR TITLE
Limit what characters module names can contain.

### DIFF
--- a/Source/Editor/Windows/ContentWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/ContentWindow.ContextMenu.cs
@@ -369,7 +369,7 @@ namespace FlaxEditor.Windows
                 }
 
                 var pluginPath = Path.Combine(Globals.ProjectFolder, "Source", nameTextBox.Text);
-                if (Directory.Exists(pluginPath))
+                if (!IsValidModuleName(nameTextBox.Text) || Directory.Exists(pluginPath))
                 {
                     nameTextBox.BorderColor = Color.Red;
                     nameTextBox.BorderSelectedColor = Color.Red;
@@ -429,6 +429,12 @@ namespace FlaxEditor.Windows
             submitButton.Clicked += () =>
             {
                 // TODO: Check all modules in project including plugins
+                if (!IsValidModuleName(nameTextBox.Text))
+                {
+                    Editor.LogWarning("Invalid module name. Module names cannot contain spaces, start with a number or contain non-alphanumeric characters.");
+                    return;
+                }
+                
                 if (Directory.Exists(Path.Combine(Globals.ProjectFolder, "Source", nameTextBox.Text)))
                 {
                     Editor.LogWarning("Cannot create module due to name conflict.");
@@ -459,6 +465,17 @@ namespace FlaxEditor.Windows
                 popup.Hide();
                 button.ParentContextMenu.Hide();
             };
+        }
+
+        private static bool IsValidModuleName(string text)
+        {
+            if (text.Contains(' '))
+                return false;
+            if (char.IsDigit(text[0]))
+                return false;
+            if (text.Any(c => !char.IsLetterOrDigit(c) && c != '_'))
+                return false;
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fixes #1746 by limiting module names to:
- Not containing any spaces.
- Not starting with a number.
- Only having alphanumeric characters and underscores.

Since the module folder can have a different name from the module project, we could allow module folders to contain spaces and them remove when generating the build file and its contents but i think that might be confusing. To me at least, limiting the module folder name too seems like a good idea.