### PR TITLE
Change color grading post process settings to use color picker. 

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ColorEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ColorEditor.cs
@@ -27,7 +27,22 @@ namespace FlaxEditor.CustomEditors.Editors
         private void OnValueChanged()
         {
             var token = element.CustomControl.IsSliding ? this : null;
-            SetValue(element.CustomControl.Value, token);
+            var value = Values[0];
+            var color = element.CustomControl.Value;
+            if (value is Color)
+                SetValue(color, token);
+            else if (value is Color32)
+            {
+                Color32 color32;
+                color.ToBgra(out color32.R, out color32.G, out color32.B, out color32.A);
+                SetValue(color32, token);
+            }
+            else if (value is Float4)
+                SetValue(new Float4(color.R, color.G, color.B, color.A), token);
+            else if (value is Double4)
+                SetValue(new Double4(color.R, color.G, color.B, color.A), token);
+            else if (value is Vector4)
+                SetValue(new Vector4(color.R, color.G, color.B, color.A), token);
         }
 
         /// <inheritdoc />
@@ -45,13 +60,13 @@ namespace FlaxEditor.CustomEditors.Editors
                 if (value is Color asColor)
                     element.CustomControl.Value = asColor;
                 else if (value is Color32 asColor32)
-                    element.CustomControl.Value = asColor32;
+                    element.CustomControl.Value = new Color(asColor32.R, asColor32.G, asColor32.B, asColor32.A);
                 else if (value is Float4 asFloat4)
-                    element.CustomControl.Value = asFloat4;
+                    element.CustomControl.Value = new Color(asFloat4.X, asFloat4.Y, asFloat4.Z, asFloat4.W);
                 else if (value is Double4 asDouble4)
-                    element.CustomControl.Value = (Float4)asDouble4;
+                    element.CustomControl.Value = new Color((float)asDouble4.X, (float)asDouble4.Y, (float)asDouble4.Z, (float)asDouble4.W);
                 else if (value is Vector4 asVector4)
-                    element.CustomControl.Value = asVector4;
+                    element.CustomControl.Value = new Color(asVector4.X, asVector4.Y, asVector4.Z, asVector4.W);
             }
         }
     }

--- a/Source/Editor/CustomEditors/Editors/ColorEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ColorEditor.cs
@@ -60,13 +60,13 @@ namespace FlaxEditor.CustomEditors.Editors
                 if (value is Color asColor)
                     element.CustomControl.Value = asColor;
                 else if (value is Color32 asColor32)
-                    element.CustomControl.Value = new Color(asColor32.R, asColor32.G, asColor32.B, asColor32.A);
+                    element.CustomControl.Value = asColor32;
                 else if (value is Float4 asFloat4)
-                    element.CustomControl.Value = new Color(asFloat4.X, asFloat4.Y, asFloat4.Z, asFloat4.W);
+                    element.CustomControl.Value = asFloat4;
                 else if (value is Double4 asDouble4)
-                    element.CustomControl.Value = new Color((float)asDouble4.X, (float)asDouble4.Y, (float)asDouble4.Z, (float)asDouble4.W);
+                    element.CustomControl.Value = (Float4)asDouble4;
                 else if (value is Vector4 asVector4)
-                    element.CustomControl.Value = new Color(asVector4.X, asVector4.Y, asVector4.Z, asVector4.W);
+                    element.CustomControl.Value = asVector4;
             }
         }
     }

--- a/Source/Engine/Graphics/PostProcessSettings.h
+++ b/Source/Engine/Graphics/PostProcessSettings.h
@@ -708,31 +708,31 @@ API_STRUCT() struct FLAXENGINE_API ColorGradingSettings : ISerializable
     /// <summary>
     /// Gets or sets the color saturation (applies globally to the whole image). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(0), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturation), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Saturation\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(0), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturation), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Saturation\")")
     Float4 ColorSaturation = Float4::One;
 
     /// <summary>
     /// Gets or sets the color contrast (applies globally to the whole image). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(1), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrast), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Contrast\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(1), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrast), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Contrast\")")
     Float4 ColorContrast = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gamma (applies globally to the whole image). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(2), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGamma), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Gamma\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(2), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGamma), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Gamma\")")
     Float4 ColorGamma = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gain (applies globally to the whole image). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(3), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGain), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Gain\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(3), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGain), Limit(0, 2, 0.01f), EditorDisplay(\"Global\", \"Gain\")")
     Float4 ColorGain = Float4::One;
 
     /// <summary>
     /// Gets or sets the color offset (applies globally to the whole image). Default is 0.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(4), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffset), Limit(-1, 1, 0.001f), EditorDisplay(\"Global\", \"Offset\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(4), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffset), Limit(-1, 1, 0.001f), EditorDisplay(\"Global\", \"Offset\")")
     Float4 ColorOffset = Float4::Zero;
 
     // Shadows
@@ -740,31 +740,31 @@ API_STRUCT() struct FLAXENGINE_API ColorGradingSettings : ISerializable
     /// <summary>
     /// Gets or sets the color saturation (applies to shadows only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(5), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturationShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Saturation\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(5), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturationShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Saturation\")")
     Float4 ColorSaturationShadows = Float4::One;
 
     /// <summary>
     /// Gets or sets the color contrast (applies to shadows only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(6), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrastShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Contrast\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(6), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrastShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Contrast\")")
     Float4 ColorContrastShadows = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gamma (applies to shadows only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(7), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGammaShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Gamma\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(7), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGammaShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Gamma\")")
     Float4 ColorGammaShadows = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gain (applies to shadows only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(8), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGainShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Gain\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(8), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGainShadows), Limit(0, 2, 0.01f), EditorDisplay(\"Shadows\", \"Shadows Gain\")")
     Float4 ColorGainShadows = Float4::One;
 
     /// <summary>
     /// Gets or sets the color offset (applies to shadows only). Default is 0.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(9), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffsetShadows), Limit(-1, 1, 0.001f), EditorDisplay(\"Shadows\", \"Shadows Offset\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(9), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffsetShadows), Limit(-1, 1, 0.001f), EditorDisplay(\"Shadows\", \"Shadows Offset\")")
     Float4 ColorOffsetShadows = Float4::Zero;
 
     // Midtones
@@ -772,31 +772,31 @@ API_STRUCT() struct FLAXENGINE_API ColorGradingSettings : ISerializable
     /// <summary>
     /// Gets or sets the color saturation (applies to midtones only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(10), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturationMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Saturation\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(10), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturationMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Saturation\")")
     Float4 ColorSaturationMidtones = Float4::One;
 
     /// <summary>
     /// Gets or sets the color contrast (applies to midtones only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(11), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrastMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Contrast\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(11), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrastMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Contrast\")")
     Float4 ColorContrastMidtones = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gamma (applies to midtones only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(12), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGammaMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Gamma\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(12), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGammaMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Gamma\")")
     Float4 ColorGammaMidtones = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gain (applies to midtones only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(13), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGainMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Gain\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(13), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGainMidtones), Limit(0, 2, 0.01f), EditorDisplay(\"Midtones\", \"Midtones Gain\")")
     Float4 ColorGainMidtones = Float4::One;
 
     /// <summary>
     /// Gets or sets the color offset (applies to midtones only). Default is 0.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(14), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffsetMidtones), Limit(-1, 1, 0.001f), EditorDisplay(\"Midtones\", \"Midtones Offset\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(14), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffsetMidtones), Limit(-1, 1, 0.001f), EditorDisplay(\"Midtones\", \"Midtones Offset\")")
     Float4 ColorOffsetMidtones = Float4::Zero;
 
     // Highlights
@@ -804,31 +804,31 @@ API_STRUCT() struct FLAXENGINE_API ColorGradingSettings : ISerializable
     /// <summary>
     /// Gets or sets the color saturation (applies to highlights only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(15), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturationHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Saturation\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(15), PostProcessSetting((int)ColorGradingSettingsOverride.ColorSaturationHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Saturation\")")
     Float4 ColorSaturationHighlights = Float4::One;
 
     /// <summary>
     /// Gets or sets the color contrast (applies to highlights only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(16), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrastHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Contrast\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(16), PostProcessSetting((int)ColorGradingSettingsOverride.ColorContrastHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Contrast\")")
     Float4 ColorContrastHighlights = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gamma (applies to highlights only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(17), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGammaHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Gamma\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(17), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGammaHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Gamma\")")
     Float4 ColorGammaHighlights = Float4::One;
 
     /// <summary>
     /// Gets or sets the color gain (applies to highlights only). Default is 1.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(18), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGainHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Gain\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"1,1,1,1\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(18), PostProcessSetting((int)ColorGradingSettingsOverride.ColorGainHighlights), Limit(0, 2, 0.01f), EditorDisplay(\"Highlights\", \"Highlights Gain\")")
     Float4 ColorGainHighlights = Float4::One;
 
     /// <summary>
     /// Gets or sets the color offset (applies to highlights only). Default is 0.
     /// </summary>
-    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorTrackball\"), EditorOrder(19), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffsetHighlights), Limit(-1, 1, 0.001f), EditorDisplay(\"Highlights\", \"Highlights Offset\")")
+    API_FIELD(Attributes="DefaultValue(typeof(Float4), \"0,0,0,0\"), CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.ColorEditor\"), EditorOrder(19), PostProcessSetting((int)ColorGradingSettingsOverride.ColorOffsetHighlights), Limit(-1, 1, 0.001f), EditorDisplay(\"Highlights\", \"Highlights Offset\")")
     Float4 ColorOffsetHighlights = Float4::Zero;
 
     //


### PR DESCRIPTION
This PR changes the color grading post process settings to use the color picker. This is a QoL change to allow for different ways of setting the color. This PR also fixes the color editor to work correctly with Float4.

 I can also get rid of the color track ball as I believe that it was only being used in the post process settings... But thought I would leave it in for now unless we should remove it.