### PR TITLE
Change rename popup length to only go to panel edge

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -266,7 +266,7 @@ namespace FlaxEditor.SceneGraph.GUI
         /// <summary>
         /// Starts the actor renaming action.
         /// </summary>
-        public void StartRenaming(EditorWindow window)
+        public void StartRenaming(EditorWindow window, Panel treePanel)
         {
             // Block renaming during scripts reload
             if (Editor.Instance.ProgressReporting.CompileScripts.IsActive)
@@ -281,7 +281,10 @@ namespace FlaxEditor.SceneGraph.GUI
                 (window as PrefabWindow).ScrollingOnTreeView(false);
 
             // Start renaming the actor
-            var dialog = RenamePopup.Show(this, TextRect, _actorNode.Name, false);
+            treePanel.ScrollViewTo(this, true);
+            var size = new Float2(treePanel.Width - TextRect.Location.X, TextRect.Height);
+            var rect = new Rectangle(TextRect.Location, size);
+            var dialog = RenamePopup.Show(this, rect, _actorNode.Name, false);
             dialog.Renamed += OnRenamed;
             dialog.Closed += popup =>
             {

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -339,7 +339,7 @@ namespace FlaxEditor.Windows.Assets
             {
                 if (selection.Count != 0)
                     Select(actor);
-                actor.TreeNode.StartRenaming(this);
+                actor.TreeNode.StartRenaming(this, _treePanel);
             }
         }
 

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -142,7 +142,7 @@ namespace FlaxEditor.Windows
             {
                 if (selection.Count != 0)
                     Editor.SceneEditing.Select(actor);
-                actor.TreeNode.StartRenaming(this);
+                actor.TreeNode.StartRenaming(this, _sceneTreePanel);
             }
         }
 


### PR DESCRIPTION
Limit the scene tree and prefab tree rename popup to only go to panel right edge. #1806