### PR TITLE
Add require script and actor attributes.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -643,9 +643,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
                             var requiredScript = script.Actor.GetScript(type.Type);
                             if (requiredScript == null)
                             {
-                                Editor.LogWarning($"{script} on {script.Actor} is missing required script of type {type}.");
+                                Editor.LogWarning($"{Utilities.Utils.GetPropertyNameUI(scriptType.Name)} on {script.Actor} is missing a required script of type {type}.");
                                 hasAllRequiredScripts = false;
-                                break;
                             }
                         }
                     }

--- a/Source/Engine/Scripting/Attributes/Editor/RequireActorAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/RequireActorAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace FlaxEngine;
+
+/// <summary>
+/// This attribute is used to check for if a script requires an Actor type.
+/// </summary>
+[Serializable]
+[AttributeUsage(AttributeTargets.Class)]
+public class RequireActorAttribute : Attribute
+{
+    /// <summary>
+    /// The required type.
+    /// </summary>
+    public Type RequiredType;
+
+    /// <summary>
+    /// Initializes a new instance of the  <see cref="RequireActorAttribute"/> class.
+    /// </summary>
+    /// <param name="type">The required type.</param>
+    public RequireActorAttribute(Type type)
+    {
+        RequiredType = type;
+    }
+}

--- a/Source/Engine/Scripting/Attributes/Editor/RequireScriptAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/RequireScriptAttribute.cs
@@ -3,19 +3,19 @@ using System;
 namespace FlaxEngine;
 
 /// <summary>
-/// This attribute is used to check for if a script requires another script type.
+/// This attribute is used to check for if a script requires other script types.
 /// </summary>
 [Serializable]
 [AttributeUsage(AttributeTargets.Class)]
 public class RequireScriptAttribute : Attribute
 {
     /// <summary>
-    /// The required type.
+    /// The required types.
     /// </summary>
     public Type[] RequiredTypes;
 
     /// <summary>
-    /// Initializes a new instance of the  <see cref="RequireScriptAttribute"/> class.
+    /// Initializes a new instance of the <see cref="RequireScriptAttribute"/> class.
     /// </summary>
     /// <param name="type">The required type.</param>
     public RequireScriptAttribute(Type type)
@@ -24,7 +24,7 @@ public class RequireScriptAttribute : Attribute
     }
 
     /// <summary>
-    /// Initializes a new instance of the  &lt;see cref="RequireScriptAttribute"/&gt; class.
+    /// Initializes a new instance of the <see cref="RequireScriptAttribute"/> class.
     /// </summary>
     /// <param name="types">The required types.</param>
     public RequireScriptAttribute(Type[] types)

--- a/Source/Engine/Scripting/Attributes/Editor/RequireScriptAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/RequireScriptAttribute.cs
@@ -12,7 +12,7 @@ public class RequireScriptAttribute : Attribute
     /// <summary>
     /// The required type.
     /// </summary>
-    public Type RequiredType;
+    public Type[] RequiredTypes;
 
     /// <summary>
     /// Initializes a new instance of the  <see cref="RequireScriptAttribute"/> class.
@@ -20,6 +20,15 @@ public class RequireScriptAttribute : Attribute
     /// <param name="type">The required type.</param>
     public RequireScriptAttribute(Type type)
     {
-        RequiredType = type;
+        RequiredTypes = new[] { type };
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the  &lt;see cref="RequireScriptAttribute"/&gt; class.
+    /// </summary>
+    /// <param name="types">The required types.</param>
+    public RequireScriptAttribute(Type[] types)
+    {
+        RequiredTypes = types;
     }
 }

--- a/Source/Engine/Scripting/Attributes/Editor/RequireScriptAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/RequireScriptAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace FlaxEngine;
+
+/// <summary>
+/// This attribute is used to check for if a script requires another script type.
+/// </summary>
+[Serializable]
+[AttributeUsage(AttributeTargets.Class)]
+public class RequireScriptAttribute : Attribute
+{
+    /// <summary>
+    /// The required type.
+    /// </summary>
+    public Type RequiredType;
+
+    /// <summary>
+    /// Initializes a new instance of the  <see cref="RequireScriptAttribute"/> class.
+    /// </summary>
+    /// <param name="type">The required type.</param>
+    public RequireScriptAttribute(Type type)
+    {
+        RequiredType = type;
+    }
+}


### PR DESCRIPTION
This PR adds a require script and actor attributes. This will also add the required scripts when the script is added if they are not already on the Actor and if the script requires a specific type of actor it will not be added to a different actor type. There is really no consequence of not having the required scripts besides letting the user know it is needed.