### PR TITLE
Add option to start game focused on GameWindow

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -484,6 +484,16 @@ namespace FlaxEditor.Windows
         {
             base.OnShowContextMenu(menu);
 
+            // Focus on play
+            {
+                var focus = menu.AddButton("Start Focused");
+                focus.CloseMenuOnClick = false;
+                var checkbox = new CheckBox(140, 2, FocusOnPlay) { Parent = focus };
+                checkbox.StateChanged += state => FocusOnPlay = state.Checked;
+            }
+
+            menu.AddSeparator();
+
             // Viewport Brightness
             {
                 var brightness = menu.AddButton("Viewport Brightness");


### PR DESCRIPTION
Adds a checkbox to start game focused or not, is more easily use this instead of change editor preference, this option don't change original user preference.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/d22a713e-1b05-4d07-86a4-6909edc5053d)
