### PR TITLE
Add an option to skip existing materials when reimporting.

### DIFF
--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -374,6 +374,7 @@ void ModelTool::Options::Serialize(SerializeStream& stream, const void* otherObj
     SERIALIZE(InstanceToImportAs);
     SERIALIZE(ImportTextures);
     SERIALIZE(RestoreMaterialsOnReimport);
+    SERIALIZE(SkipExistingMaterialsOnReimport);
     SERIALIZE(GenerateSDF);
     SERIALIZE(SDFResolution);
     SERIALIZE(SplitObjects);
@@ -422,6 +423,7 @@ void ModelTool::Options::Deserialize(DeserializeStream& stream, ISerializeModifi
     DESERIALIZE(InstanceToImportAs);
     DESERIALIZE(ImportTextures);
     DESERIALIZE(RestoreMaterialsOnReimport);
+    DESERIALIZE(SkipExistingMaterialsOnReimport);
     DESERIALIZE(GenerateSDF);
     DESERIALIZE(SDFResolution);
     DESERIALIZE(SplitObjects);
@@ -1152,6 +1154,18 @@ bool ModelTool::ImportModel(const String& path, ModelData& data, Options& option
             if (Content::GetAssetInfo(assetPath, info))
                 material.AssetID = info.ID;
             continue;
+        }
+
+        // Skip any materials that already exist from the model.
+        // This allows the use of "import as material instances" without material properties getting overridden on each import.
+        if (options.SkipExistingMaterialsOnReimport)
+        {
+            AssetInfo info;
+            if (Content::GetAssetInfo(assetPath, info))
+            {
+                material.AssetID = info.ID;
+                continue;
+            }
         }
 
         if (options.ImportMaterialsAsInstances)

--- a/Source/Engine/Tools/ModelTool/ModelTool.h
+++ b/Source/Engine/Tools/ModelTool/ModelTool.h
@@ -268,9 +268,12 @@ public:
         // If checked, the importer will import texture files used by the model and any embedded texture resources.
         API_FIELD(Attributes="EditorOrder(410), EditorDisplay(\"Materials\"), VisibleIf(nameof(ShowGeometry))")
         bool ImportTextures = true;
-        // If checked, the importer will try to keep the model's current material slots, instead of importing materials from the source file.
-        API_FIELD(Attributes="EditorOrder(420), EditorDisplay(\"Materials\", \"Keep Material Slots on Reimport\"), VisibleIf(nameof(ShowGeometry))")
+        // If checked, the importer will try to keep the model's current overridden material slots, instead of importing materials from the source file.
+        API_FIELD(Attributes="EditorOrder(420), EditorDisplay(\"Materials\", \"Keep Overridden Materials\"), VisibleIf(nameof(ShowGeometry))")
         bool RestoreMaterialsOnReimport = true;
+        // If checked, the importer will not reimport any material from this model which already exist in the sub-asset folder.
+        API_FIELD(Attributes = "EditorOrder(421), EditorDisplay(\"Materials\", \"Skip Existing Materials\"), VisibleIf(nameof(ShowGeometry))")
+        bool SkipExistingMaterialsOnReimport = true;
 
     public: // SDF
 


### PR DESCRIPTION
This resolves https://github.com/FlaxEngine/FlaxEngine/issues/1732 by adding an extra option which has different behavior than "Keep Overridden Materials."  This allows users to have either behavior.