### PR TITLE
Fix some Center geometry import issues. Add being able to shift mesh to local origin.

### DIFF
--- a/Source/Engine/Graphics/Models/ModelData.h
+++ b/Source/Engine/Graphics/Models/ModelData.h
@@ -103,7 +103,7 @@ public:
     /// <summary>
     /// Meshes scaling.
     /// </summary>
-    Vector3 Scaling = Vector3(1);
+    Vector3 Scaling = Vector3::One;
 
 public:
     /// <summary>

--- a/Source/Engine/Graphics/Models/ModelData.h
+++ b/Source/Engine/Graphics/Models/ModelData.h
@@ -90,6 +90,21 @@ public:
     /// </summary>
     Array<BlendShape> BlendShapes;
 
+    /// <summary>
+    /// Global translation for this mesh to be at it's local origin.
+    /// </summary>
+    Vector3 OriginTranslation = Vector3::Zero;
+
+    /// <summary>
+    /// Orientation for this mesh at it's local origin.
+    /// </summary>
+    Quaternion OriginOrientation = Quaternion::Identity;
+
+    /// <summary>
+    /// Meshes scaling.
+    /// </summary>
+    Vector3 Scaling = Vector3(1);
+
 public:
     /// <summary>
     /// Determines whether this instance has any mesh data.

--- a/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
-#include "OpenFBX/ofbx.h"
 #if COMPILE_WITH_MODEL_TOOL && USE_ASSIMP
 
 #include "ModelTool.h"

--- a/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
@@ -654,8 +654,6 @@ bool ImportMesh(int32 i, ImportedModelData& result, AssimpImporterData& data, St
     Array<Transform> points;
     if (root->mNumChildren == 0)
     {
-        //auto translation = ToMatrix(root->mTransformation).GetTranslation();
-        //points.Add(Vector3(translation.X, translation.Y, translation.Z));
         aiQuaternion aiQuat;
         aiVector3D aiPos;
         aiVector3D aiScale;
@@ -670,8 +668,6 @@ bool ImportMesh(int32 i, ImportedModelData& result, AssimpImporterData& data, St
     {
         for (unsigned int j = 0; j < root->mNumChildren; j++)
         {
-            //auto translation = ToMatrix(root->mChildren[j]->mTransformation).GetTranslation();
-            //points.Add(Vector3(translation.X, translation.Y, -translation.Z));
             aiQuaternion aiQuat;
             aiVector3D aiPos;
             aiVector3D aiScale;

--- a/Source/Engine/Tools/ModelTool/ModelTool.OpenFBX.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.OpenFBX.cpp
@@ -836,6 +836,21 @@ bool ProcessMesh(ImportedModelData& result, OpenFbxImporterData& data, const ofb
         mesh.TransformBuffer(geometryTransform);
     }*/
 
+    // Get local transform for origin shifting translation
+    auto translation = ToMatrix(aMesh->getGlobalTransform()).GetTranslation();
+    auto scale = data.GlobalSettings.UnitScaleFactor;
+    if (data.GlobalSettings.CoordAxis == ofbx::CoordSystem_RightHanded)
+        mesh.OriginTranslation = scale * Vector3(translation.X, translation.Y, -translation.Z);
+    else
+        mesh.OriginTranslation = scale * Vector3(translation.X, translation.Y, translation.Z);
+    
+    auto rot = aMesh->getLocalRotation();
+    auto quat = Quaternion::Euler(-(float)rot.x, -(float)rot.y, -(float)rot.z);
+    mesh.OriginOrientation = quat;
+
+    auto scaling = aMesh->getLocalScaling();
+    auto scaleFactor = data.GlobalSettings.UnitScaleFactor;
+    mesh.Scaling = Vector3(scaleFactor * (float)scaling.x, scaleFactor * (float)scaling.y, scaleFactor * (float)scaling.z);
     return false;
 }
 

--- a/Source/Engine/Tools/ModelTool/ModelTool.OpenFBX.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.OpenFBX.cpp
@@ -849,8 +849,7 @@ bool ProcessMesh(ImportedModelData& result, OpenFbxImporterData& data, const ofb
     mesh.OriginOrientation = quat;
 
     auto scaling = aMesh->getLocalScaling();
-    auto scaleFactor = data.GlobalSettings.UnitScaleFactor;
-    mesh.Scaling = Vector3(scaleFactor * (float)scaling.x, scaleFactor * (float)scaling.y, scaleFactor * (float)scaling.z);
+    mesh.Scaling = Vector3(scale * (float)scaling.x, scale * (float)scaling.y, scale * (float)scaling.z);
     return false;
 }
 

--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -372,6 +372,7 @@ void ModelTool::Options::Serialize(SerializeStream& stream, const void* otherObj
     SERIALIZE(Scale);
     SERIALIZE(Rotation);
     SERIALIZE(Translation);
+    SERIALIZE(UseLocalOrigin);
     SERIALIZE(CenterGeometry);
     SERIALIZE(Duration);
     SERIALIZE(FramesRange);
@@ -418,6 +419,7 @@ void ModelTool::Options::Deserialize(DeserializeStream& stream, ISerializeModifi
     DESERIALIZE(Scale);
     DESERIALIZE(Rotation);
     DESERIALIZE(Translation);
+    DESERIALIZE(UseLocalOrigin);
     DESERIALIZE(CenterGeometry);
     DESERIALIZE(Duration);
     DESERIALIZE(FramesRange);
@@ -1089,11 +1091,16 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
 
     // Prepare import transformation
     Transform importTransform(options.Translation, options.Rotation, Float3(options.Scale));
+    if (options.UseLocalOrigin && data.LODs.HasItems() && data.LODs[0].Meshes.HasItems())
+    {
+        importTransform.Translation -= importTransform.Orientation * data.LODs[0].Meshes[0]->OriginTranslation * importTransform.Scale;
+    }
     if (options.CenterGeometry && data.LODs.HasItems() && data.LODs[0].Meshes.HasItems())
     {
         // Calculate the bounding box (use LOD0 as a reference)
         BoundingBox box = data.LODs[0].GetBox();
-        importTransform.Translation -= box.GetCenter();
+        auto center = data.LODs[0].Meshes[0]->OriginOrientation * importTransform.Orientation * box.GetCenter() * importTransform.Scale * data.LODs[0].Meshes[0]->Scaling;
+        importTransform.Translation -= center;
     }
     const bool applyImportTransform = !importTransform.IsIdentity();
 

--- a/Source/Engine/Tools/ModelTool/ModelTool.h
+++ b/Source/Engine/Tools/ModelTool/ModelTool.h
@@ -279,8 +279,11 @@ public:
         // Custom import geometry offset.
         API_FIELD(Attributes="EditorOrder(520), EditorDisplay(\"Transform\")")
         Float3 Translation = Float3::Zero;
-        // If checked, the imported geometry will be shifted to the center of mass.
+        // If checked, the imported geometry will be shifted to its local transform origin.
         API_FIELD(Attributes="EditorOrder(530), EditorDisplay(\"Transform\")")
+        bool UseLocalOrigin = false;
+        // If checked, the imported geometry will be shifted to the center of mass.
+        API_FIELD(Attributes="EditorOrder(540), EditorDisplay(\"Transform\")")
         bool CenterGeometry = false;
 
     public: // Animation


### PR DESCRIPTION
Center geometry was not scaling or rotating correctly, this should fix those issues (I am sure there are edge cases). This also adds an option called `UseLocalOrigin` which moves the mesh to use it's local origin.