### PR TITLE
Remove ability in editor to delete content and source folders.

### DIFF
--- a/Source/Editor/Content/Tree/ContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/ContentTreeNode.cs
@@ -27,12 +27,12 @@ namespace FlaxEditor.Content
         /// <summary>
         /// Whether this node can be deleted.
         /// </summary>
-        protected virtual bool _canDelete => true;
+        protected virtual bool CanDelete => true;
         
         /// <summary>
         /// Whether this node can be duplicated.
         /// </summary>
-        protected virtual bool _canDuplicate => true;
+        protected virtual bool CanDuplicate => true;
 
         /// <summary>
         /// Gets the content folder item.
@@ -311,7 +311,7 @@ namespace FlaxEditor.Content
                     StartRenaming();
                     return true;
                 case KeyboardKeys.Delete:
-                    if (Folder.Exists && _canDelete)
+                    if (Folder.Exists && CanDelete)
                         Editor.Instance.Windows.ContentWin.Delete(Folder);
                     return true;
                 }
@@ -320,7 +320,7 @@ namespace FlaxEditor.Content
                     switch (key)
                     {
                     case KeyboardKeys.D:
-                        if (Folder.Exists && _canDuplicate)
+                        if (Folder.Exists && CanDuplicate)
                             Editor.Instance.Windows.ContentWin.Duplicate(Folder);
                         return true;
                     }

--- a/Source/Editor/Content/Tree/ContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/ContentTreeNode.cs
@@ -27,12 +27,12 @@ namespace FlaxEditor.Content
         /// <summary>
         /// Whether this node can be deleted.
         /// </summary>
-        protected virtual bool CanDelete => true;
+        public virtual bool CanDelete => true;
         
         /// <summary>
         /// Whether this node can be duplicated.
         /// </summary>
-        protected virtual bool CanDuplicate => true;
+        public virtual bool CanDuplicate => true;
 
         /// <summary>
         /// Gets the content folder item.

--- a/Source/Editor/Content/Tree/ContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/ContentTreeNode.cs
@@ -25,6 +25,11 @@ namespace FlaxEditor.Content
         protected ContentFolder _folder;
 
         /// <summary>
+        /// Whether this node can be deleted.
+        /// </summary>
+        protected virtual bool _canDelete => true;
+
+        /// <summary>
         /// Gets the content folder item.
         /// </summary>
         public ContentFolder Folder => _folder;
@@ -301,7 +306,7 @@ namespace FlaxEditor.Content
                     StartRenaming();
                     return true;
                 case KeyboardKeys.Delete:
-                    if (Folder.Exists)
+                    if (Folder.Exists && _canDelete)
                         Editor.Instance.Windows.ContentWin.Delete(Folder);
                     return true;
                 }

--- a/Source/Editor/Content/Tree/ContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/ContentTreeNode.cs
@@ -28,6 +28,11 @@ namespace FlaxEditor.Content
         /// Whether this node can be deleted.
         /// </summary>
         protected virtual bool _canDelete => true;
+        
+        /// <summary>
+        /// Whether this node can be duplicated.
+        /// </summary>
+        protected virtual bool _canDuplicate => true;
 
         /// <summary>
         /// Gets the content folder item.
@@ -315,7 +320,7 @@ namespace FlaxEditor.Content
                     switch (key)
                     {
                     case KeyboardKeys.D:
-                        if (Folder.Exists)
+                        if (Folder.Exists && _canDuplicate)
                             Editor.Instance.Windows.ContentWin.Duplicate(Folder);
                         return true;
                     }

--- a/Source/Editor/Content/Tree/MainContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/MainContentTreeNode.cs
@@ -13,10 +13,10 @@ namespace FlaxEditor.Content
         private FileSystemWatcher _watcher;
 
         /// <inheritdoc />
-        protected override bool _canDelete => false;
+        protected override bool CanDelete => false;
 
         /// <inheritdoc />
-        protected override bool _canDuplicate => false;
+        protected override bool CanDuplicate => false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MainContentTreeNode"/> class.

--- a/Source/Editor/Content/Tree/MainContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/MainContentTreeNode.cs
@@ -15,6 +15,9 @@ namespace FlaxEditor.Content
         /// <inheritdoc />
         protected override bool _canDelete => false;
 
+        /// <inheritdoc />
+        protected override bool _canDuplicate => false;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MainContentTreeNode"/> class.
         /// </summary>

--- a/Source/Editor/Content/Tree/MainContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/MainContentTreeNode.cs
@@ -13,10 +13,10 @@ namespace FlaxEditor.Content
         private FileSystemWatcher _watcher;
 
         /// <inheritdoc />
-        protected override bool CanDelete => false;
+        public override bool CanDelete => false;
 
         /// <inheritdoc />
-        protected override bool CanDuplicate => false;
+        public override bool CanDuplicate => false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MainContentTreeNode"/> class.

--- a/Source/Editor/Content/Tree/MainContentTreeNode.cs
+++ b/Source/Editor/Content/Tree/MainContentTreeNode.cs
@@ -12,6 +12,9 @@ namespace FlaxEditor.Content
     {
         private FileSystemWatcher _watcher;
 
+        /// <inheritdoc />
+        protected override bool _canDelete => false;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MainContentTreeNode"/> class.
         /// </summary>

--- a/Source/Editor/Windows/ContentWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/ContentWindow.ContextMenu.cs
@@ -114,18 +114,28 @@ namespace FlaxEditor.Windows
                     }
                 }
 
-                cm.AddButton("Delete", () => Delete(item));
+                if (isFolder && folder.Node is not MainContentTreeNode)
+                {
+                    cm.AddButton("Delete", () => Delete(item));
 
-                cm.AddSeparator();
+                    cm.AddSeparator();
 
-                cm.AddButton("Duplicate", _view.Duplicate);
+                    cm.AddButton("Duplicate", _view.Duplicate);
 
-                cm.AddButton("Copy", _view.Copy);
+                    cm.AddButton("Copy", _view.Copy);
+                }
+                else
+                {
+                    cm.AddSeparator();
+                }
 
                 b = cm.AddButton("Paste", _view.Paste);
                 b.Enabled = _view.CanPaste();
 
-                cm.AddButton("Rename", () => Rename(item));
+                if (isFolder && folder.Node is not MainContentTreeNode)
+                {
+                    cm.AddButton("Rename", () => Rename(item));
+                }
 
                 // Custom options
                 ContextMenuShow?.Invoke(cm, item);

--- a/Source/Editor/Windows/ContentWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/ContentWindow.ContextMenu.cs
@@ -114,7 +114,11 @@ namespace FlaxEditor.Windows
                     }
                 }
 
-                if (isFolder && folder.Node is not MainContentTreeNode)
+                if (isFolder && folder.Node is MainContentTreeNode)
+                {
+                    cm.AddSeparator();
+                }
+                else
                 {
                     cm.AddButton("Delete", () => Delete(item));
 
@@ -124,15 +128,15 @@ namespace FlaxEditor.Windows
 
                     cm.AddButton("Copy", _view.Copy);
                 }
-                else
-                {
-                    cm.AddSeparator();
-                }
 
                 b = cm.AddButton("Paste", _view.Paste);
                 b.Enabled = _view.CanPaste();
 
-                if (isFolder && folder.Node is not MainContentTreeNode)
+                if (isFolder && folder.Node is MainContentTreeNode)
+                {
+                    // Do nothing
+                }
+                else
                 {
                     cm.AddButton("Rename", () => Rename(item));
                 }


### PR DESCRIPTION
This removes the ability inside of the editor to delete the content and source folders. This also limits the CM options on those folder nodes only to ones that make sense (removes delete, duplicate, rename, and copy options).