### PR TITLE
Add Guid picker

### DIFF
--- a/Source/Editor/CustomEditors/Editors/GuidEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GuidEditor.cs
@@ -92,12 +92,12 @@ namespace FlaxEditor.CustomEditors.Editors
         public override void Refresh()
         {
             base.Refresh();
-
+            _isRefreshing = true;
             if (HasDifferentValues)
             {
                 if (_isReference)
                 {
-                    //_picker.Validator.SelectedID = (Guid)Values[0];
+                    // Not supported
                 }
                 else
                 {
@@ -117,6 +117,7 @@ namespace FlaxEditor.CustomEditors.Editors
                     _element.TextBox.WatermarkText = string.Empty;
                 }
             }
+            _isRefreshing = false;
         }
     }
 }

--- a/Source/Editor/CustomEditors/Editors/GuidEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GuidEditor.cs
@@ -1,8 +1,12 @@
 // Copyright (c) 2012-2023 Wojciech Figat. All rights reserved.
 
 using System;
+using System.Linq;
 using FlaxEditor.CustomEditors.Elements;
+using FlaxEditor.GUI;
+using FlaxEditor.Scripting;
 using FlaxEngine;
+using FlaxEngine.Utilities;
 
 namespace FlaxEditor.CustomEditors.Editors
 {
@@ -13,6 +17,9 @@ namespace FlaxEditor.CustomEditors.Editors
     public sealed class GuidEditor : CustomEditor
     {
         private TextBoxElement _element;
+        private AssetPicker _picker;
+        private bool _isReference;
+        private bool _isRefreshing;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -20,8 +27,57 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
         {
-            _element = layout.TextBox();
-            _element.TextBox.EditEnd += OnEditEnd;
+
+            var attributes = Values.GetAttributes();
+            var assetReference = (AssetReferenceAttribute)attributes?.FirstOrDefault(x => x is AssetReferenceAttribute);
+            if (assetReference != null)
+            {
+                _picker = layout.Custom<AssetPicker>().CustomControl;
+                ScriptType assetType = new ScriptType();
+
+                float height = 48;
+                if (assetReference.UseSmallPicker)
+                    height = 32;
+
+                if (string.IsNullOrEmpty(assetReference.TypeName))
+                {
+                    assetType = ScriptType.Void;
+                }
+                else if (assetReference.TypeName.Length > 1 && assetReference.TypeName[0] == '.')
+                {
+                    // Generic file picker
+                    assetType = ScriptType.Null;
+                    _picker.Validator.FileExtension = assetReference.TypeName;
+                }
+                else
+                {
+                    var customType = TypeUtils.GetType(assetReference.TypeName);
+                    if (customType != ScriptType.Null)
+                        assetType = customType;
+                    else if (!Content.Settings.GameSettings.OptionalPlatformSettings.Contains(assetReference.TypeName))
+                        Debug.LogWarning(string.Format("Unknown asset type '{0}' to use for asset picker filter.", assetReference.TypeName));
+                    else
+                        assetType = ScriptType.Void;
+                }
+
+                _picker.Validator.AssetType = assetType;
+                _picker.Height = height;
+                _picker.SelectedItemChanged += OnSelectedItemChanged;
+                _isReference = true;
+
+            }
+            else
+            {
+                _element = layout.TextBox();
+                _element.TextBox.EditEnd += OnEditEnd;
+            }
+        }
+
+        private void OnSelectedItemChanged()
+        {
+            if (_isRefreshing)
+                return;
+            SetValue(_picker.Validator.SelectedID);
         }
 
         private void OnEditEnd()
@@ -39,13 +95,27 @@ namespace FlaxEditor.CustomEditors.Editors
 
             if (HasDifferentValues)
             {
-                _element.TextBox.Text = string.Empty;
-                _element.TextBox.WatermarkText = "Different values";
+                if (_isReference)
+                {
+                    //_picker.Validator.SelectedID = (Guid)Values[0];
+                }
+                else
+                {
+                    _element.TextBox.Text = string.Empty;
+                    _element.TextBox.WatermarkText = "Different values";
+                }
             }
             else
             {
-                _element.TextBox.Text = ((Guid)Values[0]).ToString("D");
-                _element.TextBox.WatermarkText = string.Empty;
+                if (_isReference)
+                {
+                    _picker.Validator.SelectedID = (Guid)Values[0];
+                }
+                else
+                {
+                    _element.TextBox.Text = ((Guid)Values[0]).ToString("D");
+                    _element.TextBox.WatermarkText = string.Empty;
+                }
             }
         }
     }

--- a/Source/Editor/CustomEditors/Editors/GuidEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GuidEditor.cs
@@ -27,7 +27,6 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
         {
-
             var attributes = Values.GetAttributes();
             var assetReference = (AssetReferenceAttribute)attributes?.FirstOrDefault(x => x is AssetReferenceAttribute);
             if (assetReference != null)
@@ -64,7 +63,6 @@ namespace FlaxEditor.CustomEditors.Editors
                 _picker.Height = height;
                 _picker.SelectedItemChanged += OnSelectedItemChanged;
                 _isReference = true;
-
             }
             else
             {


### PR DESCRIPTION
This adds a way to narrow down and easily select assets that you want the Guid for.

Can use the `AssetReference` attribute to show a picker and select the type.
```
  [AssetReference(typeof(Prefab))]
  public Guid TestingId = Guid.Empty;
```

And then it will show up as an asset picker.
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/03ca1bae-a625-486c-9462-ab66f58484ec)
