### PR TITLE
Add the option to deselect all.

### DIFF
--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -190,6 +190,7 @@ namespace FlaxEditor.Content.GUI
                         OnDelete?.Invoke(_selection);
                 }),
                 new InputActionsContainer.Binding(options => options.SelectAll, SelectAll),
+                new InputActionsContainer.Binding(options => options.DeselectAll, DeselectAll),
                 new InputActionsContainer.Binding(options => options.Rename, () =>
                 {
                     if (HasSelection && _selection[0].CanRename)
@@ -394,10 +395,7 @@ namespace FlaxEditor.Content.GUI
             PerformLayout();
         }
 
-        /// <summary>
-        /// Selects all the items.
-        /// </summary>
-        public void SelectAll()
+        private void BulkSelectUpdate(bool select = true)
         {
             // Lock layout
             var wasLayoutLocked = IsLayoutLocked;
@@ -405,11 +403,28 @@ namespace FlaxEditor.Content.GUI
 
             // Select items
             _selection.Clear();
-            _selection.AddRange(_items);
+            if (select)
+                _selection.AddRange(_items);
 
             // Unload and perform UI layout
             IsLayoutLocked = wasLayoutLocked;
             PerformLayout();
+        }
+
+        /// <summary>
+        /// Selects all the items.
+        /// </summary>
+        public void SelectAll()
+        {
+            BulkSelectUpdate(true);
+        }
+
+        /// <summary>
+        /// Deselects all the items.
+        /// </summary>
+        public void DeselectAll()
+        {
+            BulkSelectUpdate(false);
         }
 
         /// <summary>

--- a/Source/Editor/GUI/CurveEditor.Contents.cs
+++ b/Source/Editor/GUI/CurveEditor.Contents.cs
@@ -484,6 +484,7 @@ namespace FlaxEditor.GUI
                         cm.AddSeparator();
                         cm.AddButton("Edit all keyframes", () => _editor.EditAllKeyframes(this, location));
                         cm.AddButton("Select all keyframes", _editor.SelectAll);
+                        cm.AddButton("Deselect all keyframes", _editor.DeselectAll);
                         cm.AddButton("Copy all keyframes", () =>
                         {
                             _editor.SelectAll();

--- a/Source/Editor/GUI/CurveEditor.cs
+++ b/Source/Editor/GUI/CurveEditor.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -926,34 +927,29 @@ namespace FlaxEditor.GUI
             if (base.OnKeyDown(key))
                 return true;
 
-            switch (key)
+            InputOptions options = Editor.Instance.Options.Options.Input;
+            if (options.SelectAll.Process(this))
             {
-            case KeyboardKeys.Delete:
+                SelectAll();
+                UpdateTangents();
+                return true;
+            }
+            else if (options.Delete.Process(this))
+            {
                 RemoveKeyframes();
                 return true;
-            case KeyboardKeys.A:
-                if (Root.GetKey(KeyboardKeys.Control))
-                {
-                    SelectAll();
-                    UpdateTangents();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.C:
-                if (Root.GetKey(KeyboardKeys.Control))
-                {
-                    CopyKeyframes();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.V:
-                if (Root.GetKey(KeyboardKeys.Control))
-                {
-                    KeyframesEditorUtils.Paste(this);
-                    return true;
-                }
-                break;
             }
+            else if (options.Copy.Process(this))
+            {
+                CopyKeyframes();
+                return true;
+            }
+            else if (options.Paste.Process(this))
+            {
+                KeyframesEditorUtils.Paste(this);
+                return true;
+            }
+
             return false;
         }
 

--- a/Source/Editor/GUI/CurveEditor.cs
+++ b/Source/Editor/GUI/CurveEditor.cs
@@ -714,15 +714,28 @@ namespace FlaxEditor.GUI
             }
         }
 
+        private void BulkSelectUpdate(bool select = true)
+        {
+            for (int i = 0; i < _points.Count; i++)
+            {
+                _points[i].IsSelected = select;
+            }
+        }
+
         /// <summary>
         /// Selects all keyframes.
         /// </summary>
         public void SelectAll()
         {
-            for (int i = 0; i < _points.Count; i++)
-            {
-                _points[i].IsSelected = true;
-            }
+            BulkSelectUpdate(true);
+        }
+
+        /// <summary>
+        /// Deselects all keyframes.
+        /// </summary>
+        public void DeselectAll()
+        {
+            BulkSelectUpdate(false);
         }
 
         /// <summary>
@@ -931,6 +944,12 @@ namespace FlaxEditor.GUI
             if (options.SelectAll.Process(this))
             {
                 SelectAll();
+                UpdateTangents();
+                return true;
+            }
+            else if (options.DeselectAll.Process(this))
+            {
+                DeselectAll();
                 UpdateTangents();
                 return true;
             }

--- a/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
+++ b/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
@@ -433,6 +433,7 @@ namespace FlaxEditor.GUI
                         if (_editor.EnableKeyframesValueEdit)
                             cm.AddButton("Edit all keyframes", () => _editor.EditAllKeyframes(this, location));
                         cm.AddButton("Select all keyframes", _editor.SelectAll).Enabled = _editor._points.Count > 0;
+                        cm.AddButton("Deselect all keyframes", _editor.DeselectAll).Enabled = _editor._points.Count > 0;
                         cm.AddButton("Copy all keyframes", () =>
                         {
                             _editor.SelectAll();
@@ -1210,15 +1211,28 @@ namespace FlaxEditor.GUI
             }
         }
 
+        private void BulkSelectUpdate(bool select = true)
+        {
+            for (int i = 0; i < _points.Count; i++)
+            {
+                _points[i].IsSelected = select;
+            }
+        }
+
         /// <summary>
         /// Selects all keyframes.
         /// </summary>
         public void SelectAll()
         {
-            for (int i = 0; i < _points.Count; i++)
-            {
-                _points[i].IsSelected = true;
-            }
+            BulkSelectUpdate(true);
+        }
+
+        /// <summary>
+        /// Deselects all keyframes.
+        /// </summary>
+        public void DeselectAll()
+        {
+            BulkSelectUpdate(false);
         }
 
         /// <inheritdoc />
@@ -1273,6 +1287,11 @@ namespace FlaxEditor.GUI
             if (options.SelectAll.Process(this))
             {
                 SelectAll();
+                return true;
+            }
+            else if (options.DeselectAll.Process(this))
+            {
+                DeselectAll();
                 return true;
             }
             else if (options.Delete.Process(this))

--- a/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
+++ b/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -1268,33 +1269,28 @@ namespace FlaxEditor.GUI
             if (base.OnKeyDown(key))
                 return true;
 
-            switch (key)
+            InputOptions options = Editor.Instance.Options.Options.Input;
+            if (options.SelectAll.Process(this))
             {
-            case KeyboardKeys.Delete:
+                SelectAll();
+                return true;
+            }
+            else if (options.Delete.Process(this))
+            {
                 RemoveKeyframes();
                 return true;
-            case KeyboardKeys.A:
-                if (Root.GetKey(KeyboardKeys.Control))
-                {
-                    SelectAll();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.C:
-                if (Root.GetKey(KeyboardKeys.Control))
-                {
-                    CopyKeyframes();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.V:
-                if (Root.GetKey(KeyboardKeys.Control))
-                {
-                    KeyframesEditorUtils.Paste(this);
-                    return true;
-                }
-                break;
             }
+            else if (options.Copy.Process(this))
+            {
+                CopyKeyframes();
+                return true;
+            }
+            else if (options.Paste.Process(this))
+            {
+                KeyframesEditorUtils.Paste(this);
+                return true;
+            }
+
             return false;
         }
 

--- a/Source/Editor/GUI/Tree/Tree.cs
+++ b/Source/Editor/GUI/Tree/Tree.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.Assertions;
 using FlaxEngine.GUI;
@@ -315,10 +316,7 @@ namespace FlaxEditor.GUI.Tree
             }
         }
 
-        /// <summary>
-        /// Select all expanded nodes
-        /// </summary>
-        public void SelectAllExpanded()
+        private void BulkSelectUpdateExpanded(bool select = true)
         {
             if (_supportMultiSelect)
             {
@@ -327,7 +325,8 @@ namespace FlaxEditor.GUI.Tree
 
                 // Update selection
                 Selection.Clear();
-                WalkSelectExpandedTree(Selection, _children[0] as TreeNode);
+                if (select)
+                    WalkSelectExpandedTree(Selection, _children[0] as TreeNode);
 
                 // Check if changed
                 if (Selection.Count != prev.Count || !Selection.SequenceEqual(prev))
@@ -336,6 +335,22 @@ namespace FlaxEditor.GUI.Tree
                     SelectedChanged?.Invoke(prev, Selection);
                 }
             }
+        }
+
+        /// <summary>
+        /// Select all expanded nodes
+        /// </summary>
+        public void SelectAllExpanded()
+        {
+            BulkSelectUpdateExpanded(true);
+        }
+
+        /// <summary>
+        /// Deselect all nodes
+        /// </summary>
+        public void DeselectAll()
+        {
+            BulkSelectUpdateExpanded(false);
         }
 
         /// <inheritdoc />
@@ -470,12 +485,17 @@ namespace FlaxEditor.GUI.Tree
             // Check if can use multi selection
             if (_supportMultiSelect)
             {
-                bool isCtrlDown = Root.GetKey(KeyboardKeys.Control);
+                InputOptions options = Editor.Instance.Options.Options.Input;
 
                 // Select all expanded nodes
-                if (key == KeyboardKeys.A && isCtrlDown)
+                if (options.SelectAll.Process(this))
                 {
                     SelectAllExpanded();
+                    return true;
+                }
+                else if (options.DeselectAll.Process(this))
+                {
+                    DeselectAll();
                     return true;
                 }
             }

--- a/Source/Editor/Modules/SceneEditingModule.cs
+++ b/Source/Editor/Modules/SceneEditingModule.cs
@@ -60,13 +60,26 @@ namespace FlaxEditor.Modules
         {
         }
 
+        private void BulkScenesSelectUpdate(bool select = true)
+        {
+            // Blank list deselects all
+            Select(select ? Editor.Scene.Root.ChildNodes : new List<SceneGraphNode>());
+        }
+
         /// <summary>
         /// Selects all scenes.
         /// </summary>
         public void SelectAllScenes()
         {
-            // Select all scenes (linked to the root node)
-            Select(Editor.Scene.Root.ChildNodes);
+            BulkScenesSelectUpdate(true);
+        }
+
+        /// <summary>
+        /// Deselects all scenes.
+        /// </summary>
+        public void DeselectAllScenes()
+        {
+            BulkScenesSelectUpdate(false);
         }
 
         /// <summary>

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -53,6 +53,7 @@ namespace FlaxEditor.Modules
         private ContextMenuButton _menuEditDelete;
         private ContextMenuButton _menuEditDuplicate;
         private ContextMenuButton _menuEditSelectAll;
+        private ContextMenuButton _menuEditDeselectAll;
         private ContextMenuButton _menuEditFind;
         private ContextMenuButton _menuSceneMoveActorToViewport;
         private ContextMenuButton _menuSceneAlignActorWithViewport;
@@ -553,6 +554,7 @@ namespace FlaxEditor.Modules
             _menuEditDuplicate = cm.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
             cm.AddSeparator();
             _menuEditSelectAll = cm.AddButton("Select all", inputOptions.SelectAll, Editor.SceneEditing.SelectAllScenes);
+            _menuEditDeselectAll = cm.AddButton("Deselect all", inputOptions.DeselectAll, Editor.SceneEditing.DeselectAllScenes);
             _menuEditFind = cm.AddButton("Find", inputOptions.Search, Editor.Windows.SceneWin.Search);
             cm.AddSeparator();
             cm.AddButton("Game Settings", () =>
@@ -671,6 +673,7 @@ namespace FlaxEditor.Modules
             _menuEditDelete.ShortKeys = inputOptions.Delete.ToString();
             _menuEditDuplicate.ShortKeys = inputOptions.Duplicate.ToString();
             _menuEditSelectAll.ShortKeys = inputOptions.SelectAll.ToString();
+            _menuEditDeselectAll.ShortKeys = inputOptions.DeselectAll.ToString();
             _menuEditFind.ShortKeys = inputOptions.Search.ToString();
             _menuGamePlayGame.ShortKeys = inputOptions.Play.ToString();
             _menuGamePlayCurrentScenes.ShortKeys = inputOptions.PlayCurrentScenes.ToString();
@@ -861,6 +864,7 @@ namespace FlaxEditor.Modules
             _menuEditDelete.Enabled = hasSthSelected;
             _menuEditDuplicate.Enabled = hasSthSelected;
             _menuEditSelectAll.Enabled = Level.IsAnySceneLoaded;
+            _menuEditDeselectAll.Enabled = hasSthSelected;
 
             control.PerformLayout();
         }

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -56,6 +56,10 @@ namespace FlaxEditor.Options
         [EditorDisplay("Common"), EditorOrder(190)]
         public InputBinding SelectAll = new InputBinding(KeyboardKeys.A, KeyboardKeys.Control);
 
+        [DefaultValue(typeof(InputBinding), "Ctrl+Shift+A")]
+        [EditorDisplay("Common"), EditorOrder(195)]
+        public InputBinding DeselectAll = new InputBinding(KeyboardKeys.A, KeyboardKeys.Shift, KeyboardKeys.Control);
+
         [DefaultValue(typeof(InputBinding), "F")]
         [EditorDisplay("Common"), EditorOrder(200)]
         public InputBinding FocusSelection = new InputBinding(KeyboardKeys.F);

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -382,6 +382,7 @@ namespace FlaxEditor.Surface
             {
                 new InputActionsContainer.Binding(options => options.Delete, Delete),
                 new InputActionsContainer.Binding(options => options.SelectAll, SelectAll),
+                new InputActionsContainer.Binding(options => options.DeselectAll, DeselectAll),
                 new InputActionsContainer.Binding(options => options.Copy, Copy),
                 new InputActionsContainer.Binding(options => options.Paste, Paste),
                 new InputActionsContainer.Binding(options => options.Cut, Cut),
@@ -611,22 +612,35 @@ namespace FlaxEditor.Surface
             _context.MarkAsModified(graphEdited);
         }
 
-        /// <summary>
-        /// Selects all the nodes.
-        /// </summary>
-        public void SelectAll()
+        private void BulkSelectUpdate(bool select = true)
         {
             bool selectionChanged = false;
             for (int i = 0; i < _rootControl.Children.Count; i++)
             {
-                if (_rootControl.Children[i] is SurfaceControl control && !control.IsSelected)
+                if (_rootControl.Children[i] is SurfaceControl control && control.IsSelected != select)
                 {
-                    control.IsSelected = true;
+                    control.IsSelected = select;
                     selectionChanged = true;
                 }
             }
             if (selectionChanged)
                 SelectionChanged?.Invoke();
+        }
+
+        /// <summary>
+        /// Selects all the nodes.
+        /// </summary>
+        public void SelectAll()
+        {
+            BulkSelectUpdate(true);
+        }
+
+        /// <summary>
+        /// Deelects all the nodes.
+        /// </summary>
+        public void DeselectAll()
+        {
+            BulkSelectUpdate(false);
         }
 
         /// <summary>

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -1289,6 +1289,7 @@ namespace FlaxEditor.Utilities
             inputActions.Add(options => options.Paste, Editor.Instance.SceneEditing.Paste);
             inputActions.Add(options => options.Duplicate, Editor.Instance.SceneEditing.Duplicate);
             inputActions.Add(options => options.SelectAll, Editor.Instance.SceneEditing.SelectAllScenes);
+            inputActions.Add(options => options.DeselectAll, Editor.Instance.SceneEditing.DeselectAllScenes);
             inputActions.Add(options => options.Delete, Editor.Instance.SceneEditing.Delete);
             inputActions.Add(options => options.Search, () => Editor.Instance.Windows.SceneWin.Search());
             inputActions.Add(options => options.MoveActorToViewport, Editor.Instance.UI.MoveActorToViewport);

--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -170,6 +170,8 @@ namespace FlaxEditor.Windows
             /// <inheritdoc />
             public override bool OnKeyDown(KeyboardKeys key)
             {
+                InputOptions options = FlaxEditor.Editor.Instance.Options.Options.Input;
+
                 // Up
                 if (key == KeyboardKeys.ArrowUp)
                 {
@@ -200,7 +202,7 @@ namespace FlaxEditor.Windows
                     Open();
                 }
                 // Ctrl+C
-                else if (key == KeyboardKeys.C && Root.GetKey(KeyboardKeys.Control))
+                else if (options.Copy.Process(this))
                 {
                     Copy();
                     return true;

--- a/Source/Editor/Windows/Search/ContentSearchWindow.cs
+++ b/Source/Editor/Windows/Search/ContentSearchWindow.cs
@@ -12,6 +12,7 @@ using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Docking;
 using FlaxEditor.GUI.Input;
 using FlaxEditor.GUI.Tree;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEditor.Surface;
 using FlaxEditor.Windows;
@@ -142,6 +143,7 @@ namespace FlaxEngine.Windows.Search
             /// <inheritdoc />
             public override bool OnKeyDown(KeyboardKeys key)
             {
+                InputOptions options = FlaxEditor.Editor.Instance.Options.Options.Input;
                 if (IsFocused)
                 {
                     if (key == KeyboardKeys.Return && Navigate != null)
@@ -149,7 +151,7 @@ namespace FlaxEngine.Windows.Search
                         Navigate.Invoke(this);
                         return true;
                     }
-                    if (key == KeyboardKeys.C && Root.GetKey(KeyboardKeys.Control))
+                    if (options.Copy.Process(this))
                     {
                         Clipboard.Text = Text;
                         return true;

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1,7 +1,9 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 using System;
+#if FLAX_EDITOR
 using FlaxEditor.Options;
+#endif
 using FlaxEngine.Assertions;
 using FlaxEngine.Utilities;
 
@@ -1298,6 +1300,7 @@ namespace FlaxEngine.GUI
             KeyDown?.Invoke(key);
 
             // Handle controls that have bindings
+#if FLAX_EDITOR
             InputOptions options = FlaxEditor.Editor.Instance.Options.Options.Input;
             if (options.Copy.Process(this))
             {
@@ -1329,6 +1332,7 @@ namespace FlaxEngine.GUI
                 Deselect();
                 return true;
             }
+#endif
 
             // Handle controls without bindings
             switch (key)
@@ -1345,6 +1349,41 @@ namespace FlaxEngine.GUI
             case KeyboardKeys.ArrowDown:
                 MoveDown(shiftDown, ctrDown);
                 return true;
+            case KeyboardKeys.C:
+                if (ctrDown)
+                {
+                    Copy();
+                    return true;
+                }
+                break;
+            case KeyboardKeys.V:
+                if (ctrDown)
+                {
+                    Paste();
+                    return true;
+                }
+                break;
+            case KeyboardKeys.D:
+                if (ctrDown)
+                {
+                    Duplicate();
+                    return true;
+                }
+                break;
+            case KeyboardKeys.X:
+                if (ctrDown)
+                {
+                    Cut();
+                    return true;
+                }
+                break;
+            case KeyboardKeys.A:
+                if (ctrDown)
+                {
+                    SelectAll();
+                    return true;
+                }
+                break;
             case KeyboardKeys.Backspace:
             {
                 if (IsReadOnly)

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 using System;
+using FlaxEditor.Options;
 using FlaxEngine.Assertions;
 using FlaxEngine.Utilities;
 
@@ -1296,6 +1297,40 @@ namespace FlaxEngine.GUI
             bool ctrDown = window.GetKey(KeyboardKeys.Control);
             KeyDown?.Invoke(key);
 
+            // Handle controls that have bindings
+            InputOptions options = FlaxEditor.Editor.Instance.Options.Options.Input;
+            if (options.Copy.Process(this))
+            {
+                Copy();
+                return true;
+            }
+            else if (options.Paste.Process(this))
+            {
+                Paste();
+                return true;
+            }
+            else if (options.Duplicate.Process(this))
+            {
+                Duplicate();
+                return true;
+            }
+            else if (options.Cut.Process(this))
+            {
+                Cut();
+                return true;
+            }
+            else if (options.SelectAll.Process(this))
+            {
+                SelectAll();
+                return true;
+            }
+            else if (options.DeselectAll.Process(this))
+            {
+                Deselect();
+                return true;
+            }
+
+            // Handle controls without bindings
             switch (key)
             {
             case KeyboardKeys.ArrowRight:
@@ -1310,41 +1345,6 @@ namespace FlaxEngine.GUI
             case KeyboardKeys.ArrowDown:
                 MoveDown(shiftDown, ctrDown);
                 return true;
-            case KeyboardKeys.C:
-                if (ctrDown)
-                {
-                    Copy();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.V:
-                if (ctrDown)
-                {
-                    Paste();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.D:
-                if (ctrDown)
-                {
-                    Duplicate();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.X:
-                if (ctrDown)
-                {
-                    Cut();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.A:
-                if (ctrDown)
-                {
-                    SelectAll();
-                    return true;
-                }
-                break;
             case KeyboardKeys.Backspace:
             {
                 if (IsReadOnly)


### PR DESCRIPTION
This PR adds the option to deselect all using (`Ctrl+Shift+A`, rebindable) wherever there is the option to select all (`Ctrl+A`, also rebindable). I also refactored most of the UI code to use the options in `InputOptions` for things like Copy, Paste, Cut, etc.