### PR TITLE
Fix for editor view's cached "CameraNearPlaneValue" getting overwritten.

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1113,7 +1113,7 @@ namespace FlaxEditor.Viewport
         private void OnFarPlaneChanged(FloatValueBox control)
         {
             _farPlane = control.Value;
-            _editor.ProjectCache.SetCustomData("CameraNearPlaneValue", _farPlane.ToString());
+            _editor.ProjectCache.SetCustomData("CameraFarPlaneValue", _farPlane.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
Changing the editor's camera sometimes results in empty views in editors. It was caused by writing the _farPlane with the wrong name in the cache.