### PR TITLE
Keep local orientation on collider spawn. 

### DIFF
--- a/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
+++ b/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
@@ -19,7 +19,8 @@ namespace FlaxEditor.SceneGraph.Actors
     [CustomEditor(typeof(BoxCollider)), DefaultEditor]
     public class BoxColliderEditor : ActorEditor
     {
-        private bool _keepLocalOrientation = false;
+        private bool _keepLocalOrientation = true;
+
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
         {

--- a/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
+++ b/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
@@ -19,12 +19,16 @@ namespace FlaxEditor.SceneGraph.Actors
     [CustomEditor(typeof(BoxCollider)), DefaultEditor]
     public class BoxColliderEditor : ActorEditor
     {
+        private bool _keepLocalOrientation = false;
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
         {
             base.Initialize(layout);
 
             layout.Space(20f);
+            var checkbox = layout.Checkbox("Keep Local Orientation", "Keeps the local orientation when resizing.").CheckBox;
+            checkbox.Checked = _keepLocalOrientation;
+            checkbox.StateChanged += box => _keepLocalOrientation = box.Checked;
             layout.Button("Resize to Fit", Editor.Instance.CodeDocs.GetTooltip(new ScriptMemberInfo(typeof(BoxCollider).GetMethod("AutoResize")))).Button.Clicked += OnResizeClicked;
         }
 
@@ -33,7 +37,7 @@ namespace FlaxEditor.SceneGraph.Actors
             foreach (var value in Values)
             {
                 if (value is BoxCollider collider)
-                    collider.AutoResize();
+                    collider.AutoResize(!_keepLocalOrientation);
             }
         }
     }
@@ -76,7 +80,7 @@ namespace FlaxEditor.SceneGraph.Actors
                 return;
             }
 
-            ((BoxCollider)Actor).AutoResize();
+            ((BoxCollider)Actor).AutoResize(false);
         }
     }
 }

--- a/Source/Engine/Physics/Colliders/BoxCollider.cpp
+++ b/Source/Engine/Physics/Colliders/BoxCollider.cpp
@@ -20,7 +20,7 @@ void BoxCollider::SetSize(const Float3& value)
     UpdateBounds();
 }
 
-void BoxCollider::AutoResize()
+void BoxCollider::AutoResize(bool globalOrientation = true)
 {
     Actor* parent = GetParent();
     if (Cast<Scene>(parent))
@@ -43,7 +43,8 @@ void BoxCollider::AutoResize()
     SetLocalPosition(Vector3::Zero);
     SetSize(parentSize / parentScale);
     SetCenter(parentCenter / parentScale);
-    SetOrientation(GetOrientation() * Quaternion::Invert(GetOrientation()));
+    if (globalOrientation)
+        SetOrientation(GetOrientation() * Quaternion::Invert(GetOrientation()));
 }
 
 #if USE_EDITOR

--- a/Source/Engine/Physics/Colliders/BoxCollider.cpp
+++ b/Source/Engine/Physics/Colliders/BoxCollider.cpp
@@ -30,7 +30,13 @@ void BoxCollider::AutoResize(bool globalOrientation = true)
     const Vector3 parentScale = parent->GetScale();
     if (parentScale.IsAnyZero())
         return; // Avoid division by zero
+
+    // Hacky way to get unrotated bounded box of parent.
+    const Quaternion parentOrientation = parent->GetOrientation();
+    parent->SetOrientation(Quaternion::Identity);
     BoundingBox parentBox = parent->GetBox();
+    parent->SetOrientation(parentOrientation);
+
     for (const Actor* sibling : parent->Children)
     {
         if (sibling != this)
@@ -45,6 +51,8 @@ void BoxCollider::AutoResize(bool globalOrientation = true)
     SetCenter(parentCenter / parentScale);
     if (globalOrientation)
         SetOrientation(GetOrientation() * Quaternion::Invert(GetOrientation()));
+    else
+        SetOrientation(parentOrientation);
 }
 
 #if USE_EDITOR

--- a/Source/Engine/Physics/Colliders/BoxCollider.h
+++ b/Source/Engine/Physics/Colliders/BoxCollider.h
@@ -46,7 +46,7 @@ public:
     /// <summary>
     /// Resizes the collider based on the bounds of it's parent to contain it whole (including any siblings).
     /// </summary>
-    API_FUNCTION() void AutoResize();
+    API_FUNCTION() void AutoResize(bool globalOrientation);
 
 public:
     // [Collider]


### PR DESCRIPTION
This PR keeps the local orientation of the collider when spawned and add option to keep orientation when resizing collider. I found it frustrating when I had a rotated model and added a collider to it and it did not keep the local rotation as I has to rotate again to match the rotation of the model. ~~The issue I have now is that the box is larger because the model is rotated than if the collider is added with the model not rotated.~~