### PR TITLE
Add custom editor for buttons that allow listening for them inside the editor.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/BindableButtonEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/BindableButtonEditor.cs
@@ -1,0 +1,96 @@
+﻿using FlaxEditor.GUI;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.CustomEditors.Editors
+{
+    /// <summary>
+    /// Base class for custom button editors.
+    /// See <seealso cref="MouseButtonEditor"/>, <seealso cref="KeyboardKeysEditor"/> and <seealso cref="GamepadButtonEditor"/>.
+    /// </summary>
+    public class BindableButtonEditor : EnumEditor
+    {
+        private bool _isListeningForInput;
+        private Button _button;
+
+        /// <summary>
+        /// Where or not we are currently listening for any input.
+        /// </summary>
+        protected bool IsListeningForInput
+        {
+            get => _isListeningForInput;
+            set
+            {
+                _isListeningForInput = value;
+                if (_isListeningForInput)
+                    SetupButton();
+                else
+                    ResetButton();
+            }
+        }
+
+        /// <summary>
+        /// The window this editor is attached to.
+        /// Useful to hook into for key pressed, mouse buttons etc.
+        /// </summary>
+        protected Window Window { get; private set; }
+
+        /// <inheritdoc />
+        public override void Initialize(LayoutElementsContainer layout)
+        {
+            Window = layout.Control.RootWindow.Window;
+
+            var panel = layout.CustomContainer<UniformGridPanel>();
+            panel.CustomControl.SlotsHorizontally = 2;
+            panel.CustomControl.SlotsVertically = 1;
+
+            var button = panel.Button("Listen");
+            _button = button.Button;
+            _button.Clicked += OnButtonClicked;
+            ResetButton();
+
+            var padding = panel.CustomControl.SlotPadding;
+            panel.CustomControl.Height = ComboBox.DefaultHeight + padding.Height;
+
+            base.Initialize(panel);
+        }
+
+        /// <inheritdoc />
+        protected override void Deinitialize()
+        {
+            _button.Clicked -= OnButtonClicked;
+            base.Deinitialize();
+        }
+
+        private void ResetButton()
+        {
+            _button.Text = "Listen";
+            _button.BorderThickness = 1;
+
+            var style = FlaxEngine.GUI.Style.Current;
+            _button.BorderColor = style.BorderNormal;
+            _button.BorderColorHighlighted = style.BorderHighlighted;
+            _button.BorderColorSelected = style.BorderSelected;
+        }
+
+        private void SetupButton()
+        {
+            _button.Text = "Listening...";
+            _button.BorderThickness = 2;
+
+            var color = FlaxEngine.GUI.Style.Current.ProgressNormal;
+            _button.BorderColor = color;
+            _button.BorderColorHighlighted = color;
+            _button.BorderColorSelected = color;
+        }
+
+        private void OnButtonClicked()
+        {
+            _isListeningForInput = !_isListeningForInput;
+            if (_isListeningForInput)
+                SetupButton();
+            else
+                ResetButton();
+        }
+    }
+}

--- a/Source/Editor/CustomEditors/Editors/BindableButtonEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/BindableButtonEditor.cs
@@ -44,7 +44,7 @@ namespace FlaxEditor.CustomEditors.Editors
             panel.CustomControl.SlotsHorizontally = 2;
             panel.CustomControl.SlotsVertically = 1;
 
-            var button = panel.Button("Listen");
+            var button = panel.Button("Listen", "Press to listen for input events");
             _button = button.Button;
             _button.Clicked += OnButtonClicked;
             ResetButton();

--- a/Source/Editor/CustomEditors/Editors/GamepadButtonEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GamepadButtonEditor.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using FlaxEngine;
+
+namespace FlaxEditor.CustomEditors.Editors
+{
+    /// <summary>
+    /// Custom editor for <see cref="GamepadButton"/>.
+    /// Allows capturing gamepad buttons and assigning them
+    /// to the edited value.
+    /// </summary>
+    [CustomEditor(typeof(GamepadButton))]
+    public class GamepadButtonEditor : BindableButtonEditor
+    {
+        /// <inheritdoc />
+        public override void Initialize(LayoutElementsContainer layout)
+        {
+            base.Initialize(layout);
+            FlaxEngine.Scripting.Update += ScriptingOnUpdate;
+        }
+
+        /// <inheritdoc />
+        protected override void Deinitialize()
+        {
+            FlaxEngine.Scripting.Update -= ScriptingOnUpdate;
+            base.Deinitialize();
+        }
+
+        private void ScriptingOnUpdate()
+        {
+            if (!IsListeningForInput)
+                return;
+
+            // Since there is no way to get an event about
+            // which gamepad pressed what button, we have
+            // to poll all gamepads and buttons manually.
+            for (var i = 0; i < Input.GamepadsCount; i++)
+            {
+                var pad = Input.Gamepads[i];
+                foreach (var btn in Enum.GetValues<GamepadButton>())
+                {
+                    if (pad.GetButtonUp(btn))
+                    {
+                        IsListeningForInput = false;
+                        SetValue(btn);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/Editor/CustomEditors/Editors/KeyboardKeysEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/KeyboardKeysEditor.cs
@@ -1,0 +1,36 @@
+﻿using FlaxEngine;
+
+namespace FlaxEditor.CustomEditors.Editors
+{
+    /// <summary>
+    /// Custom editor for <see cref="KeyboardKeys"/>.
+    /// Allows capturing key presses and assigning them
+    /// to the edited value.
+    /// </summary>
+    [CustomEditor(typeof(KeyboardKeys))]
+    public class KeyboardKeysEditor : BindableButtonEditor
+    {
+        /// <inheritdoc />
+        public override void Initialize(LayoutElementsContainer layout)
+        {
+            base.Initialize(layout);
+            Window.KeyUp += WindowOnKeyUp;
+        }
+
+        /// <inheritdoc />
+        protected override void Deinitialize()
+        {
+            Window.KeyUp -= WindowOnKeyUp;
+            base.Deinitialize();
+        }
+
+        private void WindowOnKeyUp(KeyboardKeys key)
+        {
+            if (!IsListeningForInput)
+                return;
+            IsListeningForInput = false;
+
+            SetValue(key);
+        }
+    }
+}

--- a/Source/Editor/CustomEditors/Editors/MouseButtonEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/MouseButtonEditor.cs
@@ -1,0 +1,37 @@
+﻿using FlaxEngine;
+
+namespace FlaxEditor.CustomEditors.Editors
+{
+    /// <summary>
+    /// Custom editor for <see cref="MouseButton"/>.
+    /// Allows capturing mouse button presses and assigning them
+    /// to the edited value.
+    /// </summary>
+    [CustomEditor(typeof(MouseButton))]
+    public class MouseButtonEditor : BindableButtonEditor
+    {
+        /// <inheritdoc />
+        public override void Initialize(LayoutElementsContainer layout)
+        {
+            base.Initialize(layout);
+            Window.MouseUp += WindowOnMouseUp;
+        }
+
+        /// <inheritdoc />
+        protected override void Deinitialize()
+        {
+            Window.MouseUp -= WindowOnMouseUp;
+            base.Deinitialize();
+        }
+
+        private void WindowOnMouseUp(ref Float2 mouse, MouseButton button, ref bool handled)
+        {
+            if (!IsListeningForInput)
+                return;
+            IsListeningForInput = false;
+
+            SetValue(button);
+            handled = true;
+        }
+    }
+}


### PR DESCRIPTION
This adds support for listening and capturing KeyboardKeys, MouseButtons and GamepadButtons.
It makes setting up Action and Axis mappings a bit easier.

https://github.com/FlaxEngine/FlaxEngine/assets/30367251/1b7acfaf-4677-45c4-b7e0-d48b255f3c25

In my initial implementation i made a custom editor for `ActionConfig` but having separate editor for each type of button seems more intuitive, could allow for more specialization in the future and also works anywhere, including user Scripts.