### PR TITLE
Make the message box a TASKMODEL to prevent interaction with the editor and other windows.

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -451,6 +451,7 @@ DialogResult MessageBox::Show(Window* parent, const StringView& text, const Stri
     default:
         break;
     }
+    flags |= MB_TASKMODAL;
 
     // Show dialog
     int result = MessageBoxW(parent ? static_cast<HWND>(parent->GetNativePtr()) : nullptr, String(text).GetText(), String(caption).GetText(), flags);


### PR DESCRIPTION
Fixes #1721 
This adds the MB_TASKMODEL flag to the message box, which prevents any interaction with the editor and any opened windows until the message box is dealt with by the user. Another option would be to use MB_TOPMOST but that will cause the message box to be hidden again when attempting to move opened windows, like the material graph.
Windows only, not sure if the linked issue also affects Linux or macOS.