### PR TITLE
Add drag drop for actor script items into scenes and prefabs.

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -814,6 +814,7 @@ namespace FlaxEditor.SceneGraph.GUI
             _dragScripts = null;
             _dragAssets = null;
             _dragActorType = null;
+            _dragScriptItems = null;
             _dragHandlers?.Clear();
             _dragHandlers = null;
             _highlights = null;

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FlaxEditor.Content;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
@@ -194,7 +195,7 @@ namespace FlaxEditor.Viewport
         : base(Object.New<SceneRenderTask>(), editor.Undo, editor.Scene.Root)
         {
             _editor = editor;
-            DragHandlers = new ViewportDragHandlers(this, this, ValidateDragItem, ValidateDragActorType);
+            DragHandlers = new ViewportDragHandlers(this, this, ValidateDragItem, ValidateDragActorType, ValidateDragScriptItem);
             var inputOptions = editor.Options.Options.Input;
 
             // Prepare rendering task
@@ -938,6 +939,14 @@ namespace FlaxEditor.Viewport
         private static bool ValidateDragActorType(ScriptType actorType)
         {
             return Level.IsAnySceneLoaded;
+        }
+
+        private static bool ValidateDragScriptItem(ScriptItem script)
+        {
+            var actors = Editor.Instance.CodeEditing.Actors.Get();
+            if (actors.Any(x => x.ContentItem == script))
+                return true;
+            return false;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FlaxEditor.Content;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
@@ -81,7 +82,7 @@ namespace FlaxEditor.Viewport
             _window.SelectionChanged += OnSelectionChanged;
             Undo = window.Undo;
             ViewportCamera = new FPSCamera();
-            DragHandlers = new ViewportDragHandlers(this, this, ValidateDragItem, ValidateDragActorType);
+            DragHandlers = new ViewportDragHandlers(this, this, ValidateDragItem, ValidateDragActorType, ValidateDragScriptItem);
             ShowDebugDraw = true;
             ShowEditorPrimitives = true;
             Gizmos = new GizmosCollection(this);
@@ -700,6 +701,14 @@ namespace FlaxEditor.Viewport
         private static bool ValidateDragActorType(ScriptType actorType)
         {
             return true;
+        }
+        
+        private static bool ValidateDragScriptItem(ScriptItem script)
+        {
+            var actors = Editor.Instance.CodeEditing.Actors.Get();
+            if (actors.Any(x => x.ContentItem == script))
+                return true;
+            return false;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -213,6 +213,7 @@ namespace FlaxEditor.Windows.Assets
                 _window = null;
                 _dragAssets = null;
                 _dragActorType = null;
+                _dragScriptItems = null;
                 _dragHandlers?.Clear();
                 _dragHandlers = null;
 

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -498,6 +498,7 @@ namespace FlaxEditor.Windows
         {
             _dragAssets = null;
             _dragActorType = null;
+            _dragScriptItems = null;
             _dragHandlers?.Clear();
             _dragHandlers = null;
             _tree = null;

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FlaxEditor.Gizmo;
 using FlaxEditor.Content;
 using FlaxEditor.GUI.Tree;
@@ -31,6 +32,7 @@ namespace FlaxEditor.Windows
 
         private DragAssets _dragAssets;
         private DragActorType _dragActorType;
+        private DragScriptItems _dragScriptItems;
         private DragHandlers _dragHandlers;
 
         /// <summary>
@@ -272,6 +274,14 @@ namespace FlaxEditor.Windows
         {
             return true;
         }
+        
+        private static bool ValidateDragScriptItem(ScriptItem script)
+        {
+            var actors = Editor.Instance.CodeEditing.Actors.Get();
+            if (actors.Any(x => x.ContentItem == script))
+                return true;
+            return false;
+        }
 
         /// <inheritdoc />
         public override void Draw()
@@ -380,6 +390,13 @@ namespace FlaxEditor.Windows
                 }
                 if (_dragActorType.OnDragEnter(data) && result == DragDropEffect.None)
                     return _dragActorType.Effect;
+                if (_dragScriptItems == null)
+                {
+                    _dragScriptItems = new DragScriptItems(ValidateDragScriptItem);
+                    _dragHandlers.Add(_dragScriptItems);
+                }
+                if (_dragScriptItems.OnDragEnter(data) && result == DragDropEffect.None)
+                    return _dragScriptItems.Effect;
             }
             return result;
         }
@@ -442,6 +459,31 @@ namespace FlaxEditor.Windows
                         actor.Name = item.Name;
                         Level.SpawnActor(actor);
                         Editor.Scene.MarkSceneEdited(actor.Scene);
+                    }
+                    result = DragDropEffect.Move;
+                }
+                // Drag script item
+                else if (_dragScriptItems != null && _dragScriptItems.HasValidDrag)
+                {
+                    for (int i = 0; i < _dragScriptItems.Objects.Count; i++)
+                    {
+                        var item = _dragScriptItems.Objects[i];
+                        // Find actors with the same content item and spawn them.
+                        foreach (var actorType in Editor.Instance.CodeEditing.Actors.Get())
+                        {
+                            if (actorType.ContentItem != item)
+                                continue;
+
+                            var actor = actorType.CreateInstance() as Actor;
+                            if (actor == null)
+                            {
+                                Editor.LogWarning("Failed to spawn actor of type " + actorType.TypeName);
+                                continue;
+                            }
+                            actor.Name = actorType.Name;
+                            Level.SpawnActor(actor);
+                            Editor.Scene.MarkSceneEdited(actor.Scene);
+                        }
                     }
                     result = DragDropEffect.Move;
                 }


### PR DESCRIPTION
This allows for a script item from the content window to be dragged into the scene or prefab viewport/tree and if it contains actor types it will spawn them. This is a QoL addition that I felt has been missing for a while.