### PR TITLE
Added "Start Time" option for Audio Source Actor

### DIFF
--- a/Source/Engine/Audio/AudioSource.cpp
+++ b/Source/Engine/Audio/AudioSource.cpp
@@ -19,6 +19,7 @@ AudioSource::AudioSource(const SpawnParams& params)
     , _minDistance(1000.0f)
     , _loop(false)
     , _playOnStart(false)
+    , _startTime(0.0f)
     , _allowSpatialization(true)
 {
     Clip.Changed.Bind<AudioSource, &AudioSource::OnClipChanged>(this);
@@ -69,6 +70,11 @@ void AudioSource::SetIsLooping(bool value)
 void AudioSource::SetPlayOnStart(bool value)
 {
     _playOnStart = value;
+}
+
+void AudioSource::SetStartTime(float value)
+{
+    _startTime = value;
 }
 
 void AudioSource::SetMinDistance(float value)
@@ -361,6 +367,7 @@ void AudioSource::Serialize(SerializeStream& stream, const void* otherObj)
     SERIALIZE_MEMBER(DopplerFactor, _dopplerFactor);
     SERIALIZE_MEMBER(Loop, _loop);
     SERIALIZE_MEMBER(PlayOnStart, _playOnStart);
+    SERIALIZE_MEMBER(StartTime, _startTime);
     SERIALIZE_MEMBER(AllowSpatialization, _allowSpatialization);
 }
 
@@ -377,6 +384,7 @@ void AudioSource::Deserialize(DeserializeStream& stream, ISerializeModifier* mod
     DESERIALIZE_MEMBER(DopplerFactor, _dopplerFactor);
     DESERIALIZE_MEMBER(Loop, _loop);
     DESERIALIZE_MEMBER(PlayOnStart, _playOnStart);
+    DESERIALIZE_MEMBER(StartTime, _startTime);
     DESERIALIZE_MEMBER(AllowSpatialization, _allowSpatialization);
     DESERIALIZE(Clip);
 }
@@ -538,7 +546,8 @@ void AudioSource::BeginPlay(SceneBeginData* data)
 #if USE_EDITOR
         if (Time::GetGamePaused())
             return;
-#endif
+#endif      
         Play();
+        SetTime(GetStartTime());
     }
 }

--- a/Source/Engine/Audio/AudioSource.h
+++ b/Source/Engine/Audio/AudioSource.h
@@ -52,6 +52,7 @@ private:
     float _dopplerFactor = 1.0f;
     bool _loop;
     bool _playOnStart;
+    float _startTime;
     bool _allowSpatialization;
     bool _clipChanged = false;
 
@@ -149,9 +150,23 @@ public:
     }
 
     /// <summary>
+    /// Determines the time (in seconds) at which the audio clip starts playing if Play On Start is enabled.
+    /// </summary>
+    API_PROPERTY(Attributes = "EditorOrder(51), DefaultValue(0.0f), Limit(0, float.MaxValue, 0.01f), EditorDisplay(\"Audio Source\", \"Start Time\"), VisibleIf(nameof(PlayOnStart))")
+    FORCE_INLINE float GetStartTime() const
+    {
+        return _startTime;
+    }
+
+    /// <summary>
     /// Determines whether the audio clip should auto play on game start.
     /// </summary>
     API_PROPERTY() void SetPlayOnStart(bool value);
+
+    /// <summary>
+    /// Determines the time (in seconds) at which the audio clip starts playing if Play On Start is enabled.
+    /// </summary>
+    API_PROPERTY() void SetStartTime(float value);
 
     /// <summary>
     /// Gets the minimum distance at which audio attenuation starts. When the listener is closer to the source than this value, audio is heard at full volume. Once farther away the audio starts attenuating.


### PR DESCRIPTION
Added ability to set the start time of playback if "Play On Start" is enabled.
~~There are no easter eggs in the video btw~~

https://github.com/FlaxEngine/FlaxEngine/assets/97740209/de26135b-f21a-4f87-bcad-70008584a08c

