### PR TITLE
Adjust combobox window position based on what direction it opens.

### DIFF
--- a/Source/Editor/GUI/ComboBox.cs
+++ b/Source/Editor/GUI/ComboBox.cs
@@ -428,6 +428,13 @@ namespace FlaxEditor.GUI
                 // Show dropdown list
                 _popupMenu.MinimumWidth = Width;
                 _popupMenu.Show(this, new Float2(1, Height));
+
+                // Adjust menu position if it is not the down direction
+                if (_popupMenu.Direction == ContextMenuDirection.RightUp)
+                {
+                    var position = _popupMenu.RootWindow.Window.Position;
+                    _popupMenu.RootWindow.Window.Position = new Float2(position.X, position.Y - Height);
+                }
             }
         }
 


### PR DESCRIPTION
This is a small improvement that allows the combo box to not cover what is currently selected if it is opening in the up direction due to monitor bounds.