### PR TITLE
Ensure layer confirmation does not popup in play mode.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ActorLayerEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorLayerEditor.cs
@@ -34,7 +34,7 @@ namespace FlaxEditor.CustomEditors.Editors
                 value = 0;
 
             // If selected is single actor that has children, ask if apply layer to the sub objects as well
-            if (Values.IsSingleObject && (int)Values[0] != value && ParentEditor.Values[0] is Actor actor && actor.HasChildren)
+            if (Values.IsSingleObject && (int)Values[0] != value && ParentEditor.Values[0] is Actor actor && actor.HasChildren && !Editor.IsPlayMode)
             {
                 var valueText = comboBox.SelectedItem;
 


### PR DESCRIPTION
Link <https://discord.com/channels/437989205315158016/438021321134309377/1166835261469106236>

I personally dont have this issue and can not reproduce it, but this should fix it for them. This would prevent the player from easily changing the layer type of all children when the game is in play mode... so not sure if there is a better way...