### PR TITLE
Panel 9 Slice

### DIFF
--- a/Source/Editor/EditorIcons.cs
+++ b/Source/Editor/EditorIcons.cs
@@ -55,6 +55,15 @@ namespace FlaxEditor
         public SpriteHandle Bone32;
         public SpriteHandle BoneFull32;
 
+        //panel (9 slice) 
+        public SpriteHandle Panel32;
+        public SpriteHandle PanelLeft32;
+        public SpriteHandle PanelRight32;
+        public SpriteHandle PanelTop32;
+        public SpriteHandle PanelBottom32;
+        public SpriteHandle PanelVertical32;
+        public SpriteHandle PanelHrizontal32;
+
         // Visject
         public SpriteHandle VisjectBoxOpen32;
         public SpriteHandle VisjectBoxClosed32;


### PR DESCRIPTION
the editor as it stands cant render round corners so 
i added some images to be used with 9 Slice
[IconsAtlas.flax](https://github.com/FlaxEngine/FlaxEngine/files/13063287/IconsAtlas.zip)
the https://github.com/FlaxEngine/FlaxEngine/pull/1698 will be using it
how it looks
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/89fa5209-4d06-4fce-9d14-e2be5a792f7f)