### PR TITLE
calculate follow selection on FOV and far plane

### DIFF
--- a/Source/Editor/Viewport/Cameras/FPSCamera.cs
+++ b/Source/Editor/Viewport/Cameras/FPSCamera.cs
@@ -174,7 +174,10 @@ namespace FlaxEditor.Viewport.Cameras
             }
             else
             {
-                position = sphere.Center - Vector3.Forward * orientation * (sphere.Radius * 2.5f);
+                // calculate the min. distance so that the sphere fits roughly 70% in FOV
+                // clip to far plane as a disappearing big object might be confusing
+                var distance = Mathf.Min(1.4f * sphere.Radius / Mathf.Tan(Mathf.DegreesToRadians * Viewport.FieldOfView / 2), Viewport.FarPlane);
+                position = sphere.Center - Vector3.Forward * orientation * distance;
             }
             TargetPoint = sphere.Center;
             MoveViewport(position, orientation);


### PR DESCRIPTION
fixes #1805 and keeps the actor inside the clipping planes (e.g. when you focus a terrain or a similarly big object)