### PR TITLE
Vehicle Physics Improviments

### DIFF
--- a/Source/Engine/Physics/Actors/WheeledVehicle.cpp
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.cpp
@@ -194,7 +194,10 @@ void WheeledVehicle::SetSteering(float value)
 
 void WheeledVehicle::SetBrake(float value)
 {
-    _brake = Math::Saturate(value);
+    value = Math::Saturate(value);
+    _brake = value;
+    _tankLeftBrake = value;
+    _tankRightBrake = value;
 }
 
 void WheeledVehicle::SetHandbrake(float value)
@@ -227,11 +230,11 @@ void WheeledVehicle::ClearInput()
     _throttle = 0;
     _steering = 0;
     _brake = 0;
+    _handBrake = 0;
     _tankLeftThrottle = 0;
     _tankRightThrottle = 0;
     _tankLeftBrake = 0;
     _tankRightBrake = 0;
-    _handBrake = 0;
 }
 
 float WheeledVehicle::GetForwardSpeed() const
@@ -423,10 +426,10 @@ void WheeledVehicle::OnDebugDrawSelected()
             continue;
         if (!_wheels[leftWheelIndex].Collider || !_wheels[rightWheelIndex].Collider)
             continue;
-        
+
         DEBUG_DRAW_LINE(_wheels[leftWheelIndex].Collider->GetPosition(), _wheels[rightWheelIndex].Collider->GetPosition(), Color::Yellow, 0, false);
     }
-        // Center of mass
+    // Center of mass
     DEBUG_DRAW_WIRE_SPHERE(BoundingSphere(_transform.LocalToWorld(_centerOfMassOffset), 10.0f), Color::Blue, 0, false);
 
     RigidBody::OnDebugDrawSelected();

--- a/Source/Engine/Physics/Actors/WheeledVehicle.cpp
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.cpp
@@ -48,6 +48,16 @@ const Array<WheeledVehicle::Wheel> &WheeledVehicle::GetWheels() const
     return _wheels;
 }
 
+WheeledVehicle::DriveControlSettings WheeledVehicle::GetDriveControl() const
+{
+    return _driveControl;
+}
+
+void WheeledVehicle::SetDriveControl(DriveControlSettings &value)
+{
+    _driveControl = value;
+}
+
 void WheeledVehicle::SetWheels(const Array<Wheel> &value)
 {
 #if WITH_VEHICLE
@@ -376,11 +386,13 @@ void WheeledVehicle::Serialize(SerializeStream &stream, const void *otherObj)
     SERIALIZE_MEMBER(DriveType, _driveType);
     SERIALIZE_MEMBER(DriveModes, _driveMode);
     SERIALIZE_MEMBER(Wheels, _wheels);
+    SERIALIZE_MEMBER(DriveControl, _driveControl);
     SERIALIZE(UseReverseAsBrake);
     SERIALIZE(UseAnalogSteering);
     SERIALIZE_MEMBER(Engine, _engine);
     SERIALIZE_MEMBER(Differential, _differential);
     SERIALIZE_MEMBER(Gearbox, _gearbox);
+    
 }
 
 void WheeledVehicle::Deserialize(DeserializeStream &stream, ISerializeModifier *modifier)
@@ -390,6 +402,7 @@ void WheeledVehicle::Deserialize(DeserializeStream &stream, ISerializeModifier *
     DESERIALIZE_MEMBER(DriveType, _driveType);
     DESERIALIZE_MEMBER(DriveModes, _driveMode);
     DESERIALIZE_MEMBER(Wheels, _wheels);
+    DESERIALIZE_MEMBER(DriveControl, _driveControl);
     DESERIALIZE(UseReverseAsBrake);
     DESERIALIZE(UseAnalogSteering);
     DESERIALIZE_MEMBER(Engine, _engine);

--- a/Source/Engine/Physics/Actors/WheeledVehicle.cpp
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.cpp
@@ -33,16 +33,6 @@ void WheeledVehicle::SetDriveType(DriveTypes value)
     Setup();
 }
 
-void WheeledVehicle::SetDriveMode(DriveModes value)
-{
-    _driveMode = value;
-}
-
-WheeledVehicle::DriveModes WheeledVehicle::GetDriveMode() const
-{
-    return _driveMode;
-}
-
 const Array<WheeledVehicle::Wheel> &WheeledVehicle::GetWheels() const
 {
     return _wheels;
@@ -441,7 +431,6 @@ void WheeledVehicle::Serialize(SerializeStream &stream, const void *otherObj)
     SERIALIZE_GET_OTHER_OBJ(WheeledVehicle);
 
     SERIALIZE_MEMBER(DriveType, _driveType);
-    SERIALIZE_MEMBER(DriveModes, _driveMode);
     SERIALIZE_MEMBER(Wheels, _wheels);
     SERIALIZE_MEMBER(DriveControl, _driveControl);
     SERIALIZE(UseReverseAsBrake);
@@ -457,7 +446,6 @@ void WheeledVehicle::Deserialize(DeserializeStream &stream, ISerializeModifier *
     RigidBody::Deserialize(stream, modifier);
 
     DESERIALIZE_MEMBER(DriveType, _driveType);
-    DESERIALIZE_MEMBER(DriveModes, _driveMode);
     DESERIALIZE_MEMBER(Wheels, _wheels);
     DESERIALIZE_MEMBER(DriveControl, _driveControl);
     DESERIALIZE(UseReverseAsBrake);

--- a/Source/Engine/Physics/Actors/WheeledVehicle.cpp
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.cpp
@@ -59,9 +59,7 @@ void WheeledVehicle::SetWheels(const Array<Wheel> &value)
         {
             auto &oldWheel = _wheels.Get()[wheelIndex];
             auto &newWheel = value.Get()[wheelIndex];
-            if (oldWheel.Type != newWheel.Type ||
-                Math::NotNearEqual(oldWheel.SuspensionForceOffset, newWheel.SuspensionForceOffset) ||
-                oldWheel.Collider != newWheel.Collider)
+            if (Math::NotNearEqual(oldWheel.SuspensionForceOffset, newWheel.SuspensionForceOffset) || oldWheel.Collider != newWheel.Collider)
             {
                 softUpdate = false;
                 break;
@@ -352,6 +350,9 @@ void WheeledVehicle::OnDebugDrawSelected()
         // Draw wheels axes
         if (wheelIndex % 2 == 0 && wheelIndex + 1 < _wheels.Count())
         {
+            if (!_wheels[wheelIndex].Collider || !_wheels[wheelIndex + 1].Collider)
+                continue;
+
             const Vector3 wheelPos = _wheels[wheelIndex].Collider->GetPosition();
             const Vector3 nextWheelPos = _wheels[wheelIndex + 1].Collider->GetPosition();
             DEBUG_DRAW_LINE(wheelPos, nextWheelPos, Color::Yellow, 0, false);

--- a/Source/Engine/Physics/Actors/WheeledVehicle.cpp
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.cpp
@@ -45,6 +45,16 @@ WheeledVehicle::DriveControlSettings WheeledVehicle::GetDriveControl() const
 
 void WheeledVehicle::SetDriveControl(DriveControlSettings &value)
 {
+    value.RiseRateAcceleration = Math::Max(value.RiseRateAcceleration, 0.01f);
+    value.RiseRateBrake = Math::Max(value.RiseRateBrake, 0.01f);
+    value.RiseRateHandBrake = Math::Max(value.RiseRateHandBrake, 0.01f);
+    value.RiseRateSteer = Math::Max(value.RiseRateSteer, 0.01f);
+
+    value.FallRateAcceleration = Math::Max(value.FallRateAcceleration, 0.01f);
+    value.FallRateBrake = Math::Max(value.FallRateBrake, 0.01f);
+    value.FallRateHandBrake = Math::Max(value.FallRateHandBrake, 0.01f);
+    value.FallRateSteer = Math::Max(value.FallRateSteer, 0.01f);
+
     // Don't let have an invalid steer vs speed list.
     if (value.SteerVsSpeed.Count() < 1)
         value.SteerVsSpeed.Add(WheeledVehicle::SteerControl());

--- a/Source/Engine/Physics/Actors/WheeledVehicle.cpp
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.cpp
@@ -14,7 +14,7 @@
 #include "Engine/Core/Log.h"
 #endif
 
-WheeledVehicle::WheeledVehicle(const SpawnParams &params)
+WheeledVehicle::WheeledVehicle(const SpawnParams& params)
     : RigidBody(params)
 {
     _useCCD = 1;
@@ -33,7 +33,7 @@ void WheeledVehicle::SetDriveType(DriveTypes value)
     Setup();
 }
 
-const Array<WheeledVehicle::Wheel> &WheeledVehicle::GetWheels() const
+const Array<WheeledVehicle::Wheel>& WheeledVehicle::GetWheels() const
 {
     return _wheels;
 }
@@ -43,7 +43,7 @@ WheeledVehicle::DriveControlSettings WheeledVehicle::GetDriveControl() const
     return _driveControl;
 }
 
-void WheeledVehicle::SetDriveControl(DriveControlSettings &value)
+void WheeledVehicle::SetDriveControl(DriveControlSettings& value)
 {
     value.RiseRateAcceleration = Math::Max(value.RiseRateAcceleration, 0.01f);
     value.RiseRateBrake = Math::Max(value.RiseRateBrake, 0.01f);
@@ -69,15 +69,15 @@ void WheeledVehicle::SetDriveControl(DriveControlSettings &value)
         // Apply only on changed value
         if (_driveControl.SteerVsSpeed[i].Speed != value.SteerVsSpeed[i].Speed || _driveControl.SteerVsSpeed[i].Steer != value.SteerVsSpeed[i].Steer)
         {
-            WheeledVehicle::SteerControl &steerVsSpeed = value.SteerVsSpeed[i];
+            WheeledVehicle::SteerControl& steerVsSpeed = value.SteerVsSpeed[i];
             steerVsSpeed.Steer = Math::Saturate(steerVsSpeed.Steer);
             steerVsSpeed.Speed = Math::Max(steerVsSpeed.Speed, 10.0f);
 
             // Clamp speeds to have an ordened list.
             if (i >= 1)
             {
-                WheeledVehicle::SteerControl &lastSteerVsSpeed = value.SteerVsSpeed[i - 1];
-                WheeledVehicle::SteerControl &nextSteerVsSpeed = value.SteerVsSpeed[Math::Clamp(i + 1, 0, steerVsSpeedCount - 1)];
+                WheeledVehicle::SteerControl& lastSteerVsSpeed = value.SteerVsSpeed[i - 1];
+                WheeledVehicle::SteerControl& nextSteerVsSpeed = value.SteerVsSpeed[Math::Clamp(i + 1, 0, steerVsSpeedCount - 1)];
                 float minSpeed = lastSteerVsSpeed.Speed;
                 float maxSpeed = nextSteerVsSpeed.Speed;
 
@@ -88,7 +88,7 @@ void WheeledVehicle::SetDriveControl(DriveControlSettings &value)
             }
             else if (steerVsSpeedCount > 1)
             {
-                WheeledVehicle::SteerControl &nextSteerVsSpeed = value.SteerVsSpeed[i + 1];
+                WheeledVehicle::SteerControl& nextSteerVsSpeed = value.SteerVsSpeed[i + 1];
                 steerVsSpeed.Speed = Math::Min(steerVsSpeed.Speed, nextSteerVsSpeed.Speed);
             }
         }
@@ -97,7 +97,7 @@ void WheeledVehicle::SetDriveControl(DriveControlSettings &value)
     _driveControl = value;
 }
 
-void WheeledVehicle::SetWheels(const Array<Wheel> &value)
+void WheeledVehicle::SetWheels(const Array<Wheel>& value)
 {
 #if WITH_VEHICLE
     // Don't recreate whole vehicle when some wheel properties are only changed (eg. suspension)
@@ -106,8 +106,8 @@ void WheeledVehicle::SetWheels(const Array<Wheel> &value)
         bool softUpdate = true;
         for (int32 wheelIndex = 0; wheelIndex < value.Count(); wheelIndex++)
         {
-            auto &oldWheel = _wheels.Get()[wheelIndex];
-            auto &newWheel = value.Get()[wheelIndex];
+            auto& oldWheel = _wheels.Get()[wheelIndex];
+            auto& newWheel = value.Get()[wheelIndex];
             if (Math::NotNearEqual(oldWheel.SuspensionForceOffset, newWheel.SuspensionForceOffset) || oldWheel.Collider != newWheel.Collider)
             {
                 softUpdate = false;
@@ -131,7 +131,7 @@ WheeledVehicle::EngineSettings WheeledVehicle::GetEngine() const
     return _engine;
 }
 
-void WheeledVehicle::SetEngine(const EngineSettings &value)
+void WheeledVehicle::SetEngine(const EngineSettings& value)
 {
 #if WITH_VEHICLE
     if (_vehicle)
@@ -145,7 +145,7 @@ WheeledVehicle::DifferentialSettings WheeledVehicle::GetDifferential() const
     return _differential;
 }
 
-void WheeledVehicle::SetDifferential(const DifferentialSettings &value)
+void WheeledVehicle::SetDifferential(const DifferentialSettings& value)
 {
 #if WITH_VEHICLE
     if (_vehicle)
@@ -159,7 +159,7 @@ WheeledVehicle::GearboxSettings WheeledVehicle::GetGearbox() const
     return _gearbox;
 }
 
-void WheeledVehicle::SetGearbox(const GearboxSettings &value)
+void WheeledVehicle::SetGearbox(const GearboxSettings& value)
 {
 #if WITH_VEHICLE
     if (_vehicle)
@@ -168,7 +168,7 @@ void WheeledVehicle::SetGearbox(const GearboxSettings &value)
     _gearbox = value;
 }
 
-void WheeledVehicle::SetAntiRollBars(const Array<AntiRollBar> &value)
+void WheeledVehicle::SetAntiRollBars(const Array<AntiRollBar>& value)
 {
     _antiRollBars = value;
 #if WITH_VEHICLE
@@ -177,7 +177,7 @@ void WheeledVehicle::SetAntiRollBars(const Array<AntiRollBar> &value)
 #endif
 }
 
-const Array<WheeledVehicle::AntiRollBar> &WheeledVehicle::GetAntiRollBars() const
+const Array<WheeledVehicle::AntiRollBar>& WheeledVehicle::GetAntiRollBars() const
 {
     return _antiRollBars;
 }
@@ -298,12 +298,12 @@ void WheeledVehicle::SetTargetGear(int32 value)
 #endif
 }
 
-void WheeledVehicle::GetWheelState(int32 index, WheelState &result)
+void WheeledVehicle::GetWheelState(int32 index, WheelState& result)
 {
     if (index >= 0 && index < _wheels.Count())
     {
         const auto collider = _wheels[index].Collider.Get();
-        for (auto &wheelData : _wheelsData)
+        for (auto& wheelData : _wheelsData)
         {
             if (wheelData.Collider == collider)
             {
@@ -344,10 +344,10 @@ void WheeledVehicle::Setup()
 
 #if USE_EDITOR
 
-void WheeledVehicle::DrawPhysicsDebug(RenderView &view)
+void WheeledVehicle::DrawPhysicsDebug(RenderView& view)
 {
     // Wheels shapes
-    for (const auto &data : _wheelsData)
+    for (const auto& data : _wheelsData)
     {
         int32 wheelIndex = 0;
         for (; wheelIndex < _wheels.Count(); wheelIndex++)
@@ -357,7 +357,7 @@ void WheeledVehicle::DrawPhysicsDebug(RenderView &view)
         }
         if (wheelIndex == _wheels.Count())
             break;
-        const auto &wheel = _wheels[wheelIndex];
+        const auto& wheel = _wheels[wheelIndex];
         if (wheel.Collider && wheel.Collider->GetParent() == this && !wheel.Collider->GetIsTrigger())
         {
             const Vector3 currentPos = wheel.Collider->GetPosition();
@@ -378,7 +378,7 @@ void WheeledVehicle::DrawPhysicsDebug(RenderView &view)
 void WheeledVehicle::OnDebugDrawSelected()
 {
     // Wheels shapes
-    for (const auto &data : _wheelsData)
+    for (const auto& data : _wheelsData)
     {
         int32 wheelIndex = 0;
         for (; wheelIndex < _wheels.Count(); wheelIndex++)
@@ -388,7 +388,7 @@ void WheeledVehicle::OnDebugDrawSelected()
         }
         if (wheelIndex == _wheels.Count())
             break;
-        const auto &wheel = _wheels[wheelIndex];
+        const auto& wheel = _wheels[wheelIndex];
         if (wheel.Collider && wheel.Collider->GetParent() == this && !wheel.Collider->GetIsTrigger())
         {
             const Vector3 currentPos = wheel.Collider->GetPosition();
@@ -437,7 +437,7 @@ void WheeledVehicle::OnDebugDrawSelected()
 
 #endif
 
-void WheeledVehicle::Serialize(SerializeStream &stream, const void *otherObj)
+void WheeledVehicle::Serialize(SerializeStream& stream, const void *otherObj)
 {
     RigidBody::Serialize(stream, otherObj);
 
@@ -454,7 +454,7 @@ void WheeledVehicle::Serialize(SerializeStream &stream, const void *otherObj)
     SERIALIZE_MEMBER(AntiRollBars, _antiRollBars);
 }
 
-void WheeledVehicle::Deserialize(DeserializeStream &stream, ISerializeModifier *modifier)
+void WheeledVehicle::Deserialize(DeserializeStream& stream, ISerializeModifier *modifier)
 {
     RigidBody::Deserialize(stream, modifier);
 
@@ -550,14 +550,14 @@ void WheeledVehicle::BeginPlay(SceneBeginData *data)
 #endif
 
 #if USE_EDITOR
-    GetSceneRendering()->AddPhysicsDebug<WheeledVehicle, &WheeledVehicle::DrawPhysicsDebug>(this);
+    GetSceneRendering()->AddPhysicsDebug<WheeledVehicle,& WheeledVehicle::DrawPhysicsDebug>(this);
 #endif
 }
 
 void WheeledVehicle::EndPlay()
 {
 #if USE_EDITOR
-    GetSceneRendering()->RemovePhysicsDebug<WheeledVehicle, &WheeledVehicle::DrawPhysicsDebug>(this);
+    GetSceneRendering()->RemovePhysicsDebug<WheeledVehicle,& WheeledVehicle::DrawPhysicsDebug>(this);
 #endif
 
 #if WITH_VEHICLE

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -131,6 +131,11 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         API_AUTO_SERIALIZATION();
 
         /// <summary>
+        /// Gets or sets the drive mode, used by vehicles specify the way of the tracks control.
+        /// </summary>
+        API_FIELD(Attributes="EditorOrder(0), EditorDisplay(\"Tanks\")") WheeledVehicle::DriveModes DriveMode;
+
+        /// <summary>
         /// Acceleration input sensitive.
         /// </summary>
         API_FIELD(Attributes="Limit(0), EditorOrder(10)") float RiseRateAcceleration = 6.0f;
@@ -441,7 +446,6 @@ private:
 
     void* _vehicle = nullptr;
     DriveTypes _driveType = DriveTypes::Drive4W, _driveTypeCurrent;
-    DriveModes _driveMode = DriveModes::Standard;
     Array<WheelData, FixedAllocation<20>> _wheelsData;
     float _throttle = 0.0f, _steering = 0.0f, _brake = 0.0f, _handBrake = 0.0f, _tankLeftThrottle, _tankRightThrottle, _tankLeftBrake, _tankRightBrake;
     Array<WheeledVehicle::Wheel> _wheels;
@@ -475,16 +479,6 @@ public:
     /// Sets the vehicle driving model type.
     /// </summary>
     API_PROPERTY() void SetDriveType(DriveTypes value);
-
-    /// <summary>
-    /// Used only for tanks, set the drive mode.
-    /// </summary>
-    API_PROPERTY() void SetDriveMode(DriveModes value);
-
-    /// <summary>
-    /// Gets the vehicle driving mode. Used only on tanks
-    /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(3), EditorDisplay(\"Vehicle\")") DriveModes GetDriveMode() const;
 
     /// <summary>
     /// Gets the vehicle wheels settings.

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -26,6 +26,7 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         DriveNW,
         // Non-drivable vehicle.
         NoDrive,
+        // Tank Drive. Can have more than 4 wheel. Not use steer, control acceleration for each tank track.
         Tank,
     };
     /// <summary>
@@ -447,7 +448,7 @@ private:
     void* _vehicle = nullptr;
     DriveTypes _driveType = DriveTypes::Drive4W, _driveTypeCurrent;
     Array<WheelData, FixedAllocation<20>> _wheelsData;
-    float _throttle = 0.0f, _steering = 0.0f, _brake = 0.0f, _handBrake = 0.0f, _tankLeftThrottle, _tankRightThrottle, _tankLeftBrake, _tankRightBrake;
+    float _throttle = 0.0f, _steering = 0.0f, _brake = 0.0f, _handBrake = 0.0f, _tankLeftThrottle = 0.0f, _tankRightThrottle = 0.0f, _tankLeftBrake = 0.0f, _tankRightBrake = 0.0f;
     Array<WheeledVehicle::Wheel> _wheels;
     Array<WheeledVehicle::AntiRollBar> _antiRollBars;
     DriveControlSettings _driveControl;

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -26,6 +26,18 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         DriveNW,
         // Non-drivable vehicle.
         NoDrive,
+        Tank,
+    };
+    /// <summary>
+    /// Vehicle driving types.
+    /// Used only on tanks to specify the drive mode.   
+    /// </summary>
+    API_ENUM() enum class DriveModes
+    {
+        // Drive turning the vehicle using only one track
+        Standard,
+        // Drive turning the vehicle using all tracks inverse direction.
+        Special
     };
 
     /// <summary>
@@ -127,6 +139,11 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         /// If enabled the vehicle gears will be changes automatically, otherwise it's fully manual.
         /// </summary>
         API_FIELD() bool AutoGear = true;
+
+        /// <summary>
+        /// Number of gears to move to forward
+        /// </summary>
+        API_FIELD(Attributes = "Limit(1, 30)") int ForwardGearsRatios = 5;
 
         /// <summary>
         /// Time it takes to switch gear. Specified in seconds (s).
@@ -322,8 +339,9 @@ private:
 
     void* _vehicle = nullptr;
     DriveTypes _driveType = DriveTypes::Drive4W, _driveTypeCurrent;
+    DriveModes _driveMode = DriveModes::Standard;
     Array<WheelData, FixedAllocation<20>> _wheelsData;
-    float _throttle = 0.0f, _steering = 0.0f, _brake = 0.0f, _handBrake = 0.0f;
+    float _throttle = 0.0f, _steering = 0.0f, _brake = 0.0f, _handBrake = 0.0f, _tankLeftThrottle, _tankRightThrottle, _tankLeftBrake, _tankRightBrake;
     Array<Wheel> _wheels;
     EngineSettings _engine;
     DifferentialSettings _differential;
@@ -347,7 +365,7 @@ public:
     /// <summary>
     /// Gets the vehicle driving model type.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(1), EditorDisplay(\"Vehicle\")") DriveTypes GetDriveType() const;
+    API_PROPERTY(Attributes="EditorOrder(2), EditorDisplay(\"Vehicle\")") DriveTypes GetDriveType() const;
 
     /// <summary>
     /// Sets the vehicle driving model type.
@@ -355,9 +373,19 @@ public:
     API_PROPERTY() void SetDriveType(DriveTypes value);
 
     /// <summary>
+    /// Used only for tanks, set the drive mode.
+    /// </summary>
+    API_PROPERTY() void SetDriveMode(DriveModes value);
+
+    /// <summary>
+    /// Gets the vehicle driving mode. Used only on tanks
+    /// </summary>
+    API_PROPERTY(Attributes="EditorOrder(3), EditorDisplay(\"Vehicle\")") DriveModes GetDriveMode() const;
+
+    /// <summary>
     /// Gets the vehicle wheels settings.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(2), EditorDisplay(\"Vehicle\")") const Array<Wheel>& GetWheels() const;
+    API_PROPERTY(Attributes="EditorOrder(4), EditorDisplay(\"Vehicle\")") const Array<Wheel>& GetWheels() const;
 
     /// <summary>
     /// Sets the vehicle wheels settings.
@@ -367,7 +395,7 @@ public:
     /// <summary>
     /// Gets the vehicle engine settings.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(3), EditorDisplay(\"Vehicle\")") EngineSettings GetEngine() const;
+    API_PROPERTY(Attributes="EditorOrder(5), EditorDisplay(\"Vehicle\")") EngineSettings GetEngine() const;
 
     /// <summary>
     /// Sets the vehicle engine settings.
@@ -377,7 +405,7 @@ public:
     /// <summary>
     /// Gets the vehicle differential settings.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(4), EditorDisplay(\"Vehicle\")") DifferentialSettings GetDifferential() const;
+    API_PROPERTY(Attributes="EditorOrder(6), EditorDisplay(\"Vehicle\")") DifferentialSettings GetDifferential() const;
 
     /// <summary>
     /// Sets the vehicle differential settings.
@@ -387,7 +415,7 @@ public:
     /// <summary>
     /// Gets the vehicle gearbox settings.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(5), EditorDisplay(\"Vehicle\")") GearboxSettings GetGearbox() const;
+    API_PROPERTY(Attributes="EditorOrder(7), EditorDisplay(\"Vehicle\")") GearboxSettings GetGearbox() const;
 
     /// <summary>
     /// Sets the vehicle gearbox settings.
@@ -418,6 +446,32 @@ public:
     /// </summary>
     /// <param name="value">The value (0,1 range).</param>
     API_FUNCTION() void SetHandbrake(float value);
+
+    /// <summary>
+    /// Sets the input for tank left track throttle. It is the analog accelerator pedal value in range (-1,1) where 1 represents the pedal fully pressed to move to forward, 0 to represents the 
+    /// pedal in its rest state and -1 represents the pedal fully pressed to move to backward. The track direction will be inverted if the vehicle current gear is rear.
+    /// </summary>
+    /// <param name="value">The value (-1,1 range).</param>
+    API_FUNCTION() void SetTankLeftThrottle(float value);
+
+    /// <summary>
+    /// Sets the input for tank right track throttle. It is the analog accelerator pedal value in range (-1,1) where 1 represents the pedal fully pressed to move to forward, 0 to represents the
+    /// pedal in its rest state and -1 represents the pedal fully pressed to move to backward. The track direction will be inverted if the vehicle current gear is rear.
+    /// </summary>
+    /// <param name="value">The value (-1,1 range).</param>
+    API_FUNCTION() void SetTankRightThrottle(float value);
+
+    /// <summary>
+    /// Sets the input for tank brakes the left track. Brake is the analog brake pedal value in range (0,1) where 1 represents the pedal fully pressed and 0 represents the pedal in its rest state.
+    /// </summary>
+    /// <param name="value">The value (0,1 range).</param>
+    API_FUNCTION() void SetTankLeftBrake(float value);
+
+    /// <summary>
+    /// Sets the input for tank brakes the right track. Brake is the analog brake pedal value in range (0,1) where 1 represents the pedal fully pressed and 0 represents the pedal in its rest state.
+    /// </summary>
+    /// <param name="value">The value (0,1 range).</param>
+    API_FUNCTION() void SetTankRightBrake(float value);
 
     /// <summary>
     /// Clears all the vehicle control inputs to the default values (throttle, steering, breaks).

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -138,42 +138,42 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         /// <summary>
         /// Acceleration input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(10)") float RiseRateAcceleration = 6.0f;
+        API_FIELD(Attributes="EditorOrder(10)") float RiseRateAcceleration = 6.0f;
 
         /// <summary>
         /// Deceleration input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(11)") float FallRateAcceleration = 10.0f;
+        API_FIELD(Attributes="EditorOrder(11)") float FallRateAcceleration = 10.0f;
 
         /// <summary>
         /// Brake input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(12)") float RiseRateBrake = 6.0f;
+        API_FIELD(Attributes="EditorOrder(12)") float RiseRateBrake = 6.0f;
 
         /// <summary>
         /// Release brake sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(13)") float FallRateBrake = 10.0f;
+        API_FIELD(Attributes="EditorOrder(13)") float FallRateBrake = 10.0f;
 
         /// <summary>
         /// Brake input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(14)") float RiseRateHandBrake = 12.0f;
+        API_FIELD(Attributes="EditorOrder(14)") float RiseRateHandBrake = 12.0f;
 
         /// <summary>
         /// Release handbrake sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(15)") float FallRateHandBrake = 12.0f;
+        API_FIELD(Attributes="EditorOrder(15)") float FallRateHandBrake = 12.0f;
 
         /// <summary>
         /// Steer input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(16)") float RiseRateSteer = 2.5f;
+        API_FIELD(Attributes="EditorOrder(16)") float RiseRateSteer = 2.5f;
 
         /// <summary>
         /// Release steer input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorOrder(17)") float FallRateSteer = 5.0f;
+        API_FIELD(Attributes="EditorOrder(17)") float FallRateSteer = 5.0f;
 
         /// <summary>
         /// Vehicle control relationship between speed and steer. The higher is the speed, 

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -134,7 +134,7 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         /// <summary>
         /// Gets or sets the drive mode, used by vehicles specify the way of the tracks control.
         /// </summary>
-        API_FIELD(Attributes="EditorOrder(0), EditorDisplay(\"Tanks\")") WheeledVehicle::DriveModes DriveMode;
+        API_FIELD(Attributes="EditorOrder(0), EditorDisplay(\"Tanks\")") WheeledVehicle::DriveModes DriveMode = WheeledVehicle::DriveModes::Standard;
 
         /// <summary>
         /// Acceleration input sensitive.

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -84,6 +84,55 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
     };
 
     /// <summary>
+    /// Vehicle drive control settings.
+    /// </summary>
+    API_STRUCT() struct DriveControlSettings : ISerializable
+    {
+        DECLARE_SCRIPTING_TYPE_MINIMAL(DriveControlSettings);
+        API_AUTO_SERIALIZATION();
+
+        /// <summary>
+        /// Acceleration input sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(10)") float RiseRateAcceleration = 6.0f;
+
+        /// <summary>
+        /// Deceleration input sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(11)") float FallRateAcceleration = 10.0f;
+
+        /// <summary>
+        /// Brake input sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(12)") float RiseRateBrake = 6.0f;
+
+        /// <summary>
+        /// Release brake sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(13)") float FallRateBrake = 10.0f;
+
+        /// <summary>
+        /// Brake input sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(14)") float RiseRateHandBrake = 12.0f;
+
+        /// <summary>
+        /// Release handbrake sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(15)") float FallRateHandBrake = 12.0f;
+
+        /// <summary>
+        /// Steer input sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(16)") float RiseRateSteer = 2.5f;
+
+        /// <summary>
+        /// Release steer input sensitive.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(17)") float FallRateSteer = 5.0f;
+    };
+
+    /// <summary>
     /// Vehicle differential settings.
     /// </summary>
     API_STRUCT() struct DifferentialSettings : ISerializable
@@ -321,6 +370,7 @@ private:
     Array<WheelData, FixedAllocation<20>> _wheelsData;
     float _throttle = 0.0f, _steering = 0.0f, _brake = 0.0f, _handBrake = 0.0f, _tankLeftThrottle, _tankRightThrottle, _tankLeftBrake, _tankRightBrake;
     Array<Wheel> _wheels;
+    DriveControlSettings _driveControl;
     EngineSettings _engine;
     DifferentialSettings _differential;
     GearboxSettings _gearbox;
@@ -366,6 +416,16 @@ public:
     API_PROPERTY(Attributes="EditorOrder(4), EditorDisplay(\"Vehicle\")") const Array<Wheel>& GetWheels() const;
 
     /// <summary>
+    /// Gets the vehicle drive control settings.
+    /// </summary>
+    API_PROPERTY(Attributes = "EditorOrder(5), EditorDisplay(\"Vehicle\")") DriveControlSettings GetDriveControl() const;
+
+    /// <summary>
+    /// Sets the vehicle drive control settings.
+    /// </summary>
+    API_PROPERTY() void SetDriveControl(DriveControlSettings& value);
+
+    /// <summary>
     /// Sets the vehicle wheels settings.
     /// </summary>
     API_PROPERTY() void SetWheels(const Array<Wheel>& value);
@@ -373,7 +433,7 @@ public:
     /// <summary>
     /// Gets the vehicle engine settings.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(5), EditorDisplay(\"Vehicle\")") EngineSettings GetEngine() const;
+    API_PROPERTY(Attributes="EditorOrder(6), EditorDisplay(\"Vehicle\")") EngineSettings GetEngine() const;
 
     /// <summary>
     /// Sets the vehicle engine settings.
@@ -383,7 +443,7 @@ public:
     /// <summary>
     /// Gets the vehicle differential settings.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(6), EditorDisplay(\"Vehicle\")") DifferentialSettings GetDifferential() const;
+    API_PROPERTY(Attributes="EditorOrder(7), EditorDisplay(\"Vehicle\")") DifferentialSettings GetDifferential() const;
 
     /// <summary>
     /// Sets the vehicle differential settings.
@@ -393,7 +453,7 @@ public:
     /// <summary>
     /// Gets the vehicle gearbox settings.
     /// </summary>
-    API_PROPERTY(Attributes="EditorOrder(7), EditorDisplay(\"Vehicle\")") GearboxSettings GetGearbox() const;
+    API_PROPERTY(Attributes="EditorOrder(8), EditorDisplay(\"Vehicle\")") GearboxSettings GetGearbox() const;
 
     /// <summary>
     /// Sets the vehicle gearbox settings.

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -307,6 +307,11 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         API_FIELD(Attributes="EditorOrder(4)") ScriptingObjectReference<Collider> Collider;
 
         /// <summary>
+        /// Spring sprung mass force multiplier.
+        /// </summary>
+        API_FIELD(Attributes="Limit(0.01f), EditorDisplay(\"Suspension\"), EditorOrder(19)") float SprungMassMultiplier = 1.0f;
+
+        /// <summary>
         /// Spring damper rate of suspension unit.
         /// </summary>
         API_FIELD(Attributes="Limit(0), EditorDisplay(\"Suspension\"), EditorOrder(20)") float SuspensionDampingRate = 1.0f;
@@ -407,6 +412,25 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
 #endif
     };
 
+    /// <summary>
+    /// Vehicle axle anti roll bar.
+    /// </summary>
+    API_STRUCT() struct AntiRollBar : ISerializable
+    {
+        DECLARE_SCRIPTING_TYPE_MINIMAL(AntiRollBar);
+        API_AUTO_SERIALIZATION();
+
+        /// <summary>
+        /// The specific axle with wheels to apply anti roll.
+        /// </summary>
+        API_FIELD() int Axle;
+
+        /// <summary>
+        /// The anti roll stiffness.
+        /// </summary>
+        API_FIELD() float Stiffness;
+    };
+
 private:
     struct WheelData
     {
@@ -420,7 +444,8 @@ private:
     DriveModes _driveMode = DriveModes::Standard;
     Array<WheelData, FixedAllocation<20>> _wheelsData;
     float _throttle = 0.0f, _steering = 0.0f, _brake = 0.0f, _handBrake = 0.0f, _tankLeftThrottle, _tankRightThrottle, _tankLeftBrake, _tankRightBrake;
-    Array<Wheel> _wheels;
+    Array<WheeledVehicle::Wheel> _wheels;
+    Array<WheeledVehicle::AntiRollBar> _antiRollBars;
     DriveControlSettings _driveControl;
     EngineSettings _engine;
     DifferentialSettings _differential;
@@ -510,6 +535,16 @@ public:
     /// Sets the vehicle gearbox settings.
     /// </summary>
     API_PROPERTY() void SetGearbox(const GearboxSettings& value);
+
+    // <summary>
+    /// Sets axles anti roll bars to increase vehicle estability.
+    /// </summary>
+    API_PROPERTY() void SetAntiRollBars(const Array<AntiRollBar>& value);
+
+    // <summary>
+    /// Gets axles anti roll bars.
+    /// </summary>
+    API_PROPERTY() const Array<AntiRollBar>& GetAntiRollBars() const;
 
 public:
     /// <summary>

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -282,9 +282,9 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         API_FIELD(Attributes="EditorOrder(3)") float Width = 20.0f;
 
         /// <summary>
-        /// Max steer angle that can be achieved by the wheel (in degrees).
+        /// Max steer angle that can be achieved by the wheel (in degrees, -180 to 180).
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Steering\"), EditorOrder(10)") float MaxSteerAngle = 0.0f;
+        API_FIELD(Attributes="Limit(-180, 180), EditorDisplay(\"Steering\"), EditorOrder(10)") float MaxSteerAngle = 0.0f;
 
         /// <summary>
         /// Damping rate applied to wheel. Specified in kilograms metres-squared per second (kg m^2 s^-1).

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -159,34 +159,12 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
     };
 
     /// <summary>
-    /// Vehicle wheel types.
-    /// </summary>
-    API_ENUM() enum class WheelTypes
-    {
-        // Left wheel of the front axle.
-        FrontLeft,
-        // Right wheel of the front axle.
-        FrontRight,
-        // Left wheel of the rear axle.
-        RearLeft,
-        // Right wheel of the rear axle.
-        RearRight,
-        // Non-drivable wheel.
-        NoDrive,
-    };
-
-    /// <summary>
     /// Vehicle wheel settings.
     /// </summary>
     API_STRUCT() struct Wheel : ISerializable
     {
         DECLARE_SCRIPTING_TYPE_MINIMAL(Wheel);
         API_AUTO_SERIALIZATION();
-
-        /// <summary>
-        /// Wheel placement type.
-        /// </summary>
-        API_FIELD(Attributes="EditorOrder(0)") WheelTypes Type = WheelTypes::FrontLeft;
 
         /// <summary>
         /// Combined mass of the wheel and the tire in kg. Typically, a wheel has mass between 20Kg and 80Kg but can be lower and higher depending on the vehicle.

--- a/Source/Engine/Physics/Actors/WheeledVehicle.h
+++ b/Source/Engine/Physics/Actors/WheeledVehicle.h
@@ -41,6 +41,45 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
     };
 
     /// <summary>
+    /// Storage the relationship between speed and steer.
+    /// </summary>
+    API_STRUCT() struct SteerControl : ISerializable
+    {
+        DECLARE_SCRIPTING_TYPE_MINIMAL(SteerControl);
+        API_AUTO_SERIALIZATION();
+
+        /// <summary>
+        /// The vehicle speed.
+        /// </summary>
+        API_FIELD(Attributes = "Limit(0)") float Speed;
+
+        /// <summary>
+        /// The target max steer of the speed.
+        /// </summary>
+        API_FIELD(Attributes = "Limit(0, 1)") float Steer;
+
+        /// <summary>
+        /// Create a Steer/Speed relationship structure.
+        /// </summary>
+        SteerControl()
+        {
+            Speed = 1000;
+            Steer = 1;
+        }
+
+        /// <summary>
+        /// Create a Steer/Speed relationship structure.
+        /// <param name="speed">The vehicle speed.</param>
+        /// <param name="steer">The target max steer of the speed.</param>
+        /// </summary>
+        SteerControl(float speed, float steer)
+        {
+            Speed = speed;
+            Steer = steer;
+        }
+    };
+
+    /// <summary>
     /// Vehicle engine settings.
     /// </summary>
     API_STRUCT() struct EngineSettings : ISerializable
@@ -94,42 +133,54 @@ API_CLASS(Attributes="ActorContextMenu(\"New/Physics/Wheeled Vehicle\"), ActorTo
         /// <summary>
         /// Acceleration input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(10)") float RiseRateAcceleration = 6.0f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(10)") float RiseRateAcceleration = 6.0f;
 
         /// <summary>
         /// Deceleration input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(11)") float FallRateAcceleration = 10.0f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(11)") float FallRateAcceleration = 10.0f;
 
         /// <summary>
         /// Brake input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(12)") float RiseRateBrake = 6.0f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(12)") float RiseRateBrake = 6.0f;
 
         /// <summary>
         /// Release brake sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(13)") float FallRateBrake = 10.0f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(13)") float FallRateBrake = 10.0f;
 
         /// <summary>
         /// Brake input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(14)") float RiseRateHandBrake = 12.0f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(14)") float RiseRateHandBrake = 12.0f;
 
         /// <summary>
         /// Release handbrake sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(15)") float FallRateHandBrake = 12.0f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(15)") float FallRateHandBrake = 12.0f;
 
         /// <summary>
         /// Steer input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(16)") float RiseRateSteer = 2.5f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(16)") float RiseRateSteer = 2.5f;
 
         /// <summary>
         /// Release steer input sensitive.
         /// </summary>
-        API_FIELD(Attributes="Limit(0), EditorDisplay(\"Inputs\"), EditorOrder(17)") float FallRateSteer = 5.0f;
+        API_FIELD(Attributes="Limit(0), EditorOrder(17)") float FallRateSteer = 5.0f;
+
+        /// <summary>
+        /// Vehicle control relationship between speed and steer. The higher is the speed, 
+        /// decrease steer to make vehicle more maneuverable (limited only 4 relationships).
+        /// </summary>
+        API_FIELD() Array<WheeledVehicle::SteerControl> SteerVsSpeed = Array<WheeledVehicle::SteerControl>
+        {
+            SteerControl(800, 1.0f),
+            SteerControl(1500, 0.7f),
+            SteerControl(2500, 0.5f),
+            SteerControl(5000, 0.2f),
+        };
     };
 
     /// <summary>

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -37,6 +37,7 @@
 #include <ThirdParty/PhysX/vehicle/PxVehicleNoDrive.h>
 #include <ThirdParty/PhysX/vehicle/PxVehicleDrive4W.h>
 #include <ThirdParty/PhysX/vehicle/PxVehicleDriveNW.h>
+#include <ThirdParty/PhysX/vehicle/PxVehicleDriveTank.h>
 #include <ThirdParty/PhysX/vehicle/PxVehicleUtilSetup.h>
 #include <ThirdParty/PhysX/PxFiltering.h>
 #endif
@@ -961,7 +962,6 @@ void PhysicalMaterial::UpdatePhysicsMaterial()
 
 bool CollisionCooking::CookConvexMesh(CookingInput& input, BytesContainer& output)
 {
-    PROFILE_CPU();
     ENSURE_CAN_COOK;
     if (input.VertexCount == 0)
         LOG(Warning, "Empty mesh data for collision cooking.");
@@ -1005,7 +1005,6 @@ bool CollisionCooking::CookConvexMesh(CookingInput& input, BytesContainer& outpu
 
 bool CollisionCooking::CookTriangleMesh(CookingInput& input, BytesContainer& output)
 {
-    PROFILE_CPU();
     ENSURE_CAN_COOK;
     if (input.VertexCount == 0 || input.IndexCount == 0)
         LOG(Warning, "Empty mesh data for collision cooking.");
@@ -1040,7 +1039,6 @@ bool CollisionCooking::CookTriangleMesh(CookingInput& input, BytesContainer& out
 
 bool CollisionCooking::CookHeightField(int32 cols, int32 rows, const PhysicsBackend::HeightFieldSample* data, WriteStream& stream)
 {
-    PROFILE_CPU();
     ENSURE_CAN_COOK;
 
     PxHeightFieldDesc heightFieldDesc;
@@ -1386,62 +1384,172 @@ void PhysicsBackend::EndSimulateScene(void* scene)
             WheelVehiclesCache.Add(drive);
             wheelsCount += drive->mWheelsSimData.getNbWheels();
 
+            const float deadZone = 0.1f;
+            bool isTank = wheelVehicle->_driveType == WheeledVehicle::DriveTypes::Tank;
             float throttle = wheelVehicle->_throttle;
+            float steering = wheelVehicle->_steering;
             float brake = wheelVehicle->_brake;
+            float leftThrottle = wheelVehicle->_tankLeftThrottle;
+            float rightThrottle = wheelVehicle->_tankRightThrottle;
+            float leftBrake = Math::Max(wheelVehicle->_tankLeftBrake, wheelVehicle->_handBrake);
+            float rightBrake = Math::Max(wheelVehicle->_tankRightBrake, wheelVehicle->_handBrake);
+
+            WheeledVehicle::DriveModes vehicleDriveMode = wheelVehicle->_driveMode;
+
+            if (isTank)
+            {
+                // Converting default vehicle controls to tank controls.
+                if (throttle != 0 || steering != 0)
+                {
+                    leftThrottle = throttle + steering;
+                    rightThrottle = throttle - steering;
+                }
+            }
+
+            // Converting special tank drive mode to standard tank mode when is turning.
+            if (isTank && vehicleDriveMode == WheeledVehicle::DriveModes::Standard)
+            {
+                // Special inputs when turning vehicle -1 1 to left or 1 -1 to turn right
+                // to:
+                // Standard inputs when turning vehicle 0 1 to left or 1 0 to turn right
+
+                if (leftThrottle < -deadZone && rightThrottle > deadZone)
+                {
+                    leftThrottle = 0;
+                }
+                else if (leftThrottle > deadZone && rightThrottle < -deadZone)
+                {
+                    rightThrottle = 0;
+                }
+            }
+
             if (wheelVehicle->UseReverseAsBrake)
             {
                 const float invalidDirectionThreshold = 80.0f;
                 const float breakThreshold = 8.0f;
                 const float forwardSpeed = wheelVehicle->GetForwardSpeed();
+                int currentGear = wheelVehicle->GetCurrentGear();
+                                                                                            // Tank tracks direction: 1 forward -1 backward 0 neutral
+                bool toForward = false;
+                toForward |= throttle > deadZone;
+                toForward |= (leftThrottle > deadZone) && (rightThrottle > deadZone);       // 1  1
 
+                bool toBackward = false;
+                toBackward |= throttle < -deadZone;
+                toBackward |= (leftThrottle < -deadZone) && (rightThrottle < -deadZone);    // -1 -1
+                toBackward |= (leftThrottle < -deadZone) && (rightThrottle < deadZone);     // -1  0
+                toBackward |= (leftThrottle < deadZone) && (rightThrottle < -deadZone);     //  0 -1
+
+                bool isTankTurning = false;
+
+                if (isTank)
+                {                                                                          
+                    isTankTurning |= leftThrottle > deadZone && rightThrottle < -deadZone;  //  1 -1
+                    isTankTurning |= leftThrottle < -deadZone && rightThrottle > deadZone;  // -1  1
+                    isTankTurning |= leftThrottle < deadZone && rightThrottle > deadZone;   //  0  1
+                    isTankTurning |= leftThrottle > deadZone && rightThrottle < deadZone;   //  1  0
+                    isTankTurning |= leftThrottle < -deadZone && rightThrottle < deadZone;  // -1  0
+                    isTankTurning |= leftThrottle < deadZone && rightThrottle < -deadZone;  //  0 -1
+
+                    if (toForward || toBackward)
+                    {
+                        isTankTurning = false;
+                    }
+                }
+                
                 // Automatic gear change when changing driving direction
                 if (Math::Abs(forwardSpeed) < invalidDirectionThreshold)
                 {
-                    if (throttle < -ZeroTolerance && wheelVehicle->GetCurrentGear() >= 0 && wheelVehicle->GetTargetGear() >= 0)
+                    int targetGear =  wheelVehicle->GetTargetGear();
+                    if (toBackward && currentGear > 0 && targetGear >= 0)
                     {
-                        wheelVehicle->SetCurrentGear(-1);
+                        currentGear = -1;
                     }
-                    else if (throttle > ZeroTolerance && wheelVehicle->GetCurrentGear() <= 0 && wheelVehicle->GetTargetGear() <= 0)
+                    else if (!toBackward && currentGear <= 0 && targetGear <= 0)
                     {
-                        wheelVehicle->SetCurrentGear(1);
+                       currentGear = 1;
+                    }
+                    else if (isTankTurning && currentGear <= 0)
+                    {
+                        currentGear = 1;
+                    }
+
+                    if (wheelVehicle->GetCurrentGear() != currentGear)
+                    {
+                        wheelVehicle->SetCurrentGear(currentGear);
                     }
                 }
 
                 // Automatic break when changing driving direction
-                if (throttle > 0.0f)
+                if (toForward)
                 {
                     if (forwardSpeed < -invalidDirectionThreshold)
                     {
                         brake = 1.0f;
+                        leftBrake = 1.0f;
+                        rightBrake = 1.0f;
                     }
                 }
-                else if (throttle < 0.0f)
+                else if (toBackward)
                 {
                     if (forwardSpeed > invalidDirectionThreshold)
                     {
                         brake = 1.0f;
+                        leftBrake = 1.0f;
+                        rightBrake = 1.0f;
                     }
                 }
                 else
                 {
-                    if (forwardSpeed < breakThreshold && forwardSpeed > -breakThreshold)
+                    if (forwardSpeed < breakThreshold && forwardSpeed > -breakThreshold && !isTankTurning) // not accelerating, very slow speed -> stop
                     {
                         brake = 1.0f;
+                        leftBrake = 1.0f;
+                        rightBrake = 1.0f;
                     }
                 }
 
                 // Block throttle if user is changing driving direction
-                if ((throttle > 0.0f && wheelVehicle->GetTargetGear() < 0) || (throttle < 0.0f && wheelVehicle->GetTargetGear() > 0))
+                if ((toForward && currentGear < 0) || (toBackward && currentGear > 0))
                 {
                     throttle = 0.0f;
+                    leftThrottle = 0;
+                    rightThrottle = 0;
                 }
 
                 throttle = Math::Abs(throttle);
+
+                if (isTank)
+                {
+                    // invert acceleration when moving to backward because tank inputs can be < 0
+                    if (currentGear < 0)
+                    {
+                        float lt = -leftThrottle;
+                        float rt = -rightThrottle;
+                        float lb = leftBrake;
+                        float rb = rightBrake;
+                        leftThrottle = rt;
+                        rightThrottle = lt;
+                        leftBrake = rb;
+                        rightBrake = lb;
+                    }
+                }
             }
             else
             {
                 throttle = Math::Max(throttle, 0.0f);
             }
+
+            // Force brake the another side track to turn more faster.
+            if (Math::Abs(leftThrottle) > deadZone && Math::Abs(rightThrottle) < deadZone)
+            {
+                rightBrake = 1.0f;
+            }
+            if (Math::Abs(rightThrottle) > deadZone && Math::Abs(leftThrottle) < deadZone)
+            {
+                leftBrake = 1.0f;
+            }
+
             // @formatter:off
             // Reference: PhysX SDK docs
             // TODO: expose input control smoothing data
@@ -1518,11 +1626,23 @@ void PhysicsBackend::EndSimulateScene(void* scene)
                     PxVehicleDriveNWSmoothAnalogRawInputsAndSetAnalogInputs(padSmoothing, steerVsForwardSpeed, rawInputData, scenePhysX->LastDeltaTime, false, *(PxVehicleDriveNW*)drive);
                     break;
                 }
+                case WheeledVehicle::DriveTypes::Tank:
+                {
+                    PxVehicleDriveTankRawInputData driveMode = vehicleDriveMode == WheeledVehicle::DriveModes::Standard ? PxVehicleDriveTankControlModel::eSTANDARD : PxVehicleDriveTankControlModel::eSPECIAL;
+                    PxVehicleDriveTankRawInputData rawInputData = PxVehicleDriveTankRawInputData(driveMode);
+                    rawInputData.setAnalogAccel(Math::Max(Math::Abs(leftThrottle), Math::Abs(rightThrottle)));
+                    rawInputData.setAnalogLeftBrake(leftBrake);
+                    rawInputData.setAnalogRightBrake(rightBrake);
+                    rawInputData.setAnalogLeftThrust(leftThrottle);
+                    rawInputData.setAnalogRightThrust(rightThrottle);
+
+                    PxVehicleDriveTankSmoothAnalogRawInputsAndSetAnalogInputs(padSmoothing, rawInputData, scenePhysX->LastDeltaTime, *(PxVehicleDriveTank*)drive);
+                    break;
+                }
                 }
             }
             else
-            {
-                const float deadZone = 0.1f;
+            {                
                 switch (wheelVehicle->_driveTypeCurrent)
                 {
                 case WheeledVehicle::DriveTypes::Drive4W:
@@ -1545,6 +1665,26 @@ void PhysicsBackend::EndSimulateScene(void* scene)
                     rawInputData.setDigitalSteerRight(wheelVehicle->_steering > deadZone);
                     rawInputData.setDigitalHandbrake(wheelVehicle->_handBrake > deadZone);
                     PxVehicleDriveNWSmoothDigitalRawInputsAndSetAnalogInputs(keySmoothing, steerVsForwardSpeed, rawInputData, scenePhysX->LastDeltaTime, false, *(PxVehicleDriveNW*)drive);
+                    break;
+                }
+                case WheeledVehicle::DriveTypes::Tank:
+                {
+                    // Convert analogic inputs to digital inputs.
+                    leftThrottle = Math::Round(leftThrottle);
+                    rightThrottle = Math::Round(rightThrottle);
+                    leftBrake = Math::Round(leftBrake);
+                    rightBrake = Math::Round(rightBrake);
+
+                    PxVehicleDriveTankRawInputData driveMode = vehicleDriveMode == WheeledVehicle::DriveModes::Standard ? PxVehicleDriveTankControlModel::eSTANDARD : PxVehicleDriveTankControlModel::eSPECIAL;
+                    PxVehicleDriveTankRawInputData rawInputData = PxVehicleDriveTankRawInputData(driveMode);
+                    rawInputData.setAnalogAccel(Math::Max(Math::Abs(leftThrottle), Math::Abs(rightThrottle)));
+                    rawInputData.setAnalogLeftBrake(leftBrake);
+                    rawInputData.setAnalogRightBrake(rightBrake);
+                    rawInputData.setAnalogLeftThrust(leftThrottle);
+                    rawInputData.setAnalogRightThrust(rightThrottle);
+
+                    // Needs to pass analogic values to vehicle to maintein current moviment direction because digital inputs accept only true/false values to tracks thrust instead of -1 to 1 
+                    PxVehicleDriveTankSmoothAnalogRawInputsAndSetAnalogInputs(padSmoothing, rawInputData, scenePhysX->LastDeltaTime, *(PxVehicleDriveTank *)drive);
                     break;
                 }
                 }
@@ -2803,7 +2943,7 @@ void PhysicsBackend::SetHingeJointLimit(void* joint, const LimitAngularRange& va
 void PhysicsBackend::SetHingeJointDrive(void* joint, const HingeJointDrive& value)
 {
     auto jointPhysX = (PxRevoluteJoint*)joint;
-    jointPhysX->setDriveVelocity(value.Velocity);
+    jointPhysX->setDriveVelocity(Math::Max(value.Velocity, 0.0f));
     jointPhysX->setDriveForceLimit(Math::Max(value.ForceLimit, 0.0f));
     jointPhysX->setDriveGearRatio(Math::Max(value.GearRatio, 0.0f));
     jointPhysX->setRevoluteJointFlag(PxRevoluteJointFlag::eDRIVE_FREESPIN, value.FreeSpin);
@@ -3086,6 +3226,147 @@ int32 PhysicsBackend::MoveController(void* controller, void* shape, const Vector
 
 #if WITH_VEHICLE
 
+PxVehicleDifferential4WData CreatePxVehicleDifferential4WData(const WheeledVehicle::DifferentialSettings& settings)
+{
+    PxVehicleDifferential4WData differential4WData;
+    differential4WData.mType = (PxVehicleDifferential4WData::Enum)settings.Type;
+    differential4WData.mFrontRearSplit = settings.FrontRearSplit;
+    differential4WData.mFrontLeftRightSplit = settings.FrontLeftRightSplit;
+    differential4WData.mRearLeftRightSplit = settings.RearLeftRightSplit;
+    differential4WData.mCentreBias = settings.CentreBias;
+    differential4WData.mFrontBias = settings.FrontBias;
+    differential4WData.mRearBias = settings.RearBias;
+    return differential4WData;
+}
+
+PxVehicleDifferentialNWData CreatePxVehicleDifferentialNWData(const WheeledVehicle::DifferentialSettings& settings, const Array<WheeledVehicle::Wheel*, FixedAllocation<PX_MAX_NB_WHEELS>>& wheels)
+{
+    PxVehicleDifferentialNWData differentialNwData;
+    for (int32 i = 0; i < wheels.Count(); i++)
+        differentialNwData.setDrivenWheel(i, true);
+
+    return differentialNwData;
+}
+
+PxVehicleEngineData CreatePxVehicleEngineData(const WheeledVehicle::EngineSettings& settings)
+{
+    PxVehicleEngineData engineData;
+    engineData.mMOI = M2ToCm2(settings.MOI);
+    engineData.mPeakTorque = M2ToCm2(settings.MaxTorque);
+    engineData.mMaxOmega = RpmToRadPerS(settings.MaxRotationSpeed);
+    engineData.mDampingRateFullThrottle = M2ToCm2(0.15f);
+    engineData.mDampingRateZeroThrottleClutchEngaged = M2ToCm2(2.0f);
+    engineData.mDampingRateZeroThrottleClutchDisengaged = M2ToCm2(0.35f);
+    return engineData;
+}
+
+PxVehicleGearsData CreatePxVehicleGearsData(const WheeledVehicle::GearboxSettings& settings)
+{
+    PxVehicleGearsData gears;
+
+    // Total gears is forward gears + neutral/rear gears
+    int gearsAmount = settings.ForwardGearsRatios + 2;
+
+    // Setup gears torque/top speed relations
+    // Higher torque = less speed
+    // Low torque = high speed
+
+    // Example:
+    // ForwardGearsRatios = 4
+    // GearRev = -5
+    // Gear0 = 0  
+    // Gear1 = 4.2
+    // Gear2 = 3.4
+    // Gear3 = 2.6
+    // Gear4 = 1.8
+    // Gear5 = 1
+
+    gears.mRatios[0] = -(gearsAmount - 2);  // reverse
+    gears.mRatios[1] = 0;                   // neutral
+
+    // Setup all gears except neutral and reverse
+    for (int i = gearsAmount; i > 2; i--) {
+
+        float gearsRatios = settings.ForwardGearsRatios;
+        float currentGear = i - 2;
+
+        gears.mRatios[i] = Math::Lerp(gearsRatios, 1.0f, (currentGear / gearsRatios));
+    }
+
+    // reset unused gears
+    for (int i = gearsAmount; i < PxVehicleGearsData::eGEARSRATIO_COUNT; i++) 
+        gears.mRatios[i] = 0;
+
+    gears.mSwitchTime = Math::Max(settings.SwitchTime, 0.0f);
+    gears.mNbRatios = Math::Clamp(gearsAmount, 2, (int)PxVehicleGearsData::eGEARSRATIO_COUNT);
+    return gears;
+}
+
+PxVehicleAutoBoxData CreatePxVehicleAutoBoxData()
+{
+    return PxVehicleAutoBoxData();
+}
+
+PxVehicleClutchData CreatePxVehicleClutchData(const WheeledVehicle::GearboxSettings& settings)
+{
+    PxVehicleClutchData clutch;
+    clutch.mStrength = M2ToCm2(settings.ClutchStrength);
+    return clutch;
+}
+
+PxVehicleSuspensionData CreatePxVehicleSuspensionData(const WheeledVehicle::Wheel& settings, const PxReal wheelSprungMass)
+{
+    PxVehicleSuspensionData suspensionData;
+    const float suspensionFrequency = 7.0f;
+    suspensionData.mMaxCompression = settings.SuspensionMaxRaise;
+    suspensionData.mMaxDroop = settings.SuspensionMaxDrop;
+    suspensionData.mSprungMass = wheelSprungMass;
+    suspensionData.mSpringStrength = Math::Square(suspensionFrequency) * suspensionData.mSprungMass;
+    suspensionData.mSpringDamperRate = settings.SuspensionDampingRate * 2.0f * Math::Sqrt(suspensionData.mSpringStrength * suspensionData.mSprungMass);
+    return suspensionData;
+}
+
+PxVehicleTireData CreatePxVehicleTireData(const WheeledVehicle::Wheel& settings)
+{
+    PxVehicleTireData tire;
+    int32 tireIndex = WheelTireTypes.Find(settings.TireFrictionScale);
+    if (tireIndex == -1)
+    {
+        // New tire type
+        tireIndex = WheelTireTypes.Count();
+        WheelTireTypes.Add(settings.TireFrictionScale);
+        WheelTireFrictionsDirty = true;
+    }
+    tire.mType = tireIndex;
+    tire.mLatStiffX = settings.TireLateralMax;
+    tire.mLatStiffY = settings.TireLateralStiffness;
+    tire.mLongitudinalStiffnessPerUnitGravity = settings.TireLongitudinalStiffness;
+    return tire;
+}
+
+PxVehicleWheelData CreatePxVehicleWheelData(const WheeledVehicle::Wheel& settings)
+{
+    PxVehicleWheelData wheelData;
+    wheelData.mMass = settings.Mass;
+    wheelData.mRadius = settings.Radius;
+    wheelData.mWidth = settings.Width;
+    wheelData.mMOI = 0.5f * wheelData.mMass * Math::Square(wheelData.mRadius);
+    wheelData.mDampingRate = M2ToCm2(settings.DampingRate);
+    wheelData.mMaxSteer = settings.MaxSteerAngle * DegreesToRadians;
+    wheelData.mMaxBrakeTorque = M2ToCm2(settings.MaxBrakeTorque);
+    wheelData.mMaxHandBrakeTorque = M2ToCm2(settings.MaxHandBrakeTorque);
+    return wheelData;
+}
+
+PxVehicleAckermannGeometryData CreatePxVehicleAckermannGeometryData(PxVehicleWheelsSimData* wheelsSimData)
+{
+    PxVehicleAckermannGeometryData ackermann;
+    ackermann.mAxleSeparation = Math::Abs(wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eFRONT_LEFT).z - wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eREAR_LEFT).z);
+    ackermann.mFrontWidth = Math::Abs(wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eFRONT_RIGHT).x - wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eFRONT_LEFT).x);
+    ackermann.mRearWidth = Math::Abs(wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eREAR_RIGHT).x - wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eREAR_LEFT).x);
+    return ackermann;
+}
+
 bool SortWheels(WheeledVehicle::Wheel const& a, WheeledVehicle::Wheel const& b)
 {
     return (int32)a.Type < (int32)b.Type;
@@ -3158,42 +3439,14 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
         data.Collider = wheel.Collider;
         data.LocalOrientation = wheel.Collider->GetLocalOrientation();
 
-        PxVehicleSuspensionData suspensionData;
-        const float suspensionFrequency = 7.0f;
-        suspensionData.mMaxCompression = wheel.SuspensionMaxRaise;
-        suspensionData.mMaxDroop = wheel.SuspensionMaxDrop;
-        suspensionData.mSprungMass = sprungMasses[i];
-        suspensionData.mSpringStrength = Math::Square(suspensionFrequency) * suspensionData.mSprungMass;
-        suspensionData.mSpringDamperRate = wheel.SuspensionDampingRate * 2.0f * Math::Sqrt(suspensionData.mSpringStrength * suspensionData.mSprungMass);
-
-        PxVehicleTireData tire;
-        int32 tireIndex = WheelTireTypes.Find(wheel.TireFrictionScale);
-        if (tireIndex == -1)
-        {
-            // New tire type
-            tireIndex = WheelTireTypes.Count();
-            WheelTireTypes.Add(wheel.TireFrictionScale);
-            WheelTireFrictionsDirty = true;
-        }
-        tire.mType = tireIndex;
-        tire.mLatStiffX = wheel.TireLateralMax;
-        tire.mLatStiffY = wheel.TireLateralStiffness;
-        tire.mLongitudinalStiffnessPerUnitGravity = wheel.TireLongitudinalStiffness;
-
-        PxVehicleWheelData wheelData;
-        wheelData.mMass = wheel.Mass;
-        wheelData.mRadius = wheel.Radius;
-        wheelData.mWidth = wheel.Width;
-        wheelData.mMOI = 0.5f * wheelData.mMass * Math::Square(wheelData.mRadius);
-        wheelData.mDampingRate = M2ToCm2(wheel.DampingRate);
-        wheelData.mMaxSteer = wheel.MaxSteerAngle * DegreesToRadians;
-        wheelData.mMaxBrakeTorque = M2ToCm2(wheel.MaxBrakeTorque);
-        wheelData.mMaxHandBrakeTorque = M2ToCm2(wheel.MaxHandBrakeTorque);
-
         PxVec3 centreOffset = centerOfMassOffset.transformInv(offsets[i]);
         PxVec3 forceAppPointOffset(centreOffset.x, wheel.SuspensionForceOffset, centreOffset.z);
 
-        wheelsSimData->setTireData(i, tire);
+        const PxVehicleTireData& tireData = CreatePxVehicleTireData(wheel);
+        const PxVehicleWheelData& wheelData = CreatePxVehicleWheelData(wheel);
+        const PxVehicleSuspensionData& suspensionData = CreatePxVehicleSuspensionData(wheel, sprungMasses[i]);
+
+        wheelsSimData->setTireData(i,tireData);
         wheelsSimData->setWheelData(i, wheelData);
         wheelsSimData->setSuspensionData(i, suspensionData);
         wheelsSimData->setSuspTravelDirection(i, centerOfMassOffset.rotate(PxVec3(0.0f, -1.0f, 0.0f)));
@@ -3260,48 +3513,19 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
     case WheeledVehicle::DriveTypes::Drive4W:
     {
         PxVehicleDriveSimData4W driveSimData;
+        const PxVehicleDifferential4WData& differentialData = CreatePxVehicleDifferential4WData(differential);
+        const PxVehicleEngineData& engineData = CreatePxVehicleEngineData(engine);
+        const PxVehicleGearsData& gearsData = CreatePxVehicleGearsData(gearbox);
+        const PxVehicleAutoBoxData& autoBoxData = CreatePxVehicleAutoBoxData();
+        const PxVehicleClutchData& cluchData = CreatePxVehicleClutchData(gearbox);
+        const PxVehicleAckermannGeometryData& geometryData = CreatePxVehicleAckermannGeometryData(wheelsSimData);
 
-        // Differential
-        PxVehicleDifferential4WData differential4WData;
-        differential4WData.mType = (PxVehicleDifferential4WData::Enum)differential.Type;
-        differential4WData.mFrontRearSplit = differential.FrontRearSplit;
-        differential4WData.mFrontLeftRightSplit = differential.FrontLeftRightSplit;
-        differential4WData.mRearLeftRightSplit = differential.RearLeftRightSplit;
-        differential4WData.mCentreBias = differential.CentreBias;
-        differential4WData.mFrontBias = differential.FrontBias;
-        differential4WData.mRearBias = differential.RearBias;
-        driveSimData.setDiffData(differential4WData);
-
-        // Engine
-        PxVehicleEngineData engineData;
-        engineData.mMOI = M2ToCm2(engine.MOI);
-        engineData.mPeakTorque = M2ToCm2(engine.MaxTorque);
-        engineData.mMaxOmega = RpmToRadPerS(engine.MaxRotationSpeed);
-        engineData.mDampingRateFullThrottle = M2ToCm2(0.15f);
-        engineData.mDampingRateZeroThrottleClutchEngaged = M2ToCm2(2.0f);
-        engineData.mDampingRateZeroThrottleClutchDisengaged = M2ToCm2(0.35f);
+        driveSimData.setDiffData(differentialData);
         driveSimData.setEngineData(engineData);
-
-        // Gears
-        PxVehicleGearsData gears;
-        gears.mSwitchTime = Math::Max(gearbox.SwitchTime, 0.0f);
-        driveSimData.setGearsData(gears);
-
-        // Auto Box
-        PxVehicleAutoBoxData autoBox;
-        driveSimData.setAutoBoxData(autoBox);
-
-        // Clutch
-        PxVehicleClutchData clutch;
-        clutch.mStrength = M2ToCm2(gearbox.ClutchStrength);
-        driveSimData.setClutchData(clutch);
-
-        // Ackermann steer accuracy
-        PxVehicleAckermannGeometryData ackermann;
-        ackermann.mAxleSeparation = Math::Abs(wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eFRONT_LEFT).z - wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eREAR_LEFT).z);
-        ackermann.mFrontWidth = Math::Abs(wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eFRONT_RIGHT).x - wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eFRONT_LEFT).x);
-        ackermann.mRearWidth = Math::Abs(wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eREAR_RIGHT).x - wheelsSimData->getWheelCentreOffset(PxVehicleDrive4WWheelOrder::eREAR_LEFT).x);
-        driveSimData.setAckermannGeometryData(ackermann);
+        driveSimData.setGearsData(gearsData);
+        driveSimData.setAutoBoxData(autoBoxData);
+        driveSimData.setClutchData(cluchData);
+        driveSimData.setAckermannGeometryData(geometryData);
 
         // Create vehicle drive
         auto drive4W = PxVehicleDrive4W::allocate(wheels.Count());
@@ -3315,36 +3539,18 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
     case WheeledVehicle::DriveTypes::DriveNW:
     {
         PxVehicleDriveSimDataNW driveSimData;
+        const PxVehicleDifferentialNWData& differentialData = CreatePxVehicleDifferentialNWData(differential, wheels);
+        const PxVehicleEngineData& engineData = CreatePxVehicleEngineData(engine);
+        const PxVehicleGearsData& gearsData = CreatePxVehicleGearsData(gearbox);
+        const PxVehicleAutoBoxData& autoBoxData = CreatePxVehicleAutoBoxData();
+        const PxVehicleClutchData& cluchData = CreatePxVehicleClutchData(gearbox);
+        const PxVehicleAckermannGeometryData& geometryData = CreatePxVehicleAckermannGeometryData(wheelsSimData);
 
-        // Differential
-        PxVehicleDifferentialNWData differentialNwData;
-        for (int32 i = 0; i < wheels.Count(); i++)
-            differentialNwData.setDrivenWheel(i, true);
-        driveSimData.setDiffData(differentialNwData);
-
-        // Engine
-        PxVehicleEngineData engineData;
-        engineData.mMOI = M2ToCm2(engine.MOI);
-        engineData.mPeakTorque = M2ToCm2(engine.MaxTorque);
-        engineData.mMaxOmega = RpmToRadPerS(engine.MaxRotationSpeed);
-        engineData.mDampingRateFullThrottle = M2ToCm2(0.15f);
-        engineData.mDampingRateZeroThrottleClutchEngaged = M2ToCm2(2.0f);
-        engineData.mDampingRateZeroThrottleClutchDisengaged = M2ToCm2(0.35f);
+        driveSimData.setDiffData(differentialData);
         driveSimData.setEngineData(engineData);
-
-        // Gears
-        PxVehicleGearsData gears;
-        gears.mSwitchTime = Math::Max(gearbox.SwitchTime, 0.0f);
-        driveSimData.setGearsData(gears);
-
-        // Auto Box
-        PxVehicleAutoBoxData autoBox;
-        driveSimData.setAutoBoxData(autoBox);
-
-        // Clutch
-        PxVehicleClutchData clutch;
-        clutch.mStrength = M2ToCm2(gearbox.ClutchStrength);
-        driveSimData.setClutchData(clutch);
+        driveSimData.setGearsData(gearsData);
+        driveSimData.setAutoBoxData(autoBoxData);
+        driveSimData.setClutchData(cluchData);
 
         // Create vehicle drive
         auto driveNW = PxVehicleDriveNW::allocate(wheels.Count());
@@ -3362,6 +3568,32 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
         driveNo->setup(PhysX, actorPhysX, *wheelsSimData);
         driveNo->setToRestState();
         vehicle = driveNo;
+        break;
+    }
+    case WheeledVehicle::DriveTypes::Tank:
+    {
+        PxVehicleDriveSimData4W driveSimData;
+        const PxVehicleDifferential4WData &differentialData = CreatePxVehicleDifferential4WData(differential);
+        const PxVehicleEngineData &engineData = CreatePxVehicleEngineData(engine);
+        const PxVehicleGearsData &gearsData = CreatePxVehicleGearsData(gearbox);
+        const PxVehicleAutoBoxData &autoBoxData = CreatePxVehicleAutoBoxData();
+        const PxVehicleClutchData &cluchData = CreatePxVehicleClutchData(gearbox);
+        const PxVehicleAckermannGeometryData &geometryData = CreatePxVehicleAckermannGeometryData(wheelsSimData);
+
+        driveSimData.setDiffData(differentialData);
+        driveSimData.setEngineData(engineData);
+        driveSimData.setGearsData(gearsData);
+        driveSimData.setAutoBoxData(autoBoxData);
+        driveSimData.setClutchData(cluchData);
+        driveSimData.setAckermannGeometryData(geometryData);
+
+        // Create vehicle drive
+        auto driveTank = PxVehicleDriveTank::allocate(wheels.Count());
+        driveTank->setup(PhysX, actorPhysX, *wheelsSimData, driveSimData, wheels.Count());
+        driveTank->setToRestState();
+        driveTank->mDriveDynData.forceGearChange(PxVehicleGearsData::eFIRST);
+        driveTank->mDriveDynData.setUseAutoGears(gearbox.AutoGear);
+        vehicle = driveTank;
         break;
     }
     default:
@@ -3385,6 +3617,9 @@ void PhysicsBackend::DestroyVehicle(void* vehicle, int32 driveType)
     case WheeledVehicle::DriveTypes::NoDrive:
         ((PxVehicleNoDrive*)vehicle)->free();
         break;
+    case WheeledVehicle::DriveTypes::Tank:
+        ((PxVehicleDriveTank*)vehicle)->free();
+        break;
     }
 }
 
@@ -3395,42 +3630,11 @@ void PhysicsBackend::UpdateVehicleWheels(WheeledVehicle* actor)
     for (uint32 i = 0; i < wheelsSimData->getNbWheels(); i++)
     {
         auto& wheel = actor->_wheels[i];
-
-        // Update suspension data
-        PxVehicleSuspensionData suspensionData = wheelsSimData->getSuspensionData(i);
-        const float suspensionFrequency = 7.0f;
-        suspensionData.mMaxCompression = wheel.SuspensionMaxRaise;
-        suspensionData.mMaxDroop = wheel.SuspensionMaxDrop;
-        suspensionData.mSpringStrength = Math::Square(suspensionFrequency) * suspensionData.mSprungMass;
-        suspensionData.mSpringDamperRate = wheel.SuspensionDampingRate * 2.0f * Math::Sqrt(suspensionData.mSpringStrength * suspensionData.mSprungMass);
+        const PxVehicleSuspensionData& suspensionData = CreatePxVehicleSuspensionData(wheel, wheelsSimData->getSuspensionData(i).mSprungMass);
+        const PxVehicleTireData& tireData = CreatePxVehicleTireData(wheel);
+        const PxVehicleWheelData& wheelData = CreatePxVehicleWheelData(wheel);
         wheelsSimData->setSuspensionData(i, suspensionData);
-
-        // Update tire data
-        PxVehicleTireData tire;
-        int32 tireIndex = WheelTireTypes.Find(wheel.TireFrictionScale);
-        if (tireIndex == -1)
-        {
-            // New tire type
-            tireIndex = WheelTireTypes.Count();
-            WheelTireTypes.Add(wheel.TireFrictionScale);
-            WheelTireFrictionsDirty = true;
-        }
-        tire.mType = tireIndex;
-        tire.mLatStiffX = wheel.TireLateralMax;
-        tire.mLatStiffY = wheel.TireLateralStiffness;
-        tire.mLongitudinalStiffnessPerUnitGravity = wheel.TireLongitudinalStiffness;
-        wheelsSimData->setTireData(i, tire);
-
-        // Update wheel data
-        PxVehicleWheelData wheelData;
-        wheelData.mMass = wheel.Mass;
-        wheelData.mRadius = wheel.Radius;
-        wheelData.mWidth = wheel.Width;
-        wheelData.mMOI = 0.5f * wheelData.mMass * Math::Square(wheelData.mRadius);
-        wheelData.mDampingRate = M2ToCm2(wheel.DampingRate);
-        wheelData.mMaxSteer = wheel.MaxSteerAngle * DegreesToRadians;
-        wheelData.mMaxBrakeTorque = M2ToCm2(wheel.MaxBrakeTorque);
-        wheelData.mMaxHandBrakeTorque = M2ToCm2(wheel.MaxHandBrakeTorque);
+        wheelsSimData->setTireData(i, tireData);
         wheelsSimData->setWheelData(i, wheelData);
     }
 }
@@ -3444,28 +3648,24 @@ void PhysicsBackend::SetVehicleEngine(void* vehicle, const void* value)
     case PxVehicleTypes::eDRIVE4W:
     {
         auto drive4W = (PxVehicleDrive4W*)drive;
+        const PxVehicleEngineData& engineData = CreatePxVehicleEngineData(engine);
         PxVehicleDriveSimData4W& driveSimData = drive4W->mDriveSimData;
-        PxVehicleEngineData engineData;
-        engineData.mMOI = M2ToCm2(engine.MOI);
-        engineData.mPeakTorque = M2ToCm2(engine.MaxTorque);
-        engineData.mMaxOmega = RpmToRadPerS(engine.MaxRotationSpeed);
-        engineData.mDampingRateFullThrottle = M2ToCm2(0.15f);
-        engineData.mDampingRateZeroThrottleClutchEngaged = M2ToCm2(2.0f);
-        engineData.mDampingRateZeroThrottleClutchDisengaged = M2ToCm2(0.35f);
         driveSimData.setEngineData(engineData);
         break;
     }
     case PxVehicleTypes::eDRIVENW:
     {
         auto drive4W = (PxVehicleDriveNW*)drive;
+        const PxVehicleEngineData& engineData = CreatePxVehicleEngineData(engine);
         PxVehicleDriveSimDataNW& driveSimData = drive4W->mDriveSimData;
-        PxVehicleEngineData engineData;
-        engineData.mMOI = M2ToCm2(engine.MOI);
-        engineData.mPeakTorque = M2ToCm2(engine.MaxTorque);
-        engineData.mMaxOmega = RpmToRadPerS(engine.MaxRotationSpeed);
-        engineData.mDampingRateFullThrottle = M2ToCm2(0.15f);
-        engineData.mDampingRateZeroThrottleClutchEngaged = M2ToCm2(2.0f);
-        engineData.mDampingRateZeroThrottleClutchDisengaged = M2ToCm2(0.35f);
+        driveSimData.setEngineData(engineData);
+        break;
+    }
+    case PxVehicleTypes::eDRIVETANK:
+    {
+        auto driveTank = (PxVehicleDriveTank*)drive;
+        const PxVehicleEngineData &engineData = CreatePxVehicleEngineData(engine);
+        PxVehicleDriveSimData &driveSimData = driveTank->mDriveSimData;
         driveSimData.setEngineData(engineData);
         break;
     }
@@ -3481,16 +3681,9 @@ void PhysicsBackend::SetVehicleDifferential(void* vehicle, const void* value)
     case PxVehicleTypes::eDRIVE4W:
     {
         auto drive4W = (PxVehicleDrive4W*)drive;
+        const PxVehicleDifferential4WData& differentialData = CreatePxVehicleDifferential4WData(differential);
         PxVehicleDriveSimData4W& driveSimData = drive4W->mDriveSimData;
-        PxVehicleDifferential4WData differential4WData;
-        differential4WData.mType = (PxVehicleDifferential4WData::Enum)differential.Type;
-        differential4WData.mFrontRearSplit = differential.FrontRearSplit;
-        differential4WData.mFrontLeftRightSplit = differential.FrontLeftRightSplit;
-        differential4WData.mRearLeftRightSplit = differential.RearLeftRightSplit;
-        differential4WData.mCentreBias = differential.CentreBias;
-        differential4WData.mFrontBias = differential.FrontBias;
-        differential4WData.mRearBias = differential.RearBias;
-        driveSimData.setDiffData(differential4WData);
+        driveSimData.setDiffData(differentialData);
         break;
     }
     }
@@ -3507,41 +3700,37 @@ void PhysicsBackend::SetVehicleGearbox(void* vehicle, const void* value)
     case PxVehicleTypes::eDRIVE4W:
     {
         auto drive4W = (PxVehicleDrive4W*)drive;
+        const PxVehicleGearsData& gearData = CreatePxVehicleGearsData(gearbox);
+        const PxVehicleClutchData& clutchData = CreatePxVehicleClutchData(gearbox);
+        const PxVehicleAutoBoxData& autoBoxData = CreatePxVehicleAutoBoxData();
         PxVehicleDriveSimData4W& driveSimData = drive4W->mDriveSimData;
-
-        // Gears
-        PxVehicleGearsData gears;
-        gears.mSwitchTime = Math::Max(gearbox.SwitchTime, 0.0f);
-        driveSimData.setGearsData(gears);
-
-        // Auto Box
-        PxVehicleAutoBoxData autoBox;
-        driveSimData.setAutoBoxData(autoBox);
-
-        // Clutch
-        PxVehicleClutchData clutch;
-        clutch.mStrength = M2ToCm2(gearbox.ClutchStrength);
-        driveSimData.setClutchData(clutch);
+        driveSimData.setGearsData(gearData);
+        driveSimData.setAutoBoxData(autoBoxData);
+        driveSimData.setClutchData(clutchData);
         break;
     }
     case PxVehicleTypes::eDRIVENW:
     {
         auto drive4W = (PxVehicleDriveNW*)drive;
+        const PxVehicleGearsData& gearData = CreatePxVehicleGearsData(gearbox);
+        const PxVehicleClutchData& clutchData = CreatePxVehicleClutchData(gearbox);
+        const PxVehicleAutoBoxData& autoBoxData = CreatePxVehicleAutoBoxData();
         PxVehicleDriveSimDataNW& driveSimData = drive4W->mDriveSimData;
-
-        // Gears
-        PxVehicleGearsData gears;
-        gears.mSwitchTime = Math::Max(gearbox.SwitchTime, 0.0f);
-        driveSimData.setGearsData(gears);
-
-        // Auto Box
-        PxVehicleAutoBoxData autoBox;
-        driveSimData.setAutoBoxData(autoBox);
-
-        // Clutch
-        PxVehicleClutchData clutch;
-        clutch.mStrength = M2ToCm2(gearbox.ClutchStrength);
-        driveSimData.setClutchData(clutch);
+        driveSimData.setGearsData(gearData);
+        driveSimData.setAutoBoxData(autoBoxData);
+        driveSimData.setClutchData(clutchData);
+        break;
+    }
+    case PxVehicleTypes::eDRIVETANK:
+    {
+        auto driveTank = (PxVehicleDriveTank *)drive;
+        const PxVehicleGearsData &gearData = CreatePxVehicleGearsData(gearbox);
+        const PxVehicleClutchData &clutchData = CreatePxVehicleClutchData(gearbox);
+        const PxVehicleAutoBoxData &autoBoxData = CreatePxVehicleAutoBoxData();
+        PxVehicleDriveSimData &driveSimData = driveTank->mDriveSimData;
+        driveSimData.setGearsData(gearData);
+        driveSimData.setAutoBoxData(autoBoxData);
+        driveSimData.setClutchData(clutchData);
         break;
     }
     }

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -1403,8 +1403,8 @@ void PhysicsBackend::EndSimulateScene(void* scene)
                 // Converting default vehicle controls to tank controls.
                 if (throttle != 0 || steering != 0)
                 {
-                    leftThrottle = throttle + steering;
-                    rightThrottle = throttle - steering;
+                    leftThrottle = Math::Clamp(throttle + steering, -1.0f, 1.0f);
+                    rightThrottle = Math::Clamp(throttle - steering, -1.0f, 1.0f);
                 }
             }
 
@@ -1418,10 +1418,12 @@ void PhysicsBackend::EndSimulateScene(void* scene)
                 if (leftThrottle < -deadZone && rightThrottle > deadZone)
                 {
                     leftThrottle = 0;
+                    leftBrake = 1;
                 }
                 else if (leftThrottle > deadZone && rightThrottle < -deadZone)
                 {
                     rightThrottle = 0;
+                    rightBrake = 1;
                 }
             }
 

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -3588,7 +3588,6 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
         // Create vehicle drive
         auto drive4W = PxVehicleDrive4W::allocate(wheels.Count());
         drive4W->setup(PhysX, actorPhysX, *wheelsSimData, driveSimData, Math::Max(wheels.Count() - 4, 0));
-        drive4W->setToRestState();
         drive4W->mDriveDynData.forceGearChange(PxVehicleGearsData::eFIRST);
         drive4W->mDriveDynData.setUseAutoGears(gearbox.AutoGear);
         vehicle = drive4W;
@@ -3613,7 +3612,6 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
         // Create vehicle drive
         auto driveNW = PxVehicleDriveNW::allocate(wheels.Count());
         driveNW->setup(PhysX, actorPhysX, *wheelsSimData, driveSimData, wheels.Count());
-        driveNW->setToRestState();
         driveNW->mDriveDynData.forceGearChange(PxVehicleGearsData::eFIRST);
         driveNW->mDriveDynData.setUseAutoGears(gearbox.AutoGear);
         vehicle = driveNW;
@@ -3624,7 +3622,6 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
         // Create vehicle drive
         auto driveNo = PxVehicleNoDrive::allocate(wheels.Count());
         driveNo->setup(PhysX, actorPhysX, *wheelsSimData);
-        driveNo->setToRestState();
         vehicle = driveNo;
         break;
     }
@@ -3648,7 +3645,6 @@ void* PhysicsBackend::CreateVehicle(WheeledVehicle* actor)
         // Create vehicle drive
         auto driveTank = PxVehicleDriveTank::allocate(wheels.Count());
         driveTank->setup(PhysX, actorPhysX, *wheelsSimData, driveSimData, wheels.Count());
-        driveTank->setToRestState();
         driveTank->mDriveDynData.forceGearChange(PxVehicleGearsData::eFIRST);
         driveTank->mDriveDynData.setUseAutoGears(gearbox.AutoGear);
         vehicle = driveTank;

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -59,9 +59,6 @@
 #if WITH_PVD
 #include <ThirdParty/PhysX/pvd/PxPvd.h>
 #endif
-#if USE_EDITOR
-#include "Editor/Editor.h"
-#endif
 // Temporary memory size used by the PhysX during the simulation. Must be multiply of 4kB and 16bit aligned.
 #define PHYSX_SCRATCH_BLOCK_SIZE (1024 * 128)
 

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -1397,7 +1397,7 @@ void PhysicsBackend::EndSimulateScene(void* scene)
             float leftBrake = Math::Max(wheelVehicle->_tankLeftBrake, wheelVehicle->_handBrake);
             float rightBrake = Math::Max(wheelVehicle->_tankRightBrake, wheelVehicle->_handBrake);
 
-            WheeledVehicle::DriveModes vehicleDriveMode = wheelVehicle->_driveMode;
+            WheeledVehicle::DriveModes vehicleDriveMode = wheelVehicle->_driveControl.DriveMode;
 
             if (isTank)
             {

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -1557,38 +1557,38 @@ void PhysicsBackend::EndSimulateScene(void* scene)
             // @formatter:off
             // Reference: PhysX SDK docs
             // TODO: expose input control smoothing data
-            static constexpr PxVehiclePadSmoothingData padSmoothing =
-            {
-	            {
-		            6.0f,  // rise rate eANALOG_INPUT_ACCEL
-		            6.0f,  // rise rate eANALOG_INPUT_BRAKE
-		            12.0f, // rise rate eANALOG_INPUT_HANDBRAKE
-		            2.5f,  // rise rate eANALOG_INPUT_STEER_LEFT
-		            2.5f,  // rise rate eANALOG_INPUT_STEER_RIGHT
-	            },
-	            {
-		            10.0f, // fall rate eANALOG_INPUT_ACCEL
-		            10.0f, // fall rate eANALOG_INPUT_BRAKE
-		            12.0f, // fall rate eANALOG_INPUT_HANDBRAKE
-		            5.0f,  // fall rate eANALOG_INPUT_STEER_LEFT
-		            5.0f,  // fall rate eANALOG_INPUT_STEER_RIGHT
-	            }
-            };
-            static constexpr PxVehicleKeySmoothingData keySmoothing =
+            PxVehiclePadSmoothingData padSmoothing =
+                {
+                    {
+                        wheelVehicle->_driveControl.RiseRateAcceleration, // rise rate eANALOG_INPUT_ACCEL
+                        wheelVehicle->_driveControl.RiseRateBrake,        // rise rate eANALOG_INPUT_BRAKE
+                        wheelVehicle->_driveControl.RiseRateHandBrake,    // rise rate eANALOG_INPUT_HANDBRAKE
+                        wheelVehicle->_driveControl.RiseRateSteer,        // rise rate eANALOG_INPUT_STEER_LEFT
+                        wheelVehicle->_driveControl.RiseRateSteer,        // rise rate eANALOG_INPUT_STEER_RIGHT
+                    },
+                    {
+                        wheelVehicle->_driveControl.FallRateAcceleration, // fall rate eANALOG_INPUT_ACCEL
+                        wheelVehicle->_driveControl.FallRateBrake,        // fall rate eANALOG_INPUT_BRAKE
+                        wheelVehicle->_driveControl.FallRateHandBrake,    // fall rate eANALOG_INPUT_HANDBRAKE
+                        wheelVehicle->_driveControl.FallRateSteer,        // fall rate eANALOG_INPUT_STEER_LEFT
+                        wheelVehicle->_driveControl.FallRateSteer,        // fall rate eANALOG_INPUT_STEER_RIGHT
+                    }
+                };
+            PxVehicleKeySmoothingData keySmoothing =
             {
                 {
-                    3.0f,  // rise rate eANALOG_INPUT_ACCEL
-                    3.0f,  // rise rate eANALOG_INPUT_BRAKE
-                    10.0f, // rise rate eANALOG_INPUT_HANDBRAKE
-                    2.5f,  // rise rate eANALOG_INPUT_STEER_LEFT
-                    2.5f,  // rise rate eANALOG_INPUT_STEER_RIGHT
+                    wheelVehicle->_driveControl.RiseRateAcceleration, // rise rate eANALOG_INPUT_ACCEL
+                    wheelVehicle->_driveControl.RiseRateBrake,        // rise rate eANALOG_INPUT_BRAKE
+                    wheelVehicle->_driveControl.RiseRateHandBrake,    // rise rate eANALOG_INPUT_HANDBRAKE
+                    wheelVehicle->_driveControl.RiseRateSteer,        // rise rate eANALOG_INPUT_STEER_LEFT
+                    wheelVehicle->_driveControl.RiseRateSteer,        // rise rate eANALOG_INPUT_STEER_RIGHT
                 },
                 {
-                    5.0f,  // fall rate eANALOG_INPUT__ACCEL
-                    5.0f,  // fall rate eANALOG_INPUT__BRAKE
-                    10.0f, // fall rate eANALOG_INPUT__HANDBRAKE
-                    5.0f,  // fall rate eANALOG_INPUT_STEER_LEFT
-                    5.0f   // fall rate eANALOG_INPUT_STEER_RIGHT
+                    wheelVehicle->_driveControl.FallRateAcceleration, // fall rate eANALOG_INPUT_ACCEL
+                    wheelVehicle->_driveControl.FallRateBrake,        // fall rate eANALOG_INPUT_BRAKE
+                    wheelVehicle->_driveControl.FallRateHandBrake,    // fall rate eANALOG_INPUT_HANDBRAKE
+                    wheelVehicle->_driveControl.FallRateSteer,        // fall rate eANALOG_INPUT_STEER_LEFT
+                    wheelVehicle->_driveControl.FallRateSteer,        // fall rate eANALOG_INPUT_STEER_RIGHT
                 }
             };
             // Reference: PhysX SDK docs

--- a/Source/Engine/Physics/PhysicsBackend.h
+++ b/Source/Engine/Physics/PhysicsBackend.h
@@ -262,6 +262,7 @@ public:
     static void* CreateVehicle(class WheeledVehicle* actor);
     static void DestroyVehicle(void* vehicle, int32 driveType);
     static void UpdateVehicleWheels(WheeledVehicle* actor);
+    static void UpdateVehicleAntiRollBars(WheeledVehicle* actor);
     static void SetVehicleEngine(void* vehicle, const void* value);
     static void SetVehicleDifferential(void* vehicle, const void* value);
     static void SetVehicleGearbox(void* vehicle, const void* value);


### PR DESCRIPTION
Hello, i made some changes on vehicle system to make more flexible and easy to use.

# Drive Control

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/07492b94-3518-48b9-bed5-85dee0fd4fec)

Able to configure the vehicle control behavior, very useful to improve the maneuvering on curves for example, making the steer more smooth or change throttle sensitive. 

## Steer vs Speed

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/a7fb1246-b422-4a5f-94c0-1046cd3ee513)

Now is possible set the relationship between steer and velocity, its very good to improve the vehicle control on high speed decreasing the steer angle.

https://github.com/FlaxEngine/FlaxEngine/assets/79365912/dceee1fc-556d-410b-bc8e-b93bbd7e53b1

# Tank Drive Type

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/1242419d-098e-444c-97be-72b22be7d8bb)

Added Tank Drive Type to vehicles, tanks can move applying throttle on each side, left or side.
All wheels of a side move together depending of the throttle.

https://github.com/FlaxEngine/FlaxEngine/assets/79365912/58fe7efe-b6cb-4516-9d1d-6ec1989bcf69

[reference](https://nvidia-omniverse.github.io/PhysX/physx/5.1.0/docs/Vehicles.html#pxvehicledrivetank)

### Tank drive mode

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/01ec3f16-95be-42e5-946c-bb13d76d0dc0)

Tanks can have different drives modes, like Special and Standard.

* Standard can throttle only one track by time, so if you need turn to left for example, the left track will be stoped and right track will move to forward.

* Special apply acceleration in all tracks, so if you need to turn to left for example, the left track will accelerate to backward and right track will accelerate to forward.

# Gears

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/5ac12f22-366d-476a-ad28-4c79b41a1e7b)

Added Forward Gears Ratio to able configure gears count to move to forward.

# Wheels

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/5b1e9017-348c-4b50-951d-5845f21f348d)

Removed wheel type from wheels, the unique reason to exist it is sort wheels on start game because DriveW4, DriveNW and TankDrive needs to have all wheels sorted to know the correct wheel position, now the sort is made automatically based on wheel local position on vehicle: 

## Drive W4

| wheels index  | type |
| -- | ------------------------ |
| 0  | forward right      |
| 1  | forward left         |
| 2  | backward right   |
| 3  | backward left      |

## Drive NW

This not need to know the wheel index, but wheels are sorted because anti roll bars needs to know the wheel side.

## Tank Drive

Tank Drive needs to have sorted wheels to know the side to apply throttle correctly on each side.

| wheels index  | type |
| -- | ------------------------ |
| 0  | right                     | 
| 1  | left                        |
| 2  | right                     |
| 3  | left                        |

## Wheel Angle

Wheel steer angle has been changed to -180 180 because this helps to create negative steer. Negative steer is applied automatically on vehicles DriveW4 on back wheels but this not happen on DriveNW vehicles.

Negative wheel angle is very useful to create vehicles with various maneuverable axles, front and back, like large trucks.

https://github.com/FlaxEngine/FlaxEngine/assets/79365912/23f1345d-9ecf-4956-8956-3c6b8d547cb4

## Sprung Mass Multiplier

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/61e74f52-9d1f-4676-ac68-bb4e484029ed)

By default, the suspension spring force is based on vehicle mass distribution, for example, if you have 4 wheels and the vehicle have 1000 of mass, the sprung force is 250 for each wheel (only an simple example).

This force is based on center of mass of the vehicle, so if the center mass is on front, the front suspension will have more force than back suspension springs. 

Now is possible edit this force changing the sprung mass multiplier to make the spring more strong or more weak.

# Anti Roll Bars

![image](https://github.com/FlaxEngine/FlaxEngine/assets/79365912/eb79a152-1fb4-4212-8201-de1b30a989e0)
Increase the stability on each vehicle axle (each axle is made using left and right wheel).

Anti roll apply a contrary force to avoid vehicle turn around your our axis, making more maneuvering in curves for example but me personally don't see much difference with it.

Anti roll bars needs to have wheels sorted to know the wheel side and apply the force correctly.

| wheels axle 0 | type |
| -- | ------------------------ |
| 0  | right                     | 
| 1  | left                        |
| wheels axle 1 | type |
| 2  | right                     |
| 3  | left                        |

more info about [anti roll bars](https://nvidia-omniverse.github.io/PhysX/physx/5.1.0/docs/Vehicles.html#pxvehicleantirollbar).

