### PR TITLE
Expose Freetype font style flags in `FontAsset`

### DIFF
--- a/Source/Engine/Render2D/FontAsset.cpp
+++ b/Source/Engine/Render2D/FontAsset.cpp
@@ -87,6 +87,16 @@ bool FontAsset::Init()
     return error;
 }
 
+FontFlags FontAsset::GetStyle() const
+{
+    FontFlags flags = FontFlags::None;
+    if ((_face->style_flags & FT_STYLE_FLAG_ITALIC) != 0)
+        flags |= FontFlags::Italic;
+    if ((_face->style_flags & FT_STYLE_FLAG_BOLD) != 0)
+        flags |= FontFlags::Bold;
+    return flags;
+}
+
 void FontAsset::SetOptions(const FontOptions& value)
 {
     _options = value;

--- a/Source/Engine/Render2D/FontAsset.h
+++ b/Source/Engine/Render2D/FontAsset.h
@@ -129,6 +129,11 @@ public:
     }
 
     /// <summary>
+    /// Gets the font style flags.
+    /// </summary>
+    API_PROPERTY() FontFlags GetStyle() const;
+
+    /// <summary>
     /// Sets the font options.
     /// </summary>
     API_PROPERTY() void SetOptions(const FontOptions& value);


### PR DESCRIPTION
Needed for RmlUi-plugin to detect the style of the underlying Freetype face (https://github.com/GoaLitiuM/RmlUi/pull/8).