### PR TITLE
Fix `Dropdown` panel to scale correctly.

### DIFF
--- a/Source/Engine/UI/GUI/Common/Dropdown.cs
+++ b/Source/Engine/UI/GUI/Common/Dropdown.cs
@@ -606,14 +606,15 @@ namespace FlaxEngine.GUI
             _popup.LostFocus += DestroyPopup;
 
             // Show dropdown popup
-            var locationRootSpace = Location + new Float2(0, Height);
+            var locationRootSpace = Location + new Float2(0, Height - Height * (1 - Scale.Y) / 2);
             var parent = Parent;
             while (parent != null && parent != root)
             {
                 locationRootSpace = parent.PointToParent(ref locationRootSpace);
                 parent = parent.Parent;
             }
-            _popup.Location = locationRootSpace;
+            _popup.Scale = Scale;
+            _popup.Location = locationRootSpace - new Float2(0, _popup.Height * (1 - _popup.Scale.Y) / 2);
             _popup.Parent = root;
             _popup.Focus();
             _popup.StartMouseCapture();


### PR DESCRIPTION

Before: Scale at (0.5, 0.5)
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/3e0f4eca-7f8b-4814-a475-e85972abc2f7)

After: Scale at (0.5, 0.5)
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/301fb23c-1709-412d-8822-94df66101282)
