### PR TITLE
Fix particles effect not being able to call play to play again if islooping is false

### DIFF
--- a/Source/Engine/Particles/ParticleEffect.cpp
+++ b/Source/Engine/Particles/ParticleEffect.cpp
@@ -283,11 +283,8 @@ void ParticleEffect::UpdateSimulation(bool singleFrame)
 
 void ParticleEffect::Play()
 {
-    // Reset simulation when play is called and particle system is time is complete - ex. if IsLooping is false and simulation is complete
-    if (!IsLooping && Instance.Time >= (float)ParticleSystem->DurationFrames / ParticleSystem->FramesPerSecond)
-        ResetSimulation();
-
     _isPlaying = true;
+    _isStopped = false;
 }
 
 void ParticleEffect::Pause()
@@ -297,6 +294,7 @@ void ParticleEffect::Pause()
 
 void ParticleEffect::Stop()
 {
+    _isStopped = true;
     _isPlaying = false;
     ResetSimulation();
 }
@@ -452,7 +450,7 @@ void ParticleEffect::Update()
 void ParticleEffect::UpdateExecuteInEditor()
 {
     // Auto-play in Editor
-    if (!Editor::IsPlayMode)
+    if (!Editor::IsPlayMode && !_isStopped)
     {
         _isPlaying = true;
         Update();

--- a/Source/Engine/Particles/ParticleEffect.cpp
+++ b/Source/Engine/Particles/ParticleEffect.cpp
@@ -283,6 +283,10 @@ void ParticleEffect::UpdateSimulation(bool singleFrame)
 
 void ParticleEffect::Play()
 {
+    // Reset simulation when play is called and particle system is time is complete - ex. if IsLooping is false and simulation is complete
+    if (!IsLooping && Instance.Time >= (float)ParticleSystem->DurationFrames / ParticleSystem->FramesPerSecond)
+        ResetSimulation();
+
     _isPlaying = true;
 }
 

--- a/Source/Engine/Particles/ParticleEffect.h
+++ b/Source/Engine/Particles/ParticleEffect.h
@@ -185,6 +185,7 @@ private:
     Array<ParticleEffectParameter> _parameters; // Cached for scripting API
     Array<ParameterOverride> _parametersOverrides; // Cached parameter modifications to be applied to the parameters
     bool _isPlaying = false;
+    bool _isStopped = false;
 
 public:
     /// <summary>

--- a/Source/Engine/Particles/ParticleEffect.h
+++ b/Source/Engine/Particles/ParticleEffect.h
@@ -133,7 +133,7 @@ public:
 /// <summary>
 /// The particle system instance that plays the particles simulation in the game.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Particle Effects\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Particle Effect\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API ParticleEffect : public Actor
 {
     DECLARE_SCENE_OBJECT(ParticleEffect);

--- a/Source/Engine/Particles/Particles.cpp
+++ b/Source/Engine/Particles/Particles.cpp
@@ -1318,6 +1318,7 @@ void ParticlesSystem::Job(int32 index)
                     emitterInstance.Buffer = nullptr;
                 }
             }
+            effect->Stop();
             return;
         }
     }

--- a/Source/Engine/Particles/Particles.cpp
+++ b/Source/Engine/Particles/Particles.cpp
@@ -1318,8 +1318,8 @@ void ParticlesSystem::Job(int32 index)
                     emitterInstance.Buffer = nullptr;
                 }
             }
-            // Set is playing to false because it is not playing anymore.
-            effect->Pause();
+            // Stop playing effect.
+            effect->Stop();
             return;
         }
     }

--- a/Source/Engine/Particles/Particles.cpp
+++ b/Source/Engine/Particles/Particles.cpp
@@ -1318,7 +1318,8 @@ void ParticlesSystem::Job(int32 index)
                     emitterInstance.Buffer = nullptr;
                 }
             }
-            effect->Stop();
+            // Set is playing to false because it is not playing anymore.
+            effect->Pause();
             return;
         }
     }


### PR DESCRIPTION
I think the better solution is my first commit, but calling stop resets the simulation which then causes the editor (non-play mode) to repeat playing the simulation for non-looping effects.