### PR TITLE
Added "Create parent for selected actors" context menu button

### DIFF
--- a/Source/Editor/Modules/SceneEditingModule.cs
+++ b/Source/Editor/Modules/SceneEditingModule.cs
@@ -535,6 +535,38 @@ namespace FlaxEditor.Modules
         }
 
         /// <summary>
+        /// Create parent for selected actors.
+        /// </summary>
+        public void CreateParentForSelectedActors()
+        {
+            Actor actor = new EmptyActor();
+            Editor.SceneEditing.Spawn(actor, null, false);
+            List<SceneGraphNode> selection = Editor.SceneEditing.Selection;
+            for (int i = 0; i < selection.Count; i++)
+            {
+                if (selection[i] is ActorNode node)
+                {
+                    if (node.ParentNode != node.ParentScene) // if parent node is not Scene
+                    {
+                        if (selection.Contains(node.ParentNode))
+                        {
+                            return; // if parent and child nodes selected together, don't touch child nodes
+                        }
+                        else
+                        {   // put created node as child of the Parent Node of node
+                            int parentOrder = node.Actor.OrderInParent;
+                            actor.Parent = node.Actor.Parent;
+                            actor.OrderInParent = parentOrder;
+                        }
+                    }
+                    node.Actor.Parent = actor;
+                }
+            }
+            Editor.SceneEditing.Select(actor);
+            Editor.Scene.GetActorNode(actor).TreeNode.StartRenaming(Editor.Windows.SceneWin, Editor.Windows.SceneWin.SceneTreePanel);
+        }
+
+        /// <summary>
         /// Duplicates the selected objects. Supports undo/redo.
         /// </summary>
         public void Duplicate()

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -50,6 +50,7 @@ namespace FlaxEditor.Modules
         private ContextMenuButton _menuEditCut;
         private ContextMenuButton _menuEditCopy;
         private ContextMenuButton _menuEditPaste;
+        private ContextMenuButton _menuCreateParentForSelectedActors;
         private ContextMenuButton _menuEditDelete;
         private ContextMenuButton _menuEditDuplicate;
         private ContextMenuButton _menuEditSelectAll;
@@ -549,6 +550,8 @@ namespace FlaxEditor.Modules
             _menuEditCopy = cm.AddButton("Copy", inputOptions.Copy, Editor.SceneEditing.Copy);
             _menuEditPaste = cm.AddButton("Paste", inputOptions.Paste, Editor.SceneEditing.Paste);
             cm.AddSeparator();
+            _menuCreateParentForSelectedActors = cm.AddButton("Create parent for selected actors", Editor.SceneEditing.CreateParentForSelectedActors);
+            cm.AddSeparator();
             _menuEditDelete = cm.AddButton("Delete", inputOptions.Delete, Editor.SceneEditing.Delete);
             _menuEditDuplicate = cm.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
             cm.AddSeparator();
@@ -858,6 +861,7 @@ namespace FlaxEditor.Modules
             _menuEditCut.Enabled = hasSthSelected;
             _menuEditCopy.Enabled = hasSthSelected;
             _menuEditPaste.Enabled = canEditScene;
+            _menuCreateParentForSelectedActors.Enabled = canEditScene && hasSthSelected;
             _menuEditDelete.Enabled = hasSthSelected;
             _menuEditDuplicate.Enabled = hasSthSelected;
             _menuEditSelectAll.Enabled = Level.IsAnySceneLoaded;

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -132,6 +132,13 @@ namespace FlaxEditor.Windows
             b = contextMenu.AddButton("Cut", inputOptions.Cut, Editor.SceneEditing.Cut);
             b.Enabled = canEditScene;
 
+            // Create a new hierarchy from selected actors 
+
+            contextMenu.AddSeparator();
+
+            b = contextMenu.AddButton("Create parent for selected actors", Editor.SceneEditing.CreateParentForSelectedActors);
+            b.Enabled = canEditScene && hasSthSelected;
+
             // Prefab options
 
             contextMenu.AddSeparator();

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -23,6 +23,8 @@ namespace FlaxEditor.Windows
     /// <seealso cref="FlaxEditor.Windows.SceneEditorWindow" />
     public partial class SceneTreeWindow : SceneEditorWindow
     {
+        public Panel SceneTreePanel => _sceneTreePanel;
+
         private TextBox _searchBox;
         private Tree _tree;
         private Panel _sceneTreePanel;


### PR DESCRIPTION
A little but useful QoL feature
There is an Undo bug: it deletes new parent actors with its child actors. I'm not sure if it's my fault.

https://github.com/FlaxEngine/FlaxEngine/assets/97740209/468f0835-eca8-4599-934c-ffd6d5722f58

