### PR TITLE
Multi field statusbar and usage hints

### DIFF
--- a/Source/Editor/GUI/MultiFieldStatusBar.cs
+++ b/Source/Editor/GUI/MultiFieldStatusBar.cs
@@ -25,6 +25,15 @@ public class MultiFieldStatusBar : ContainerControl
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="MultiFieldStatusBar"/> class.
+    /// </summary>
+    public MultiFieldStatusBar()
+    {
+        AutoFocus = false;
+        AnchorPreset = AnchorPresets.HorizontalStretchBottom;
+    }
+
+    /// <summary>
     /// Definition of a field inside a status bar
     /// </summary>
     public Dictionary<string, StatusBarField> Field = new();
@@ -71,7 +80,7 @@ public class MultiFieldStatusBar : ContainerControl
         else
         {
             // add a default field spanning the available width for compatibility with a single field status bar
-            Field[DefaultFieldName] = new StatusBarField
+            Field[name] = new StatusBarField
             {
                 Text = text,
                 TextColor = Style.Current.Foreground,
@@ -105,7 +114,7 @@ public class MultiFieldStatusBar : ContainerControl
         else
         {
             // add a default field spanning the available width for compatibility with a single field status bar
-            Field[DefaultFieldName] = new StatusBarField
+            Field[name] = new StatusBarField
             {
                 Text = "",
                 TextColor = color,
@@ -143,7 +152,8 @@ public class MultiFieldStatusBar : ContainerControl
         {
             var field = keyValue.Value;
             var x = (Width - 24) * field.RelativeX + 4;
-            var width = (Width - 24) * field.RelativeWidth;
+            var width = (Width - 20) * field.RelativeWidth;
+            //Debug.Log($"draw status bar with {Field.Count} fields, text {field.Text}, x {x}, width {width}");
             // Draw status field text
             Render2D.DrawText(style.FontSmall, field.Text, new Rectangle(x, 0, width, Height),
                               field.TextColor, TextAlignment.Near, TextAlignment.Center);

--- a/Source/Editor/GUI/MultiFieldStatusBar.cs
+++ b/Source/Editor/GUI/MultiFieldStatusBar.cs
@@ -1,0 +1,152 @@
+
+using System.Collections.Generic;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.GUI;
+
+/// <summary>
+/// Status bar with multiple fields
+/// </summary>
+public class MultiFieldStatusBar : ContainerControl
+{
+    /// <summary>
+    /// Name of the default field if only one is used
+    /// </summary>
+    public const string DefaultFieldName = "_DefaultField";
+    public const int DefaultHeight = 22;
+
+    public struct StatusBarField
+    {
+        public string Text;
+        public Color TextColor;
+        public float RelativeX;
+        public float RelativeWidth;
+    }
+
+    /// <summary>
+    /// Definition of a field inside a status bar
+    /// </summary>
+    public Dictionary<string, StatusBarField> Field = new();
+
+    /// <summary>
+    /// Set text for a default field
+    /// </summary>
+    public string Text
+    {
+        get => GetText(DefaultFieldName);
+        set => SetText(DefaultFieldName, value);
+    }
+
+    /// <summary>
+    /// Set text color for a default field
+    /// </summary>
+    public Color TextColor
+    {
+        get => GetTextColor(DefaultFieldName);
+        set => SetTextColor(DefaultFieldName, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the color of the status strip.
+    /// </summary>
+    public Color StatusColor
+    {
+        get => BackgroundColor;
+        set => BackgroundColor = value;
+    }
+
+    /// <summary>
+    /// Set the Text for the named field
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="text"></param>
+    public void SetText(string name, string text)
+    {
+        if (Field.TryGetValue(name, out var field))
+        {
+            field.Text = text;
+            Field[name] = field;
+        }
+        else
+        {
+            // add a default field spanning the available width for compatibility with a single field status bar
+            Field[DefaultFieldName] = new StatusBarField
+            {
+                Text = text,
+                TextColor = Style.Current.Foreground,
+                RelativeX = 0f,
+                RelativeWidth = 1f
+            };
+        }
+    }
+
+    /// <summary>
+    /// Get the text of the named field
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public string GetText(string name)
+    {
+        if (Field.TryGetValue(name, out var field))
+        {
+            return field.Text;
+        }
+        return "";
+    }
+
+    public void SetTextColor(string name, Color color)
+    {
+        if (Field.TryGetValue(name, out var field))
+        {
+            field.TextColor = color;
+            Field[name] = field;
+        }
+        else
+        {
+            // add a default field spanning the available width for compatibility with a single field status bar
+            Field[DefaultFieldName] = new StatusBarField
+            {
+                Text = "",
+                TextColor = color,
+                RelativeX = 0f,
+                RelativeWidth = 1f
+            };
+        }
+    }
+
+    public Color GetTextColor(string name)
+    {
+        return Field.TryGetValue(name, out var field) ? field.TextColor : Style.Current.Foreground;
+    }
+
+    public void SetRelativeWidthDefaultField(float value)
+    {
+        if (Field.TryGetValue(DefaultFieldName, out var field))
+        {
+            field.RelativeWidth = value;
+            Field[DefaultFieldName] = field;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override void Draw()
+    {
+        base.Draw();
+        var style = Style.Current;
+
+        // Draw size grip
+        if (Root is WindowRootControl window && !window.IsMaximized)
+            Render2D.DrawSprite(style.StatusBarSizeGrip, new Rectangle(Width - 12, 10, 12, 12), style.Foreground);
+
+        foreach (var keyValue in Field)
+        {
+            var field = keyValue.Value;
+            var x = (Width - 24) * field.RelativeX + 4;
+            var width = (Width - 24) * field.RelativeWidth;
+            // Draw status field text
+            Render2D.DrawText(style.FontSmall, field.Text, new Rectangle(x, 0, width, Height),
+                              field.TextColor, TextAlignment.Near, TextAlignment.Center);
+        }
+    }
+}

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -29,6 +29,7 @@ namespace FlaxEditor.Modules
     /// <seealso cref="FlaxEditor.Modules.EditorModule" />
     public sealed class UIModule : EditorModule
     {
+        private const string UsageStatusBarField = "Usage";
         private Label _progressLabel;
         private ProgressBar _progressBar;
         private Button _outputLogButton;
@@ -304,9 +305,21 @@ namespace FlaxEditor.Modules
                 color = Style.Current.Statusbar.Loading;
             }
 
+            UpdateUsageHint();
+
             StatusBar.Text = text;
             StatusBar.StatusColor = color;
             _contentStats = contentStats;
+        }
+
+        public void UpdateUsageHint()
+        {
+            // fake some hints to showcase what the usage field is supposed to do
+            if (Editor.Windows.SceneWin.IsFocused)
+                StatusBar.SetText(UsageStatusBarField, "F: focus selected");
+            else if (Editor.Windows.EditWin.IsFocused)
+                StatusBar.SetText(UsageStatusBarField, "LMB: select, MMB: pan, RMB: rotate");
+            else StatusBar.SetText(UsageStatusBarField, "(no hints available)");
         }
 
         /// <summary>
@@ -406,6 +419,7 @@ namespace FlaxEditor.Modules
             {
                 UpdateStatusBar();
             }
+            UpdateUsageHint();
         }
 
         private class CustomWindowBorderControl : Control
@@ -753,6 +767,12 @@ namespace FlaxEditor.Modules
                 Offsets = new Margin(0, 0, -MultiFieldStatusBar.DefaultHeight, MultiFieldStatusBar.DefaultHeight),
             };
             StatusBar.SetRelativeWidthDefaultField(0.4f);
+            StatusBar.Field[UsageStatusBarField] = new MultiFieldStatusBar.StatusBarField
+            {
+                RelativeWidth = 0.6f,
+                RelativeX = 0.4f,
+                TextColor = Style.Current.Foreground
+            };
             // Output log button
             _outputLogButton = new Button()
             {

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -108,7 +108,7 @@ namespace FlaxEditor.Modules
         /// <summary>
         /// The status strip control.
         /// </summary>
-        public StatusBar StatusBar;
+        public MultiFieldStatusBar StatusBar;
 
         /// <summary>
         /// The visject surface background texture. Cached to be used globally.
@@ -418,7 +418,7 @@ namespace FlaxEditor.Modules
                     return;
 
                 var color = Editor.Instance.UI.StatusBar.StatusColor;
-                var rect = new Rectangle(0.5f, 0.5f, Parent.Width - 1.0f, Parent.Height - 1.0f - StatusBar.DefaultHeight);
+                var rect = new Rectangle(0.5f, 0.5f, Parent.Width - 1.0f, Parent.Height - 1.0f - MultiFieldStatusBar.DefaultHeight);
                 Render2D.DrawLine(rect.UpperLeft, rect.UpperRight, color);
                 Render2D.DrawLine(rect.UpperLeft, rect.BottomLeft, color);
                 Render2D.DrawLine(rect.UpperRight, rect.BottomRight, color);
@@ -746,12 +746,13 @@ namespace FlaxEditor.Modules
         private void InitStatusBar(RootControl mainWindow)
         {
             // Status Bar
-            StatusBar = new StatusBar
+            StatusBar = new MultiFieldStatusBar
             {
                 Text = "Loading...",
                 Parent = mainWindow,
-                Offsets = new Margin(0, 0, -StatusBar.DefaultHeight, StatusBar.DefaultHeight),
+                Offsets = new Margin(0, 0, -MultiFieldStatusBar.DefaultHeight, MultiFieldStatusBar.DefaultHeight),
             };
+            StatusBar.SetRelativeWidthDefaultField(0.4f);
             // Output log button
             _outputLogButton = new Button()
             {

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -305,21 +305,14 @@ namespace FlaxEditor.Modules
                 color = Style.Current.Statusbar.Loading;
             }
 
-            UpdateUsageHint();
-
             StatusBar.Text = text;
             StatusBar.StatusColor = color;
             _contentStats = contentStats;
         }
 
-        public void UpdateUsageHint()
+        public void DisplayUsageHint(string hint)
         {
-            // fake some hints to showcase what the usage field is supposed to do
-            if (Editor.Windows.SceneWin.IsFocused)
-                StatusBar.SetText(UsageStatusBarField, "F: focus selected");
-            else if (Editor.Windows.EditWin.IsFocused)
-                StatusBar.SetText(UsageStatusBarField, "LMB: select, MMB: pan, RMB: rotate");
-            else StatusBar.SetText(UsageStatusBarField, "(no hints available)");
+            StatusBar.SetText(UsageStatusBarField, hint);
         }
 
         /// <summary>
@@ -419,7 +412,6 @@ namespace FlaxEditor.Modules
             {
                 UpdateStatusBar();
             }
-            UpdateUsageHint();
         }
 
         private class CustomWindowBorderControl : Control

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -66,6 +66,9 @@ namespace FlaxEditor.Windows
         /// </summary>
         public ContentView View => _view;
 
+        /// <inheritdoc />
+        protected override string UsageHint { get; set; }
+
         internal bool ShowEngineFiles
         {
             get => _showEngineFiles;
@@ -281,6 +284,10 @@ namespace FlaxEditor.Windows
             _view.OnDelete += Delete;
             _view.OnDuplicate += Duplicate;
             _view.OnPaste += Paste;
+
+            // Set up usage hints
+            UsageHint = Editor.Options.Options.Input.Duplicate + ": duplicate, " +
+                        Editor.Options.Options.Input.Rename + ": rename";
         }
 
         private ContextMenu OnViewDropdownPopupCreate(ComboBox comboBox)

--- a/Source/Editor/Windows/EditGameWindow.cs
+++ b/Source/Editor/Windows/EditGameWindow.cs
@@ -19,6 +19,10 @@ namespace FlaxEditor.Windows
     /// <seealso cref="FlaxEditor.Windows.SceneEditorWindow" />
     public sealed class EditGameWindow : SceneEditorWindow
     {
+        /// <inheritdoc />
+        protected override string UsageHint => "LMB: select, MMB: pan, RMB: rotate, " +
+                                               Editor.Options.Options.Input.Play + ": play";
+
         /// <summary>
         /// Camera preview output control.
         /// </summary>

--- a/Source/Editor/Windows/EditGameWindow.cs
+++ b/Source/Editor/Windows/EditGameWindow.cs
@@ -20,7 +20,7 @@ namespace FlaxEditor.Windows
     public sealed class EditGameWindow : SceneEditorWindow
     {
         /// <inheritdoc />
-        protected override string UsageHint => "LMB: select, MMB: pan, RMB: rotate, " +
+        protected override string UsageHint => "LMB: select, MMB: pan, RMB: rotate, Alt+LMB: orbit, " +
                                                Editor.Options.Options.Input.Play + ": play";
 
         /// <summary>

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -30,6 +30,15 @@ namespace FlaxEditor.Windows
         protected virtual bool CanUseNavigation => true;
 
         /// <summary>
+        /// Gets a usage hint that is displayed in the status bar when this window gets focused.
+        /// </summary>
+        protected virtual string UsageHint
+        {
+            get => string.Empty;
+            set => value = "";
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="EditorWindow"/> class.
         /// </summary>
         /// <param name="editor">The editor.</param>
@@ -60,6 +69,16 @@ namespace FlaxEditor.Windows
         public virtual bool IsEditingItem(ContentItem item)
         {
             return false;
+        }
+
+        public virtual void DisplayUsageHint()
+        {
+            Editor.UI.DisplayUsageHint(UsageHint);
+        }
+
+        public virtual void HideUsageHint()
+        {
+            Editor.UI.DisplayUsageHint("");
         }
 
         #region Window Events
@@ -188,6 +207,20 @@ namespace FlaxEditor.Windows
         }
 
         #endregion
+
+        /// <inheritdoc />
+        public override void OnStartContainsFocus()
+        {
+            base.OnStartContainsFocus();
+            DisplayUsageHint();
+        }
+
+        /// <inheritdoc />
+        public override void OnEndContainsFocus()
+        {
+            base.OnEndContainsFocus();
+            HideUsageHint();
+        }
 
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -42,6 +42,9 @@ namespace FlaxEditor.Windows
         /// </summary>
         public RenderOutputControl Viewport => _viewport;
 
+        /// <inheritdoc />
+        protected override string UsageHint => Editor.Options.Options.Input.ToggleFullscreen + ": toggle fullscreen";
+
         /// <summary>
         /// Gets or sets a value indicating whether show game GUI in the view or keep it hidden.
         /// </summary>

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -91,6 +91,9 @@ namespace FlaxEditor.Windows
             InputActions.Add(options => options.Rename, Rename);
         }
 
+        /// <inheritdoc />
+        protected override string UsageHint { get; set; }
+
         /// <summary>
         /// Enables or disables vertical and horizontal scrolling on the scene tree panel.
         /// </summary>
@@ -204,12 +207,16 @@ namespace FlaxEditor.Windows
 
                 // Select
                 Editor.SceneEditing.Select(actors);
+                UsageHint = Editor.Options.Options.Input.FocusSelection + ": focus selected, " +
+                            Editor.Options.Options.Input.LockFocusSelection + ": lock focus";
             }
             else
             {
                 // Deselect
                 Editor.SceneEditing.Deselect();
+                UsageHint = "";
             }
+            DisplayUsageHint();
         }
 
         private void OnTreeRightClick(TreeNode node, Float2 location)

--- a/Source/Engine/Scripting/Internal/EngineInternalCalls.cpp
+++ b/Source/Engine/Scripting/Internal/EngineInternalCalls.cpp
@@ -108,7 +108,7 @@ namespace
     };
 
     ChunkedArray<Location, 256> ManagedSourceLocations;
-    uint32 ManagedEventsCount[PLATFORM_THREADS_LIMIT] = { 0 };
+    ThreadLocal<uint32> ManagedEventsCount;
 #endif
 #endif
 }
@@ -148,7 +148,7 @@ DEFINE_INTERNAL_CALL(void) ProfilerInternal_BeginEvent(MString* nameObj)
     //static constexpr tracy::SourceLocationData tracySrcLoc{ nullptr, __FUNCTION__, __FILE__, (uint32_t)__LINE__, 0 };
     const bool tracyActive = tracy::ScopedZone::Begin(srcLoc);
     if (tracyActive)
-        ManagedEventsCount[Platform::GetCurrentThreadID()]++;
+        ManagedEventsCount.Get()++;
 #endif
 #endif
 #endif
@@ -158,7 +158,7 @@ DEFINE_INTERNAL_CALL(void) ProfilerInternal_EndEvent()
 {
 #if COMPILE_WITH_PROFILER
 #if TRACY_ENABLE
-    auto& tracyActive = ManagedEventsCount[Platform::GetCurrentThreadID()];
+    uint32& tracyActive = ManagedEventsCount.Get();
     if (tracyActive > 0)
     {
         tracyActive--;


### PR DESCRIPTION
The basics are there:
- a new MultiFieldStatusbar that is code-compatible to the Statusbar but can hold multiple distinct fields. The default is to the left and 60% of the remaining horizontal space is used for displaying usage hints. The progress bar and the resize handle are unaffected by this change.
- some usage hints for editor windows. I picked those I personally would have loved to know from the beginning and like to be reminded of.

I hope for feedback on what you think which input actions should be shown in the usage hints.