### PR TITLE
Allow quick creation of scripts.

### DIFF
--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -189,6 +189,8 @@ namespace FlaxEditor.GUI
         /// </summary>
         public event Action<Item> ItemClicked;
 
+        public event Action<string> TextChanged;
+
         /// <summary>
         /// The panel control where you should add your items.
         /// </summary>
@@ -263,6 +265,7 @@ namespace FlaxEditor.GUI
             UnlockChildrenRecursive();
             PerformLayout(true);
             _searchBox.Focus();
+            TextChanged?.Invoke(_searchBox.Text);
         }
 
         /// <summary>


### PR DESCRIPTION
Implements #1820

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/aea9b0b4-ebaf-469a-b736-66c0142259cc

This allows for quick creation and attachment of scripts when clicking the "Add script" button in the properties window for an Actor. I am not at all happy with this implementation for a couple of reasons:
- The Editor has no knowledge about which modules exist and are active. As such, we have to resort to hacky solutions by manually scanning the target files and search for strings, which *might* indicate what modules are available. This PR reads all *.Build.cs files in the source directory and scans for the "Modules.Add" string to see if the Game module exists. But what happens if a user modifies their build script as such:
```cs
var mods = Modules;
mods.Add(
"Game");
```
Ideally, the editor would have a list of active modules, their names, their paths, if they are editor modules or not etc.
- There is no "main" game module. All modules are treated equally and maybe that's a good thing. But this makes it harder to make certain assumptions. In this case, we could assume that newly created scripts, not including ones created from the Content Window, would be put inside the "main" module. Right now, because all the project templates create a "Game" module, i treat it as the "main" module and if it is not available i ask the user to pick a module folder.
- The ScriptsEditor is destroyed after scripts compilation, because the editor "reloads", and it becomes impossible to keep some data around, like the script name. I decided to make a static variable but i don't like it.

I'm not sure if this should be merged but i decided to open this PR to highlight some of these problems.