### PR TITLE
fix Linux windows and docking, add mouse tracking

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxPlatform.h
+++ b/Source/Engine/Platform/Linux/LinuxPlatform.h
@@ -139,6 +139,8 @@ public:
     static String GetWorkingDirectory();
     static bool SetWorkingDirectory(const String& path);
     static Window* CreateWindow(const CreateWindowSettings& settings);
+    static void StartTrackingMouse(const Window* window);
+    static void EndTrackingMouse(const Window *window);
     static void GetEnvironmentVariables(Dictionary<String, String, HeapAllocation>& result);
     static bool GetEnvironmentVariable(const String& name, String& value);
     static bool SetEnvironmentVariable(const String& name, const String& value);

--- a/Source/Engine/Platform/Linux/LinuxWindow.cpp
+++ b/Source/Engine/Platform/Linux/LinuxWindow.cpp
@@ -54,7 +54,7 @@ LinuxWindow::LinuxWindow(const CreateWindowSettings& settings)
         return;
 	auto screen = XDefaultScreen(display);
 
-	// Cache data
+    // Cache data
 	int32 width = Math::TruncToInt(settings.Size.X);
 	int32 height = Math::TruncToInt(settings.Size.Y);
 	_clientSize = Float2((float)width, (float)height);
@@ -111,6 +111,12 @@ LinuxWindow::LinuxWindow(const CreateWindowSettings& settings)
 	windowAttributes.border_pixel = XBlackPixel(display, screen);
 	windowAttributes.event_mask = KeyPressMask | KeyReleaseMask | StructureNotifyMask | ExposureMask;
 
+    if (!settings.IsRegularWindow)
+    {
+        windowAttributes.save_under = true;
+        windowAttributes.override_redirect = true;
+    }
+
 	// TODO: implement all window settings
 	/*
 	bool Fullscreen;
@@ -118,11 +124,16 @@ LinuxWindow::LinuxWindow(const CreateWindowSettings& settings)
 	bool AllowMaximize;
 	*/
 
+    unsigned long valueMask = CWBackPixel | CWBorderPixel | CWEventMask | CWColormap;
+    if (!settings.IsRegularWindow)
+    {
+        valueMask |= CWOverrideRedirect | CWSaveUnder;
+    }
 	const X11::Window window = X11::XCreateWindow(
 		display, X11::XRootWindow(display, screen), x, y,
 		width, height, 0, visualInfo->depth, InputOutput,
 		visualInfo->visual,
-		CWBackPixel | CWBorderPixel | CWEventMask | CWColormap, &windowAttributes);
+		valueMask, &windowAttributes);
 	_window = window;
 	LinuxWindow::SetTitle(settings.Title);
 
@@ -811,12 +822,12 @@ void LinuxWindow::SetTitle(const StringView& title)
 
 void LinuxWindow::StartTrackingMouse(bool useMouseScreenOffset)
 {
-	// TODO: impl this
+	LinuxPlatform::StartTrackingMouse(this);
 }
 
 void LinuxWindow::EndTrackingMouse()
 {
-	// TODO: impl this
+	LinuxPlatform::EndTrackingMouse(this);
 }
 
 void LinuxWindow::SetCursor(CursorType type)


### PR DESCRIPTION
All non-regular windows on Linux are created with the flags to bypass the windowmanager. Unfortunately this does not fix the main menu but should reduce the flickering and overhead for tooltips and popup menus that is introduced by reverting the changes the WM does (i.e. fighting the WM with application logic).
Beside that this change opened a path to fix the dragging issue with a dockable panel. Implementing the start and end mouse tracking, panels can be docked now (#1603 seems to be fixed now). Only remaining issue with docking is that the hint for the dockable panel sometimes appears on the wrong screen before returning to the correct one on a mouse motion event.