### PR TITLE
Added Actor.GetPrefabRoot().

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -1339,6 +1339,21 @@ bool Actor::IsPrefabRoot() const
     return _isPrefabRoot != 0;
 }
 
+Actor* Actor::GetPrefabRoot()
+{
+    if (!this->HasPrefabLink())
+    {
+        return NULL;
+    }
+
+    Actor* result = this;
+    while (!result == NULL && !result->IsPrefabRoot())
+    {
+        result = result->GetParent();
+    }
+    return result;
+}
+
 Actor* Actor::FindActor(const StringView& name) const
 {
     Actor* result = nullptr;

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -739,6 +739,12 @@ public:
     /// </summary>
     API_PROPERTY() bool IsPrefabRoot() const;
 
+    /// <summary>
+    /// Gets the root of the prefab this actor is attached to.
+    /// </summary>
+    /// <returns>The root prefab object, or null if this actor is not a prefab.</returns>
+    API_FUNCTION() Actor* GetPrefabRoot();
+
 public:
     /// <summary>
     /// Tries to find the actor with the given name in this actor hierarchy (checks this actor and all children hierarchy).


### PR DESCRIPTION
Maybe this could be added to `SceneObject` instead, but I think this makes the most sense.