### PR TITLE
Improved editor UI Api

### DIFF
--- a/Source/Editor/CustomEditors/Elements/Container/PropertiesListElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/PropertiesListElement.cs
@@ -38,15 +38,15 @@ namespace FlaxEditor.CustomEditors.Elements
             {
                 var group = Group(name, editor, true);
                 group.Panel.Open();
-                return group.Object(values, editor);
+                return group.Object(values:values, overrideEditor:editor);
             }
-            return Object(values, editor);
+            return Object(values:values, overrideEditor:editor);
         }
 
         /// <inheritdoc />
         public override CustomEditor Property(string name, ValueContainer values)
         {
-            var element = Property(name, values, overrideEditor: null);
+            var element = Property(name:name, values:values, overrideEditor: null);
             return element;
         }
 

--- a/Source/Editor/CustomEditors/Elements/Container/PropertiesListElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/PropertiesListElement.cs
@@ -29,14 +29,8 @@ namespace FlaxEditor.CustomEditors.Elements
             Properties = new PropertiesList(this);
         }
 
-        /// <summary>
-        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
-        /// </summary>
-        /// <param name="name">The property name.</param>
-        /// <param name="values">The values.</param>
-        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
-        /// <returns>The created element.</returns>
-        public CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor = null)
+        /// <inheritdoc />
+        public override CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor)
         {
             var editor = CustomEditorsUtil.CreateEditor(values, overrideEditor);
             var style = editor.Style;
@@ -47,6 +41,13 @@ namespace FlaxEditor.CustomEditors.Elements
                 return group.Object(values, editor);
             }
             return Object(values, editor);
+        }
+
+        /// <inheritdoc />
+        public override CustomEditor Property(string name, ValueContainer values)
+        {
+            var element = Property(name, values, overrideEditor: null);
+            return element;
         }
 
         internal readonly List<PropertyNameLabel> Labels = new List<PropertyNameLabel>();

--- a/Source/Editor/CustomEditors/Elements/Container/Split.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/Split.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
+
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.CustomEditors.Elements
+{
+    /// <summary>
+    /// The split element.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.CustomEditors.LayoutElementsContainer" />
+    public class SplitElement<TElement1, TElement2> : LayoutElementsContainer
+        where TElement1 : LayoutElement
+        where TElement2 : LayoutElement
+    {
+
+        /// <summary>
+        /// The split container.
+        /// </summary>
+        public readonly SplitContainer Split;
+
+        /// <summary>
+        /// The first control (left or upper based on Orientation).
+        /// </summary>
+        public readonly TElement1 Element1;
+
+        /// <summary>
+        /// The second control.
+        /// </summary>
+        public readonly TElement2 Element2;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitElement{TElement1, TElement2}"/> class.
+        /// </summary>
+        /// <param name="orientation">The orientation.</param>       
+        public SplitElement(Orientation orientation) : base()
+        {
+            Element1 = Element<TElement1>();
+            Element2 = Element<TElement2>();
+            Split = new SplitContainer(Element1.Control, Element2.Control, orientation);
+        }
+
+        /// <inheritdoc />
+        public override ContainerControl ContainerControl => Split;
+    }
+
+
+    /// <summary>
+    /// The split element.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.CustomEditors.LayoutElementsContainer" />
+    public class SplitPanelElement : SplitElement<VerticalPanelElement, VerticalPanelElement>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitPanelElement"/> class.
+        /// </summary>
+        /// <param name="orientation">The orientation.</param>       
+        public SplitPanelElement(Orientation orientation = Orientation.Horizontal) : base(orientation)
+        {
+        }
+    }
+}

--- a/Source/Editor/CustomEditors/Elements/Container/Split.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/Split.cs
@@ -16,7 +16,7 @@ namespace FlaxEditor.CustomEditors.Elements
         /// <summary>
         /// The split container.
         /// </summary>
-        public readonly SplitContainer Split;
+        public readonly SplitContainer SplitContainer;
 
         /// <summary>
         /// The first control (left or upper based on Orientation).
@@ -36,11 +36,11 @@ namespace FlaxEditor.CustomEditors.Elements
         {
             Element1 = Element<TElement1>();
             Element2 = Element<TElement2>();
-            Split = new SplitContainer(Element1.Control, Element2.Control, orientation);
+            SplitContainer = new SplitContainer(Element1.Control, Element2.Control, orientation);
         }
 
         /// <inheritdoc />
-        public override ContainerControl ContainerControl => Split;
+        public override ContainerControl ContainerControl => SplitContainer;
     }
 
 

--- a/Source/Editor/CustomEditors/LayoutElement.cs
+++ b/Source/Editor/CustomEditors/LayoutElement.cs
@@ -15,5 +15,12 @@ namespace FlaxEditor.CustomEditors
         /// Gets the control represented by this element.
         /// </summary>
         public abstract Control Control { get; }
+
+        /// <summary>
+        /// Implicit cast using LayoutElement.Control
+        /// </summary>
+        /// <param name="layoutElement"></param>
+        public static implicit operator Control(LayoutElement layoutElement) => layoutElement?.Control;
+
     }
 }

--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -17,7 +17,7 @@ namespace FlaxEditor.CustomEditors
     /// </summary>
     /// <seealso cref="FlaxEditor.CustomEditors.LayoutElement" />
     [HideInEditor]
-    public abstract class LayoutElementsContainer : LayoutElement
+    public abstract partial class LayoutElementsContainer : LayoutElement
     {
         /// <summary>
         /// Helper flag that is set to true if this container is in root presenter area, otherwise it's one of child groups.
@@ -40,6 +40,9 @@ namespace FlaxEditor.CustomEditors
         /// </summary>
         public abstract ContainerControl ContainerControl { get; }
 
+
+        #region Group
+
         /// <summary>
         /// Adds new group element.
         /// </summary>
@@ -47,7 +50,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="linkedEditor">The custom editor to be linked for a group. Used to provide more utility functions for a drop panel UI via context menu.</param>
         /// <param name="useTransparentHeader">True if use drop down icon and transparent group header, otherwise use normal style.</param>
         /// <returns>The created element.</returns>
-        public GroupElement Group(string title, CustomEditor linkedEditor, bool useTransparentHeader = false)
+        public virtual GroupElement Group(string title, CustomEditor linkedEditor, bool useTransparentHeader)
         {
             var element = Group(title, useTransparentHeader);
             element.Panel.Tag = linkedEditor;
@@ -55,21 +58,16 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
-        private void OnGroupPanelMouseButtonRightClicked(DropPanel groupPanel, Float2 location)
+        /// <summary>
+        /// Adds new group element.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <param name="linkedEditor">The custom editor to be linked for a group. Used to provide more utility functions for a drop panel UI via context menu.</param>
+        /// <returns>The created element.</returns>
+        public virtual GroupElement Group(string title, CustomEditor linkedEditor)
         {
-            var linkedEditor = (CustomEditor)groupPanel.Tag;
-            var menu = new ContextMenu();
-
-            var revertToPrefab = menu.AddButton("Revert to Prefab", linkedEditor.RevertToReferenceValue);
-            revertToPrefab.Enabled = linkedEditor.CanRevertReferenceValue;
-            var resetToDefault = menu.AddButton("Reset to default", linkedEditor.RevertToDefaultValue);
-            resetToDefault.Enabled = linkedEditor.CanRevertDefaultValue;
-            menu.AddSeparator();
-            menu.AddButton("Copy", linkedEditor.Copy);
-            var paste = menu.AddButton("Paste", linkedEditor.Paste);
-            paste.Enabled = linkedEditor.CanPaste;
-
-            menu.Show(groupPanel, location);
+            var element = Group(title, linkedEditor, useTransparentHeader:false);         
+            return element;
         }
 
         /// <summary>
@@ -78,7 +76,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="title">The title.</param>
         /// <param name="useTransparentHeader">True if use drop down icon and transparent group header, otherwise use normal style.</param>
         /// <returns>The created element.</returns>
-        public GroupElement Group(string title, bool useTransparentHeader = false)
+        public virtual GroupElement Group(string title, bool useTransparentHeader)
         {
             var element = new GroupElement();
             if (!isRootGroup)
@@ -103,29 +101,84 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds new group element.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <returns>The created element.</returns>
+        public virtual GroupElement Group(string title)
+        {
+            var element = Group(title, useTransparentHeader:false);
+            return element;
+        }
+
+        private void OnGroupPanelMouseButtonRightClicked(DropPanel groupPanel, Float2 location)
+        {
+            var linkedEditor = (CustomEditor)groupPanel.Tag;
+            var menu = new ContextMenu();
+
+            var revertToPrefab = menu.AddButton("Revert to Prefab", linkedEditor.RevertToReferenceValue);
+            revertToPrefab.Enabled = linkedEditor.CanRevertReferenceValue;
+            var resetToDefault = menu.AddButton("Reset to default", linkedEditor.RevertToDefaultValue);
+            resetToDefault.Enabled = linkedEditor.CanRevertDefaultValue;
+            menu.AddSeparator();
+            menu.AddButton("Copy", linkedEditor.Copy);
+            var paste = menu.AddButton("Paste", linkedEditor.Paste);
+            paste.Enabled = linkedEditor.CanPaste;
+
+            menu.Show(groupPanel, location);
+        }
+
         private void OnPanelIsClosedChanged(DropPanel panel)
         {
             Editor.Instance.ProjectCache.SetCollapsedGroup(panel.HeaderText, panel.IsClosed);
         }
 
+        #endregion
+
+        #region HorizontalPanel
+
         /// <summary>
         /// Adds new horizontal panel element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public HorizontalPanelElement HorizontalPanel()
+        public virtual HorizontalPanelElement HorizontalPanel()
         {
             var element = new HorizontalPanelElement();
             OnAddElement(element);
             return element;
         }
 
+        #endregion
+
+        #region VerticallPanel
+
         /// <summary>
         /// Adds new vertical panel element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public VerticalPanelElement VerticalPanel()
+        public virtual VerticalPanelElement VerticalPanel()
         {
             var element = new VerticalPanelElement();
+            OnAddElement(element);
+            return element;
+        }
+
+        #endregion
+
+        #region Button
+
+        /// <summary>
+        /// Adds new button element.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="tooltip">The tooltip text.</param>
+        /// <returns>The created element.</returns>
+        public virtual ButtonElement Button(string text, string tooltip)
+        {
+            var element = new ButtonElement();
+            element.Button.Text = text;
+            element.Button.TooltipText = tooltip;
             OnAddElement(element);
             return element;
         }
@@ -134,14 +187,10 @@ namespace FlaxEditor.CustomEditors
         /// Adds new button element.
         /// </summary>
         /// <param name="text">The text.</param>
-        /// <param name="tooltip">The tooltip text.</param>
         /// <returns>The created element.</returns>
-        public ButtonElement Button(string text, string tooltip = null)
+        public virtual ButtonElement Button(string text)
         {
-            var element = new ButtonElement();
-            element.Button.Text = text;
-            element.Button.TooltipText = tooltip;
-            OnAddElement(element);
+            var element = Button(text, tooltip:null);          
             return element;
         }
 
@@ -152,7 +201,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="color">The color.</param>
         /// <param name="tooltip">The tooltip text.</param>
         /// <returns>The created element.</returns>
-        public ButtonElement Button(string text, Color color, string tooltip = null)
+        public virtual ButtonElement Button(string text, Color color, string tooltip)
         {
             ButtonElement element = new ButtonElement();
             element.Button.Text = text;
@@ -163,11 +212,26 @@ namespace FlaxEditor.CustomEditors
         }
 
         /// <summary>
+        /// Adds new button element with custom color.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="color">The color.</param>
+        /// <returns>The created element.</returns>
+        public virtual ButtonElement Button(string text, Color color)
+        {
+            var element = Button(text, color, tooltip: null);
+            return element;
+        }
+
+        #endregion Button
+
+        #region CustomElement
+        /// <summary>
         /// Adds new custom element.
         /// </summary>
         /// <typeparam name="T">The custom control.</typeparam>
         /// <returns>The created element.</returns>
-        public CustomElement<T> Custom<T>()
+        public virtual CustomElement<T> Custom<T>()
         where T : Control, new()
         {
             var element = new CustomElement<T>();
@@ -182,7 +246,7 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="T">The custom control.</typeparam>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CustomElement<T> Custom<T>(string name, string tooltip = null)
+        public virtual CustomElement<T> Custom<T>(string name, string tooltip)
         where T : Control, new()
         {
             var property = AddPropertyItem(name, tooltip);
@@ -190,11 +254,28 @@ namespace FlaxEditor.CustomEditors
         }
 
         /// <summary>
+        /// Adds new custom element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <typeparam name="T">The custom control.</typeparam>
+        /// <returns>The created element.</returns>
+        public virtual CustomElement<T> Custom<T>(string name)
+        where T : Control, new()
+        {
+            var property = AddPropertyItem(name, null);
+            return property.Custom<T>();
+        }
+
+        #endregion
+
+        #region CustomContainer
+
+        /// <summary>
         /// Adds new custom elements container.
         /// </summary>
         /// <typeparam name="T">The custom control.</typeparam>
         /// <returns>The created element.</returns>
-        public CustomElementsContainer<T> CustomContainer<T>()
+        public virtual CustomElementsContainer<T> CustomContainer<T>()
         where T : ContainerControl, new()
         {
             var element = new CustomElementsContainer<T>();
@@ -209,19 +290,36 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="T">The custom control.</typeparam>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CustomElementsContainer<T> CustomContainer<T>(string name, string tooltip = null)
+        public virtual CustomElementsContainer<T> CustomContainer<T>(string name, string tooltip)
         where T : ContainerControl, new()
         {
-            var property = AddPropertyItem(name);
+            var property = AddPropertyItem(name,tooltip);
             return property.CustomContainer<T>();
         }
+
+        /// <summary>
+        /// Adds new custom elements container with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <typeparam name="T">The custom control.</typeparam>
+        /// <returns>The created element.</returns>
+        public virtual CustomElementsContainer<T> CustomContainer<T>(string name)
+        where T : ContainerControl, new()
+        {
+            var element = CustomContainer<T>(name, tooltip:null);
+            return element;
+        }
+
+        #endregion
+
+        #region Space
 
         /// <summary>
         /// Adds new space.
         /// </summary>
         /// <param name="height">The space height.</param>
         /// <returns>The created element.</returns>
-        public SpaceElement Space(float height)
+        public virtual SpaceElement Space(float height)
         {
             var element = new SpaceElement();
             element.Init(height);
@@ -229,12 +327,16 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        #endregion
+
+        #region Image
+
         /// <summary>
         /// Adds sprite image to the layout.
         /// </summary>
         /// <param name="sprite">The sprite.</param>
         /// <returns>The created element.</returns>
-        public ImageElement Image(SpriteHandle sprite)
+        public virtual ImageElement Image(SpriteHandle sprite)
         {
             var element = new ImageElement();
             element.Image.Brush = new SpriteBrush(sprite);
@@ -247,7 +349,7 @@ namespace FlaxEditor.CustomEditors
         /// </summary>
         /// <param name="texture">The texture.</param>
         /// <returns>The created element.</returns>
-        public ImageElement Image(Texture texture)
+        public virtual ImageElement Image(Texture texture)
         {
             var element = new ImageElement();
             element.Image.Brush = new TextureBrush(texture);
@@ -260,7 +362,7 @@ namespace FlaxEditor.CustomEditors
         /// </summary>
         /// <param name="texture">The GPU texture.</param>
         /// <returns>The created element.</returns>
-        public ImageElement Image(GPUTexture texture)
+        public virtual ImageElement Image(GPUTexture texture)
         {
             var element = new ImageElement();
             element.Image.Brush = new GPUTextureBrush(texture);
@@ -268,19 +370,23 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        #endregion
+
+        #region Header
+
         /// <summary>
         /// Adds new header control.
         /// </summary>
         /// <param name="text">The header text.</param>
         /// <returns>The created element.</returns>
-        public LabelElement Header(string text)
+        public virtual LabelElement Header(string text)
         {
             var element = Label(text);
             element.Label.Font = new FontReference(Style.Current.FontLarge);
             return element;
         }
 
-        internal LabelElement Header(HeaderAttribute header)
+        internal virtual LabelElement Header(HeaderAttribute header)
         {
             var element = Header(header.Text);
             if (header.FontSize != -1)
@@ -290,12 +396,16 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        #endregion
+
+        #region TextBox
+
         /// <summary>
         /// Adds new text box element.
         /// </summary>
         /// <param name="isMultiline">Enable/disable multiline text input support</param>
         /// <returns>The created element.</returns>
-        public TextBoxElement TextBox(bool isMultiline = false)
+        public virtual TextBoxElement TextBox(bool isMultiline)
         {
             var element = new TextBoxElement(isMultiline);
             OnAddElement(element);
@@ -303,10 +413,24 @@ namespace FlaxEditor.CustomEditors
         }
 
         /// <summary>
+        /// Adds new text box element.
+        /// </summary>
+        /// <returns>The created element.</returns>
+        public virtual TextBoxElement TextBox()
+        {
+            var element = TextBox(false);
+            return element;
+        }
+
+        #endregion
+
+        #region Checkbox
+
+        /// <summary>
         /// Adds new check box element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public CheckBoxElement Checkbox()
+        public virtual CheckBoxElement Checkbox()
         {
             var element = new CheckBoxElement();
             OnAddElement(element);
@@ -319,22 +443,41 @@ namespace FlaxEditor.CustomEditors
         /// <param name="name">The property name.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CheckBoxElement Checkbox(string name, string tooltip = null)
+        public virtual CheckBoxElement Checkbox(string name, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.Checkbox();
         }
 
         /// <summary>
+        /// Adds new check box element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The created element.</returns>
+        public virtual CheckBoxElement Checkbox(string name)
+        {
+            var element = Checkbox(name, null);
+            return element;
+        }
+
+        #endregion
+
+        #region Tree
+
+        /// <summary>
         /// Adds new tree element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public TreeElement Tree()
+        public virtual TreeElement Tree()
         {
             var element = new TreeElement();
             OnAddElement(element);
             return element;
         }
+
+        #endregion
+
+        #region Label
 
         /// <summary>
         /// Adds new label element.
@@ -342,7 +485,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="text">The label text.</param>
         /// <param name="horizontalAlignment">The label text horizontal alignment.</param>
         /// <returns>The created element.</returns>
-        public LabelElement Label(string text, TextAlignment horizontalAlignment = TextAlignment.Near)
+        public virtual LabelElement Label(string text, TextAlignment horizontalAlignment)
         {
             var element = new LabelElement();
             element.Label.Text = text;
@@ -358,7 +501,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="text">The label text.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public LabelElement Label(string name, string text, string tooltip = null)
+        public virtual LabelElement Label(string name, string text, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.Label(text);
@@ -368,9 +511,36 @@ namespace FlaxEditor.CustomEditors
         /// Adds new label element.
         /// </summary>
         /// <param name="text">The label text.</param>
+        /// <returns>The created element.</returns>
+        public virtual LabelElement Label(string text)
+        {
+            var element = Label(text, TextAlignment.Near);      
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="text">The label text.</param>
+        /// <returns>The created element.</returns>
+        public virtual LabelElement Label(string name, string text)
+        {
+            var element = Label(text, text, null);
+            return element;
+        }
+
+        #endregion
+
+        #region ClickableLabel
+
+        /// <summary>
+        /// Adds new label element.
+        /// </summary>
+        /// <param name="text">The label text.</param>
         /// <param name="horizontalAlignment">The label text horizontal alignment.</param>
         /// <returns>The created element.</returns>
-        public CustomElement<ClickableLabel> ClickableLabel(string text, TextAlignment horizontalAlignment = TextAlignment.Near)
+        public virtual CustomElement<ClickableLabel> ClickableLabel(string text, TextAlignment horizontalAlignment)
         {
             var element = new CustomElement<ClickableLabel>();
             element.CustomControl.Height = 18.0f;
@@ -387,17 +557,44 @@ namespace FlaxEditor.CustomEditors
         /// <param name="text">The label text.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CustomElement<ClickableLabel> ClickableLabel(string name, string text, string tooltip = null)
+        public virtual CustomElement<ClickableLabel> ClickableLabel(string name, string text, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.ClickableLabel(text);
         }
 
         /// <summary>
+        /// Adds new label element.
+        /// </summary>
+        /// <param name="text">The label text.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomElement<ClickableLabel> ClickableLabel(string text)
+        {
+            var element = ClickableLabel(text, horizontalAlignment: TextAlignment.Near);        
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="text">The label text.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomElement<ClickableLabel> ClickableLabel(string name, string text)
+        {
+            var element = ClickableLabel(name, text, null);
+            return element;
+        }
+
+        #endregion
+
+        #region Float
+
+        /// <summary>
         /// Adds new float value element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public FloatValueElement FloatValue()
+        public virtual FloatValueElement FloatValue()
         {
             var element = new FloatValueElement();
             OnAddElement(element);
@@ -410,17 +607,32 @@ namespace FlaxEditor.CustomEditors
         /// <param name="name">The property name.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public FloatValueElement FloatValue(string name, string tooltip = null)
+        public virtual FloatValueElement FloatValue(string name, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.FloatValue();
         }
 
         /// <summary>
+        /// Adds new float value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The created element.</returns>
+        public virtual FloatValueElement FloatValue(string name)
+        {
+            var element = FloatValue(name, tooltip:null);
+            return element;
+        }
+
+        #endregion
+
+        #region Double
+
+        /// <summary>
         /// Adds new double value element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public DoubleValueElement DoubleValue()
+        public virtual DoubleValueElement DoubleValue()
         {
             var element = new DoubleValueElement();
             OnAddElement(element);
@@ -433,17 +645,32 @@ namespace FlaxEditor.CustomEditors
         /// <param name="name">The property name.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public DoubleValueElement DoubleValue(string name, string tooltip = null)
+        public virtual DoubleValueElement DoubleValue(string name, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.DoubleValue();
         }
 
         /// <summary>
+        /// Adds new double value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The created element.</returns>
+        public virtual DoubleValueElement DoubleValue(string name)
+        {
+            var element = DoubleValue(name, tooltip: null);
+            return element;
+        }
+
+        #endregion
+
+        #region Slide
+
+        /// <summary>
         /// Adds new slider element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public SliderElement Slider()
+        public virtual SliderElement Slider()
         {
             var element = new SliderElement();
             OnAddElement(element);
@@ -456,17 +683,33 @@ namespace FlaxEditor.CustomEditors
         /// <param name="name">The property name.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public SliderElement Slider(string name, string tooltip = null)
+        public virtual SliderElement Slider(string name, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.Slider();
         }
 
         /// <summary>
+        /// Adds new slider element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+
+        /// <returns>The created element.</returns>
+        public virtual SliderElement Slider(string name)
+        {
+            var element = Slider(name,null);
+            return element;
+        }
+
+        #endregion
+
+        #region SignedIntegerValue
+
+        /// <summary>
         /// Adds new signed integer (up to long range) value element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public SignedIntegerValueElement SignedIntegerValue()
+        public virtual SignedIntegerValueElement SignedIntegerValue()
         {
             var element = new SignedIntegerValueElement();
             OnAddElement(element);
@@ -474,10 +717,37 @@ namespace FlaxEditor.CustomEditors
         }
 
         /// <summary>
+        /// Adds new signed integer (up to long range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <returns>The created element.</returns>
+        public virtual SignedIntegerValueElement SignedIntegerValue(string name, string tooltip)
+        {
+            var property = AddPropertyItem(name, tooltip);
+            return property.SignedIntegerValue();
+        }
+
+        /// <summary>
+        /// Adds new signed integer (up to long range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The created element.</returns>
+        public virtual SignedIntegerValueElement SignedIntegerValue(string name)
+        {
+            var element = SignedIntegerValue(name, null);
+            return element;
+        }
+
+        #endregion
+
+        #region UnsignedIntegerValueElement
+
+        /// <summary>
         /// Adds new unsigned signed integer (up to ulong range) value element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public UnsignedIntegerValueElement UnsignedIntegerValue()
+        public virtual UnsignedIntegerValueElement UnsignedIntegerValue()
         {
             var element = new UnsignedIntegerValueElement();
             OnAddElement(element);
@@ -485,10 +755,37 @@ namespace FlaxEditor.CustomEditors
         }
 
         /// <summary>
+        /// Adds new unsigned signed integer (up to ulong range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <returns>The created element.</returns>
+        public virtual UnsignedIntegerValueElement UnsignedIntegerValue(string name, string tooltip)
+        {
+            var property = AddPropertyItem(name, tooltip);
+            return property.UnsignedIntegerValue();
+        }
+
+        /// <summary>
+        /// Adds new unsigned signed integer (up to ulong range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The created element.</returns>
+        public virtual UnsignedIntegerValueElement UnsignedIntegerValue(string name)
+        {
+            var property = AddPropertyItem(name, null);
+            return property.UnsignedIntegerValue();
+        }
+
+        #endregion
+
+        #region IntegerValue
+
+        /// <summary>
         /// Adds new integer value element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public IntegerValueElement IntegerValue()
+        public virtual IntegerValueElement IntegerValue()
         {
             var element = new IntegerValueElement();
             OnAddElement(element);
@@ -501,17 +798,32 @@ namespace FlaxEditor.CustomEditors
         /// <param name="name">The property name.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public IntegerValueElement IntegerValue(string name, string tooltip = null)
+        public virtual IntegerValueElement IntegerValue(string name, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.IntegerValue();
         }
 
         /// <summary>
+        /// Adds new integer value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The created element.</returns>
+        public virtual IntegerValueElement IntegerValue(string name)
+        {
+            var element = IntegerValue(name, null);
+            return element;
+        }
+
+        #endregion
+
+        #region ComboBox
+
+        /// <summary>
         /// Adds new combobox element.
         /// </summary>
         /// <returns>The created element.</returns>
-        public ComboBoxElement ComboBox()
+        public virtual ComboBoxElement ComboBox()
         {
             var element = new ComboBoxElement();
             OnAddElement(element);
@@ -524,11 +836,26 @@ namespace FlaxEditor.CustomEditors
         /// <param name="name">The property name.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public ComboBoxElement ComboBox(string name, string tooltip = null)
+        public virtual ComboBoxElement ComboBox(string name, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.ComboBox();
         }
+
+        /// <summary>
+        /// Adds new combobox element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The created element.</returns>
+        public virtual ComboBoxElement ComboBox(string name)
+        {
+            var element = ComboBox(name, null);
+            return element;
+        }
+
+        #endregion
+
+        #region Enum
 
         /// <summary>
         /// Adds new enum value element.
@@ -537,7 +864,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
         /// <param name="formatMode">The formatting mode.</param>
         /// <returns>The created element.</returns>
-        public EnumElement Enum(Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate = null, EnumDisplayAttribute.FormatMode formatMode = EnumDisplayAttribute.FormatMode.Default)
+        public virtual EnumElement Enum(Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, EnumDisplayAttribute.FormatMode formatMode)
         {
             var element = new EnumElement(type, customBuildEntriesDelegate, formatMode);
             OnAddElement(element);
@@ -553,11 +880,66 @@ namespace FlaxEditor.CustomEditors
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <param name="formatMode">The formatting mode.</param>
         /// <returns>The created element.</returns>
-        public EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate = null, string tooltip = null, EnumDisplayAttribute.FormatMode formatMode = EnumDisplayAttribute.FormatMode.Default)
+        public virtual EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, string tooltip, EnumDisplayAttribute.FormatMode formatMode)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.Enum(type, customBuildEntriesDelegate, formatMode);
         }
+
+        /// <summary>
+        /// Adds new enum value element.
+        /// </summary>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <returns>The created element.</returns>
+        public virtual EnumElement Enum(Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate)
+        {
+            var element = Enum(type, customBuildEntriesDelegate, formatMode: EnumDisplayAttribute.FormatMode.Default);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <returns>The created element.</returns>
+        public virtual EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, string tooltip)
+        {
+            var element = Enum(name,type, customBuildEntriesDelegate, tooltip, formatMode:EnumDisplayAttribute.FormatMode.Default);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <returns>The created element.</returns>
+        public virtual EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate)
+        {
+            var element = Enum(name, type, customBuildEntriesDelegate, tooltip:null, formatMode:EnumDisplayAttribute.FormatMode.Default);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The enum type.</param>
+        /// <returns>The created element.</returns>
+        public virtual EnumElement Enum(string name, Type type)
+        {
+            var element = Enum(name, type, customBuildEntriesDelegate: null, tooltip: null);
+            return element;
+        }
+
+        #endregion
+
+        #region Object
 
         /// <summary>
         /// Adds object(s) editor. Selects proper <see cref="CustomEditor"/> based on overrides.
@@ -565,7 +947,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="values">The values.</param>
         /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
         /// <returns>The created element.</returns>
-        public CustomEditor Object(ValueContainer values, CustomEditor overrideEditor = null)
+        public virtual CustomEditor Object(ValueContainer values, CustomEditor overrideEditor)
         {
             if (values == null)
                 throw new ArgumentNullException();
@@ -586,7 +968,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CustomEditor Object(string name, ValueContainer values, CustomEditor overrideEditor = null, string tooltip = null)
+        public virtual CustomEditor Object(string name, ValueContainer values, CustomEditor overrideEditor, string tooltip)
         {
             var property = AddPropertyItem(name, tooltip);
             return property.Object(values, overrideEditor);
@@ -600,11 +982,64 @@ namespace FlaxEditor.CustomEditors
         /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CustomEditor Object(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor = null, string tooltip = null)
+        public virtual CustomEditor Object(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor, string tooltip)
         {
             var property = AddPropertyItem(label, tooltip);
             return property.Object(values, overrideEditor);
         }
+
+        /// <summary>
+        /// Adds object(s) editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Object(ValueContainer values)
+        {
+            var element = Object(values, null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Object(string name, ValueContainer values, CustomEditor overrideEditor)
+        {
+            var element = Object(name, values, overrideEditor, tooltip: null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Object(PropertyNameLabel label, ValueContainer values)
+        {
+            var element = Object(label, values, overrideEditor: null, tooltip: null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Object(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor)
+        {
+            var element = Object(label, values, overrideEditor, tooltip: null);
+            return element;
+        }
+
+        #endregion
+
+        #region Property
 
         /// <summary>
         /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
@@ -614,7 +1049,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor = null, string tooltip = null)
+        public virtual CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor, string tooltip)
         {
             var editor = CustomEditorsUtil.CreateEditor(values, overrideEditor);
             var style = editor.Style;
@@ -644,7 +1079,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The created element.</returns>
-        public CustomEditor Property(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor = null, string tooltip = null)
+        public virtual CustomEditor Property(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor, string tooltip)
         {
             var editor = CustomEditorsUtil.CreateEditor(values, overrideEditor);
             var style = editor.Style;
@@ -666,7 +1101,60 @@ namespace FlaxEditor.CustomEditors
             return property.Object(values, editor);
         }
 
-        private PropertiesListElement AddPropertyItem()
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor) 
+        {
+            var element = Property(name,values, overrideEditor, tooltip: null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Property(string name, ValueContainer values)
+        {
+            var element = Property(name, values, overrideEditor: null, tooltip: null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Property(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor)
+        {
+            var element = Property(label, values, overrideEditor, tooltip: null);
+            return element;
+        }
+
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Property(PropertyNameLabel label, ValueContainer values)
+        {
+            var element = Property(label, values, overrideEditor: null, tooltip: null);
+            return element;
+        }
+
+        #endregion
+
+        protected PropertiesListElement AddPropertyItem()
         {
             // Try to reuse previous control
             PropertiesListElement element;
@@ -688,7 +1176,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="name">The property label name.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The element.</returns>
-        public PropertiesListElement AddPropertyItem(string name, string tooltip = null)
+        public virtual PropertiesListElement AddPropertyItem(string name, string tooltip = null)
         {
             var element = AddPropertyItem();
             element.OnAddProperty(name, tooltip);
@@ -701,7 +1189,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="label">The property label.</param>
         /// <param name="tooltip">The property label tooltip text.</param>
         /// <returns>The element.</returns>
-        public PropertiesListElement AddPropertyItem(PropertyNameLabel label, string tooltip = null)
+        public virtual PropertiesListElement AddPropertyItem(PropertyNameLabel label, string tooltip = null)
         {
             if (label == null)
                 throw new ArgumentNullException();
@@ -757,5 +1245,6 @@ namespace FlaxEditor.CustomEditors
 
         /// <inheritdoc />
         public override Control Control => ContainerControl;
+
     }
 }

--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -2177,7 +2177,7 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="TElement2"></typeparam>
         /// <param name="orientation">The orientation.</param>  
         /// <returns>The created element.</returns>
-        public SplitElement<TElement1,TElement2> SplitContainer<TElement1, TElement2>(Orientation orientation) 
+        public SplitElement<TElement1,TElement2> Split<TElement1, TElement2>(Orientation orientation) 
             where TElement1 : LayoutElement
             where TElement2 : LayoutElement
         {
@@ -2194,7 +2194,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="orientation">The orientation.</param>  
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The created element.</returns>
-        public SplitElement<TElement1, TElement2> SplitContainer<TElement1, TElement2>(Orientation orientation, Action<SplitElement<TElement1, TElement2>> onAdd)
+        public SplitElement<TElement1, TElement2> Split<TElement1, TElement2>(Orientation orientation, Action<SplitElement<TElement1, TElement2>> onAdd)
             where TElement1 : LayoutElement
             where TElement2 : LayoutElement
         {
@@ -2209,12 +2209,12 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="TElement1"></typeparam>
         /// <typeparam name="TElement2"></typeparam>
         /// <returns>The created element.</returns>
-        public SplitElement<TElement1, TElement2> SplitContainer
+        public SplitElement<TElement1, TElement2> Split
             <TElement1, TElement2>()
            where TElement1 : LayoutElement
            where TElement2 : LayoutElement
         {
-            var element = SplitContainer<TElement1, TElement2>(Orientation.Horizontal);         
+            var element = Split<TElement1, TElement2>(Orientation.Horizontal);         
             return element;
         }
 
@@ -2225,11 +2225,11 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="TElement2"></typeparam>
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The created element.</returns>
-        public SplitElement<TElement1, TElement2> SplitContainer<TElement1, TElement2>(Action<SplitElement<TElement1, TElement2>> onAdd)
+        public SplitElement<TElement1, TElement2> Split<TElement1, TElement2>(Action<SplitElement<TElement1, TElement2>> onAdd)
             where TElement1 : LayoutElement
             where TElement2 : LayoutElement
         {
-            var element = SplitContainer<TElement1, TElement2>(Orientation.Horizontal, onAdd);
+            var element = Split<TElement1, TElement2>(Orientation.Horizontal, onAdd);
             return element;
         }
 
@@ -2239,10 +2239,10 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="TElement"></typeparam>
         /// <param name="orientation">The orientation.</param>  
         /// <returns>The created element.</returns>
-        public SplitElement<TElement, TElement> SplitContainer<TElement>(Orientation orientation)
+        public SplitElement<TElement, TElement> Split<TElement>(Orientation orientation)
             where TElement : LayoutElement
         {
-            var element = SplitContainer<TElement, TElement>(orientation);
+            var element = Split<TElement, TElement>(orientation);
             return element;
         }
 
@@ -2253,10 +2253,10 @@ namespace FlaxEditor.CustomEditors
         /// <param name="orientation">The orientation.</param>  
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The created element.</returns>
-        public SplitElement<TElement, TElement> SplitContainer<TElement>(Orientation orientation, Action<SplitElement<TElement, TElement>> onAdd)
+        public SplitElement<TElement, TElement> Split<TElement>(Orientation orientation, Action<SplitElement<TElement, TElement>> onAdd)
             where TElement : LayoutElement
         {
-            var element = SplitContainer<TElement, TElement>(orientation, onAdd);
+            var element = Split<TElement, TElement>(orientation, onAdd);
             return element;
         }
 
@@ -2265,10 +2265,10 @@ namespace FlaxEditor.CustomEditors
         /// </summary>
         /// <typeparam name="TElement"></typeparam>
         /// <returns>The created element.</returns>
-        public SplitElement<TElement, TElement> SplitContainer<TElement>()
+        public SplitElement<TElement, TElement> Split<TElement>()
             where TElement : LayoutElement
         {
-            var element = SplitContainer<TElement, TElement>(Orientation.Horizontal);
+            var element = Split<TElement, TElement>(Orientation.Horizontal);
             return element;
         }
 
@@ -2278,10 +2278,10 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="TElement"></typeparam>
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The created element.</returns>
-        public SplitElement<TElement, TElement> SplitContainer<TElement>(Action<SplitElement<TElement, TElement>> onAdd)
+        public SplitElement<TElement, TElement> Split<TElement>(Action<SplitElement<TElement, TElement>> onAdd)
             where TElement : LayoutElement
         {
-            var element = SplitContainer<TElement,TElement>(Orientation.Horizontal, onAdd);
+            var element = Split<TElement,TElement>(Orientation.Horizontal, onAdd);
             return element;
         }
 
@@ -2294,7 +2294,7 @@ namespace FlaxEditor.CustomEditors
         /// </summary>    
         /// <param name="orientation">The orientation.</param>  
         /// <returns>The created element.</returns>
-        public SplitPanelElement SplitPanel(Orientation orientation)         
+        public SplitPanelElement Split(Orientation orientation)         
         {
             var element = new SplitPanelElement(orientation);
             AddElement(element);
@@ -2307,7 +2307,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="orientation">The orientation.</param>  
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The created element.</returns>
-        public SplitPanelElement SplitPanel(Orientation orientation, Action<SplitPanelElement> onAdd)
+        public SplitPanelElement Split(Orientation orientation, Action<SplitPanelElement> onAdd)
         {
             var element = new SplitPanelElement(orientation);
             AddElement(element,onAdd);
@@ -2318,9 +2318,9 @@ namespace FlaxEditor.CustomEditors
         /// Adds a new split panel element
         /// </summary>    
         /// <returns>The created element.</returns>
-        public SplitPanelElement SplitPanel()
+        public SplitPanelElement Split()
         {
-            var element = SplitPanel(Orientation.Horizontal);
+            var element = Split(Orientation.Horizontal);
             return element;
         }
 
@@ -2329,9 +2329,9 @@ namespace FlaxEditor.CustomEditors
         /// </summary>    
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The created element.</returns>
-        public SplitPanelElement SplitPanel(Action<SplitPanelElement> onAdd)
+        public SplitPanelElement Split(Action<SplitPanelElement> onAdd)
         {
-            var element = SplitPanel(Orientation.Horizontal, onAdd);
+            var element = Split(Orientation.Horizontal, onAdd);
             return element;
         }
 
@@ -2412,7 +2412,7 @@ namespace FlaxEditor.CustomEditors
         /// <typeparam name="T"></typeparam>
         /// <param name="element">The element.</param>
         /// <returns></returns>
-        public T Addchild<T>(T element) where T : LayoutElement
+        public T AddChild<T>(T element) where T : LayoutElement
         {
             AddElement(element); 
             return element;
@@ -2424,7 +2424,7 @@ namespace FlaxEditor.CustomEditors
         /// <param name="element">The element.</param>
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns></returns>
-        public T Addchild<T>(T element, Action<T> onAdd) where T : LayoutElement
+        public T AddChild<T>(T element, Action<T> onAdd) where T : LayoutElement
         {
             AddElement(element,onAdd);
             return element;

--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -40,9 +40,6 @@ namespace FlaxEditor.CustomEditors
         /// </summary>
         public abstract ContainerControl ContainerControl { get; }
 
-
-        #region Group
-
         /// <summary>
         /// Adds new group element.
         /// </summary>
@@ -112,6 +109,47 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds new group element.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <param name="linkedEditor">The custom editor to be linked for a group. Used to provide more utility functions for a drop panel UI via context menu.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public GroupElement Group(string title, CustomEditor linkedEditor, Action<GroupElement> onAdd)
+        {
+            var e = Group(title, linkedEditor);
+            onAdd?.Invoke(e);
+            return e;
+        }
+
+        /// <summary>
+        /// Adds new group element.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <param name="useTransparentHeader">True if use drop down icon and transparent group header, otherwise use normal style.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public GroupElement Group(string title, bool useTransparentHeader, Action<GroupElement> onAdd)
+        {
+            var e = Group(title, useTransparentHeader);
+            onAdd?.Invoke(e);
+            return e;
+        }
+
+        /// <summary>
+        /// Adds new group element.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public GroupElement Group(string title, Action<GroupElement> onAdd)
+        {
+            var e = Group(title);
+            onAdd?.Invoke(e);
+            return e;
+        }
+     
         private void OnGroupPanelMouseButtonRightClicked(DropPanel groupPanel, Float2 location)
         {
             var linkedEditor = (CustomEditor)groupPanel.Tag;
@@ -134,8 +172,6 @@ namespace FlaxEditor.CustomEditors
             Editor.Instance.ProjectCache.SetCollapsedGroup(panel.HeaderText, panel.IsClosed);
         }
 
-        #endregion
-
         #region HorizontalPanel
 
         /// <summary>
@@ -146,6 +182,17 @@ namespace FlaxEditor.CustomEditors
         {
             var element = new HorizontalPanelElement();
             OnAddElement(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new horizontal panel element.
+        /// </summary>
+        /// <returns>The created element.</returns>
+        public HorizontalPanelElement HorizontalPanel(Action<HorizontalPanelElement> onAdd)
+        {
+            var element = HorizontalPanel();
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -161,6 +208,17 @@ namespace FlaxEditor.CustomEditors
         {
             var element = new VerticalPanelElement();
             OnAddElement(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new vertical panel element.
+        /// </summary>
+        /// <returns>The created element.</returns>
+        public VerticalPanelElement VerticalPanel(Action<VerticalPanelElement> onAdd)
+        {
+            var element = VerticalPanel();
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -223,9 +281,66 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds new button element.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="tooltip">The tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public ButtonElement Button(string text, string tooltip, Action<ButtonElement> onAdd)
+        {
+            var element = Button(text, tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new button element.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public ButtonElement Button(string text, Action<ButtonElement> onAdd)
+        {
+            var element = Button(text);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new button element with custom color.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="color">The color.</param>
+        /// <param name="tooltip">The tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public ButtonElement Button(string text, Color color, string tooltip, Action<ButtonElement> onAdd)
+        {
+            var element = Button(text, color, tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new button element with custom color.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="color">The color.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public ButtonElement Button(string text, Color color, Action<ButtonElement> onAdd)
+        {
+            var element = Button(text, color);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
         #endregion Button
 
         #region CustomElement
+
         /// <summary>
         /// Adds new custom element.
         /// </summary>
@@ -264,6 +379,50 @@ namespace FlaxEditor.CustomEditors
         {
             var property = AddPropertyItem(name, null);
             return property.Custom<T>();
+        }
+
+        /// <summary>
+        /// Adds new custom element.
+        /// </summary>
+        /// <typeparam name="T">The custom control.</typeparam>
+        /// <returns>The created element.</returns>
+        public virtual CustomElement<T> Custom<T>(Action<CustomElement<T>> onAdd)
+        where T : Control, new()
+        {
+            var element = Custom<T>();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new custom element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <typeparam name="T">The custom control.</typeparam>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomElement<T> Custom<T>(string name, string tooltip, Action<CustomElement<T>> onAdd)
+        where T : Control, new()
+        {
+            var element = Custom<T>(name, tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new custom element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <typeparam name="T">The custom control.</typeparam>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomElement<T> Custom<T>(string name, Action<CustomElement<T>> onAdd)
+        where T : Control, new()
+        {
+            var element = Custom<T>(name);
+            onAdd?.Invoke(element);
+            return element;
         }
 
         #endregion
@@ -327,6 +486,19 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds new space.
+        /// </summary>
+        /// <param name="height">The space height.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual SpaceElement Space(float height, Action<SpaceElement> onAdd)
+        {
+            var element = Space(height);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
         #endregion
 
         #region Image
@@ -370,6 +542,45 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds sprite image to the layout.
+        /// </summary>
+        /// <param name="sprite">The sprite.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual ImageElement Image(SpriteHandle sprite, Action<ImageElement> onAdd)
+        {
+            var element = Image(sprite);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds texture image to the layout.
+        /// </summary>
+        /// <param name="texture">The texture.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual ImageElement Image(Texture texture, Action<ImageElement> onAdd)
+        {
+            var element = Image(texture);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds GPU texture image to the layout.
+        /// </summary>
+        /// <param name="texture">The GPU texture.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual ImageElement Image(GPUTexture texture, Action<ImageElement> onAdd)
+        {
+            var element = Image(texture);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
         #endregion
 
         #region Header
@@ -395,6 +606,27 @@ namespace FlaxEditor.CustomEditors
                 element.Label.TextColor = Color.FromRGBA(header.Color);
             return element;
         }
+
+        /// <summary>
+        /// Adds new header control.
+        /// </summary>
+        /// <param name="text">The header text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual LabelElement Header(string text, Action<LabelElement> onAdd)
+        {
+            var element = Header(text);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        internal virtual LabelElement Header(HeaderAttribute header, Action<LabelElement> onAdd)
+        {
+            var element = Header(header);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
 
         #endregion
 
@@ -422,6 +654,31 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds new text box element.
+        /// </summary>
+        /// <param name="isMultiline">Enable/disable multiline text input support</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public TextBoxElement TextBox(bool isMultiline, Action<TextBoxElement> onAdd)
+        {
+            var element = TextBox(isMultiline);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new text box element.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public TextBoxElement TextBox(Action<TextBoxElement> onAdd)
+        {
+            var element = TextBox();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
         #endregion
 
         #region Checkbox
@@ -445,7 +702,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CheckBoxElement Checkbox(string name, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.Checkbox();
         }
 
@@ -456,9 +713,48 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CheckBoxElement Checkbox(string name)
         {
-            var element = Checkbox(name, null);
+            var element = Checkbox(name:name, tooltip:null);
             return element;
         }
+
+        /// <summary>
+        /// Adds new check box element.
+        /// </summary>
+        /// <returns>The created element.</returns>
+        public CheckBoxElement Checkbox(Action<CheckBoxElement> onAdd)
+        {
+            var element = Checkbox();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new check box element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CheckBoxElement Checkbox(string name, string tooltip, Action<CheckBoxElement> onAdd)
+        {
+            var element = Checkbox(name,tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new check box element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CheckBoxElement Checkbox(string name, Action<CheckBoxElement> onAdd)
+        {
+            var element = Checkbox(name);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
 
         #endregion
 
@@ -472,6 +768,17 @@ namespace FlaxEditor.CustomEditors
         {
             var element = new TreeElement();
             OnAddElement(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new tree element.
+        /// </summary>
+        /// <returns>The created element.</returns>
+        public TreeElement Tree(Action<TreeElement> onAdd)
+        {
+            var element = Tree();
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -503,7 +810,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual LabelElement Label(string name, string text, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.Label(text);
         }
 
@@ -514,7 +821,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual LabelElement Label(string text)
         {
-            var element = Label(text, TextAlignment.Near);      
+            var element = Label(text:text, horizontalAlignment:TextAlignment.Near);      
             return element;
         }
 
@@ -526,7 +833,63 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual LabelElement Label(string name, string text)
         {
-            var element = Label(text, text, null);
+            var element = Label(name:name, text:text, tooltip:null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element.
+        /// </summary>
+        /// <param name="text">The label text.</param>
+        /// <param name="horizontalAlignment">The label text horizontal alignment.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public LabelElement Label(string text, TextAlignment horizontalAlignment, Action<LabelElement> onAdd)
+        {
+            var element = Label(text, horizontalAlignment);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="text">The label text.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public LabelElement Label(string name, string text, string tooltip, Action<LabelElement> onAdd)
+        {
+            var element = Label(name, text, tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element.
+        /// </summary>
+        /// <param name="text">The label text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public LabelElement Label(string text, Action<LabelElement> onAdd)
+        {
+            var element = Label(text);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="text">The label text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public LabelElement Label(string name, string text, Action<LabelElement> onAdd)
+        {
+            var element = Label(name, text);
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -559,7 +922,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomElement<ClickableLabel> ClickableLabel(string name, string text, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.ClickableLabel(text);
         }
 
@@ -570,7 +933,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomElement<ClickableLabel> ClickableLabel(string text)
         {
-            var element = ClickableLabel(text, horizontalAlignment: TextAlignment.Near);        
+            var element = ClickableLabel(text:text, horizontalAlignment:TextAlignment.Near);        
             return element;
         }
 
@@ -582,7 +945,63 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomElement<ClickableLabel> ClickableLabel(string name, string text)
         {
-            var element = ClickableLabel(name, text, null);
+            var element = ClickableLabel(name:name, text:text, tooltip:null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element.
+        /// </summary>
+        /// <param name="text">The label text.</param>
+        /// <param name="horizontalAlignment">The label text horizontal alignment.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomElement<ClickableLabel> ClickableLabel(string text, TextAlignment horizontalAlignment, Action<CustomElement<ClickableLabel>> onAdd)
+        {
+            var element = ClickableLabel(text:text, horizontalAlignment:horizontalAlignment);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="text">The label text.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomElement<ClickableLabel> ClickableLabel(string name, string text, string tooltip, Action<CustomElement<ClickableLabel>> onAdd)
+        {
+            var element = ClickableLabel(name:name, text:text, tooltip:tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element.
+        /// </summary>
+        /// <param name="text">The label text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomElement<ClickableLabel> ClickableLabel(string text, Action<CustomElement<ClickableLabel>> onAdd)
+        {
+            var element = ClickableLabel(text:text);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new label element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="text">The label text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomElement<ClickableLabel> ClickableLabel(string name, string text, Action<CustomElement<ClickableLabel>> onAdd)
+        {
+            var element = ClickableLabel(name:name, text:text);
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -624,6 +1043,45 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds new float value element.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public FloatValueElement FloatValue(Action<FloatValueElement> onAdd)
+        {
+            var element = FloatValue();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new float value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public FloatValueElement FloatValue(string name, string tooltip, Action<FloatValueElement> onAdd)
+        {
+            var element = FloatValue(name,tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new float value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public FloatValueElement FloatValue(string name, Action<FloatValueElement> onAdd)
+        {
+            var element = FloatValue(name);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
         #endregion
 
         #region Double
@@ -662,6 +1120,45 @@ namespace FlaxEditor.CustomEditors
             return element;
         }
 
+        /// <summary>
+        /// Adds new double value element.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public DoubleValueElement DoubleValue(Action<DoubleValueElement> onAdd)
+        {
+            var element = DoubleValue();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new double value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public DoubleValueElement DoubleValue(string name, string tooltip, Action<DoubleValueElement> onAdd)
+        {
+            var element = DoubleValue(name,tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new double value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public DoubleValueElement DoubleValue(string name, Action<DoubleValueElement> onAdd)
+        {
+            var element = DoubleValue(name);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
         #endregion
 
         #region Slide
@@ -685,7 +1182,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual SliderElement Slider(string name, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.Slider();
         }
 
@@ -697,9 +1194,50 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual SliderElement Slider(string name)
         {
-            var element = Slider(name,null);
+            var element = Slider(name:name, tooltip:null);
             return element;
         }
+
+
+        /// <summary>
+        /// Adds new slider element.
+        /// </summary>
+        /// <returns>The created element.</returns>
+        public SliderElement Slider(Action<SliderElement> onAdd)
+        {
+            var element = Slider();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new slider element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SliderElement Slider(string name, string tooltip, Action<SliderElement> onAdd)
+        {
+            var element = Slider(name:name, tooltip:tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new slider element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+
+        /// <returns>The created element.</returns>
+        public SliderElement Slider(string name, Action<SliderElement> onAdd)
+        {
+            var element = Slider(name:name);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
 
         #endregion
 
@@ -724,7 +1262,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual SignedIntegerValueElement SignedIntegerValue(string name, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.SignedIntegerValue();
         }
 
@@ -735,9 +1273,49 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual SignedIntegerValueElement SignedIntegerValue(string name)
         {
-            var element = SignedIntegerValue(name, null);
+            var element = SignedIntegerValue(name:name, tooltip:null);
             return element;
         }
+
+        /// <summary>
+        /// Adds new signed integer (up to long range) value element.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SignedIntegerValueElement SignedIntegerValue(Action<SignedIntegerValueElement> onAdd)
+        {
+            var element = SignedIntegerValue();
+            onAdd.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new signed integer (up to long range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SignedIntegerValueElement SignedIntegerValue(string name, string tooltip, Action<SignedIntegerValueElement> onAdd)
+        {
+            var element = SignedIntegerValue(name:name, tooltip:tooltip);
+            onAdd.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new signed integer (up to long range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SignedIntegerValueElement SignedIntegerValue(string name, Action<SignedIntegerValueElement> onAdd)
+        {
+            var element = SignedIntegerValue(name:name);
+            onAdd.Invoke(element);
+            return element;
+        }
+
 
         #endregion
 
@@ -762,7 +1340,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual UnsignedIntegerValueElement UnsignedIntegerValue(string name, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.UnsignedIntegerValue();
         }
 
@@ -773,8 +1351,47 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual UnsignedIntegerValueElement UnsignedIntegerValue(string name)
         {
-            var property = AddPropertyItem(name, null);
+            var property = AddPropertyItem(name:name, tooltip:null);
             return property.UnsignedIntegerValue();
+        }
+
+        /// <summary>
+        /// Adds new unsigned signed integer (up to ulong range) value element.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public UnsignedIntegerValueElement UnsignedIntegerValue(Action<UnsignedIntegerValueElement> onAdd)
+        {
+            var element = UnsignedIntegerValue();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new unsigned signed integer (up to ulong range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public UnsignedIntegerValueElement UnsignedIntegerValue(string name, string tooltip, Action<UnsignedIntegerValueElement> onAdd)
+        {
+            var element = UnsignedIntegerValue(name:name, tooltip:tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new unsigned signed integer (up to ulong range) value element.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public UnsignedIntegerValueElement UnsignedIntegerValue(string name, Action<UnsignedIntegerValueElement> onAdd)
+        {
+            var element = UnsignedIntegerValue(name: name);
+            onAdd?.Invoke(element);
+            return element;
         }
 
         #endregion
@@ -800,7 +1417,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual IntegerValueElement IntegerValue(string name, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.IntegerValue();
         }
 
@@ -811,7 +1428,46 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual IntegerValueElement IntegerValue(string name)
         {
-            var element = IntegerValue(name, null);
+            var element = IntegerValue(name:name, tooltip:null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new integer value element.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public IntegerValueElement IntegerValue(Action<IntegerValueElement> onAdd)
+        {
+            var element = IntegerValue();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new integer value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public IntegerValueElement IntegerValue(string name, string tooltip, Action<IntegerValueElement> onAdd)
+        {
+            var element = IntegerValue(name:name, tooltip:tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new integer value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual IntegerValueElement IntegerValue(string name, Action<IntegerValueElement> onAdd)
+        {
+            var element = IntegerValue(name: name);
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -838,7 +1494,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual ComboBoxElement ComboBox(string name, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name: name, tooltip:tooltip);
             return property.ComboBox();
         }
 
@@ -849,7 +1505,46 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual ComboBoxElement ComboBox(string name)
         {
-            var element = ComboBox(name, null);
+            var element = ComboBox(name:name, tooltip:null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new combobox element.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public ComboBoxElement ComboBox(Action<ComboBoxElement> onAdd)
+        {
+            var element = ComboBox();
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new combobox element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public ComboBoxElement ComboBox(string name, string tooltip, Action<ComboBoxElement> onAdd)
+        {
+            var element = ComboBox(name:name, tooltip:tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new combobox element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public ComboBoxElement ComboBox(string name, Action<ComboBoxElement> onAdd)
+        {
+            var element = ComboBox(name:name);
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -866,7 +1561,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual EnumElement Enum(Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, EnumDisplayAttribute.FormatMode formatMode)
         {
-            var element = new EnumElement(type, customBuildEntriesDelegate, formatMode);
+            var element = new EnumElement(type:type, customBuildEntriesDelegate:customBuildEntriesDelegate, formatMode:formatMode);
             OnAddElement(element);
             return element;
         }
@@ -882,7 +1577,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, string tooltip, EnumDisplayAttribute.FormatMode formatMode)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.Enum(type, customBuildEntriesDelegate, formatMode);
         }
 
@@ -894,7 +1589,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual EnumElement Enum(Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate)
         {
-            var element = Enum(type, customBuildEntriesDelegate, formatMode: EnumDisplayAttribute.FormatMode.Default);
+            var element = Enum(type:type, customBuildEntriesDelegate:customBuildEntriesDelegate, formatMode: EnumDisplayAttribute.FormatMode.Default);
             return element;
         }
 
@@ -908,7 +1603,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, string tooltip)
         {
-            var element = Enum(name,type, customBuildEntriesDelegate, tooltip, formatMode:EnumDisplayAttribute.FormatMode.Default);
+            var element = Enum(name:name, type:type, customBuildEntriesDelegate:customBuildEntriesDelegate, tooltip:tooltip, formatMode:EnumDisplayAttribute.FormatMode.Default);
             return element;
         }
 
@@ -921,7 +1616,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate)
         {
-            var element = Enum(name, type, customBuildEntriesDelegate, tooltip:null, formatMode:EnumDisplayAttribute.FormatMode.Default);
+            var element = Enum(name:name, type:type, customBuildEntriesDelegate:customBuildEntriesDelegate, tooltip:null, formatMode:EnumDisplayAttribute.FormatMode.Default);
             return element;
         }
 
@@ -936,6 +1631,98 @@ namespace FlaxEditor.CustomEditors
             var element = Enum(name, type, customBuildEntriesDelegate: null, tooltip: null);
             return element;
         }
+
+        /// <summary>
+        /// Adds new enum value element.
+        /// </summary>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <param name="formatMode">The formatting mode.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public EnumElement Enum(Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, EnumDisplayAttribute.FormatMode formatMode, Action<EnumElement> onAdd)
+        {
+            var element = Enum(type: type, customBuildEntriesDelegate: customBuildEntriesDelegate, formatMode: formatMode);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="formatMode">The formatting mode.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, string tooltip, EnumDisplayAttribute.FormatMode formatMode, Action<EnumElement> onAdd)
+        {
+            var element = Enum(name:name, type:type, customBuildEntriesDelegate:customBuildEntriesDelegate, tooltip:tooltip, formatMode:formatMode);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element.
+        /// </summary>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public EnumElement Enum(Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, Action<EnumElement> onAdd)
+        {
+            var element = Enum(type: type, customBuildEntriesDelegate: customBuildEntriesDelegate);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, string tooltip, Action<EnumElement> onAdd)
+        {
+            var element = Enum(name: name, type: type, customBuildEntriesDelegate: customBuildEntriesDelegate, tooltip: tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The enum type.</param>
+        /// <param name="customBuildEntriesDelegate">The custom entries layout builder. Allows to hide existing or add different enum values to editor.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public EnumElement Enum(string name, Type type, EnumComboBox.BuildEntriesDelegate customBuildEntriesDelegate, Action<EnumElement> onAdd)
+        {
+            var element = Enum(name: name, type: type, customBuildEntriesDelegate: customBuildEntriesDelegate);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds new enum value element with name label.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The enum type.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public EnumElement Enum(string name, Type type, Action<EnumElement> onAdd)
+        {
+            var element = Enum(name: name, type: type);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
 
         #endregion
 
@@ -970,7 +1757,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Object(string name, ValueContainer values, CustomEditor overrideEditor, string tooltip)
         {
-            var property = AddPropertyItem(name, tooltip);
+            var property = AddPropertyItem(name:name, tooltip:tooltip);
             return property.Object(values, overrideEditor);
         }
 
@@ -984,8 +1771,8 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Object(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor, string tooltip)
         {
-            var property = AddPropertyItem(label, tooltip);
-            return property.Object(values, overrideEditor);
+            var property = AddPropertyItem(label:label, tooltip:tooltip);
+            return property.Object(values:values, overrideEditor:overrideEditor);
         }
 
         /// <summary>
@@ -995,7 +1782,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Object(ValueContainer values)
         {
-            var element = Object(values, null);
+            var element = Object(values:values, overrideEditor:null);
             return element;
         }
 
@@ -1008,7 +1795,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Object(string name, ValueContainer values, CustomEditor overrideEditor)
         {
-            var element = Object(name, values, overrideEditor, tooltip: null);
+            var element = Object(name:name, values:values, overrideEditor:overrideEditor, tooltip: null);
             return element;
         }
 
@@ -1020,7 +1807,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Object(PropertyNameLabel label, ValueContainer values)
         {
-            var element = Object(label, values, overrideEditor: null, tooltip: null);
+            var element = Object(label:label, values:values, overrideEditor: null, tooltip: null);
             return element;
         }
 
@@ -1033,7 +1820,110 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Object(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor)
         {
-            var element = Object(label, values, overrideEditor, tooltip: null);
+            var element = Object(label:label, values:values, overrideEditor: overrideEditor, tooltip: null);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual CustomEditor Object(ValueContainer values, CustomEditor overrideEditor, Action<CustomEditor> onAdd)
+        {
+            var element = Object(values: values, overrideEditor: overrideEditor);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Object(string name, ValueContainer values, CustomEditor overrideEditor, string tooltip, Action<CustomEditor> onAdd)
+        {
+            var element = Object(name:name, values: values, overrideEditor: overrideEditor, tooltip: tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Object(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor, string tooltip, Action<CustomEditor> onAdd)
+        {
+            var element = Object(label:label,values:values, overrideEditor:overrideEditor,tooltip:tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Object(ValueContainer values, Action<CustomEditor> onAdd)
+        {
+            var element = Object(values: values);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Object(string name, ValueContainer values, CustomEditor overrideEditor, Action<CustomEditor> onAdd)
+        {
+            var element = Object(name:name, values: values, overrideEditor: overrideEditor);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Object(PropertyNameLabel label, ValueContainer values, Action<CustomEditor> onAdd)
+        {
+            var element = Object(label: label, values: values);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object(s) editor with name label. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Object(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor, Action<CustomEditor> onAdd)
+        {
+            var element = Object(label: label, values: values, overrideEditor: overrideEditor);
+            onAdd?.Invoke(element);
             return element;
         }
 
@@ -1110,7 +2000,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor) 
         {
-            var element = Property(name,values, overrideEditor, tooltip: null);
+            var element = Property(name:name, values:values, overrideEditor:overrideEditor, tooltip: null);
             return element;
         }
 
@@ -1122,7 +2012,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Property(string name, ValueContainer values)
         {
-            var element = Property(name, values, overrideEditor: null, tooltip: null);
+            var element = Property(name:name, values:values, overrideEditor: null, tooltip: null);
             return element;
         }
 
@@ -1135,7 +2025,7 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Property(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor)
         {
-            var element = Property(label, values, overrideEditor, tooltip: null);
+            var element = Property(label:label, values:values, overrideEditor:overrideEditor, tooltip: null);
             return element;
         }
 
@@ -1148,13 +2038,107 @@ namespace FlaxEditor.CustomEditors
         /// <returns>The created element.</returns>
         public virtual CustomEditor Property(PropertyNameLabel label, ValueContainer values)
         {
-            var element = Property(label, values, overrideEditor: null, tooltip: null);
+            var element = Property(label:label, values:values, overrideEditor: null, tooltip: null);
             return element;
         }
 
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor, string tooltip, Action<CustomEditor> onAdd)
+        {
+            var element = Property(name: name, values: values, overrideEditor: overrideEditor, tooltip: tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="tooltip">The property label tooltip text.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Property(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor, string tooltip, Action<CustomEditor> onAdd)
+        {
+            var element = Property(label:label, values: values, overrideEditor: overrideEditor, tooltip: tooltip);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Property(string name, ValueContainer values, CustomEditor overrideEditor, Action<CustomEditor> onAdd)
+        {
+            var element = Property(name: name, values: values, overrideEditor: overrideEditor);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Property(string name, ValueContainer values, Action<CustomEditor> onAdd)
+        {
+            var element = Property(name: name, values: values);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="overrideEditor">The custom editor to use. If null will detect it by auto.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Property(PropertyNameLabel label, ValueContainer values, CustomEditor overrideEditor, Action<CustomEditor> onAdd)
+        {
+            var element = Property(label: label, values: values, overrideEditor: overrideEditor);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+
+        /// <summary>
+        /// Adds object property editor. Selects proper <see cref="CustomEditor"/> based on overrides.
+        /// </summary>
+        /// <param name="label">The property label.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public CustomEditor Property(PropertyNameLabel label, ValueContainer values, Action<CustomEditor> onAdd)
+        {
+            var element = Property(label: label, values: values);
+            onAdd?.Invoke(element);
+            return element;
+        }
+
+
         #endregion
 
-        protected PropertiesListElement AddPropertyItem()
+
+
+        private PropertiesListElement AddPropertyItem()
         {
             // Try to reuse previous control
             PropertiesListElement element;
@@ -1211,6 +2195,42 @@ namespace FlaxEditor.CustomEditors
         }
 
         /// <summary>
+        /// Adds custom element to the layout.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element">The element.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        public void AddElement<T>(T element, Action<T> onAdd) where T : LayoutElement
+        {
+            AddElement(element);
+            onAdd?.Invoke(element);
+        }
+
+        /// <summary>
+        /// Adds custom element to the layout.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element">The element.</param>
+        /// <returns></returns>
+        public T Addchild<T>(T element) where T : LayoutElement
+        {
+            AddElement(element); 
+            return element;
+        }
+
+        /// <summary>
+        /// Adds custom element to the layout.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns></returns>
+        public T Addchild<T>(T element, Action<T> onAdd) where T : LayoutElement
+        {
+            AddElement(element,onAdd);
+            return element;
+        }
+
+        /// <summary>
         /// Called when element is added to the layout.
         /// </summary>
         /// <param name="element">The element.</param>
@@ -1245,6 +2265,18 @@ namespace FlaxEditor.CustomEditors
 
         /// <inheritdoc />
         public override Control Control => ContainerControl;
+
+        /// <summary>
+        /// Implicit cast using LayoutElementsContrainer.Control
+        /// </summary>
+        /// <param name="layoutElement"></param>
+        public static implicit operator Control(LayoutElementsContainer layoutElement) => layoutElement?.Control;
+
+        /// <summary>
+        /// Implicit cast using LayoutElementsContrainer.ContainerControl
+        /// </summary>
+        /// <param name="layoutElement"></param>
+        public static implicit operator ContainerControl(LayoutElementsContainer layoutElement) => layoutElement?.ContainerControl;
 
     }
 }

--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -172,6 +172,7 @@ namespace FlaxEditor.CustomEditors
             Editor.Instance.ProjectCache.SetCollapsedGroup(panel.HeaderText, panel.IsClosed);
         }
 
+
         #region HorizontalPanel
 
         /// <summary>
@@ -2136,6 +2137,205 @@ namespace FlaxEditor.CustomEditors
 
         #endregion
 
+        #region Element
+
+        /// <summary>
+        /// Adds a new element
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The created element.</returns>
+        public virtual T Element<T>() 
+            where T : LayoutElement
+        {
+            var element = Activator.CreateInstance(typeof(T), true) as T;
+            AddElement(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new element
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public virtual T Element<T>(Action<T> onAdd)
+           where T : LayoutElement
+        {
+            var element = Activator.CreateInstance(typeof(T), true) as T;
+            AddElement(element,onAdd);
+            return element;
+        }
+
+        #endregion
+
+        #region Split
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement1"></typeparam>
+        /// <typeparam name="TElement2"></typeparam>
+        /// <param name="orientation">The orientation.</param>  
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement1,TElement2> SplitContainer<TElement1, TElement2>(Orientation orientation) 
+            where TElement1 : LayoutElement
+            where TElement2 : LayoutElement
+        {
+            var element = new SplitElement<TElement1, TElement2>(orientation);
+            AddElement(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement1"></typeparam>
+        /// <typeparam name="TElement2"></typeparam>
+        /// <param name="orientation">The orientation.</param>  
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement1, TElement2> SplitContainer<TElement1, TElement2>(Orientation orientation, Action<SplitElement<TElement1, TElement2>> onAdd)
+            where TElement1 : LayoutElement
+            where TElement2 : LayoutElement
+        {
+            var element = new SplitElement<TElement1, TElement2>(orientation);
+            AddElement(element,onAdd);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement1"></typeparam>
+        /// <typeparam name="TElement2"></typeparam>
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement1, TElement2> SplitContainer
+            <TElement1, TElement2>()
+           where TElement1 : LayoutElement
+           where TElement2 : LayoutElement
+        {
+            var element = SplitContainer<TElement1, TElement2>(Orientation.Horizontal);         
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement1"></typeparam>
+        /// <typeparam name="TElement2"></typeparam>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement1, TElement2> SplitContainer<TElement1, TElement2>(Action<SplitElement<TElement1, TElement2>> onAdd)
+            where TElement1 : LayoutElement
+            where TElement2 : LayoutElement
+        {
+            var element = SplitContainer<TElement1, TElement2>(Orientation.Horizontal, onAdd);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement"></typeparam>
+        /// <param name="orientation">The orientation.</param>  
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement, TElement> SplitContainer<TElement>(Orientation orientation)
+            where TElement : LayoutElement
+        {
+            var element = SplitContainer<TElement, TElement>(orientation);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement"></typeparam>
+        /// <param name="orientation">The orientation.</param>  
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement, TElement> SplitContainer<TElement>(Orientation orientation, Action<SplitElement<TElement, TElement>> onAdd)
+            where TElement : LayoutElement
+        {
+            var element = SplitContainer<TElement, TElement>(orientation, onAdd);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement"></typeparam>
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement, TElement> SplitContainer<TElement>()
+            where TElement : LayoutElement
+        {
+            var element = SplitContainer<TElement, TElement>(Orientation.Horizontal);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split container element
+        /// </summary>
+        /// <typeparam name="TElement"></typeparam>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SplitElement<TElement, TElement> SplitContainer<TElement>(Action<SplitElement<TElement, TElement>> onAdd)
+            where TElement : LayoutElement
+        {
+            var element = SplitContainer<TElement,TElement>(Orientation.Horizontal, onAdd);
+            return element;
+        }
+
+        #endregion
+
+        #region SplitPanel
+
+        /// <summary>
+        /// Adds a new split panel element
+        /// </summary>    
+        /// <param name="orientation">The orientation.</param>  
+        /// <returns>The created element.</returns>
+        public SplitPanelElement SplitPanel(Orientation orientation)         
+        {
+            var element = new SplitPanelElement(orientation);
+            AddElement(element);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split panel element
+        /// </summary>    
+        /// <param name="orientation">The orientation.</param>  
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SplitPanelElement SplitPanel(Orientation orientation, Action<SplitPanelElement> onAdd)
+        {
+            var element = new SplitPanelElement(orientation);
+            AddElement(element,onAdd);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split panel element
+        /// </summary>    
+        /// <returns>The created element.</returns>
+        public SplitPanelElement SplitPanel()
+        {
+            var element = SplitPanel(Orientation.Horizontal);
+            return element;
+        }
+
+        /// <summary>
+        /// Adds a new split panel element
+        /// </summary>    
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The created element.</returns>
+        public SplitPanelElement SplitPanel(Action<SplitPanelElement> onAdd)
+        {
+            var element = SplitPanel(Orientation.Horizontal, onAdd);
+            return element;
+        }
+
+        #endregion
 
 
         private PropertiesListElement AddPropertyItem()

--- a/Source/Engine/UI/GUI/ContainerControl.cs
+++ b/Source/Engine/UI/GUI/ContainerControl.cs
@@ -260,6 +260,21 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
+        /// Gets child control at given index.
+        /// </summary>
+        /// <param name="index">The control index.</param>
+        /// <param name="onGet">Invoked after child retrieved.</param>
+        /// <param name="onFail">Invoked if failed to retrieve child.</param>
+        /// <returns>The child control.</returns>
+        public Control GetChild(int index, Action<Control> onGet, Action onFail = null)
+        {
+            var result = GetChild(index);
+            if (result != null) onGet?.Invoke(result);
+            else onFail?.Invoke();
+            return result;
+        }
+
+        /// <summary>
         /// Searches for a child control of a specific type. If there are multiple controls matching the type, only the first one found is returned.
         /// </summary>
         /// <typeparam name="T">The type of the control to search for. Includes any controls derived from the type.</typeparam>
@@ -274,6 +289,21 @@ namespace FlaxEngine.GUI
                     return (T)_children[i];
             }
             return null;
+        }
+
+        /// <summary>
+        /// Searches for a child control of a specific type. If there are multiple controls matching the type, only the first one found is returned.
+        /// </summary>
+        /// <typeparam name="T">The type of the control to search for. Includes any controls derived from the type.</typeparam>
+        /// <param name="onGet">Invoked after child retrieved.</param>
+        /// <param name="onFail">Invoked if failed to retrieve child.</param>
+        /// <returns>The control instance if found, otherwise null.</returns>
+        public T GetChild<T>(Action<T> onGet, Action onFail) where T : Control
+        {
+            var result = GetChild<T>();
+            if (result != null) onGet?.Invoke(result);
+            else onFail?.Invoke();
+            return result;
         }
 
         /// <summary>
@@ -348,6 +378,21 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
+        /// Tries to find any child control at given point in control local coordinates
+        /// </summary>
+        /// <param name="point">The local point to check.</param>
+        /// <param name="onGet">Invoked after child retrieved.</param>
+        /// <param name="onFail">Invoked if failed to retrieve child.</param>
+        /// <returns>The found control or null.</returns>
+        public Control GetChildAt(Float2 point, Action<Control> onGet, Action onFail = null)
+        {
+            Control result = GetChildAt(point);
+            if (result != null) onGet?.Invoke(result);
+            else onFail?.Invoke();
+            return result;
+        }
+
+        /// <summary>
         /// Tries to find valid child control at given point in control local coordinates. Uses custom callback method to test controls to pick.
         /// </summary>
         /// <param name="point">The local point to check.</param>
@@ -367,6 +412,22 @@ namespace FlaxEngine.GUI
                     break;
                 }
             }
+            return result;
+        }
+
+        /// <summary>
+        /// Tries to find valid child control at given point in control local coordinates. Uses custom callback method to test controls to pick.
+        /// </summary>
+        /// <param name="point">The local point to check.</param>
+        /// <param name="isValid">The control validation callback.</param>
+        /// <param name="onGet">Invoked after child retrieved.</param>
+        /// <param name="onFail">Invoked if failed to retrieve child.</param>
+        /// <returns>The found control or null.</returns>
+        public Control GetChildAt(Float2 point, Func<Control, bool> isValid, Action<Control> onGet, Action onFail = null)
+        {
+            var result = GetChildAt(point, isValid);
+            if (result != null) onGet?.Invoke(result);
+            else onFail?.Invoke();
             return result;
         }
 
@@ -393,6 +454,18 @@ namespace FlaxEngine.GUI
                     break;
                 }
             }
+            return result;
+        }
+
+        /// Tries to find lowest child control at given point in control local coordinates.
+        /// </summary>
+        /// <param name="point">The local point to check.</param>
+        /// <returns>The found control or null.</returns>
+        public Control GetChildAtRecursive(Float2 point, Action<Control> onGet, Action onFail = null)
+        {
+            var result = GetChildAtRecursive(point);
+            if (result != null) onGet?.Invoke(result);
+            else onFail?.Invoke();
             return result;
         }
 

--- a/Source/Engine/UI/GUI/ContainerControl.cs
+++ b/Source/Engine/UI/GUI/ContainerControl.cs
@@ -183,6 +183,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Creates a new control and adds it to the container.
         /// </summary>
+        /// <typeparam name="T"></typeparam>
         /// <returns>The added control.</returns>
         public T AddChild<T>() where T : Control
         {
@@ -194,6 +195,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Adds the control to the container.
         /// </summary>
+        /// <typeparam name="T"></typeparam>
         /// <param name="child">The control to add.</param>
         /// <returns>The added control.</returns>
         public T AddChild<T>(T child) where T : Control
@@ -212,6 +214,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Creates a new control and adds it to the container.
         /// </summary>
+        /// <typeparam name="T"></typeparam>
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The added control.</returns>
         public T AddChild<T>(Action<T> onAdd) where T : Control
@@ -224,6 +227,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Adds the control to the container.
         /// </summary>
+        /// <typeparam name="T"></typeparam>
         /// <param name="child">The control to add.</param>
         /// <param name="onAdd">Invoke after child is added.</param>
         /// <returns>The added control.</returns>
@@ -233,6 +237,32 @@ namespace FlaxEngine.GUI
             onAdd?.Invoke(child);
             return child;
         }
+
+        
+       /// <summary>
+       /// Adds the control to the container.
+       /// </summary>
+       /// <param name="child">The control to add.</param>
+       /// <returns>The added control.</returns>
+       public Control AddChild(Control child)
+       {
+           child.Parent = this;
+           return child;
+       }
+
+       /// <summary>
+       /// Adds the control to the container.
+       /// </summary>
+       /// <param name="child">The control to add.</param>
+       /// <param name="onAdd">Invoke after child is added.</param>
+       /// <returns>The added control.</returns>
+       public Control AddChild(Control child, Action<Control> onAdd)
+       {
+           AddChild(child);
+           onAdd?.Invoke(child);
+           return child;
+       }
+       
 
         /// <summary>
         /// Removes control from the container.
@@ -457,9 +487,12 @@ namespace FlaxEngine.GUI
             return result;
         }
 
+        /// <summary>
         /// Tries to find lowest child control at given point in control local coordinates.
         /// </summary>
         /// <param name="point">The local point to check.</param>
+        /// <param name="onGet">Invoked after child retrieved.</param>
+        /// <param name="onFail">Invoked if failed to retrieve child.</param>
         /// <returns>The found control or null.</returns>
         public Control GetChildAtRecursive(Float2 point, Action<Control> onGet, Action onFail = null)
         {

--- a/Source/Engine/UI/GUI/ContainerControl.cs
+++ b/Source/Engine/UI/GUI/ContainerControl.cs
@@ -210,6 +210,31 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
+        /// Creates a new control and adds it to the container.
+        /// </summary>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The added control.</returns>
+        public T AddChild<T>(Action<T> onAdd) where T : Control
+        {
+            var child = AddChild<T>();
+            onAdd?.Invoke(child);
+            return child;
+        }
+
+        /// <summary>
+        /// Adds the control to the container.
+        /// </summary>
+        /// <param name="child">The control to add.</param>
+        /// <param name="onAdd">Invoke after child is added.</param>
+        /// <returns>The added control.</returns>
+        public T AddChild<T>(T child, Action<T> onAdd) where T : Control
+        {
+            AddChild<T>(child);
+            onAdd?.Invoke(child);
+            return child;
+        }
+
+        /// <summary>
         /// Removes control from the container.
         /// </summary>
         /// <param name="child">The control to remove.</param>

--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -5,9 +5,81 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// GUI control that contains two child panels and the splitter between them.
     /// </summary>
+    /// <seealso cref="FlaxEngine.GUI.SplitContainer{Panel,Panel}" />
+    [HideInEditor]
+    public class SplitPanel : SplitContainer<Panel,Panel>
+    {
+        /// <summary>
+        /// The first panel (left or upper based on Orientation).
+        /// </summary>
+        public Panel Panel1 => Control1;
+
+        /// <summary>
+        /// The second panel.
+        /// </summary>
+        public Panel Panel2 => Control2;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitPanel"/> class.
+        /// </summary>
+        /// <param name="orientation">The orientation.</param>
+        /// <param name="panel1Scroll">The panel1 scroll bars.</param>
+        /// <param name="panel2Scroll">The panel2 scroll bars.</param>
+        public SplitPanel(Orientation orientation = Orientation.Horizontal, ScrollBars panel1Scroll = ScrollBars.Both, ScrollBars panel2Scroll = ScrollBars.Both) : 
+            base(new Panel(panel1Scroll), new Panel(panel2Scroll),orientation)
+        {       
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitPanel"/> class.
+        /// </summary>
+        /// <param name="panel1">The first panel.</param>
+        /// <param name="panel2">The second panel.</param>
+        /// <param name="orientation">The orientation.</param>     
+        public SplitPanel(Panel panel1, Panel panel2, Orientation orientation = Orientation.Horizontal) :
+            base(panel1, panel2, orientation)
+        {
+        }
+    }
+
+    /// <summary>
+    /// GUI control that contains two child controls and the splitter between them.
+    /// </summary>
+    /// <seealso cref="FlaxEngine.GUI.SplitContainer{Control,Control}" />
+    [HideInEditor]
+    public class SplitContainer : SplitContainer<Control,Control>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitContainer"/> class.
+        /// </summary>
+        /// <param name="orientation">The orientation.</param>      
+        public SplitContainer(Orientation orientation = Orientation.Horizontal) :
+            base(orientation)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitPanel"/> class.
+        /// </summary>
+        /// <param name="control1">The first control.</param>
+        /// <param name="control2">The second control.</param>
+        /// <param name="orientation">The orientation.</param>     
+        public SplitContainer(Control control1, Control control2, Orientation orientation = Orientation.Horizontal) :
+            base(control1, control2, orientation)
+        {
+        }
+
+    }
+
+
+    /// <summary>
+    /// GUI control that contains two child controls and the splitter between them.
+    /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
     [HideInEditor]
-    public class SplitPanel : ContainerControl
+    public class SplitContainer<TControl1, TControl2> : ContainerControl
+        where TControl1 : Control
+        where TControl2 : Control
     {
         /// <summary>
         /// The splitter size (in pixels).
@@ -26,14 +98,14 @@ namespace FlaxEngine.GUI
         private bool _cursorChanged;
 
         /// <summary>
-        /// The first panel (left or upper based on Orientation).
+        /// The first control (left or upper based on Orientation).
         /// </summary>
-        public readonly Panel Panel1;
+        public readonly TControl1 Control1;
 
         /// <summary>
-        /// The second panel.
+        /// The second control.
         /// </summary>
-        public readonly Panel Panel2;
+        public readonly TControl2 Control2;
 
         /// <summary>
         /// Gets or sets the panel orientation.
@@ -80,23 +152,43 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SplitPanel"/> class.
+        /// Initializes a new instance of the <see cref="SplitContainer{TControl1,TControl2}"/> class.
         /// </summary>
+        /// <param name="control1">The first conrol.</param>
+        /// <param name="control2">The second conrol.</param>
         /// <param name="orientation">The orientation.</param>
-        /// <param name="panel1Scroll">The panel1 scroll bars.</param>
-        /// <param name="panel2Scroll">The panel2 scroll bars.</param>
-        public SplitPanel(Orientation orientation = Orientation.Horizontal, ScrollBars panel1Scroll = ScrollBars.Both, ScrollBars panel2Scroll = ScrollBars.Both)
+        public SplitContainer(TControl1 control1, TControl2 control2, Orientation orientation = Orientation.Horizontal)
         {
             AutoFocus = false;
 
             _orientation = orientation;
             _splitterValue = 0.5f;
 
-            Panel1 = new Panel(panel1Scroll);
-            Panel2 = new Panel(panel2Scroll);
+            Control1 = control1;
+            Control2 = control2;
 
-            Panel1.Parent = this;
-            Panel2.Parent = this;
+            Control1.Parent = this;
+            Control2.Parent = this;
+
+            UpdateSplitRect();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitPanel"/> class.
+        /// </summary>
+        /// <param name="orientation">The orientation.</param>       
+        public SplitContainer(Orientation orientation = Orientation.Horizontal)
+        {
+            AutoFocus = false;
+
+            _orientation = orientation;
+            _splitterValue = 0.5f;
+
+            Control1 = System.Activator.CreateInstance(typeof(TControl1), true) as TControl1;
+            Control2 = System.Activator.CreateInstance(typeof(TControl2), true) as TControl2;
+
+            Control1.Parent = this;
+            Control2.Parent = this;
 
             UpdateSplitRect();
         }
@@ -242,14 +334,14 @@ namespace FlaxEngine.GUI
             if (_orientation == Orientation.Horizontal)
             {
                 var split = Mathf.RoundToInt(_splitterValue * Width);
-                Panel1.Bounds = new Rectangle(0, 0, split - SplitterSizeHalf, Height);
-                Panel2.Bounds = new Rectangle(split + SplitterSizeHalf, 0, Width - split - SplitterSizeHalf, Height);
+                Control1.Bounds = new Rectangle(0, 0, split - SplitterSizeHalf, Height);
+                Control2.Bounds = new Rectangle(split + SplitterSizeHalf, 0, Width - split - SplitterSizeHalf, Height);
             }
             else
             {
                 var split = Mathf.RoundToInt(_splitterValue * Height);
-                Panel1.Bounds = new Rectangle(0, 0, Width, split - SplitterSizeHalf);
-                Panel2.Bounds = new Rectangle(0, split + SplitterSizeHalf, Width, Height - split - SplitterSizeHalf);
+                Control1.Bounds = new Rectangle(0, 0, Width, split - SplitterSizeHalf);
+                Control2.Bounds = new Rectangle(0, split + SplitterSizeHalf, Width, Height - split - SplitterSizeHalf);
             }
         }
     }


### PR DESCRIPTION
Additional functionally added to Control and LayoutElement API

Implicit conversion between LayoutElement and Control base types.
`
void ImplicitConverionToControlBaseTypes(ContainerControl containerControl) 
{
    Control control;
    ContainerControl controlContainer;

    var buttonElement = new ButtonElement();
    var verticalPanelElement = new VerticalPanelElement();

    control = buttonElement;
    controlContainer = verticalPanelElement;

    containerControl.AddChild(buttonElement);
    controlContainer.AddChild(verticalPanelElement);
}
`

Action<T> callback overloads for all Add type methods for ContainerControl and LayoutElementsContainer.
This required refactoring the original overloads to not use default parameters.
`
void OnAddLayoutElementsCallbacks(LayoutElementsContainer layout) 
{
    var horizontalPanel = layout.HorizontalPanel((panel) => 
    {
        //do some stuff
        panel.VerticalPanel((panel) =>
        {
           //add elements
        });

        panel.VerticalPanel((panel) =>
        {
            //add elements
        });
    });          
}

void OnAddControlCallbacks() 
{
    var control = new Control();
    var containerControl = new ContainerControl();

    containerControl.AddChild(control, (control) =>
    {
        //do some stuff
    });
}
`

SplitPanel has now been refactored to inheriti from generic SplitContainer<T1,T2>.
SplitElement added and create Method "Split" added to LayoutElementsContainer.
`
void SpitContainerFeature() 
{
    var splitContainer = new SplitContainer<GridPanel,VerticalPanel>(Orientation.Horizontal);
}


void SplitPanelAdditionConstructor()
{
    var panel1 = new Panel(ScrollBars.Vertical);
    var panel2 = new Panel(ScrollBars.Vertical);
    var splitPanel = new SplitPanel(panel1, panel2, Orientation.Horizontal);
}

void SplitPanelAndContainerElements(LayoutElementsContainer layout) 
{
   var splitPanel = layout.Split();
   var splitContainer1 = layout.Split<VerticalPanelElement>();
   var splitContainer2 = layout.Split<GroupElement,VerticalPanelElement>();      
}
`

Generic create element method Element<T> added to LayoutElementsContainer.
` 
void GenericElementMethod(LayoutElementsContainer layout) 
 {
     var element = layout.Element<VerticalPanelElement>();
 }
 `

AddChild function method added to match ContainerControl that adds and element and returns it.
` 
void LayoutElementsContaineReturningAdd(LayoutElementsContainer layout)
 {
     var element = layout.AddChild(new GroupElement());

 }
 `
