### PR TITLE
Fix `swap` for non-copyable types. Fix swapping core collections.

### DIFF
--- a/Source/Engine/Core/Collections/Array.h
+++ b/Source/Engine/Core/Collections/Array.h
@@ -734,9 +734,7 @@ public:
         }
         else
         {
-            Array tmp = MoveTemp(other);
-            other = *this;
-            *this = MoveTemp(tmp);
+            ::Swap(other, *this);
         }
     }
 

--- a/Source/Engine/Core/Collections/Dictionary.h
+++ b/Source/Engine/Core/Collections/Dictionary.h
@@ -616,9 +616,7 @@ public:
         }
         else
         {
-            Dictionary tmp = MoveTemp(other);
-            other = *this;
-            *this = MoveTemp(tmp);
+            ::Swap(other, *this);
         }
     }
 

--- a/Source/Engine/Core/Templates.h
+++ b/Source/Engine/Core/Templates.h
@@ -304,7 +304,7 @@ template<typename T>
 inline void Swap(T& a, T& b) noexcept
 {
     T tmp = MoveTemp(a);
-    a = b;
+    a = MoveTemp(b);
     b = MoveTemp(tmp);
 }
 


### PR DESCRIPTION
The existing implementation of `Swap<T>` fails to handle non-copyable objects. It relied on copy semantics, which is not applicable for move-only types. Additionally, new implementation allows for more optimizations.

For reference, Microsoft's implementation of the function uses 3 moves: https://github.com/microsoft/STL/blob/cf1313c39169dc376761eddee23c5e408e01aaa9/stl/inc/utility#L130

Note: Even though the number of lines is very small, the change to API is big (including both compatibility and performance).