### PR TITLE
fix off-by-one in collection range check

### DIFF
--- a/Source/Editor/GUI/Tabs/Tabs.cs
+++ b/Source/Editor/GUI/Tabs/Tabs.cs
@@ -239,7 +239,7 @@ namespace FlaxEditor.GUI.Tabs
         /// </summary>
         public Tab SelectedTab
         {
-            get => _selectedIndex < 0 || Children.Count <= _selectedIndex ? null : Children[_selectedIndex + 1] as Tab;
+            get => _selectedIndex < 0 || Children.Count <= (_selectedIndex+1) ? null : Children[_selectedIndex + 1] as Tab;
             set => SelectedTabIndex = value != null ? Children.IndexOf(value) - 1 : -1;
         }
 


### PR DESCRIPTION
The check failed randomly after script reloading and issued the following error:

```
00:19:37.789 ]: [Error] Exception has been thrown during Window.OnDraw.
Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
[ 00:19:37.805 ]: [Warning] Exception has been thrown during Window.OnUpdate. Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
Stack strace:
   at FlaxEditor.GUI.Tabs.Tabs.get_SelectedTab() in /home/me/Flax/FlaxEngine/Source/Editor/GUI/Tabs/Tabs.cs:line 242
```