### PR TITLE
Refactor joints to use auto serialization, excluding D6Joint.

### DIFF
--- a/Source/Engine/Physics/Joints/DistanceJoint.cpp
+++ b/Source/Engine/Physics/Joints/DistanceJoint.cpp
@@ -2,7 +2,6 @@
 
 #include "DistanceJoint.h"
 #include "Engine/Physics/PhysicsBackend.h"
-#include "Engine/Serialization/Serialization.h"
 
 DistanceJoint::DistanceJoint(const SpawnParams& params)
     : Joint(params)
@@ -98,34 +97,6 @@ void DistanceJoint::OnDebugDrawSelected()
 }
 
 #endif
-
-void DistanceJoint::Serialize(SerializeStream& stream, const void* otherObj)
-{
-    // Base
-    Joint::Serialize(stream, otherObj);
-
-    SERIALIZE_GET_OTHER_OBJ(DistanceJoint);
-
-    SERIALIZE_MEMBER(Flags, _flags);
-    SERIALIZE_MEMBER(MinDistance, _minDistance);
-    SERIALIZE_MEMBER(MaxDistance, _maxDistance);
-    SERIALIZE_MEMBER(Tolerance, _tolerance);
-    SERIALIZE_MEMBER(Stiffness, _spring.Stiffness);
-    SERIALIZE_MEMBER(Damping, _spring.Damping);
-}
-
-void DistanceJoint::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
-{
-    // Base
-    Joint::Deserialize(stream, modifier);
-
-    DESERIALIZE_MEMBER(Flags, _flags);
-    DESERIALIZE_MEMBER(MinDistance, _minDistance);
-    DESERIALIZE_MEMBER(MaxDistance, _maxDistance);
-    DESERIALIZE_MEMBER(Tolerance, _tolerance);
-    DESERIALIZE_MEMBER(Stiffness, _spring.Stiffness);
-    DESERIALIZE_MEMBER(Damping, _spring.Damping);
-}
 
 void* DistanceJoint::CreateJoint(const PhysicsJointDesc& desc)
 {

--- a/Source/Engine/Physics/Joints/DistanceJoint.h
+++ b/Source/Engine/Physics/Joints/DistanceJoint.h
@@ -40,6 +40,7 @@ DECLARE_ENUM_OPERATORS(DistanceJointFlag);
 API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/Distance Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API DistanceJoint : public Joint
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCENE_OBJECT(DistanceJoint);
 private:
     DistanceJointFlag _flags;
@@ -136,8 +137,6 @@ public:
 #if USE_EDITOR
     void OnDebugDrawSelected() override;
 #endif
-    void Serialize(SerializeStream& stream, const void* otherObj) override;
-    void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
 
 protected:
     // [Joint]

--- a/Source/Engine/Physics/Joints/HingeJoint.cpp
+++ b/Source/Engine/Physics/Joints/HingeJoint.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #include "HingeJoint.h"
-#include "Engine/Serialization/Serialization.h"
 #include "Engine/Physics/PhysicsBackend.h"
 
 HingeJoint::HingeJoint(const SpawnParams& params)
@@ -83,44 +82,6 @@ void HingeJoint::OnDebugDrawSelected()
 }
 
 #endif
-
-void HingeJoint::Serialize(SerializeStream& stream, const void* otherObj)
-{
-    // Base
-    Joint::Serialize(stream, otherObj);
-
-    SERIALIZE_GET_OTHER_OBJ(HingeJoint);
-
-    SERIALIZE_MEMBER(Flags, _flags);
-    SERIALIZE_MEMBER(ContactDist, _limit.ContactDist);
-    SERIALIZE_MEMBER(Restitution, _limit.Restitution);
-    SERIALIZE_MEMBER(Stiffness, _limit.Spring.Stiffness);
-    SERIALIZE_MEMBER(Damping, _limit.Spring.Damping);
-    SERIALIZE_MEMBER(LowerLimit, _limit.Lower);
-    SERIALIZE_MEMBER(UpperLimit, _limit.Upper);
-    SERIALIZE_MEMBER(Velocity, _drive.Velocity);
-    SERIALIZE_MEMBER(ForceLimit, _drive.ForceLimit);
-    SERIALIZE_MEMBER(GearRatio, _drive.GearRatio);
-    SERIALIZE_MEMBER(FreeSpin, _drive.FreeSpin);
-}
-
-void HingeJoint::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
-{
-    // Base
-    Joint::Deserialize(stream, modifier);
-
-    DESERIALIZE_MEMBER(Flags, _flags);
-    DESERIALIZE_MEMBER(ContactDist, _limit.ContactDist);
-    DESERIALIZE_MEMBER(Restitution, _limit.Restitution);
-    DESERIALIZE_MEMBER(Stiffness, _limit.Spring.Stiffness);
-    DESERIALIZE_MEMBER(Damping, _limit.Spring.Damping);
-    DESERIALIZE_MEMBER(LowerLimit, _limit.Lower);
-    DESERIALIZE_MEMBER(UpperLimit, _limit.Upper);
-    DESERIALIZE_MEMBER(Velocity, _drive.Velocity);
-    DESERIALIZE_MEMBER(ForceLimit, _drive.ForceLimit);
-    DESERIALIZE_MEMBER(GearRatio, _drive.GearRatio);
-    DESERIALIZE_MEMBER(FreeSpin, _drive.FreeSpin);
-}
 
 void* HingeJoint::CreateJoint(const PhysicsJointDesc& desc)
 {

--- a/Source/Engine/Physics/Joints/HingeJoint.h
+++ b/Source/Engine/Physics/Joints/HingeJoint.h
@@ -31,8 +31,9 @@ DECLARE_ENUM_OPERATORS(HingeJointFlag);
 /// <summary>
 /// Properties of a drive that drives the joint's angular velocity towards a particular value.
 /// </summary>
-API_STRUCT() struct HingeJointDrive
+API_STRUCT() struct FLAXENGINE_API HingeJointDrive : ISerializable
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE_MINIMAL(HingeJointDrive);
 
     /// <summary>
@@ -70,6 +71,7 @@ public:
 API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/Hinge Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API HingeJoint : public Joint
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCENE_OBJECT(HingeJoint);
 private:
     HingeJointFlag _flags;
@@ -80,7 +82,7 @@ public:
     /// <summary>
     /// Gets the joint mode flags. Controls joint behaviour.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(100), DefaultValue(HingeJointFlag.Limit | HingeJointFlag.Drive)")
+    API_PROPERTY(Attributes="EditorOrder(100), DefaultValue(HingeJointFlag.Limit | HingeJointFlag.Drive), EditorDisplay(\"Joint\")")
     FORCE_INLINE HingeJointFlag GetFlags() const
     {
         return _flags;
@@ -139,8 +141,6 @@ public:
 #if USE_EDITOR
     void OnDebugDrawSelected() override;
 #endif
-    void Serialize(SerializeStream& stream, const void* otherObj) override;
-    void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
 
 protected:
     // [Joint]

--- a/Source/Engine/Physics/Joints/Joint.cpp
+++ b/Source/Engine/Physics/Joints/Joint.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #include "Joint.h"
-#include "Engine/Serialization/Serialization.h"
 #include "Engine/Core/Log.h"
 #include "Engine/Physics/Physics.h"
 #include "Engine/Physics/PhysicsBackend.h"
@@ -239,36 +238,6 @@ void Joint::OnDebugDrawSelected()
 }
 
 #endif
-
-void Joint::Serialize(SerializeStream& stream, const void* otherObj)
-{
-    // Base
-    Actor::Serialize(stream, otherObj);
-
-    SERIALIZE_GET_OTHER_OBJ(Joint);
-
-    SERIALIZE(Target);
-    SERIALIZE_MEMBER(BreakForce, _breakForce);
-    SERIALIZE_MEMBER(BreakTorque, _breakTorque);
-    SERIALIZE_MEMBER(TargetAnchor, _targetAnchor);
-    SERIALIZE_MEMBER(TargetAnchorRotation, _targetAnchorRotation);
-    SERIALIZE_MEMBER(EnableCollision, _enableCollision);
-    SERIALIZE_MEMBER(EnableAutoAnchor, _enableAutoAnchor);
-}
-
-void Joint::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
-{
-    // Base
-    Actor::Deserialize(stream, modifier);
-
-    DESERIALIZE(Target);
-    DESERIALIZE_MEMBER(BreakForce, _breakForce);
-    DESERIALIZE_MEMBER(BreakTorque, _breakTorque);
-    DESERIALIZE_MEMBER(TargetAnchor, _targetAnchor);
-    DESERIALIZE_MEMBER(TargetAnchorRotation, _targetAnchorRotation);
-    DESERIALIZE_MEMBER(EnableCollision, _enableCollision);
-    DESERIALIZE_MEMBER(EnableAutoAnchor, _enableAutoAnchor);
-}
 
 void Joint::BeginPlay(SceneBeginData* data)
 {

--- a/Source/Engine/Physics/Joints/Joint.h
+++ b/Source/Engine/Physics/Joints/Joint.h
@@ -18,6 +18,7 @@ class IPhysicsActor;
 /// <seealso cref="Actor" />
 API_CLASS(Abstract) class FLAXENGINE_API Joint : public Actor
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCENE_OBJECT_ABSTRACT(Joint);
 protected:
     void* _joint;
@@ -188,8 +189,6 @@ public:
 #if USE_EDITOR
     void OnDebugDrawSelected() override;
 #endif
-    void Serialize(SerializeStream& stream, const void* otherObj) override;
-    void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
 
 protected:
     // [Actor]

--- a/Source/Engine/Physics/Joints/Limits.h
+++ b/Source/Engine/Physics/Joints/Limits.h
@@ -8,8 +8,9 @@
 /// Controls spring parameters for a physics joint limits. If a limit is soft (body bounces back due to restitution when 
 /// the limit is reached) the spring will pull the body back towards the limit using the specified parameters.
 /// </summary>
-API_STRUCT() struct SpringParameters
+API_STRUCT() struct FLAXENGINE_API SpringParameters : ISerializable
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE_MINIMAL(SpringParameters);
 
     /// <summary>
@@ -53,8 +54,9 @@ public:
 /// <summary>
 /// Represents a joint limit between two distance values. Lower value must be less than the upper value.
 /// </summary>
-API_STRUCT() struct LimitLinearRange
+API_STRUCT() struct FLAXENGINE_API LimitLinearRange : ISerializable
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE_MINIMAL(LimitLinearRange);
 
     /// <summary>
@@ -128,8 +130,9 @@ public:
 /// <summary>
 /// Represents a joint limit between zero a single distance value.
 /// </summary>
-API_STRUCT() struct LimitLinear
+API_STRUCT() struct FLAXENGINE_API LimitLinear : ISerializable
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE_MINIMAL(LimitLinear);
 
     /// <summary>
@@ -194,8 +197,9 @@ public:
 /// <summary>
 /// Represents a joint limit between two angles.
 /// </summary>
-API_STRUCT() struct LimitAngularRange
+API_STRUCT() struct FLAXENGINE_API LimitAngularRange : ISerializable
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE_MINIMAL(LimitAngularRange);
 
     /// <summary>
@@ -269,8 +273,9 @@ public:
 /// <summary>
 /// Represents a joint limit that constraints movement to within an elliptical cone.
 /// </summary>
-API_STRUCT() struct LimitConeRange
+API_STRUCT() struct FLAXENGINE_API LimitConeRange :ISerializable
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE_MINIMAL(LimitConeRange);
 
     /// <summary>

--- a/Source/Engine/Physics/Joints/SliderJoint.cpp
+++ b/Source/Engine/Physics/Joints/SliderJoint.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #include "SliderJoint.h"
-#include "Engine/Serialization/Serialization.h"
 #include "Engine/Physics/PhysicsBackend.h"
 
 SliderJoint::SliderJoint(const SpawnParams& params)
@@ -63,36 +62,6 @@ void SliderJoint::OnDebugDrawSelected()
 }
 
 #endif
-
-void SliderJoint::Serialize(SerializeStream& stream, const void* otherObj)
-{
-    // Base
-    Joint::Serialize(stream, otherObj);
-
-    SERIALIZE_GET_OTHER_OBJ(SliderJoint);
-
-    SERIALIZE_MEMBER(Flags, _flags);
-    SERIALIZE_MEMBER(ContactDist, _limit.ContactDist);
-    SERIALIZE_MEMBER(Restitution, _limit.Restitution);
-    SERIALIZE_MEMBER(Stiffness, _limit.Spring.Stiffness);
-    SERIALIZE_MEMBER(Damping, _limit.Spring.Damping);
-    SERIALIZE_MEMBER(LowerLimit, _limit.Lower);
-    SERIALIZE_MEMBER(UpperLimit, _limit.Upper);
-}
-
-void SliderJoint::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
-{
-    // Base
-    Joint::Deserialize(stream, modifier);
-
-    DESERIALIZE_MEMBER(Flags, _flags);
-    DESERIALIZE_MEMBER(ContactDist, _limit.ContactDist);
-    DESERIALIZE_MEMBER(Restitution, _limit.Restitution);
-    DESERIALIZE_MEMBER(Stiffness, _limit.Spring.Stiffness);
-    DESERIALIZE_MEMBER(Damping, _limit.Spring.Damping);
-    DESERIALIZE_MEMBER(LowerLimit, _limit.Lower);
-    DESERIALIZE_MEMBER(UpperLimit, _limit.Upper);
-}
 
 void* SliderJoint::CreateJoint(const PhysicsJointDesc& desc)
 {

--- a/Source/Engine/Physics/Joints/SliderJoint.h
+++ b/Source/Engine/Physics/Joints/SliderJoint.h
@@ -30,6 +30,7 @@ DECLARE_ENUM_OPERATORS(SliderJointFlag);
 API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Joints/Slider Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API SliderJoint : public Joint
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCENE_OBJECT(SliderJoint);
 private:
     SliderJointFlag _flags;
@@ -82,8 +83,6 @@ public:
 #if USE_EDITOR
     void OnDebugDrawSelected() override;
 #endif
-    void Serialize(SerializeStream& stream, const void* otherObj) override;
-    void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
 
 protected:
     // [Joint]

--- a/Source/Engine/Physics/Joints/SphericalJoint.cpp
+++ b/Source/Engine/Physics/Joints/SphericalJoint.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 #include "SphericalJoint.h"
-#include "Engine/Serialization/Serialization.h"
 #include "Engine/Physics/PhysicsBackend.h"
 
 SphericalJoint::SphericalJoint(const SpawnParams& params)
@@ -55,36 +54,6 @@ void SphericalJoint::OnDebugDrawSelected()
 }
 
 #endif
-
-void SphericalJoint::Serialize(SerializeStream& stream, const void* otherObj)
-{
-    // Base
-    Joint::Serialize(stream, otherObj);
-
-    SERIALIZE_GET_OTHER_OBJ(SphericalJoint);
-
-    SERIALIZE_MEMBER(Flags, _flags);
-    SERIALIZE_MEMBER(ContactDist, _limit.ContactDist);
-    SERIALIZE_MEMBER(Restitution, _limit.Restitution);
-    SERIALIZE_MEMBER(Stiffness, _limit.Spring.Stiffness);
-    SERIALIZE_MEMBER(Damping, _limit.Spring.Damping);
-    SERIALIZE_MEMBER(YLimitAngle, _limit.YLimitAngle);
-    SERIALIZE_MEMBER(ZLimitAngle, _limit.ZLimitAngle);
-}
-
-void SphericalJoint::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
-{
-    // Base
-    Joint::Deserialize(stream, modifier);
-
-    DESERIALIZE_MEMBER(Flags, _flags);
-    DESERIALIZE_MEMBER(ContactDist, _limit.ContactDist);
-    DESERIALIZE_MEMBER(Restitution, _limit.Restitution);
-    DESERIALIZE_MEMBER(Stiffness, _limit.Spring.Stiffness);
-    DESERIALIZE_MEMBER(Damping, _limit.Spring.Damping);
-    DESERIALIZE_MEMBER(YLimitAngle, _limit.YLimitAngle);
-    DESERIALIZE_MEMBER(ZLimitAngle, _limit.ZLimitAngle);
-}
 
 void* SphericalJoint::CreateJoint(const PhysicsJointDesc& desc)
 {

--- a/Source/Engine/Physics/Joints/SphericalJoint.h
+++ b/Source/Engine/Physics/Joints/SphericalJoint.h
@@ -32,6 +32,7 @@ DECLARE_ENUM_OPERATORS(SphericalJointFlag);
 API_CLASS(Attributes = "ActorContextMenu(\"New/Physics/Joints/Spherical Joint\"), ActorToolbox(\"Physics\")")
 class FLAXENGINE_API SphericalJoint : public Joint
 {
+    API_AUTO_SERIALIZATION();
     DECLARE_SCENE_OBJECT(SphericalJoint);
 private:
     SphericalJointFlag _flags;
@@ -73,8 +74,6 @@ public:
 #if USE_EDITOR
     void OnDebugDrawSelected() override;
 #endif
-    void Serialize(SerializeStream& stream, const void* otherObj) override;
-    void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
 
 protected:
     // [Joint]


### PR DESCRIPTION
This refactors joints to use auto serialize. This excludes the D6Joint as that has some special serialization going on. Also fixes missing editor group for Flags in Hinge joint.