### PR TITLE
Fix plugin clone and loading

### DIFF
--- a/Source/Editor/Windows/PluginsWindow.cs
+++ b/Source/Editor/Windows/PluginsWindow.cs
@@ -381,6 +381,7 @@ namespace FlaxEditor.Windows
                     Arguments = $"clone {gitPath} \"{clonePath}\"",
                     ShellExecute = false,
                     LogOutput = true,
+                    WaitForEnd = true
                 };
                 Platform.CreateProcess(ref settings);
             }
@@ -402,6 +403,7 @@ namespace FlaxEditor.Windows
                     Arguments = "submodule update --init",
                     ShellExecute = false,
                     LogOutput = true,
+                    WaitForEnd = true
                 };
                 Platform.CreateProcess(ref settings);
             }


### PR DESCRIPTION
When trying to add a game plugin through the plugin editor window there was an error message:
```[ 00:00:32.964 ]: [Error] Failed to find plugin project file to add to Project config. Please add manually.```

The git processes ran asynchronously and FlaxEditor reported that there is no project file because the git processes were not finished yet.
If you check the Plugin directory after this error occurs all files are there but the missing wait in the editor made the check run too early.