### PR TITLE
don't rotate a rigidbody around locked axis by AddMovement

### DIFF
--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -549,33 +549,7 @@ void AnimatedModel::ApplyRootMotion(const Transform& rootMotionDelta)
 
     // Apply movement
     Actor* target = RootMotionTarget ? RootMotionTarget.Get() : this;
-    // filter rotation according to constraints if the target is a rigidbody
-    const auto rigidBody = dynamic_cast<RigidBody*>(target);
-    auto rotation = rootMotionDelta.Orientation;
-    if (rigidBody)
-    {
-        if (static_cast<unsigned int>(rigidBody->GetConstraints()) & static_cast<unsigned int>(RigidbodyConstraints::LockRotation))
-            rotation = Quaternion::Identity;
-        else
-        {
-            Float3 euler = rotation.GetEuler();
-            const auto constraints = static_cast<unsigned int>(rigidBody->GetConstraints());
-            if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationX))
-            {
-                euler.X = 0;
-            }
-            if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationY))
-            {
-                euler.Y = 0;
-            }
-            if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationZ))
-            {
-                euler.Z = 0;
-            }
-            rotation = Quaternion::Euler(euler);
-        }
-    }
-    target->AddMovement(translation, rotation);
+    target->AddMovement(translation, rootMotionDelta.Orientation);
 }
 
 void AnimatedModel::SyncParameters()

--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -15,7 +15,6 @@
 #include "Engine/Graphics/Models/MeshDeformation.h"
 #include "Engine/Level/Scene/Scene.h"
 #include "Engine/Level/SceneObjectsFactory.h"
-#include "Engine/Physics/Actors/RigidBody.h"
 #include "Engine/Serialization/Serialization.h"
 
 AnimatedModel::AnimatedModel(const SpawnParams& params)

--- a/Source/Engine/Physics/Actors/RigidBody.cpp
+++ b/Source/Engine/Physics/Actors/RigidBody.cpp
@@ -300,6 +300,46 @@ void RigidBody::ClosestPoint(const Vector3& position, Vector3& result) const
     }
 }
 
+void RigidBody::AddMovement(const Vector3& translation, const Quaternion& rotation)
+{
+    // filter rotation according to constraints
+    Quaternion allowedRotation;
+    if (static_cast<unsigned int>(GetConstraints()) & static_cast<unsigned int>(RigidbodyConstraints::LockRotation))
+        allowedRotation = Quaternion::Identity;
+    else
+    {
+        Float3 euler = rotation.GetEuler();
+        const auto constraints = static_cast<unsigned int>(GetConstraints());
+        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationX))
+            euler.X = 0;
+        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationY))
+            euler.Y = 0;
+        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationZ))
+            euler.Z = 0;
+        allowedRotation = Quaternion::Euler(euler);
+    }
+
+    // filter translation according to the constraints
+    auto allowedTranslation = translation;
+    if (static_cast<unsigned int>(GetConstraints()) & static_cast<unsigned int>(RigidbodyConstraints::LockPosition))
+        allowedTranslation = Vector3::Zero;
+    else
+    {
+        const auto constraints = static_cast<unsigned int>(GetConstraints());
+        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockPositionX))
+            allowedTranslation.X = 0;
+        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockPositionY))
+            allowedTranslation.Y = 0;
+        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockPositionZ))
+            allowedTranslation.Z = 0;
+    }
+    Transform t;
+    t.Translation = _transform.Translation + allowedTranslation;
+    t.Orientation = _transform.Orientation * allowedRotation;
+    t.Scale = _transform.Scale;
+    SetTransform(t);
+}
+
 void RigidBody::OnCollisionEnter(const Collision& c)
 {
     CollisionEnter(c);

--- a/Source/Engine/Physics/Actors/RigidBody.cpp
+++ b/Source/Engine/Physics/Actors/RigidBody.cpp
@@ -304,33 +304,31 @@ void RigidBody::AddMovement(const Vector3& translation, const Quaternion& rotati
 {
     // filter rotation according to constraints
     Quaternion allowedRotation;
-    if (static_cast<unsigned int>(GetConstraints()) & static_cast<unsigned int>(RigidbodyConstraints::LockRotation))
+    if (EnumHasAllFlags(GetConstraints(), RigidbodyConstraints::LockRotation))
         allowedRotation = Quaternion::Identity;
     else
     {
         Float3 euler = rotation.GetEuler();
-        const auto constraints = static_cast<unsigned int>(GetConstraints());
-        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationX))
+        if (EnumHasAnyFlags(GetConstraints(), RigidbodyConstraints::LockRotationX))
             euler.X = 0;
-        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationY))
+        if (EnumHasAnyFlags(GetConstraints(), RigidbodyConstraints::LockRotationY))
             euler.Y = 0;
-        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockRotationZ))
+        if (EnumHasAnyFlags(GetConstraints(), RigidbodyConstraints::LockRotationZ))
             euler.Z = 0;
         allowedRotation = Quaternion::Euler(euler);
     }
 
     // filter translation according to the constraints
     auto allowedTranslation = translation;
-    if (static_cast<unsigned int>(GetConstraints()) & static_cast<unsigned int>(RigidbodyConstraints::LockPosition))
+    if (EnumHasAllFlags(GetConstraints(), RigidbodyConstraints::LockPosition))
         allowedTranslation = Vector3::Zero;
     else
     {
-        const auto constraints = static_cast<unsigned int>(GetConstraints());
-        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockPositionX))
+        if (EnumHasAnyFlags(GetConstraints(), RigidbodyConstraints::LockPositionX))
             allowedTranslation.X = 0;
-        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockPositionY))
+        if (EnumHasAnyFlags(GetConstraints(), RigidbodyConstraints::LockPositionY))
             allowedTranslation.Y = 0;
-        if (constraints & static_cast<unsigned int>(RigidbodyConstraints::LockPositionZ))
+        if (EnumHasAnyFlags(GetConstraints(), RigidbodyConstraints::LockPositionZ))
             allowedTranslation.Z = 0;
     }
     Transform t;

--- a/Source/Engine/Physics/Actors/RigidBody.h
+++ b/Source/Engine/Physics/Actors/RigidBody.h
@@ -430,6 +430,12 @@ public:
     /// <param name="result">The result point on the rigidbody shape that is closest to the specified location.</param>
     API_FUNCTION() void ClosestPoint(const Vector3& position, API_PARAM(Out) Vector3& result) const;
 
+    /// <summary>
+    /// Moves and rotates the rigidbody in world space within the limits of defined constraints.
+    /// </summary>
+    /// <param name="translation">The translation vector.</param>
+    /// <param name="rotation">The rotation quaternion.</param>
+    API_FUNCTION() void AddMovement(const Vector3& translation, const Quaternion& rotation) override;
 public:
     /// <summary>
     /// Occurs when a collision start gets registered for this rigidbody (it collides with something).

--- a/Source/Engine/Physics/Actors/RigidBody.h
+++ b/Source/Engine/Physics/Actors/RigidBody.h
@@ -430,12 +430,6 @@ public:
     /// <param name="result">The result point on the rigidbody shape that is closest to the specified location.</param>
     API_FUNCTION() void ClosestPoint(const Vector3& position, API_PARAM(Out) Vector3& result) const;
 
-    /// <summary>
-    /// Moves and rotates the rigidbody in world space within the limits of defined constraints.
-    /// </summary>
-    /// <param name="translation">The translation vector.</param>
-    /// <param name="rotation">The rotation quaternion.</param>
-    API_FUNCTION() void AddMovement(const Vector3& translation, const Quaternion& rotation) override;
 public:
     /// <summary>
     /// Occurs when a collision start gets registered for this rigidbody (it collides with something).
@@ -492,6 +486,7 @@ public:
     // [Actor]
     void Serialize(SerializeStream& stream, const void* otherObj) override;
     void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
+    void AddMovement(const Vector3& translation, const Quaternion& rotation) override;
 
     // [IPhysicsActor]
     void* GetPhysicsActor() const override;


### PR DESCRIPTION
This fix will prevent rotating a rigidbody around locked axis by the root motion delta.