### PR TITLE
fix command line parsing for all platforms

### DIFF
--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -15,7 +15,7 @@ bool CommandLine::HasOption(const String& name, const Array<String>& arg)
 Nullable<bool> CommandLine::GetOption(const String& name, const Array<String>& arg)
 {
     if (!HasOption(name, arg))
-        return nullptr;
+        return Nullable<bool>();
     return true;
 }
 

--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
-#if PLATFORM_LINUX | PLATFORM_MAC | PLATFORM_IOS
+#if PLATFORM_LINUX | PLATFORM_MAC
 #include "CommandLine.h"
 #include "Engine/Core/Collections/Array.h"
 #include "Engine/Core/Types/StringBuilder.h"

--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -29,12 +29,13 @@ String CommandLine::GetOptionValue(const String& name, const Array<String>& arg)
     return String::Empty;
 }
 
+// arg is already excluding the argv[0] (the called program name)
 bool CommandLine::Parse(const Array<String>& arg)
 {
     StringBuilder sb;
-    for (int i = 1; i < arg.Count(); i++)
+    for (int i = 0; i < arg.Count(); i++)
     {
-        if (i > 1)
+        if (i > 0)
             sb.Append(TEXT(" "));
         sb.Append(arg[i]);
     }

--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -4,6 +4,8 @@
 #include "Engine/Core/Collections/Array.h"
 #include <iostream>
 
+#include "Engine/Core/Types/StringBuilder.h"
+
 CommandLine::OptionsData CommandLine::Options;
 
 bool ParseArg(Char* ptr, Char*& start, Char*& end)
@@ -57,6 +59,182 @@ bool ParseArg(Char* ptr, Char*& start, Char*& end)
     return true;
 }
 
+#if PLATFORM_LINUX | PLATFORM_MAC
+
+// a map as OptionsData would make sense
+void CommandLine::SetValue(const char *name, const Char *value)
+{
+    if (strcmp("-windowed", name) == 0)
+        Options.Windowed = true;
+    else if (strcmp("-fullscreen", name) == 0)
+        Options.Fullscreen = true;
+    else if (strcmp("-vsync", name) == 0)
+        Options.VSync = true;
+    else if (strcmp("-novsync", name) == 0)
+        Options.NoVSync = true;
+    else if (strcmp("-nolog", name) == 0)
+        Options.NoLog = true;
+    else if (strcmp("-std", name) == 0)
+        Options.Std = true;
+#if !BUILD_RELEASE
+    else if (strcmp("-debug", name) == 0)
+        Options.DebuggerAddress = String(value);
+    else if (strcmp("-debugwait", name) == 0)
+        Options.WaitForDebugger = true;
+#endif
+#if PLATFORM_HAS_HEADLESS_MODE
+    else if (strcmp("-headless", name) == 0)
+        Options.Headless = true;
+#endif
+    else if (strcmp("-d3d12", name) == 0)
+        Options.D3D12 = true;
+    else if (strcmp("-d3d11", name) == 0)
+        Options.D3D11 = true;
+    else if (strcmp("-d3d10", name) == 0)
+        Options.D3D10 = true;
+    else if (strcmp("-null", name) == 0)
+        Options.Null = true;
+    else if (strcmp("-vulkan", name) == 0)
+        Options.Vulkan = true;
+    else if (strcmp("-nvidia", name) == 0)
+        Options.NVIDIA = true;
+    else if (strcmp("-amd", name) == 0)
+        Options.AMD = true;
+    else if (strcmp("-intel", name) == 0)
+        Options.Intel = true;
+    else if (strcmp("-monolog", name) == 0)
+        Options.MonoLog = true;
+    else if (strcmp("-mute", name) == 0)
+        Options.Mute = true;
+    else if (strcmp("-lowdpi", name) == 0)
+        Options.LowDPI = true;
+#if USE_EDITOR
+    else if (strcmp("-clearcache", name) == 0)
+        Options.ClearCache = true;
+    else if (strcmp("-clearcooker", name) == 0)
+        Options.ClearCookerCache = true;
+    else if (strcmp("-project", name) == 0)
+        Options.Project = String(value);
+    else if (strcmp("-new", name) == 0)
+        Options.NewProject = true;
+    else if (strcmp("-genprojectfiles", name) == 0)
+        Options.GenProjectFiles = true;
+    else if (strcmp("-build", name) == 0)
+        Options.Build = String(value);
+    else if (strcmp("-skipcompile", name) == 0)
+        Options.SkipCompile = true;
+    else if (strcmp("-shaderdebug", name) == 0)
+        Options.ShaderDebug = true;
+    else if (strcmp("-play", name) == 0)
+        Options.Play = String(value);
+#endif
+}
+
+bool CommandLine::Parse(int argc, const char** argv)
+{
+    enum ArgType { Flag, Value, OptionalValue, Invalid };
+    struct OptArg
+    {
+        const char *name;
+        ArgType type;
+    };
+    OptArg optArgs[] =
+    {
+        { "-windowed", Flag },
+        { "-fullscreen", Flag },
+        { "-vsync", Flag },
+        { "-novsync", Flag },
+        { "-nolog", Flag },
+        { "-std", Flag },
+#if !BUILD_RELEASE
+        { "-debug", Value },
+        { "-debugwait", Flag },
+#endif
+#if PLATFORM_HAS_HEADLESS_MODE
+        { "-headless", Flag },
+#endif
+        { "-d3d12", Flag },
+        { "-d3d11", Flag },
+        { "-d3d10", Flag },
+        { "-null", Flag },
+        { "-vulkan", Flag },
+        { "-nvidia", Flag },
+        { "-amd", Flag },
+        { "-intel", Flag },
+        { "-monolog", Flag },
+        { "-mute", Flag },
+        { "-lowdpi", Flag },
+#if USE_EDITOR
+        { "-clearcache", Flag },
+        { "-clearcooker", Flag },
+        { "-project", Value },
+        { "-new", Flag },
+        { "-genprojectfiles", Flag },
+        { "-build", Value },
+        { "-skipcompile", Flag },
+        { "-shaderdebug", Flag },
+        { "-play", OptionalValue }
+#endif
+    };
+
+    StringBuilder cmdString;
+    for (int i = 1; i < argc; i++)
+    {
+        cmdString.Append(argv[i]);
+
+        if (i + 1 != argc)
+            cmdString.Append(TEXT(' '));
+    }
+    cmdString.Append(TEXT('\0'));
+    Options.CmdLine = *cmdString;
+
+    int argvP = 1;
+    while (argvP < argc)
+    {
+        OptArg optarg = { "", Invalid };
+        const Char *optValue;
+        for (int i = 0; i < sizeof(optArgs); i++)
+        {
+            if (strcmp(argv[argvP], optArgs[i].name) == 0)
+            {
+                optarg = optArgs[i];
+                break;
+            }
+        }
+        if (optarg.type == Invalid)
+        {
+            std::cerr << "Unknown command line option: " << argv[argvP] << std::endl;
+            break;
+        }
+        if (optarg.type == Flag)
+        {
+            // set boolean flag, the value is ignored
+            SetValue(optarg.name, nullptr);
+        }
+        else
+        {
+            if (argvP < argc-1)
+            {
+                argvP++;
+                auto sb = StringBuilder();
+                sb.Append(argv[argvP]);
+                optValue = *sb;
+            }
+            else
+            {
+                if (optarg.type == OptionalValue)
+                    optValue = TEXT("");
+                else
+                {
+                    std::cerr << "Command line option " << optarg.name << "requires an argument" << std::endl;
+                    break;
+                }
+            }
+            SetValue(optarg.name, optValue);
+        }
+        argvP++;
+    }
+#else
 bool CommandLine::Parse(const Char* cmdLine)
 {
     Options.CmdLine = cmdLine;
@@ -159,5 +337,7 @@ bool CommandLine::Parse(const Char* cmdLine)
 
 #endif
 
+#endif
     return false;
 }
+

--- a/Source/Engine/Engine/CommandLine.cpp
+++ b/Source/Engine/Engine/CommandLine.cpp
@@ -29,6 +29,16 @@ String CommandLine::GetOptionValue(const String& name, const Array<String>& arg)
     return String::Empty;
 }
 
+Nullable<String> CommandLine::GetOptionalValue(const String& name, const Array<String>& arg)
+{
+    const int index = arg.Find(name);
+    if (index < 0)
+        return Nullable<String>();
+    if (index+1 < arg.Count())
+        return Nullable<String>(arg[index+1]);
+    return Nullable<String>(String::Empty);
+}
+
 // arg is already excluding the argv[0] (the called program name)
 bool CommandLine::Parse(const Array<String>& arg)
 {
@@ -39,6 +49,7 @@ bool CommandLine::Parse(const Array<String>& arg)
             sb.Append(TEXT(" "));
         sb.Append(arg[i]);
     }
+    sb.Append(TEXT('\0'));
     Options.CmdLine = *sb;
 
     Options.Windowed = GetOption(TEXT("-windowed"), arg);
@@ -48,7 +59,7 @@ bool CommandLine::Parse(const Array<String>& arg)
     Options.NoLog = GetOption(TEXT("-nolog"), arg);
     Options.Std = GetOption(TEXT("-std"), arg);
 #if !BUILD_RELEASE
-    Options.DebuggerAddress = GetOptionValue(TEXT("-debug"), arg);
+    Options.DebuggerAddress = GetOptionalValue(TEXT("-debug"), arg);
     Options.WaitForDebugger = GetOption(TEXT("-debugwait"), arg);
 #endif
 #if PLATFORM_HAS_HEADLESS_MODE
@@ -71,10 +82,10 @@ bool CommandLine::Parse(const Array<String>& arg)
     Options.Project = GetOptionValue(TEXT("-project"), arg);
     Options.NewProject = GetOption(TEXT("-new"), arg);
     Options.GenProjectFiles = GetOption(TEXT("-genprojectfiles"), arg);
-    Options.Build = GetOptionValue(TEXT("-build"), arg);
+    Options.Build = GetOptionalValue(TEXT("-build"), arg);
     Options.SkipCompile = GetOption(TEXT("-skipcompile"), arg);
     Options.ShaderDebug = GetOption(TEXT("-shaderdebug"), arg);
-    Options.Play = GetOptionValue(TEXT("-play"), arg);
+    Options.Play = GetOptionalValue(TEXT("-play"), arg);
 #endif
 
     return false;

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -195,6 +195,7 @@ public:
     static bool HasOption(const String& name, const Array<String>& arg);
     static Nullable<bool> GetOption(const String& name, const Array<String>& arg);
     static String GetOptionValue(const String& name, const Array<String>& arg);
+    static Nullable<String> GetOptionalValue(const String& name, const Array<String>& arg);
 
 #else
     /// <summary>

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -193,7 +193,7 @@ public:
     /// <returns>True if failed, otherwise false.</returns>
     static bool Parse(const Array<String>& arg);
     static bool HasOption(const String& name, const Array<String>& arg);
-    static Nullable<bool> CommandLine::GetOption(const String& name, const Array<String>& arg);
+    static Nullable<bool> GetOption(const String& name, const Array<String>& arg);
     static String GetOptionValue(const String& name, const Array<String>& arg);
 
 #else

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -4,6 +4,7 @@
 
 #include "Engine/Core/Types/String.h"
 #include "Engine/Core/Types/Nullable.h"
+#include "Engine/Core/Collections/Array.h"
 
 /// <summary>
 /// Command line options helper.
@@ -188,11 +189,12 @@ public:
     /// <summary>
     /// Parses the input command line.
     /// </summary>
-    /// <param name="argc">The number of args</param>
-    /// <param name="argv">The argument values</param>
+    /// <param name="arg">The argument values</param>
     /// <returns>True if failed, otherwise false.</returns>
-    static bool Parse(int argc, const char** argv);
-    static void SetValue(const char *name, const Char *value);
+    static bool Parse(const Array<String>& arg);
+    static bool HasOption(const String& name, const Array<String>& arg);
+    static Nullable<bool> CommandLine::GetOption(const String& name, const Array<String>& arg);
+    static String GetOptionValue(const String& name, const Array<String>& arg);
 
 #else
     /// <summary>

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -184,10 +184,22 @@ public:
 
 public:
 
+#if PLATFORM_LINUX | PLATFORM_MAC
+    /// <summary>
+    /// Parses the input command line.
+    /// </summary>
+    /// <param name="argc">The number of args</param>
+    /// <param name="argv">The argument values</param>
+    /// <returns>True if failed, otherwise false.</returns>
+    static bool Parse(int argc, const char** argv);
+    static void SetValue(const char *name, const Char *value);
+
+#else
     /// <summary>
     /// Parses the input command line.
     /// </summary>
     /// <param name="cmdLine">The command line.</param>
     /// <returns>True if failed, otherwise false.</returns>
     static bool Parse(const Char* cmdLine);
+#endif
 };

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -185,7 +185,7 @@ public:
 
 public:
 
-#if PLATFORM_LINUX | PLATFORM_MAC
+#if PLATFORM_LINUX | PLATFORM_MAC | PLATFORM_IOS
     /// <summary>
     /// Parses the input command line.
     /// </summary>

--- a/Source/Engine/Engine/CommandLine.h
+++ b/Source/Engine/Engine/CommandLine.h
@@ -185,7 +185,7 @@ public:
 
 public:
 
-#if PLATFORM_LINUX | PLATFORM_MAC | PLATFORM_IOS
+#if PLATFORM_LINUX | PLATFORM_MAC
     /// <summary>
     /// Parses the input command line.
     /// </summary>

--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -24,10 +24,12 @@
 #include "Engine/Content/Content.h"
 #include "Engine/Content/JsonAsset.h"
 #include "Engine/Core/Config/GameSettings.h"
+#include "Engine/Core/Types/StringBuilder.h"
 #include "Engine/Graphics/RenderTargetPool.h"
 #include "Engine/Graphics/RenderTask.h"
 #include "Engine/Profiler/Profiler.h"
 #include "Engine/Threading/TaskGraph.h"
+
 #if USE_EDITOR
 #include "Editor/Editor.h"
 #include "Editor/ProjectInfo.h"
@@ -41,6 +43,9 @@
 #include "Engine/Scripting/ManagedCLR/MMethod.h"
 #include "Engine/Scripting/ManagedCLR/MException.h"
 #include "Engine/Core/Config/PlatformSettings.h"
+#endif
+#if PLATFORM_LINUX | PLATFORM_MAC
+#include <iostream>
 #endif
 
 namespace EngineImpl
@@ -71,19 +76,32 @@ Action Engine::Pause;
 Action Engine::Unpause;
 Window* Engine::MainWindow = nullptr;
 
+#if PLATFORM_LINUX | PLATFORM_MAC
+int32 Engine::Main(const int argc, const char** argv)
+{
+    if (CommandLine::Parse(argc, argv))
+    {
+        std::cerr << "Invalid command line.";
+        return -1;
+    }
+    const Char *cmdLine = CommandLine::Options.CmdLine;
+#else
 int32 Engine::Main(const Char* cmdLine)
 {
+#endif
     EngineImpl::CommandLine = cmdLine;
     Globals::MainThreadID = Platform::GetCurrentThreadID();
     StartupTime = DateTime::Now();
 
     EngineService::Sort();
 
+#if !(PLATFORM_LINUX | PLATFORM_MAC)
     if (CommandLine::Parse(cmdLine))
     {
         Platform::Fatal(TEXT("Invalid command line."));
         return -1;
     }
+#endif
 
 #if FLAX_TESTS
     // Configure engine for test running environment

--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -76,10 +76,12 @@ Action Engine::Pause;
 Action Engine::Unpause;
 Window* Engine::MainWindow = nullptr;
 
+// if the general command line parsing can be adopted to Windows as well
+// we can get rid of these preprocessor directives
 #if PLATFORM_LINUX | PLATFORM_MAC
-int32 Engine::Main(const int argc, const char** argv)
+int32 Engine::Main(Array<String> arg)
 {
-    if (CommandLine::Parse(argc, argv))
+    if (CommandLine::Parse(arg))
     {
         std::cerr << "Invalid command line.";
         return -1;

--- a/Source/Engine/Engine/Engine.h
+++ b/Source/Engine/Engine/Engine.h
@@ -4,6 +4,7 @@
 
 #include "Engine/Core/Delegate.h"
 #include "Engine/Core/Types/DateTime.h"
+#include "Engine/Core/Collections/Array.h"
 #include "Engine/Scripting/ScriptingType.h"
 
 class TaskGraph;
@@ -82,7 +83,7 @@ public:
     /// <param name="cmdLine">The input application command line arguments.</param>
     /// <returns>The application exit code.</returns>
 #if PLATFORM_LINUX | PLATFORM_MAC
-    static int32 Main(int argc, const char** argv);
+    static int32 Main(Array<String> arg);
 #else
     static int32 Main(const Char* cmdLine);
 #endif

--- a/Source/Engine/Engine/Engine.h
+++ b/Source/Engine/Engine/Engine.h
@@ -81,8 +81,11 @@ public:
     /// </summary>
     /// <param name="cmdLine">The input application command line arguments.</param>
     /// <returns>The application exit code.</returns>
+#if PLATFORM_LINUX | PLATFORM_MAC
+    static int32 Main(int argc, const char** argv);
+#else
     static int32 Main(const Char* cmdLine);
-
+#endif
     /// <summary>
     /// Exits the engine.
     /// </summary>

--- a/Source/Engine/Main/Default/main.cpp
+++ b/Source/Engine/Main/Default/main.cpp
@@ -1,7 +1,15 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #if PLATFORM_LINUX || PLATFORM_MAC || PLATFORM_IOS
+#include "Engine/Engine/Engine.h"
+#include "Engine/Core/Types/StringBuilder.h"
 
+int main(int argc, const char** argv)
+{
+    return Engine::Main(argc, argv);
+}
+
+#else
 #include "Engine/Engine/Engine.h"
 #include "Engine/Core/Types/StringBuilder.h"
 

--- a/Source/Engine/Main/Default/main.cpp
+++ b/Source/Engine/Main/Default/main.cpp
@@ -1,12 +1,17 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
+#include "Engine/Core/Collections/Array.h"
+#include "Engine/Core/Types/String.h"
 #if PLATFORM_LINUX || PLATFORM_MAC || PLATFORM_IOS
 #if PLATFORM_LINUX || PLATFORM_MAC
 #include "Engine/Engine/Engine.h"
 
 int main(int argc, const char** argv)
 {
-    return Engine::Main(argc, argv);
+    auto arg = Array<String>(argc);
+    for (int i = 1; i < argc; i++)
+        arg.Add(String(argv[i]));
+    return Engine::Main(arg);
 }
 
 #else

--- a/Source/Engine/Main/Default/main.cpp
+++ b/Source/Engine/Main/Default/main.cpp
@@ -1,16 +1,18 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
-#include "Engine/Core/Collections/Array.h"
-#include "Engine/Core/Types/String.h"
 #if PLATFORM_LINUX || PLATFORM_MAC || PLATFORM_IOS
 #if PLATFORM_LINUX || PLATFORM_MAC
+#include "Engine/Core/Collections/Array.h"
+#include "Engine/Core/Types/String.h"
 #include "Engine/Engine/Engine.h"
 
 int main(int argc, const char** argv)
 {
     auto arg = Array<String>(argc);
     for (int i = 1; i < argc; i++)
+    {
         arg.Add(String(argv[i]));
+    }
     return Engine::Main(arg);
 }
 

--- a/Source/Engine/Main/Default/main.cpp
+++ b/Source/Engine/Main/Default/main.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #if PLATFORM_LINUX || PLATFORM_MAC || PLATFORM_IOS
+#if PLATFORM_LINUX || PLATFORM_MAC
 #include "Engine/Engine/Engine.h"
-#include "Engine/Core/Types/StringBuilder.h"
 
 int main(int argc, const char** argv)
 {
@@ -29,4 +29,5 @@ int main(int argc, char* argv[])
     return Engine::Main(*args);
 }
 
+#endif
 #endif


### PR DESCRIPTION
For systems using a posix-compliant shell command line arguments are parsed by the shell and relayed to the program via an array. The previous concatenation and parsing meant that escaped spaces were lost for Linux and OSX.