### PR TITLE
Fix negate node not converting bool to the appropriate float number.

### DIFF
--- a/Source/Engine/Visject/GraphUtilities.cpp
+++ b/Source/Engine/Visject/GraphUtilities.cpp
@@ -297,7 +297,7 @@ void GraphUtilities::ApplySomeMathHere(Variant& v, Variant& a, MathOp1 op)
     switch (a.Type.Type)
     {
     case VariantType::Bool:
-        v.AsBool = op(a.AsBool ? 1.0f : 0.0f) > ZeroTolerance;
+        v.AsBool = op(a.AsBool ? 1.0f : -1.0f) > ZeroTolerance;
         break;
     case VariantType::Int:
         v.AsInt = (int32)op((float)a.AsInt);


### PR DESCRIPTION
Fixes #2156.

This makes sure that a false boolean is turned into -1.0f so that when the negate operation is run, it will turn to 1(true). Otherwise, a false boolean would be converted to 0 and stay 0 after the negate operation.