### PR TITLE
Material Editor: Removed unsupported parameter types

### DIFF
--- a/Source/Editor/Windows/Assets/MaterialWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialWindow.cs
@@ -41,8 +41,6 @@ namespace FlaxEditor.Windows.Assets
             new ScriptType(typeof(Vector3)),
             new ScriptType(typeof(Vector4)),
             new ScriptType(typeof(Color)),
-            new ScriptType(typeof(Quaternion)),
-            new ScriptType(typeof(Transform)),
             new ScriptType(typeof(Matrix)),
         };
 


### PR DESCRIPTION
Quaternion and Transform are not supported by the material editor, yet the user can create parameters of those types, which throws an error.

![FlaxEditor_8QDQN798sM](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/1d903fb7-3903-42ea-aa23-6a88ddd6f43f)
![FlaxEditor_xD3rbYitSn](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/6f8691f0-987b-4a0f-9f1b-2d0a5f1889b7)

This PR removes the Quaternion and Transform types from the add parameter context menu - only for the material editor.

![FlaxEditor_67fIhUpBz9](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/9ce1e4ed-b1f1-467d-a8ea-1bae44c04a42)

Note: When for whatever reason, someone used a transform or quaternion parameter in an older version and opens the material editor with this fix, nothing will break. The Transform and Quaternion parameters will still be there, the user just won't be able to add new parameters of those types.

I also checked if they could be used as data containers for whatever reason, but nope, even if i unpack the transform and use e.g. it's x-position or rotation pitch value for color (0 black, 1 white) it doesn't do anything. So i don't see a reason to have them there for now.

![FlaxEditor_0tbfABj9Gj](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/eb8789ab-ad53-4097-b29f-1e5a011e6025)
![FlaxEditor_0o3gX8fvmx](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/a745ce79-b486-4130-94e8-0e0b6e5942eb)

Note 2: Of course instead of straight up removing them, they can also just be commented out, if there is any intention to keep them for future plans.

Note 3: If this PR gets accepted, i might as well also remove things like (Un)Pack Transform and Quaternion

Note 4: Yes i wrote a lot for only 2 lines of code 🗿