### PR TITLE
Fix color picker dialog not staying inside the current screen.

### DIFF
--- a/Source/Editor/GUI/Dialogs/Dialog.cs
+++ b/Source/Editor/GUI/Dialogs/Dialog.cs
@@ -40,6 +40,11 @@ namespace FlaxEditor.GUI.Dialogs
         public DialogResult Result => _result;
 
         /// <summary>
+        /// Returns the size of the dialog.
+        /// </summary>
+        public Float2 DialogSize => _dialogSize;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Dialog"/> class.
         /// </summary>
         /// <param name="title">The title.</param>

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -470,13 +470,13 @@ namespace FlaxEditor.Modules
                 // Place dialog nearby the target control
                 var targetControlDesktopCenter = targetControl.PointToScreen(targetControl.Size * 0.5f);
                 var desktopSize = Platform.GetMonitorBounds(targetControlDesktopCenter);
-                var pos = targetControlDesktopCenter + new Float2(10.0f, -dialog.Height * 0.5f);
-                var dialogEnd = pos + dialog.Size;
+                var pos = targetControlDesktopCenter + new Float2(10.0f, -dialog.DialogSize.Y * 0.5f);
+                var dialogEnd = pos + dialog.DialogSize;
                 var desktopEnd = desktopSize.BottomRight - new Float2(10.0f);
                 if (dialogEnd.X >= desktopEnd.X || dialogEnd.Y >= desktopEnd.Y)
-                    pos = targetControl.PointToScreen(Float2.Zero) - new Float2(10.0f + dialog.Width, dialog.Height);
+                    pos = targetControl.PointToScreen(Float2.Zero) - new Float2(10.0f + dialog.DialogSize.X, dialog.DialogSize.Y);
                 var desktopBounds = Platform.VirtualDesktopBounds;
-                pos = Float2.Clamp(pos, desktopBounds.UpperLeft, desktopBounds.BottomRight - dialog.Size);
+                pos = Float2.Clamp(pos, desktopBounds.UpperLeft, desktopBounds.BottomRight - dialog.DialogSize);
                 dialog.RootWindow.Window.Position = pos;
 
                 // Register for context menu (prevent auto-closing context menu when selecting color)


### PR DESCRIPTION
Fixes #1851
Dialog resets(?) the bounds when calling the `Show` method, by setting the `Offsets` property to `Margin.Zero`, so accessing the `Size` property after calling `Show` will return incorrect data. I tried not setting the Offsets property but other dialogs rely on that behavior. I decided to add a new property for `Dialog` which returns the actual size stored in `_dialogSize` and use that when positioning the window.