### PR TITLE
Add creating prefab from models.

### DIFF
--- a/Source/Editor/Content/Proxy/ModelProxy.cs
+++ b/Source/Editor/Content/Proxy/ModelProxy.cs
@@ -67,10 +67,10 @@ namespace FlaxEditor.Content
             });
             var createPrefabButton = menu.AddButton("Create Prefab");
             createPrefabButton.CloseMenuOnClick = false;
-            createPrefabButton.Clicked += () => OnCreatePrefab(createPrefabButton, item);
+            createPrefabButton.Clicked += () => OnCreatePrefabClicked(createPrefabButton, item);
         }
 
-        private void OnCreatePrefab(ContextMenuButton button, ContentItem item)
+        private void OnCreatePrefabClicked(ContextMenuButton button, ContentItem item)
         {
             var popup = new ContextMenuBase
             {

--- a/Source/Editor/Content/Proxy/ModelProxy.cs
+++ b/Source/Editor/Content/Proxy/ModelProxy.cs
@@ -65,6 +65,146 @@ namespace FlaxEditor.Content
                     collisionDataProxy.CreateCollisionDataFromModel(model);
                 }
             });
+            var createPrefabButton = menu.AddButton("Create Prefab");
+            createPrefabButton.CloseMenuOnClick = false;
+            createPrefabButton.Clicked += () => OnCreatePrefab(createPrefabButton, item);
+        }
+
+        private void OnCreatePrefab(ContextMenuButton button, ContentItem item)
+        {
+            var popup = new ContextMenuBase
+            {
+                Size = new Float2(170, 100),
+                ClipChildren = false,
+                CullChildren = false,
+            };
+            popup.Show(button, new Float2(button.Width, 0));
+
+            var centerModelsLabel = new Label
+            {
+                Parent = popup,
+                AnchorPreset = AnchorPresets.TopLeft,
+                Text = "Center Models",
+                HorizontalAlignment = TextAlignment.Near,
+            };
+            centerModelsLabel.LocalX += 10;
+            centerModelsLabel.LocalY += 10;
+
+            var centerModelsCb = new CheckBox()
+            {
+                Parent = popup,
+                AnchorPreset = AnchorPresets.TopLeft,
+            };
+            centerModelsCb.LocalX += 145;
+            centerModelsCb.LocalY += 10;
+
+            var origPosLabel = new Label
+            {
+                Parent = popup,
+                AnchorPreset = AnchorPresets.TopLeft,
+                Text = "Use original position",
+                HorizontalAlignment = TextAlignment.Near,
+            };
+            origPosLabel.LocalX += 10;
+            origPosLabel.LocalY += 35;
+
+            var origPosCb = new CheckBox
+            {
+                Parent = popup,
+                AnchorPreset = AnchorPresets.TopLeft,
+            };
+            origPosCb.LocalY += 35;
+            origPosCb.LocalX += 145;
+
+            var submitButton = new Button
+            {
+                Parent = popup,
+                AnchorPreset = AnchorPresets.TopLeft,
+                Text = "Create",
+                Width = 70,
+            };
+            submitButton.LocalX += 10;
+            submitButton.LocalY += 65;
+            submitButton.Clicked += () =>
+            {
+                CreatePrefab(item, centerModelsCb.Checked, origPosCb.Checked);
+                centerModelsCb.Checked = false;
+                origPosCb.Checked = false;
+                popup.Hide();
+                button.ParentContextMenu.Hide();
+            };
+
+            var cancelButton = new Button
+            {
+                Parent = popup,
+                AnchorPreset = AnchorPresets.TopLeft,
+                Text = "Cancel",
+                Width = 70,
+            };
+            cancelButton.LocalX += 90;
+            cancelButton.LocalY += 65;
+            cancelButton.Clicked += () =>
+            {
+                centerModelsCb.Checked = false;
+                origPosCb.Checked = false;
+                popup.Hide();
+                button.ParentContextMenu.Hide();
+            };
+        }
+
+        private void CreatePrefab(ContentItem item, bool centerModels, bool useOrigPos)
+        {
+            var selection = Editor.Instance.Windows.ContentWin.View.Selection;
+            if (selection.Count > 1)
+            {
+                var items = selection.ToArray();
+                var parentActor = new EmptyActor();
+                parentActor.Name = "Root";
+                Vector3 addedPositions = Vector3.Zero;
+                int positionsCount = 0;
+                foreach (var contentItem in items)
+                {
+                    if (contentItem is not ModelItem modelItem)
+                        continue;
+                    var model = FlaxEngine.Content.LoadAsync<Model>(modelItem.ID);
+                    model.WaitForLoaded();
+                    var staticModel = parentActor.AddChild<StaticModel>();
+                    staticModel.Name = modelItem.ShortName;
+                    staticModel.Model = model;
+                    if (useOrigPos)
+                    {
+                        var transform = model.OriginalTransform;
+                        staticModel.Position = transform.Translation;
+                    }
+                    addedPositions += staticModel.Position;
+                    positionsCount += 1;
+                }
+                if (centerModels)
+                {
+                    Vector3 avgPosition = addedPositions / positionsCount;
+                    foreach (var child in parentActor.Children)
+                        child.Position -= avgPosition;
+                }
+                Editor.Instance.Prefabs.CreatePrefab(parentActor);
+            }
+            else
+            {
+                var model = FlaxEngine.Content.LoadAsync<Model>(((ModelItem)item).ID);
+                model.WaitForLoaded();
+                var staticModel = new StaticModel
+                {
+                    Name = item.ShortName,
+                    Model = model
+                };
+                if (useOrigPos)
+                {
+                    var transform = model.OriginalTransform;
+                    staticModel.Position = transform.Translation;
+                }
+                if (centerModels)
+                    staticModel.Position -= staticModel.Box.Center;
+                Editor.Instance.Prefabs.CreatePrefab(staticModel);
+            }
         }
 
         /// <inheritdoc />

--- a/Source/Engine/Content/Assets/Model.cpp
+++ b/Source/Engine/Content/Assets/Model.cpp
@@ -914,6 +914,7 @@ Asset::LoadResult Model::load()
     // Amount of LODs
     byte lods;
     stream->ReadByte(&lods);
+    stream->ReadTransform(&_originalTransform);
     if (lods == 0 || lods > MODEL_MAX_LODS)
         return LoadResult::InvalidData;
     LODs.Resize(lods);

--- a/Source/Engine/Content/Assets/Model.h
+++ b/Source/Engine/Content/Assets/Model.h
@@ -4,6 +4,7 @@
 
 #include "ModelBase.h"
 #include "Engine/Graphics/Models/ModelLOD.h"
+#include "Engine/Core/Math/Transform.h"
 
 class Mesh;
 class StreamModelLODTask;

--- a/Source/Engine/Content/Assets/Model.h
+++ b/Source/Engine/Content/Assets/Model.h
@@ -13,12 +13,13 @@ class StreamModelLODTask;
 /// </summary>
 API_CLASS(NoSpawn) class FLAXENGINE_API Model : public ModelBase
 {
-    DECLARE_BINARY_ASSET_HEADER(Model, 25);
+    DECLARE_BINARY_ASSET_HEADER(Model, 26);
     friend Mesh;
     friend StreamModelLODTask;
 private:
     int32 _loadedLODs = 0;
     StreamModelLODTask* _streamingTask = nullptr;
+    Transform _originalTransform = Transform::Identity;
 
 public:
     /// <summary>
@@ -86,6 +87,14 @@ public:
     FORCE_INLINE bool CanBeRendered() const
     {
         return _loadedLODs > 0;
+    }
+
+    /// <summary>
+    /// Gets the original transform before importation.
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE Transform GetOriginalTransform() const
+    {
+        return _originalTransform;
     }
 
 public:

--- a/Source/Engine/Graphics/Models/ModelData.cpp
+++ b/Source/Engine/Graphics/Models/ModelData.cpp
@@ -713,6 +713,21 @@ bool ModelData::Pack2ModelHeader(WriteStream* stream) const
 
     // Amount of LODs
     stream->WriteByte(lodCount);
+    Transform originalTransform = Transform::Identity;
+    if (lodCount != 0)
+    {
+        if (LODs[0].Meshes.Count() != 0)
+        {
+            auto meshData = LODs[0].Meshes[0];
+            if (meshData)
+            {
+                originalTransform.Translation = meshData->OriginalTranslation;
+                originalTransform.Orientation = meshData->OriginOrientation;
+                originalTransform.Scale = meshData->Scaling;
+            }
+        }
+    }
+    stream->WriteTransform(originalTransform);
 
     // For each LOD
     for (int32 lodIndex = 0; lodIndex < lodCount; lodIndex++)

--- a/Source/Engine/Graphics/Models/ModelData.h
+++ b/Source/Engine/Graphics/Models/ModelData.h
@@ -105,6 +105,11 @@ public:
     /// </summary>
     Vector3 Scaling = Vector3::One;
 
+    /// <summary>
+    /// Original Transform.
+    /// </summary>
+    Vector3 OriginalTranslation = Vector3::Zero;
+
 public:
     /// <summary>
     /// Determines whether this instance has any mesh data.

--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -1096,6 +1096,7 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
     if (options.UseLocalOrigin && data.LODs.HasItems() && data.LODs[0].Meshes.HasItems())
     {
         importTransform.Translation -= importTransform.Orientation * data.LODs[0].Meshes[0]->OriginTranslation * importTransform.Scale;
+        data.LODs[0].Meshes[0]->OriginalTranslation = importTransform.Orientation * data.LODs[0].Meshes[0]->OriginTranslation * importTransform.Scale;
     }
     if (options.CenterGeometry && data.LODs.HasItems() && data.LODs[0].Meshes.HasItems())
     {
@@ -1103,6 +1104,7 @@ bool ModelTool::ImportModel(const String& path, ModelData& meshData, Options& op
         BoundingBox box = data.LODs[0].GetBox();
         auto center = data.LODs[0].Meshes[0]->OriginOrientation * importTransform.Orientation * box.GetCenter() * importTransform.Scale * data.LODs[0].Meshes[0]->Scaling;
         importTransform.Translation -= center;
+        data.LODs[0].Meshes[0]->OriginalTranslation += center;
     }
     const bool applyImportTransform = !importTransform.IsIdentity();
 


### PR DESCRIPTION
This adds an easy way to create a prefab from 1 or more models and adds the options to use the "before imported" positions and can center the models. I am sure there are plenty of edge cases and I only tested a few... so I am sure it could use more testing. This only really works well with models using local transform and/or being centered. Let me know if there is an easier way besides transferring the data through the model.

Simple create Prefab:

https://github.com/FlaxEngine/FlaxEngine/assets/71274967/36c24142-5aad-4518-827f-f0f303ef4983

Create prefab with original positions:

https://github.com/FlaxEngine/FlaxEngine/assets/71274967/6e8df2c2-7b48-4454-b64c-3086b0af9562

Create prefab with original positions and center models:

https://github.com/FlaxEngine/FlaxEngine/assets/71274967/854aeab8-9d33-4219-8516-36577144bc00
