### PR TITLE
Add selecting actor spawned in the prefab window.

### DIFF
--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -386,6 +386,7 @@ namespace FlaxEditor.Windows.Assets
 
             // Spawn it
             Spawn(actor);
+            Rename();
         }
 
         /// <summary>
@@ -415,6 +416,7 @@ namespace FlaxEditor.Windows.Assets
             // Create undo action
             var action = new CustomDeleteActorsAction(new List<SceneGraphNode>(1) { actorNode }, true);
             Undo.AddAction(action);
+            Select(actorNode);
         }
 
         private void OnTreeRightClick(TreeNode node, Float2 location)


### PR DESCRIPTION
This selects a new actor spawned in the prefab window and starts the rename of it if it was spawned in by type (usually this is via the context menu).