### PR TITLE
Bindings extinction (Interface,and usage of virtual)

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -1986,8 +1986,8 @@ namespace Flax.Build.Bindings
                     throw new Exception($"Not supported {"static"} function {functionInfo.Name} inside interface {interfaceInfo.Name}.");
                 if (functionInfo.NoProxy)
                     throw new Exception($"Not supported {"NoProxy"} function {functionInfo.Name} inside interface {interfaceInfo.Name}.");
-                if (!functionInfo.IsVirtual)
-                    throw new Exception($"Not supported {"non-virtual"} function {functionInfo.Name} inside interface {interfaceInfo.Name}.");
+                //if (!functionInfo.IsVirtual)
+                //    throw new Exception($"Not supported {"non-virtual"} function {functionInfo.Name} inside interface {interfaceInfo.Name}.");
                 if (functionInfo.Access != AccessLevel.Public)
                     throw new Exception($"Not supported {"non-public"} function {functionInfo.Name} inside interface {interfaceInfo.Name}.");
 

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -687,7 +687,7 @@ namespace Flax.Build.Bindings
 #endif
             if (caller.IsInterface)
             {
-                contents.Append("Debug.Log(GetType().ToString());").AppendLine();
+                //contents.Append("Debug.Log(GetType().ToString());").AppendLine();
                 indent += "    ";
                 if (!IsInterfaceFuncion)
                 {
@@ -726,7 +726,7 @@ namespace Flax.Build.Bindings
             {
                 if (caller.IsInterface)
                 {
-                    contents.Append("Object.GetUnmanagedPtr((Object)this)");
+                    contents.Append("FlaxEngine.Object.GetUnmanagedInterface(this, typeof("+ caller.FullNameManaged+"))");
                 }
                 else
                 {
@@ -2141,31 +2141,37 @@ namespace Flax.Build.Bindings
                         contents.Append(" = ").Append(defaultValue);
                 }
 
-                
+
                 if (generateCSharpWrapperFunction)
                 {
-                    if (functionInfo.Glue.LibraryEntryPoint == null)
-                    {
-                        Console.WriteLine($"Function {interfaceInfo.FullNameNative}::{functionInfo.Name} has missing entry point for library import. \n Skipping \n Implemeted as Pure");
-                        contents.Append(");").AppendLine();
-                    }
+                    Console.WriteLine($"Function {interfaceInfo.FullNameNative}::{functionInfo.Name}. Implemeted as not Pure c#");
+                    if (functionInfo.ReturnType.IsVoid)
+                        contents.Append(") {}").AppendLine();
                     else
-                    {
-                        contents.Append(")");
-                        contents.AppendLine();
-                        contents.Append(indent);
-                        contents.Append("{\n");
-                        GenerateCSharpWrapperFunctionCall(buildData, contents, interfaceInfo, functionInfo, false, indent,true);
-                        contents.AppendLine();
-                        contents.Append(indent);
-                        contents.Append("}\n");
+                        contents.Append(") { return default; }").AppendLine();
 
-                        GenerateCSharpWrapperFunction(buildData, contents, indent, interfaceInfo, functionInfo);
-                    }
+                    //if (functionInfo.Glue.LibraryEntryPoint == null)
+                    //{
+
+                    //    contents.Append(");").AppendLine();
+                    //}
+                    //else
+                    //{
+                    //    contents.Append(")");
+                    //    contents.AppendLine();
+                    //    contents.Append(indent);
+                    //    contents.Append("{\n");
+                    //    GenerateCSharpWrapperFunctionCall(buildData, contents, interfaceInfo, functionInfo, false, indent,true);
+                    //    contents.AppendLine();
+                    //    contents.Append(indent);
+                    //    contents.Append("}\n");
+
+                    //    GenerateCSharpWrapperFunction(buildData, contents, indent, interfaceInfo, functionInfo);
+                    //}
                 }
                 else
                 {
-                    
+
                     contents.Append(");").AppendLine();
                 }
             }

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -671,12 +671,7 @@ namespace Flax.Build.Bindings
 
         private static void GenerateCSharpWrapperFunctionCall(BuildData buildData, StringBuilder contents, ApiTypeInfo caller, FunctionInfo functionInfo, bool isSetter = false,string indent = "")
         {
-            bool isInterface = false;
-            if(caller is InterfaceInfo)
-            {
-                isInterface = true;
-                //System.Diagnostics.Debugger.Break();
-            }
+
 #if USE_NETCORE
             for (var i = 0; i < functionInfo.Parameters.Count; i++)
             {
@@ -688,7 +683,7 @@ namespace Flax.Build.Bindings
                 }
             }
 #endif
-            if (isInterface)
+            if (caller.IsInterface)
             {
                 indent += "    ";
                 // create default 
@@ -723,7 +718,7 @@ namespace Flax.Build.Bindings
             var separator = false;
             if (!functionInfo.IsStatic)
             {
-                if (isInterface)
+                if (caller.IsInterface)
                 {
                     contents.Append("Object.GetUnmanagedPtr(obj)");
                 }
@@ -780,7 +775,7 @@ namespace Flax.Build.Bindings
                         contents.Append("ref ");
 
                     // Pass value
-                    if (isInterface)
+                    if (caller.IsInterface)
                     {
                         contents.Append(parameterInfo.Name);
                     }
@@ -806,7 +801,7 @@ namespace Flax.Build.Bindings
                 contents.Append("    ");
                 contents.Append("return __resultAsRef;");
             }
-            if (isInterface)
+            if (caller.IsInterface)
             {
                 contents.AppendLine();
                 contents.Append(indent);

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -2039,6 +2039,20 @@ namespace Flax.Build.Bindings
             GenerateCSharpAttributes(buildData, contents, indent, interfaceInfo, true);
             contents.Append(indent).Append(GenerateCSharpAccessLevel(interfaceInfo.Access));
             contents.Append("unsafe partial interface ").Append(interfaceInfo.Name);
+            {
+                if (interfaceInfo.Interfaces != null)
+                {
+                    contents.Append(" : ");
+                    bool separetor = false;
+                    foreach (var item in interfaceInfo.Interfaces)
+                    {
+                        if (separetor)
+                            contents.Append(" , ");
+                        contents.Append(item.Name);
+                        separetor = true;
+                    }
+                }
+            }
             contents.AppendLine();
             contents.Append(indent + "{");
             indent += "    ";

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -2629,6 +2629,13 @@ namespace Flax.Build.Bindings
                     GenerateCppWrapperFunction(buildData, contents, interfaceInfo, interfaceTypeNameInternal, propertyInfo.Setter, callFormat);
                 }
             }
+            //// Functions
+            //foreach (var functionInfo in interfaceInfo.Functions)
+            //{
+            //    if (!useCSharp || functionInfo.IsHidden)
+            //        continue;
+            //    GenerateCppWrapperFunction(buildData, contents, interfaceInfo, interfaceTypeNameInternal, functionInfo);
+            //}
 
             contents.Append('}').Append(';').AppendLine();
             contents.AppendLine();
@@ -2669,14 +2676,6 @@ namespace Flax.Build.Bindings
             contents.Append($"StringAnsiView(\"{interfaceTypeNameManaged}\", {interfaceTypeNameManaged.Length}), &{interfaceTypeNameInternal}Internal::InitRuntime,");
             contents.Append(setupScriptVTable).Append($", &{interfaceTypeNameInternal}Internal::GetInterfaceWrapper").Append(");");
             contents.AppendLine();
-
-            // Functions
-            foreach (var functionInfo in interfaceInfo.Functions)
-            {
-                if (!useCSharp || functionInfo.IsHidden)
-                    continue;
-                GenerateCppWrapperFunction(buildData, contents, interfaceInfo, interfaceTypeNameInternal, functionInfo);
-            }
 
             // Nested types
             foreach (var apiTypeInfo in interfaceInfo.Children)

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
@@ -820,6 +820,7 @@ namespace Flax.Build.Bindings
                         break;
                     case "override":
                         desc.IsVirtual = true;
+                        desc.IsOverridden = true;
                         break;
                     default: throw new Exception($"Unknown identifier '{token.Value}' in function {desc.Name} at line {context.Tokenizer.CurrentLine}.");
                     }

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
@@ -806,6 +806,8 @@ namespace Flax.Build.Bindings
                 var token = context.Tokenizer.ExpectAnyTokens(new[] { TokenType.SemiColon, TokenType.LeftCurlyBrace, TokenType.Equal, TokenType.Identifier });
                 if (token.Type == TokenType.Equal)
                 {
+                    if (desc.IsVirtual)
+                        desc.IsPure = true;
                     context.Tokenizer.SkipUntil(TokenType.SemiColon);
                     break;
                 }
@@ -813,20 +815,16 @@ namespace Flax.Build.Bindings
                 {
                     switch (token.Value)
                     {
-                    case "const":
-                        if (desc.IsConst)
-                            throw new Exception($"Invalid double 'const' specifier in function {desc.Name} at line {context.Tokenizer.CurrentLine}.");
-                        desc.IsConst = true;
-                        break;
-                    case "override":
-                        desc.IsVirtual = true;
-                        desc.IsOverridden = true;
-                        break;
-                    case " = 0;"://pure Virtual
-                        desc.IsVirtual = true;
-                        desc.IsPure = true;
-                        break;
-                    default: throw new Exception($"Unknown identifier '{token.Value}' in function {desc.Name} at line {context.Tokenizer.CurrentLine}.");
+                        case "const":
+                            if (desc.IsConst)
+                                throw new Exception($"Invalid double 'const' specifier in function {desc.Name} at line {context.Tokenizer.CurrentLine}.");
+                            desc.IsConst = true;
+                            break;
+                        case "override":
+                            desc.IsVirtual = true;
+                            desc.IsOverridden = true;
+                            break;
+                        default: throw new Exception($"Unknown identifier '{token.Value}' in function {desc.Name} at line {context.Tokenizer.CurrentLine}.");
                     }
                 }
                 else if (token.Type == TokenType.LeftCurlyBrace)

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
@@ -822,6 +822,10 @@ namespace Flax.Build.Bindings
                         desc.IsVirtual = true;
                         desc.IsOverridden = true;
                         break;
+                    case " = 0;"://pure Virtual
+                        desc.IsVirtual = true;
+                        desc.IsPure = true;
+                        break;
                     default: throw new Exception($"Unknown identifier '{token.Value}' in function {desc.Name} at line {context.Tokenizer.CurrentLine}.");
                     }
                 }

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.cs
@@ -316,8 +316,8 @@ namespace Flax.Build.Bindings
                                 classInfo.Fields.Add(fieldInfo);
                             else if (scopeInfo is StructureInfo structureInfo)
                                 structureInfo.Fields.Add(fieldInfo);
-                            else
-                                throw new Exception($"Not supported location for field {fieldInfo.Name} at line {tokenizer.CurrentLine}. Place it in the class or structure to use API bindings for it.");
+                            else if (scopeInfo is InterfaceInfo interfaceInfo)
+                                interfaceInfo.Fields.Add(fieldInfo);
                         }
                         else if (string.Equals(token.Value, ApiTokens.Event, StringComparison.Ordinal))
                         {

--- a/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
@@ -74,6 +74,7 @@ namespace Flax.Build.Bindings
         public TypeInfo ReturnType;
         public List<ParameterInfo> Parameters = new List<ParameterInfo>();
         public bool IsVirtual;
+        public bool IsOverridden;
         public bool IsConst;
         public bool NoProxy;
         public GlueInfo Glue;
@@ -84,6 +85,7 @@ namespace Flax.Build.Bindings
             BindingsGenerator.Write(writer, Parameters);
             // TODO: convert into flags
             writer.Write(IsVirtual);
+            writer.Write(IsOverridden);
             writer.Write(IsConst);
             writer.Write(NoProxy);
 
@@ -96,6 +98,7 @@ namespace Flax.Build.Bindings
             Parameters = BindingsGenerator.Read(reader, Parameters);
             // TODO: convert into flags
             IsVirtual = reader.ReadBoolean();
+            IsOverridden = reader.ReadBoolean();
             IsConst = reader.ReadBoolean();
             NoProxy = reader.ReadBoolean();
 

--- a/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/FunctionInfo.cs
@@ -74,6 +74,7 @@ namespace Flax.Build.Bindings
         public TypeInfo ReturnType;
         public List<ParameterInfo> Parameters = new List<ParameterInfo>();
         public bool IsVirtual;
+        public bool IsPure;
         public bool IsOverridden;
         public bool IsConst;
         public bool NoProxy;
@@ -85,6 +86,7 @@ namespace Flax.Build.Bindings
             BindingsGenerator.Write(writer, Parameters);
             // TODO: convert into flags
             writer.Write(IsVirtual);
+            writer.Write(IsPure);
             writer.Write(IsOverridden);
             writer.Write(IsConst);
             writer.Write(NoProxy);
@@ -98,6 +100,7 @@ namespace Flax.Build.Bindings
             Parameters = BindingsGenerator.Read(reader, Parameters);
             // TODO: convert into flags
             IsVirtual = reader.ReadBoolean();
+            IsPure = reader.ReadBoolean();
             IsOverridden = reader.ReadBoolean();
             IsConst = reader.ReadBoolean();
             NoProxy = reader.ReadBoolean();

--- a/Source/Tools/Flax.Build/Bindings/InterfaceInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/InterfaceInfo.cs
@@ -31,9 +31,16 @@ namespace Flax.Build.Bindings
 
             if (BaseType != null)
                 throw new Exception(string.Format("Interface {0} cannot inherit from {1}.", FullNameNative, BaseType));
-            if (Interfaces != null && Interfaces.Count != 0)
-                throw new Exception(string.Format("Interface {0} cannot inherit from {1}.", FullNameNative, "interfaces"));
-
+            if (Interfaces != null)
+            {
+                for (int i = 0; i < Interfaces.Count; i++)
+                {
+                    if (!Interfaces[i].IsInterface)
+                    {
+                        throw new Exception(string.Format("Interface {0} cannot inherit from {1}. Because the {1} is not a Interface", FullNameNative, Interfaces[i]));
+                    }
+                }
+            }
             foreach (var fieldInfo in Fields)
             {
                 if (fieldInfo.IsHidden)


### PR DESCRIPTION
# **Linked to**
- https://github.com/FlaxEngine/FlaxEngine/issues/1908
- https://github.com/FlaxEngine/FlaxEngine/issues/1912
- fix while using override https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0114 
  the base class was defining virtual foo and delivered also was having virtual foo
  now is virtual foo and delivered override foo
  
# **What is added**
API_FIELD
function with out a virtual keyword
[Interfaces  inheritance support c# generation](https://github.com/FlaxEngine/FlaxEngine/pull/1913/commits/a180c6e9e6dd7c7cf82a9ac8c3bc42320f1bf4cb)

test
```c++
API_INTERFACE(Namespace = "FlaxEngine.Testing") 
class FLAXENGINE_API ITest
{
    DECLARE_SCRIPTING_TYPE_MINIMAL(ITest);

    API_FIELD() float Location;                                                   // c# side Location;

    API_FUNCTION() virtual int GetCountOfFloats() = 0;           // c# side virtual int GetCountOfFloats();

    API_FUNCTION() float GetFloat();                                          // c# side  float GetFloat();
};
//invalid kinda u cant access Location
API_CLASS(Namespace = "FlaxEngine.Testing")
class FLAXENGINE_API Test: public ITest
{
    //this is a fixed usage of override keyword.  what was generated: c# side virtual int GetCountOfFloats(); this will throw a warning
    API_FUNCTION() virtual int GetCountOfFloats() override {return 3.0f;}  // c# side override int GetCountOfFloats();
};
//valid 
API_CLASS(Namespace = "FlaxEngine.Testing")
class FLAXENGINE_API Test2: public ScriptingObject , public ITest
{
    DECLARE_SCRIPTING_TYPE(Test2);
    
    //this is a fixed usage of override keyword.  what was generated:  c# side virtual int GetCountOfFloats(); this will throw a warning
    API_FUNCTION() virtual int GetCountOfFloats() override {return 3.0f;}  // c# side override int GetCountOfFloats();
};

//Interfaces intermittence support c# generation
//test
API_INTERFACE(Namespace = "FlaxEngine.Testing") 
class FLAXENGINE_API Test3 : public ITest
{
    DECLARE_SCRIPTING_TYPE(Test2);
    

    API_FUNCTION() virtual void SetCountOfFloats() { Location += 3.0f; }  
};
```
# **To do**
- [x] Distinct between (maybe with tag usage)
       implement virtual 
       c++
       ```
       virtual float GetCountOfFloats();
       ```
       c#
       ```
        virtual float GetCountOfFloats() {return Internal_GetCountOfFloats(pointer)};
       ```
       and pure virtual
       c++
       ```
        virtual float GetCountOfFloats() = 0;
       ```
       c#
       ```
       float GetCountOfFloats();
       ```
- [ ]  Test it ?
# **Binding generation flow chart**
**API_FIELD** usage (simplified)
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/ce8a1b6e-4be3-42b7-8371-bc9de1023c1c)