### PR TITLE
Change `ScaleWithResolution` defaults in Canvas Scalar

### DIFF
--- a/Source/Editor/SceneGraph/Actors/UICanvasNode.cs
+++ b/Source/Editor/SceneGraph/Actors/UICanvasNode.cs
@@ -31,13 +31,25 @@ namespace FlaxEditor.SceneGraph.Actors
 
             // Rotate to match the space (GUI uses upper left corner as a root)
             Actor.LocalOrientation = Quaternion.Euler(0, -180, -180);
-            var uiControl = new UIControl
+            bool canSpawn = true;
+            foreach (var uiControl in Actor.GetChildren<UIControl>())
             {
-                Name = "Canvas Scalar",
-                Transform = Actor.Transform,
-                Control = new CanvasScaler()
-            };
-            Root.Spawn(uiControl, Actor);
+                if (uiControl.Get<CanvasScaler>() == null)
+                    continue;
+                canSpawn = false;
+            }
+
+            if (canSpawn)
+            {
+                var uiControl = new UIControl
+                {
+                    Name = "Canvas Scalar",
+                    Transform = Actor.Transform,
+                    Control = new CanvasScaler()
+                };
+                Root.Spawn(uiControl, Actor);
+            }
+            _treeNode.Expand();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/SceneGraph/Actors/UICanvasNode.cs
+++ b/Source/Editor/SceneGraph/Actors/UICanvasNode.cs
@@ -37,6 +37,7 @@ namespace FlaxEditor.SceneGraph.Actors
                 if (uiControl.Get<CanvasScaler>() == null)
                     continue;
                 canSpawn = false;
+                break;
             }
 
             if (canSpawn)

--- a/Source/Engine/UI/GUI/CanvasScaler.cs
+++ b/Source/Engine/UI/GUI/CanvasScaler.cs
@@ -98,8 +98,8 @@ namespace FlaxEngine.GUI
         private float _scale = 1.0f;
         private float _scaleFactor = 1.0f;
         private float _physicalUnitSize = 1.0f;
-        private Float2 _resolutionMin = new Float2(1, 1);
-        private Float2 _resolutionMax = new Float2(10000, 10000);
+        private Float2 _resolutionMin = new Float2(640, 480);
+        private Float2 _resolutionMax = new Float2(7680, 4320);
 
         /// <summary>
         /// Gets the current UI scale. Computed based on the setup when performing layout.


### PR DESCRIPTION
Changes `ScaleWithReoslution` in Canvas scalar min resolution to 640x480, and max resolution to 7680x4320. Closes #1789 

This PR also adds to not spawn a canvas scalar under a UICanvas if it already has one., I ran into this issue when converting a UICanvas to a UICanvas again...