### PR TITLE
Fix freeze when prefab ID is empty.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ModelPrefabEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ModelPrefabEditor.cs
@@ -31,6 +31,11 @@ public class ModelPrefabEditor : GenericEditor
         _prefabId = modelPrefab.PrefabID;
         while (true)
         {
+            if (_prefabId == Guid.Empty)
+            {
+                break;
+            }
+
             var prefab = FlaxEngine.Content.Load<Prefab>(_prefabId);
             if (prefab)
             {


### PR DESCRIPTION
If you break the prefab link, and then try to delete the model, it will freeze trying to load the model prefab editor, this fixes that by breaking from the loop if the ID is null.