### PR TITLE
Add ability to change default Android screen orientation.

### DIFF
--- a/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
@@ -169,6 +169,30 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
         permissions += String::Format(TEXT("\n    <uses-permission android:name=\"{0}\" />"), e.Item);
     }
 
+    // Setup default Android screen orientation
+    auto defaultOrienation = platformSettings->DefaultOrientation;
+    String orientation = String("fullSensor");
+    switch (defaultOrienation)
+    {
+    case AndroidScreenOrientation::Portrait:
+        orientation = String("portrait");
+        break;
+    case AndroidScreenOrientation::PortraitReverse:
+        orientation = String("reversePortrait");
+        break;
+    case AndroidScreenOrientation::LandscapeRight:
+        orientation = String("landscape");
+        break;
+    case AndroidScreenOrientation::LandscapeLeft:
+        orientation = String("reverseLandscape");
+        break;
+    case AndroidScreenOrientation::AutoRotation:
+        orientation = String("fullSensor");
+        break;
+    default:
+        break;
+    }
+
     // Setup Android application attributes
     String attributes;
     if (data.Configuration != BuildConfiguration::Release)
@@ -223,6 +247,7 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
     EditorUtilities::ReplaceInFile(manifestPath, TEXT("${PackageName}"), packageName);
     EditorUtilities::ReplaceInFile(manifestPath, TEXT("${ProjectVersion}"), projectVersion);
     EditorUtilities::ReplaceInFile(manifestPath, TEXT("${AndroidPermissions}"), permissions);
+    EditorUtilities::ReplaceInFile(manifestPath, TEXT("${DefaultOrientation}"), orientation);
     EditorUtilities::ReplaceInFile(manifestPath, TEXT("${AndroidAttributes}"), attributes);
     const String stringsPath = data.OriginalOutputPath / TEXT("app/src/main/res/values/strings.xml");
     EditorUtilities::ReplaceInFile(stringsPath, TEXT("${ProjectName}"), gameSettings->ProductName);

--- a/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
@@ -174,19 +174,19 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
     String orientation = String("fullSensor");
     switch (defaultOrienation)
     {
-    case AndroidScreenOrientation::Portrait:
+    case AndroidPlatformSettings::ScreenOrientation::Portrait:
         orientation = String("portrait");
         break;
-    case AndroidScreenOrientation::PortraitReverse:
+    case AndroidPlatformSettings::ScreenOrientation::PortraitReverse:
         orientation = String("reversePortrait");
         break;
-    case AndroidScreenOrientation::LandscapeRight:
+    case AndroidPlatformSettings::ScreenOrientation::LandscapeRight:
         orientation = String("landscape");
         break;
-    case AndroidScreenOrientation::LandscapeLeft:
+    case AndroidPlatformSettings::ScreenOrientation::LandscapeLeft:
         orientation = String("reverseLandscape");
         break;
-    case AndroidScreenOrientation::AutoRotation:
+    case AndroidPlatformSettings::ScreenOrientation::AutoRotation:
         orientation = String("fullSensor");
         break;
     default:

--- a/Source/Engine/Platform/Android/AndroidPlatformSettings.h
+++ b/Source/Engine/Platform/Android/AndroidPlatformSettings.h
@@ -10,6 +10,37 @@
 class Texture;
 
 /// <summary>
+/// Android screen orientation options.
+/// </summary>
+API_ENUM() enum class FLAXENGINE_API AndroidScreenOrientation 
+{
+    /// <summary>
+    /// "portrait" mode
+    /// </summary>
+    Portrait,
+
+    /// <summary>
+    /// "reversePortrait" mode
+    /// </summary>
+    PortraitReverse,
+
+    /// <summary>
+    /// "landscape" mode
+    /// </summary>
+    LandscapeRight,
+
+    /// <summary>
+    /// "reverseLandscape" mode
+    /// </summary>
+    LandscapeLeft,
+
+    /// <summary>
+    /// "fullSensor" mode
+    /// </summary>
+    AutoRotation,
+};
+
+/// <summary>
 /// Android platform settings.
 /// </summary>
 API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API AndroidPlatformSettings : public SettingsBase
@@ -28,6 +59,12 @@ API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API 
     /// </summary>
     API_FIELD(Attributes="EditorOrder(100), EditorDisplay(\"General\")")
     Array<String> Permissions;
+
+    /// <summary>
+    /// The default screen orientation.
+    /// </summary>
+    API_FIELD(Attributes = "EditorOrder(110), EditorDisplay(\"General\")")
+    AndroidScreenOrientation DefaultOrientation = AndroidScreenOrientation::AutoRotation;
 
     /// <summary>
     /// Custom icon texture to use for the application (overrides the default one).

--- a/Source/Engine/Platform/Android/AndroidPlatformSettings.h
+++ b/Source/Engine/Platform/Android/AndroidPlatformSettings.h
@@ -10,43 +10,43 @@
 class Texture;
 
 /// <summary>
-/// Android screen orientation options.
-/// </summary>
-API_ENUM() enum class FLAXENGINE_API AndroidScreenOrientation 
-{
-    /// <summary>
-    /// "portrait" mode
-    /// </summary>
-    Portrait,
-
-    /// <summary>
-    /// "reversePortrait" mode
-    /// </summary>
-    PortraitReverse,
-
-    /// <summary>
-    /// "landscape" mode
-    /// </summary>
-    LandscapeRight,
-
-    /// <summary>
-    /// "reverseLandscape" mode
-    /// </summary>
-    LandscapeLeft,
-
-    /// <summary>
-    /// "fullSensor" mode
-    /// </summary>
-    AutoRotation,
-};
-
-/// <summary>
 /// Android platform settings.
 /// </summary>
 API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API AndroidPlatformSettings : public SettingsBase
 {
     DECLARE_SCRIPTING_TYPE_MINIMAL(AndroidPlatformSettings);
     API_AUTO_SERIALIZATION();
+
+    /// <summary>
+    /// Android screen orientation options.
+    /// </summary>
+    API_ENUM() enum class FLAXENGINE_API ScreenOrientation
+    {
+        /// <summary>
+        /// "portrait" mode
+        /// </summary>
+        Portrait,
+
+        /// <summary>
+        /// "reversePortrait" mode
+        /// </summary>
+        PortraitReverse,
+
+        /// <summary>
+        /// "landscape" mode
+        /// </summary>
+        LandscapeRight,
+
+        /// <summary>
+        /// "reverseLandscape" mode
+        /// </summary>
+        LandscapeLeft,
+
+        /// <summary>
+        /// "fullSensor" mode
+        /// </summary>
+        AutoRotation,
+    };
 
     /// <summary>
     /// The application package name (eg. com.company.product). Custom tokens: ${PROJECT_NAME}, ${COMPANY_NAME}.
@@ -64,7 +64,7 @@ API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API 
     /// The default screen orientation.
     /// </summary>
     API_FIELD(Attributes = "EditorOrder(110), EditorDisplay(\"General\")")
-    AndroidScreenOrientation DefaultOrientation = AndroidScreenOrientation::AutoRotation;
+    ScreenOrientation DefaultOrientation = ScreenOrientation::AutoRotation;
 
     /// <summary>
     /// Custom icon texture to use for the application (overrides the default one).

--- a/Source/Platforms/Android/Binaries/Project/app/src/main/AndroidManifest.xml
+++ b/Source/Platforms/Android/Binaries/Project/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         <activity android:name="com.flaxengine.GameActivity"
             android:label="@string/app_name"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:screenOrientation="fullSensor">
+            android:screenOrientation="${DefaultOrientation}">
             <meta-data android:name="android.app.lib_name" android:value="FlaxGame" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This is a feature for android where the user can change the default orientation of their application. This is nice because it allows for the user to lock it in portrait or landscape mode without the sensor changing it.

My build for android fails to build because it fails to copy .Net runtime data files. Once that is fixed then I will test this more. This is not a big change and should just work though...