### PR TITLE
Fix anim slot from playing animations more than 1 time based on speed.

### DIFF
--- a/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
+++ b/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
@@ -2109,7 +2109,8 @@ void AnimGraphExecutor::ProcessGroupAnimation(Box* boxBase, Node* nodeBase, Valu
                 bucket.LoopsLeft--;
             bucket.LoopsDone++;
         }
-        value = SampleAnimation(node, loop, length, 0.0f, bucket.TimePosition, newTimePos, anim, slot.Speed);
+        // Speed is accounted for in the new time pos, so keep sample speed at 1
+        value = SampleAnimation(node, loop, length, 0.0f, bucket.TimePosition, newTimePos, anim, 1);
         bucket.TimePosition = newTimePos;
         if (bucket.LoopsLeft == 0 && slot.BlendOutTime > 0.0f && length - slot.BlendOutTime < bucket.TimePosition)
         {


### PR DESCRIPTION
Fix #1868. This should fix the issue of the animation playing more than once when the speed is greater than 1 for an anim slot at least it seems to fix it for me. I do recommend trying it out to make sure it works.