### PR TITLE
Fix C++ Intellisense not working with latest version of Rider

### DIFF
--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
@@ -179,7 +179,10 @@ namespace Flax.Build.Projects.VisualStudio
                     customizer.WriteVisualStudioBuildProperties(vsProject, platform, toolchain, configuration, vcProjectFileContent, vcFiltersFileContent, vcUserFileContent);
                 vcProjectFileContent.AppendLine(string.Format("    <IntDir>{0}</IntDir>", targetBuildOptions.IntermediateFolder));
                 vcProjectFileContent.AppendLine(string.Format("    <OutDir>{0}</OutDir>", targetBuildOptions.OutputFolder));
-                vcProjectFileContent.AppendLine("    <IncludePath />");
+                if (includePaths.Count != 0)
+                    vcProjectFileContent.AppendLine(string.Format("    <IncludePath>$(IncludePath);{0}</IncludePath>", string.Join(";", includePaths)));
+                else
+                    vcProjectFileContent.AppendLine("    <IncludePath />");
                 vcProjectFileContent.AppendLine("    <ReferencePath />");
                 vcProjectFileContent.AppendLine("    <LibraryPath />");
                 vcProjectFileContent.AppendLine("    <LibraryWPath />");


### PR DESCRIPTION
Project `IncludePath` doesn't seem to include NMake include paths anymore in Rider, populate the property with same paths to work around the issue.