### PR TITLE
Add skeleton mask asset parameter to Blend With Mask anim node.

### DIFF
--- a/Source/Editor/Surface/Archetypes/Animation.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.cs
@@ -29,6 +29,52 @@ namespace FlaxEditor.Surface.Archetypes
         }
 
         /// <summary>
+        /// Customized <see cref="SurfaceNode"/> for Blend with Mask node.
+        /// </summary>
+        public class SkeletonMaskSample : SurfaceNode
+        {
+            private AssetSelect _assetSelect;
+            private Box _assetBox;
+
+            /// <inheritdoc />
+            public SkeletonMaskSample(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
+            : base(id, context, nodeArch, groupArch)
+            {
+            }
+
+            /// <inheritdoc />
+            public override void OnSurfaceLoaded(SurfaceNodeActions action)
+            {
+                base.OnSurfaceLoaded(action);
+
+                if (Surface != null)
+                {
+                    _assetSelect = GetChild<AssetSelect>();
+
+                    // 4 is the id of skeleton mask parameter node.
+                    if (TryGetBox(4, out var box))
+                    {
+                        _assetBox = box;
+                        _assetSelect.Visible = !_assetBox.HasAnyConnection;
+                    }
+                }
+            }
+
+            /// <inheritdoc />
+            public override void ConnectionTick(Box box)
+            {
+                base.ConnectionTick(box);
+
+                if (_assetBox == null)
+                    return;
+                if (box.ID != _assetBox.ID)
+                    return;
+
+                _assetSelect.Visible = !box.HasAnyConnection;
+            }
+        }
+
+        /// <summary>
         /// Customized <see cref="SurfaceNode"/> for the animation sampling nodes
         /// </summary>
         /// <seealso cref="FlaxEditor.Surface.SurfaceNode" />
@@ -552,6 +598,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 11,
                 Title = "Blend with Mask",
                 Description = "Blend animation poses using skeleton mask",
+                Create =  (id, context, arch, groupArch) => new SkeletonMaskSample(id, context, arch, groupArch),
                 Flags = NodeFlags.AnimGraph,
                 Size = new Float2(180, 140),
                 DefaultValues = new object[]
@@ -565,7 +612,8 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Input(0, "Pose A", true, typeof(void), 1),
                     NodeElementArchetype.Factory.Input(1, "Pose B", true, typeof(void), 2),
                     NodeElementArchetype.Factory.Input(2, "Alpha", true, typeof(float), 3, 0),
-                    NodeElementArchetype.Factory.Asset(0, 70, 1, typeof(SkeletonMask)),
+                    NodeElementArchetype.Factory.Input(3, "Skeleton Mask Asset", true, typeof(SkeletonMask), 4),
+                    NodeElementArchetype.Factory.Asset(0, Surface.Constants.LayoutOffsetY * 4, 1, typeof(SkeletonMask)),
                 }
             },
             new NodeArchetype

--- a/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
+++ b/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
@@ -1131,6 +1131,17 @@ void AnimGraphExecutor::ProcessGroupAnimation(Box* boxBase, Node* nodeBase, Valu
     {
         const float alpha = Math::Saturate((float)tryGetValue(node->GetBox(3), node->Values[0]));
         auto mask = node->Assets[0].As<SkeletonMask>();
+        auto maskAssetBox = node->GetBox(4); // 4 is the id of skeleton mask parameter node.
+
+        // Check if have some mask asset conected with the mask node
+        if (maskAssetBox->HasConnection())
+        {
+            const Value assetBoxValue = tryGetValue(maskAssetBox, Value::Null);
+
+            // Use the mask conected with this node instead of default mask asset 
+            if (assetBoxValue != Value::Null)
+                mask = (SkeletonMask *)assetBoxValue.AsAsset;
+        }
 
         // Only A or missing/invalid mask
         if (Math::NearEqual(alpha, 0.0f, ANIM_GRAPH_BLEND_THRESHOLD) || mask == nullptr || mask->WaitForLoaded())


### PR DESCRIPTION
This pr allow to change skeleton mask by anim graph parameter.

Example:

https://github.com/FlaxEngine/FlaxEngine/assets/79365912/091776ad-d7b1-4ada-8760-7e0d1f6ce519

This is a very similar implementation of #1627 
Thanks @Chikinsupu this helped me a lot :) 
