### PR TITLE
Visject: More alternative titles

### DIFF
--- a/Source/Editor/Surface/Archetypes/Bitwise.cs
+++ b/Source/Editor/Surface/Archetypes/Bitwise.cs
@@ -60,7 +60,7 @@ namespace FlaxEditor.Surface.Archetypes
             Op1(1, "Bitwise NOT", "Negates the value using bitwise operation", new[] { "!", "~" }),
             Op2(2, "Bitwise AND", "Performs a bitwise conjunction on two values", new[] { "&" }),
             Op2(3, "Bitwise OR", "", new[] { "|" }),
-            Op2(4, "Bitwise XOR", ""),
+            Op2(4, "Bitwise XOR", "", new[] { "^" }),
         };
     }
 }

--- a/Source/Editor/Surface/Archetypes/Boolean.cs
+++ b/Source/Editor/Surface/Archetypes/Boolean.cs
@@ -60,7 +60,7 @@ namespace FlaxEditor.Surface.Archetypes
             Op1(1, "Boolean NOT", "Negates the boolean value", new[] { "!", "~" }),
             Op2(2, "Boolean AND", "Performs a logical conjunction on two values", new[] { "&&" }),
             Op2(3, "Boolean OR", "Returns true if either (or both) of its operands is true", new[] { "||" }),
-            Op2(4, "Boolean XOR", ""),
+            Op2(4, "Boolean XOR", "", new [] { "^" } ),
             Op2(5, "Boolean NOR", ""),
             Op2(6, "Boolean NAND", ""),
         };

--- a/Source/Editor/Surface/Archetypes/Comparisons.cs
+++ b/Source/Editor/Surface/Archetypes/Comparisons.cs
@@ -14,7 +14,7 @@ namespace FlaxEditor.Surface.Archetypes
     [HideInEditor]
     public static class Comparisons
     {
-        private static NodeArchetype Op(ushort id, string title, string desc)
+        private static NodeArchetype Op(ushort id, string title, string desc, string[] altTitles = null)
         {
             return new NodeArchetype
             {
@@ -22,6 +22,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = title,
                 Description = desc,
                 Flags = NodeFlags.AllGraphs,
+                AlternativeTitles = altTitles,
                 ConnectionsHints = ConnectionsHint.Value,
                 Size = new Float2(100, 40),
                 IndependentBoxes = new[]
@@ -170,12 +171,12 @@ namespace FlaxEditor.Surface.Archetypes
         /// </summary>
         public static NodeArchetype[] Nodes =
         {
-            Op(1, "==", "Determines whether two values are equal"),
-            Op(2, "!=", "Determines whether two values are not equal"),
-            Op(3, ">", "Determines whether the first value is greater than the other"),
-            Op(4, "<", "Determines whether the first value is less than the other"),
-            Op(5, "<=", "Determines whether the first value is less or equal to the other"),
-            Op(6, ">=", "Determines whether the first value is greater or equal to the other"),
+            Op(1, "==", "Determines whether two values are equal", new[] { "equals" }),
+            Op(2, "!=", "Determines whether two values are not equal", new[] { "not equals" }),
+            Op(3, ">", "Determines whether the first value is greater than the other", new[] { "greater than", "larger than", "bigger than" }),
+            Op(4, "<", "Determines whether the first value is less than the other", new[] { "less than", "smaller than" }),
+            Op(5, "<=", "Determines whether the first value is less or equal to the other", new[] { "less equals than", "smaller equals than" }),
+            Op(6, ">=", "Determines whether the first value is greater or equal to the other", new[] { "greater equals than", "larger equals than", "bigger equals than" }),
             new NodeArchetype
             {
                 TypeID = 7,

--- a/Source/Editor/Surface/Archetypes/Constants.cs
+++ b/Source/Editor/Surface/Archetypes/Constants.cs
@@ -644,6 +644,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 12,
                 Title = "Unsigned Integer",
+                AlternativeTitles = new[] { "UInt" , "U Int" },
                 Description = "Constant unsigned integer value",
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(170, 20),

--- a/Source/Editor/Surface/Archetypes/Math.cs
+++ b/Source/Editor/Surface/Archetypes/Math.cs
@@ -16,7 +16,7 @@ namespace FlaxEditor.Surface.Archetypes
         {
             return Op1(id, title, desc, null, hints, type);
         }
-        
+
         private static NodeArchetype Op1(ushort id, string title, string desc, string[] altTitles, ConnectionsHint hints = ConnectionsHint.Numeric, Type type = null)
         {
             return new NodeArchetype

--- a/Source/Editor/Surface/Archetypes/Math.cs
+++ b/Source/Editor/Surface/Archetypes/Math.cs
@@ -14,12 +14,18 @@ namespace FlaxEditor.Surface.Archetypes
     {
         private static NodeArchetype Op1(ushort id, string title, string desc, ConnectionsHint hints = ConnectionsHint.Numeric, Type type = null)
         {
+            return Op1(id, title, desc, null, hints, type);
+        }
+        
+        private static NodeArchetype Op1(ushort id, string title, string desc, string[] altTitles, ConnectionsHint hints = ConnectionsHint.Numeric, Type type = null)
+        {
             return new NodeArchetype
             {
                 TypeID = id,
                 Title = title,
                 Description = desc,
                 Flags = NodeFlags.AllGraphs,
+                AlternativeTitles = altTitles,
                 Size = new Float2(110, 20),
                 DefaultType = new ScriptType(type),
                 ConnectionsHints = hints,
@@ -92,6 +98,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 11,
                 Title = "Length",
+                AlternativeTitles = new[] { "Magnitude", "Mag" },
                 Description = "Returns the length of A vector",
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(110, 20),
@@ -107,10 +114,10 @@ namespace FlaxEditor.Surface.Archetypes
             Op1(13, "Round", "Rounds A to the nearest integer"),
             Op1(14, "Saturate", "Clamps A to the range [0, 1]"),
             Op1(15, "Sine", "Returns sine of A"),
-            Op1(16, "Sqrt", "Returns square root of A"),
+            Op1(16, "Sqrt", "Returns square root of A", new [] { "Square Root", "Square", "Root" }),
             Op1(17, "Tangent", "Returns tangent of A"),
             Op2(18, "Cross", "Returns the cross product of A and B", ConnectionsHint.None, typeof(Float3)),
-            Op2(19, "Distance", "Returns a distance scalar between A and B", ConnectionsHint.Vector, null, typeof(float), false),
+            Op2(19, "Distance", "Returns a distance scalar between A and B", new [] { "Magnitude", "Mag", "Length" }, ConnectionsHint.Vector, null, typeof(float), false),
             Op2(20, "Dot", "Returns the dot product of A and B", ConnectionsHint.Vector, null, typeof(float), false),
             Op2(21, "Max", "Selects the greater of A and B"),
             Op2(22, "Min", "Selects the lesser of A and B"),
@@ -185,7 +192,7 @@ namespace FlaxEditor.Surface.Archetypes
                 }
             },
             //
-            Op1(27, "Negate", "Returns opposite value"),
+            Op1(27, "Negate", "Returns opposite value", new [] { "Invert" }),
             Op1(28, "One Minus", "Returns 1 - value"),
             //
             new NodeArchetype
@@ -225,6 +232,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 31,
                 Title = "Mad",
+                AlternativeTitles = new [] { "Multiply", "Add", "*+" },
                 Description = "Performs value multiplication and addition at once",
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(160, 60),

--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1483,7 +1483,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 11,
                 Title = "Comment",
-                AlternativeTitles = new[] { "//" },
+                AlternativeTitles = new[] { "//" , "Group" },
                 TryParseText = (string filterText, out object[] data) =>
                 {
                     data = null;
@@ -1638,6 +1638,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 22,
                 Title = "As",
+                AlternativeTitles = new [] { "Cast" },
                 Create = (id, context, arch, groupArch) => new AsNode(id, context, arch, groupArch),
                 Description = "Casts the object to a different type. Returns null if cast fails.",
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph,


### PR DESCRIPTION
This PR just adds some more alternative titles to some nodes, to make them easier to find for users that are used to other engines, programs or terminology.

List of added titles:
| Node | Alt. Title | Explanation |
|--------|--------|--------|
| Bitwise XOR | ^ | Since OR, NOT, AND etc. have their operator as alternative titles, this one should too |
| Boolean XOR | ^ | Same as above |
| Unsigned Integer | Uint, U Int | Often when i searched for uint, it never listed the unsigned integer |
| Length | Magnitude, Mag | I am very used to 'magnitude' for length, even though i know that length is correct in HLSL |
| Distance | Magnitude, Mag, Length | Often get used interchangeably as well, especially in a certain other engine | 
| Sqrt | Square Root, Square, Root | Some other engines use the full word and not just sqrt, just makes it easier to find | 
| Negate | Invert | A word people might search instead of negate | 
| Mad | Multiply, Add, *+ | Welp, mad is multiply and add | 
| Comment | Group | Comments can be used as groups and some other engines call their comment node 'group' as well | 
| As | Cast | People might search for cast but actually mean the as node | 
| == | equals | Self explanatory i think, people might search for the word not the condition | 
| != | not equals | Same as above | 
| > | greater than, larger than, bigger than | Same as above, though i added 'larger' and 'bigger' as well, since people use these words interchangeably. Especially non native english speakers | 
| < | less than, smaller than | Same as above, but also added 'smaller' | 
| >= | greater equals than, larger equals than, bigger equals than | Same as above | 
| <= | less equals than, smaller equals than | Same as above | 

Note: The reason i sometimes added a shortened version of a word (e.g. mag) or redundant duplicates (e.g. square root) is because the alternative titles don't get filtered like the titles do. The alternative titles have to be fully typed to be found.
This might be something for a future PR to make alternative titles more powerful (edit: #1813). Then i will remove these redundancies again.

PR #50 mentions Fuzzy search as a possible addition. So, this PR is more of a temporary QoL improvement, since i want to improve the search in visject anyways.
Edit: Search improvements here: #1813 - this doesn't make this PR obsolete though