### PR TITLE
Add to be able to specify order of plugin initialization and deinitialization.

### DIFF
--- a/Source/Engine/Scripting/Attributes/PluginLoadOrder.cs
+++ b/Source/Engine/Scripting/Attributes/PluginLoadOrder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace FlaxEngine;
+
+/// <summary>
+/// This attribute allows for specifying initialization and deinitialization order for plugins
+/// </summary>
+[Serializable]
+[AttributeUsage(AttributeTargets.Class)]
+public class PluginLoadOrderAttribute : Attribute
+{
+    /// <summary>
+    /// The plugin type to initialize this plugin after.
+    /// </summary>
+    public Type InitializeAfter;
+
+    /// <summary>
+    /// The plugin type to deinitialize this plugin before.
+    /// </summary>
+    public Type DeinitializeBefore;
+}


### PR DESCRIPTION
I am sure that this can be simplified quite a bit... but this lets the user specify via a attribute to initialize a plugin after another plugin and deinitialize a plugin before another plugin. This allows for plugins to depend on other plugins. I am sure that this adds some overhead and has some edge cases.

`[PluginLoadOrder(InitializeAfter = typeof(TestPlugin4), DeinitializeBefore = typeof(TestPlugin4))]`