### PR TITLE
Virtual AssetProxy

### DIFF
--- a/Source/Editor/Content/Proxy/AssetProxy.cs
+++ b/Source/Editor/Content/Proxy/AssetProxy.cs
@@ -23,6 +23,22 @@ namespace FlaxEditor.Content
         public abstract string TypeName { get; }
 
         /// <summary>
+        /// Gets a value indicating whether this instance is virtual Proxy not linked to any asset.
+        /// </summary>
+        protected virtual bool IsVirtual { get; }
+
+        /// <summary>
+        /// Determines whether [is virtual proxy].
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if [is virtual proxy]; otherwise, <c>false</c>.
+        /// </returns>
+        public bool IsVirtualProxy()
+        {
+            return IsVirtual && CanExport == false;
+        }
+
+        /// <summary>
         /// Checks if this proxy supports the given asset type id at the given path.
         /// </summary>
         /// <param name="typeName">The asset type identifier.</param>

--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -196,6 +196,25 @@ namespace FlaxEditor.Modules
 
             return null;
         }
+        /// <summary>
+        /// Gets the virtual proxy object from given path.
+        /// <br></br>use case if the asset u trying to display is not a flax asset but u like to add custom functionality
+        /// <br></br>to context menu,or display it the asset
+        /// </summary>
+        /// <param name="path">The asset path.</param>
+        /// <returns>Asset proxy or null if cannot find.</returns>
+        public AssetProxy GetAssetVirtuallProxy(string path)
+        {
+            for (int i = 0; i < Proxy.Count; i++)
+            {
+                if (Proxy[i] is AssetProxy proxy && proxy.IsVirtualProxy() && path.EndsWith(proxy.FileExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return proxy;
+                }
+            }
+
+            return null;
+        }
 
         /// <summary>
         /// Refreshes the given item folder. Tries to find new content items and remove not existing ones.
@@ -996,7 +1015,14 @@ namespace FlaxEditor.Modules
                         item = proxy?.ConstructItem(path, assetInfo.TypeName, ref assetInfo.ID);
                     }
                     if (item == null)
-                        item = new FileItem(path);
+                    {
+                        var proxy = GetAssetVirtuallProxy(path);
+                        item = proxy?.ConstructItem(path, assetInfo.TypeName, ref assetInfo.ID);
+                        if (item == null)
+                        {
+                            item = new FileItem(path);
+                        }
+                    }
 
                     // Link
                     item.ParentFolder = parent.Folder;


### PR DESCRIPTION
allows to show files with are not a flax asset, but external ones
usage example
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/dab28f22-21fd-432c-922f-6ddf06274ef4)
