### PR TITLE
Adjust `ContextMenu` ShortKeys as needed to accommodate for scrollbar when visible

### DIFF
--- a/Source/Editor/GUI/ContextMenu/ContextMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenu.cs
@@ -408,9 +408,9 @@ namespace FlaxEditor.GUI.ContextMenu
             {
                 foreach (var child in _panel.Children)
                 {
-                    if (child is ContextMenuChildMenu item && item.Visible)
+                    if (child is ContextMenuButton item && item.Visible)
                     {
-                        item.AdjustArrowAmount = -_panel.VScrollBar.Width;
+                        item.ExtraAdjustmentAmount = -_panel.VScrollBar.Width;
                     }
                 }
             }

--- a/Source/Editor/GUI/ContextMenu/ContextMenuButton.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuButton.cs
@@ -14,6 +14,11 @@ namespace FlaxEditor.GUI.ContextMenu
     public class ContextMenuButton : ContextMenuItem
     {
         private bool _isMouseDown;
+        
+        /// <summary>
+        /// The amount to adjust the short keys and arrow image by in x coordinates.
+        /// </summary>
+        public float ExtraAdjustmentAmount = 0;
 
         /// <summary>
         /// Event fired when user clicks on the button.
@@ -133,7 +138,7 @@ namespace FlaxEditor.GUI.ContextMenu
             if (!string.IsNullOrEmpty(ShortKeys))
             {
                 // Draw short keys
-                Render2D.DrawText(style.FontMedium, ShortKeys, textRect, textColor, TextAlignment.Far, TextAlignment.Center);
+                Render2D.DrawText(style.FontMedium, ShortKeys, new Rectangle(ExtraAdjustmentAmount, textRect.Y, textRect.Width, textRect.Height), textColor, TextAlignment.Far, TextAlignment.Center);
             }
 
             // Draw icon

--- a/Source/Editor/GUI/ContextMenu/ContextMenuButton.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuButton.cs
@@ -138,7 +138,7 @@ namespace FlaxEditor.GUI.ContextMenu
             if (!string.IsNullOrEmpty(ShortKeys))
             {
                 // Draw short keys
-                Render2D.DrawText(style.FontMedium, ShortKeys, new Rectangle(ExtraAdjustmentAmount, textRect.Y, textRect.Width, textRect.Height), textColor, TextAlignment.Far, TextAlignment.Center);
+                Render2D.DrawText(style.FontMedium, ShortKeys, new Rectangle(textRect.X + ExtraAdjustmentAmount, textRect.Y, textRect.Width, textRect.Height), textColor, TextAlignment.Far, TextAlignment.Center);
             }
 
             // Draw icon

--- a/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
@@ -18,11 +18,6 @@ namespace FlaxEditor.GUI.ContextMenu
         public readonly ContextMenu ContextMenu = new ContextMenu();
 
         /// <summary>
-        /// The amount to adjust the arrow image by in x coordinates.
-        /// </summary>
-        public float AdjustArrowAmount = 0;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ContextMenuChildMenu"/> class.
         /// </summary>
         /// <param name="parent">The parent context menu.</param>
@@ -49,7 +44,7 @@ namespace FlaxEditor.GUI.ContextMenu
 
             // Draw arrow
             if (ContextMenu.HasChildren)
-                Render2D.DrawSprite(style.ArrowRight, new Rectangle(Width - 15 + AdjustArrowAmount, (Height - 12) / 2, 12, 12), Enabled ? isCMopened ? style.BackgroundSelected : style.Foreground : style.ForegroundDisabled);
+                Render2D.DrawSprite(style.ArrowRight, new Rectangle(Width - 15 + ExtraAdjustmentAmount, (Height - 12) / 2, 12, 12), Enabled ? isCMopened ? style.BackgroundSelected : style.Foreground : style.ForegroundDisabled);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This changes it so not only the arrow moves in the context menu to accommodate for a scroll bar but the short keys will as well.