### PR TITLE
Update BindingsGenerator.Cpp.cs fixed nested enums generation for eventInfo

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -1937,7 +1937,7 @@ namespace Flax.Build.Bindings
             var useCSharp = EngineConfiguration.WithCSharp(buildData.TargetOptions);
             var hasInterface = classInfo.Interfaces != null && classInfo.Interfaces.Any(x => x.Access == AccessLevel.Public);
             CppInternalCalls.Clear();
-
+            
             if (classInfo.IsAutoSerialization)
                 GenerateCppAutoSerialization(buildData, contents, moduleInfo, classInfo, classTypeNameNative);
             GenerateCppTypeInternalsStatics?.Invoke(buildData, classInfo, contents);
@@ -1955,7 +1955,7 @@ namespace Flax.Build.Bindings
                 var paramsCount = eventInfo.Type.GenericArgs?.Count ?? 0;
                 CppIncludeFiles.Add("Engine/Profiler/ProfilerCPU.h");
                 var bindPrefix = eventInfo.IsStatic ? classTypeNameNative + "::" : "__obj->";
-
+                //eventInfo.
                 if (useCSharp)
                 {
                     // C# event invoking wrapper (calls C# event from C++ delegate)
@@ -1965,12 +1965,12 @@ namespace Flax.Build.Bindings
                     contents.Append("    ");
                     if (eventInfo.IsStatic)
                         contents.Append("static ");
-                    contents.AppendFormat("void {0}_ManagedWrapper(", eventInfo.Name);
+                    contents.AppendFormat("void {0}_ManagedWrapper(", eventInfo.Name); 
                     for (var i = 0; i < paramsCount; i++)
                     {
                         if (i != 0)
                             contents.Append(", ");
-                        contents.Append(eventInfo.Type.GenericArgs[i]).Append(" arg" + i);
+                        contents.Append(eventInfo.Type.GenericArgs[i].GetFullNameNative(buildData,classInfo)).Append(" arg" + i);
                     }
                     contents.Append(')').AppendLine();
                     contents.Append("    {").AppendLine();
@@ -2058,7 +2058,7 @@ namespace Flax.Build.Bindings
                     {
                         if (i != 0)
                             contents.Append(", ");
-                        contents.Append(eventInfo.Type.GenericArgs[i]);
+                        contents.Append(eventInfo.Type.GenericArgs[i].GetFullNameNative(buildData, classInfo));
                     }
                     contents.Append(")> f;").AppendLine();
                     if (eventInfo.IsStatic)
@@ -2084,7 +2084,7 @@ namespace Flax.Build.Bindings
                 {
                     if (i != 0)
                         contents.Append(", ");
-                    contents.Append(eventInfo.Type.GenericArgs[i]).Append(" arg" + i);
+                    contents.Append(eventInfo.Type.GenericArgs[i].GetFullNameNative(buildData, classInfo)).Append(" arg" + i);
                 }
                 contents.Append(')').AppendLine();
                 contents.Append("    {").AppendLine();
@@ -2111,7 +2111,7 @@ namespace Flax.Build.Bindings
                 {
                     if (i != 0)
                         contents.Append(", ");
-                    contents.Append(eventInfo.Type.GenericArgs[i]);
+                    contents.Append(eventInfo.Type.GenericArgs[i].GetFullNameNative(buildData, classInfo));
                 }
                 contents.Append(")> f;").AppendLine();
                 if (eventInfo.IsStatic)


### PR DESCRIPTION
```c++
class foo
{
public:
  enum bar
  {
  val,
  val2,
  };
};
```

the generetor was genereting `bar arg`
insted of `foo::bar arg`