### PR TITLE
Automatically show skeleton when entering skeleton tab in skinned model editor

### DIFF
--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -371,7 +371,10 @@ namespace FlaxEditor.Windows.Assets
                 private void OnTreeSelectedChanged(List<TreeNode> before, List<TreeNode> after)
                 {
                     if (after.Count != 0)
-                        ((SkeletonPropertiesProxy)Values[0]).Window._preview.ShowDebugDraw = true;
+                    {
+                        var proxy = (SkeletonPropertiesProxy)Values[0];
+                        proxy.Window._preview.ShowDebugDraw = true;
+                    }
                 }
 
                 private void OnTreeNodeCopyName(ContextMenuButton b)
@@ -1045,6 +1048,7 @@ namespace FlaxEditor.Windows.Assets
             {
                 Proxy = new SkeletonPropertiesProxy();
                 Presenter.Select(Proxy);
+                // Draw highlight on selected node
                 window._preview.CustomDebugDraw += OnDebugDraw;
             }
 
@@ -1145,6 +1149,15 @@ namespace FlaxEditor.Windows.Assets
             _tabs.AddTab(new UVsTab(this));
             _tabs.AddTab(new RetargetTab(this));
             _tabs.AddTab(new ImportTab(this));
+
+            // Automatically show nodes when switching to skeleton page
+            _tabs.SelectedTabChanged += (tabs) =>
+            {
+                if (tabs.SelectedTab is SkeletonTab)
+                {
+                    _preview.ShowNodes = true;
+                }
+            };
 
             // Highlight actor (used to highlight selected material slot, see UpdateEffectsOnAsset)
             _highlightActor = new AnimatedModel

--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -188,6 +188,7 @@ void AnimatedModel::SetNodeTransformation(int32 nodeIndex, const Matrix& nodeTra
     }
     OnAnimationUpdated();
 }
+
 void AnimatedModel::SetNodeTransformation(const StringView& nodeName, const Matrix& nodeTransformation, bool worldSpace)
 {
     SetNodeTransformation(SkinnedModel ? SkinnedModel->FindNode(nodeName) : -1, nodeTransformation, worldSpace);


### PR DESCRIPTION
It's more natural to show the skeletal bones and nodes automatically after entering the `skeleton` tab. 

Additionally, I am trying to implement a properties panel to show transform and index of the selected node. However, I encountered difficulties when trying to add new elements to GroupElement dynamically (outside `Initialize` function) in order to update the properties shown when I select a node. The new element added doesn't show up unless I call the presenter to redraw the whole page (which is costly). Am I doing the thing in a wrong way or is there a function to be called to do the partial update? 