### PR TITLE
Removed "Useless" Division 

### DIFF
--- a/Source/Engine/Engine/Time.cpp
+++ b/Source/Engine/Engine/Time.cpp
@@ -104,7 +104,7 @@ bool Time::TickData::OnTickBegin(float targetFps, float maxDeltaTime)
 
         if (targetFps > ZeroTolerance)
         {
-            int skip = (int)(1 + (time - NextBegin) / (1.0 / targetFps));
+            int skip = (int)(1 + (time - NextBegin) * targetFps);
             NextBegin += (1.0 / targetFps) * skip;
         }
     }

--- a/Source/Engine/Engine/Time.cpp
+++ b/Source/Engine/Engine/Time.cpp
@@ -160,7 +160,7 @@ bool Time::FixedStepTickData::OnTickBegin(float targetFps, float maxDeltaTime)
 
         if (targetFps > ZeroTolerance)
         {
-            int skip = (int)(1 + (time - NextBegin) / (1.0 / targetFps));
+            int skip = (int)(1 + (time - NextBegin) * targetFps);
             NextBegin += (1.0 / targetFps) * skip;
         }
     }


### PR DESCRIPTION
Since the application performs this operation frequently, changing `y / (1 / x) = z` to `yx = z` could increase performance since the CPU difficulty time computing division.