### PR TITLE
force DeepClone() to use runtime class

### DIFF
--- a/Source/Engine/Utilities/Extensions.cs
+++ b/Source/Engine/Utilities/Extensions.cs
@@ -27,7 +27,7 @@ namespace FlaxEngine.Utilities
         where T : new()
         {
             var json = Json.JsonSerializer.Serialize(instance);
-            return Json.JsonSerializer.Deserialize<T>(json);
+            return (T)Json.JsonSerializer.Deserialize(json, instance.GetType());
         }
 
         /// <summary>


### PR DESCRIPTION
The current DeepClone function in Extensions will always return an instance of T which might be the base class. For a true clone we need the runtime class.