### PR TITLE
Honor the XDG_DATA_HOME env var and use the approved default as per specification.

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
+++ b/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
@@ -679,8 +679,14 @@ void LinuxFileSystem::GetSpecialFolderPath(const SpecialFolder type, String& res
         result = TEXT("/usr/share");
         break;
     case SpecialFolder::LocalAppData:
-        result = home;
+    {
+        String dataHome;
+        if (!Platform::GetEnvironmentVariable(TEXT("XDG_DATA_HOME"), dataHome))
+            result = dataHome;
+        else
+            result = home / TEXT(".local/share");
         break;
+    }
     case SpecialFolder::ProgramData:
         result = String::Empty;
         break;


### PR DESCRIPTION
The current behavior pollutes the users' home directory by using it for local app data. This means a new directory will be created for every company that makes a game with Flax and releases it for Linux.

According to https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html `XDG_DATA_HOME` is to be used for user specific app data. Also, the .Net runtime uses the same default when requesting the `LocalApplicationData` special folder(not sure if it will respect the env var).