### PR TITLE
Save docking state for custom editor windows

### DIFF
--- a/Source/Editor/CustomEditorWindow.cs
+++ b/Source/Editor/CustomEditorWindow.cs
@@ -1,9 +1,9 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 using FlaxEditor.CustomEditors;
+using FlaxEditor.GUI.Docking;
 using FlaxEditor.Windows;
 using FlaxEngine.GUI;
-using DockState = FlaxEditor.GUI.Docking.DockState;
 
 namespace FlaxEditor
 {
@@ -97,9 +97,12 @@ namespace FlaxEditor
         /// Shows the window.
         /// </summary>
         /// <param name="state">Initial window state.</param>
-        public void Show(DockState state = DockState.Float)
+        /// <param name="toDock">The panel to dock to, if any.</param>
+        /// <param name="autoSelect">Only used if <paramref name="toDock"/> is set. If true the window will be selected after docking it.</param>
+        /// <param name="splitterValue">The splitter value to use if toDock is not null. If not specified, a default value will be used.</param>
+        public void Show(DockState state = DockState.Float, DockPanel toDock = null, bool autoSelect = true, float? splitterValue = null)
         {
-            _win.Show(state);
+            _win.Show(state, toDock, autoSelect, splitterValue);
         }
     }
 }

--- a/Source/Editor/GUI/Docking/DockPanel.cs
+++ b/Source/Editor/GUI/Docking/DockPanel.cs
@@ -518,9 +518,9 @@ namespace FlaxEditor.GUI.Docking
             }
         }
 
-        internal virtual void DockWindowInternal(DockState state, DockWindow window)
+        internal virtual void DockWindowInternal(DockState state, DockWindow window, bool autoSelect = true, float? splitterValue = null)
         {
-            DockWindow(state, window);
+            DockWindow(state, window, autoSelect, splitterValue);
         }
 
         /// <summary>
@@ -528,7 +528,9 @@ namespace FlaxEditor.GUI.Docking
         /// </summary>
         /// <param name="state">The state.</param>
         /// <param name="window">The window.</param>
-        protected virtual void DockWindow(DockState state, DockWindow window)
+        /// <param name="autoSelect">Whether or not to automatically select the window after docking it.</param>
+        /// <param name="splitterValue">The splitter value to use when docking to window.</param>
+        protected virtual void DockWindow(DockState state, DockWindow window, bool autoSelect = true, float? splitterValue = null)
         {
             CreateTabsProxy();
 
@@ -536,12 +538,12 @@ namespace FlaxEditor.GUI.Docking
             if (state == DockState.DockFill)
             {
                 // Add tab
-                AddTab(window);
+                AddTab(window, autoSelect);
             }
             else
             {
                 // Create child panel
-                var dockPanel = CreateChildPanel(state, DefaultSplitterValue);
+                var dockPanel = CreateChildPanel(state, splitterValue ?? DefaultSplitterValue);
 
                 // Dock window as a tab in a child panel
                 dockPanel.DockWindow(DockState.DockFill, window);

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -214,7 +214,9 @@ namespace FlaxEditor.GUI.Docking
         /// </summary>
         /// <param name="state">Initial window state.</param>
         /// <param name="toDock">Panel to dock to it.</param>
-        public void Show(DockState state = DockState.Float, DockPanel toDock = null)
+        /// <param name="autoSelect">Only used if <paramref name="toDock"/> is set. If true the window will be selected after docking it.</param>
+        /// <param name="splitterValue">Only used if <paramref name="toDock"/> is set. The splitter value to use. If not specified, a default value will be used.</param>
+        public void Show(DockState state = DockState.Float, DockPanel toDock = null, bool autoSelect = true, float? splitterValue = null)
         {
             if (state == DockState.Hidden)
             {
@@ -232,7 +234,7 @@ namespace FlaxEditor.GUI.Docking
                 Undock();
 
                 // Then dock
-                (toDock ?? _masterPanel).DockWindowInternal(state, this);
+                (toDock ?? _masterPanel).DockWindowInternal(state, this, autoSelect, splitterValue);
                 OnShow();
                 PerformLayout();
             }

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -43,6 +43,11 @@ namespace FlaxEditor.Modules
 
             public bool SelectOnShow = false;
 
+            public bool Maximize;
+            public bool Minimize;
+            public Float2 FloatSize;
+            public Float2 FloatPosition;
+
             // Constructor, to allow for default values
             public WindowRestoreData()
             {
@@ -824,6 +829,11 @@ namespace FlaxEditor.Modules
             if (panel is FloatWindowDockPanel)
             {
                 winData.DockState = DockState.Float;
+                var window = win.Window.RootWindow.Window;
+                winData.FloatPosition = window.Position;
+                winData.FloatSize = window.ClientSize;
+                winData.Maximize = window.IsMaximized;
+                winData.Minimize = window.IsMinimized;
             }
             else
             {
@@ -859,6 +869,23 @@ namespace FlaxEditor.Modules
                         {
                             var win = (CustomEditorWindow)Activator.CreateInstance(type);
                             win.Show(winData.DockState, winData.DockedTo, winData.SelectOnShow, winData.SplitterValue);
+                            if (winData.DockState == DockState.Float)
+                            {
+                                var window = win.Window.RootWindow.Window;
+                                window.Position = winData.FloatPosition;
+                                if (winData.Maximize)
+                                {
+                                    window.Maximize();
+                                }
+                                else if (winData.Minimize)
+                                {
+                                    window.Minimize();
+                                }
+                                else 
+                                {
+                                    window.ClientSize = winData.FloatSize;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #2133 but introduces another problem and makes an existing one more prominent.

_See linked issue for a video of the problem_

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/f3b8ef46-55a7-422f-8c60-a0de7f567290

Assuming this gets merged, it will make editor windows more usable by saving and restoring their dock state or their location and size if they are floating. However, a new issue arises for custom editor windows that are docked within each other. The current implementation assumes that the DockPanel for each editor window remains valid between reloads, which holds true for all standard editor windows. However, this assumption fails for custom editor windows, as they are destroyed and recreated. Therefore, if custom window A is docked to custom window B, the saved DockPanel reference for B to be redocked to A will be invalid, as window A will be destroyed.

A similar problem occurs when standard editor windows are docked to custom editor windows. Once the custom editor window is destroyed, the other Editor windows will be undocked and redocked to its immediate parent, so we have to keep track of them too somehow.

This is far from ideal but, it will make custom windows usable, which is not the case right now.