### PR TITLE
Add ability to rename multiple actors using scene hierarchy

### DIFF
--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -55,8 +55,6 @@ namespace FlaxEditor.Windows
             // Basic editing options
 
             b = contextMenu.AddButton("Rename", inputOptions.Rename, Rename);
-            b.Enabled = isSingleActorSelected;
-
             b = contextMenu.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
             b.Enabled = hasSthSelected;
 

--- a/Source/Editor/Windows/SceneTreeWindow.RenameWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.RenameWindow.cs
@@ -69,7 +69,7 @@ namespace FlaxEditor.Windows
         {
             OnlyName,
             UsePrefix,
-            UseSufix
+            UseSuffix
         }
 
         private string _newActorsName;
@@ -84,7 +84,7 @@ namespace FlaxEditor.Windows
             Size = new Float2(300, 110);
 
             _newActorsName = "Actor ";
-            _renameOption = RenameOptions.UseSufix;
+            _renameOption = RenameOptions.UseSuffix;
             _actorsToRename = actorsToRename;
 
             var container = new VerticalPanel
@@ -213,7 +213,7 @@ namespace FlaxEditor.Windows
                     newName.Append(i);
                     newName.Append(_newActorsName);
                 }
-                else if (_renameOption == RenameOptions.UseSufix)
+                else if (_renameOption == RenameOptions.UseSuffix)
                     newName.Append(i.ToString());
 
                 var newNameStr = newName.ToString();

--- a/Source/Editor/Windows/SceneTreeWindow.RenameWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.RenameWindow.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using FlaxEditor.CustomEditors;
+using FlaxEditor.GUI;
+using FlaxEditor.Windows.Assets;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.Windows
+{
+    /// <summary>
+    /// A window used to rename multiple actors.
+    /// </summary>
+    public class RenameWindow : EditorWindow
+    {
+        /// <inheritdoc/>
+        private class RenameUndoAction : IUndoAction
+        {
+            /// <summary>
+            /// The old actors name to use on <see cref="Undo"/> action.
+            /// </summary>
+            public string[] OldNames;
+
+            /// <summary>
+            /// The new actors name to use on <see cref="Do"/> action.
+            /// </summary>
+            public string[] NewNames;
+
+            /// <summary>
+            /// All actors to rename.
+            /// </summary>
+            public Actor[] ActorsToRename;
+
+            /// <summary>
+            /// Create a <see cref="RenameUndoAction"/> undo action.
+            /// </summary>
+            /// <param name="nodes"></param>
+            public RenameUndoAction(Actor[] nodes)
+            {
+                ActorsToRename = nodes;
+                OldNames = new string[nodes.Length];
+
+                for (int i = 0; i < nodes.Length; i++)
+                    OldNames[i] = nodes[i].Name;
+            }
+
+            /// <inheritdoc/>
+            public void Do()
+            {
+                for (int i = 0; i < ActorsToRename.Length; i++)
+                    ActorsToRename[i].Name = NewNames[i];
+            }
+
+            /// <inheritdoc/>
+            public void Undo()
+            {
+                for (int i = 0; i < ActorsToRename.Length; i++)
+                    ActorsToRename[i].Name = OldNames[i];
+            }
+
+            /// <inheritdoc/>
+            public string ActionString => "Renaming actors.";
+
+            /// <inheritdoc/>
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        /// Rename options.
+        /// </summary>
+        private enum RenameOptions
+        {
+            OnlyName,
+            UsePrefix,
+            UseSufix
+        }
+
+        private Label _label;
+        private TextBox _textBox;
+        private EnumComboBox _renameOptions;
+        private Button _renameButton;
+
+        private Actor[] _actorsToRename;
+
+        /// <summary>
+        /// Create an instance of the <see cref="RenameWindow"/> to rename actors.
+        /// </summary>
+        /// <param name="actorsToRename">All actors to rename</param>
+        /// <param name="editor">The editor.</param>
+        public RenameWindow(Actor[] actorsToRename, Editor editor) : base(editor, true, FlaxEngine.GUI.ScrollBars.None)
+        {
+            Title = "Rename";
+            _actorsToRename = actorsToRename;
+
+            var container = new VerticalPanel
+            {
+                Parent = this,
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offset = Vector2.Zero,
+
+            };
+
+            _label = new Label
+            {
+                Text = "New Name",
+                AnchorPreset = AnchorPresets.TopLeft,
+                Parent = container,
+                Size = new Float2(100, 25)
+            };
+
+            _textBox = new TextBox
+            {
+                Text = "Actor",
+                AnchorPreset = AnchorPresets.TopLeft,
+                Parent = container,
+                Size = new Float2(200, 25)
+            };
+
+            var renameOptionLabel = new Label
+            {
+                Text = "Rename Option",
+                AnchorPreset = AnchorPresets.TopLeft,
+                Parent = container,
+                Size = new Float2(100, 25)
+            };
+
+            _renameOptions = new EnumComboBox(typeof(RenameOptions))
+            {
+                Parent = container,
+                Value = 0
+            };
+
+            _renameButton = new Button
+            {
+                Text = "Rename",
+                AnchorPreset = AnchorPresets.TopLeft,
+                Parent = container,
+                Size = new Float2(200, 25),
+            };
+
+            _renameButton.Clicked += () =>
+            {
+                var renameUndoAction = new RenameUndoAction(_actorsToRename);
+                Editor.Instance.SceneEditing.Undo.AddAction(renameUndoAction);
+                renameUndoAction.NewNames = new string[_actorsToRename.Length];
+                for (int i = 0; i < _actorsToRename.Length; i++)
+                {
+                    var actor = _actorsToRename[i];
+                    if (!actor)
+                        continue;
+                    var newName = new StringBuilder(_textBox.Text);
+                    if (_renameOptions.Value == (int)RenameOptions.UsePrefix)
+                    {
+                        newName = new StringBuilder();
+                        newName.Append(i);
+                        newName.Append(_textBox.Text);
+                    }
+                    else if (_renameOptions.Value == (int)RenameOptions.UseSufix)
+                        newName.Append(i.ToString());
+                    var newNameStr = newName.ToString();
+                    actor.Name = newNameStr;
+                    renameUndoAction.NewNames[i] = newNameStr;
+                }
+                Editor.Instance.Scene.MarkAllScenesEdited();
+                Close();
+            };
+        }
+
+        ~RenameWindow()
+        {
+            _actorsToRename = null;
+            _renameButton = null;
+            _label = null;
+            _textBox = null;
+            _renameOptions = null;
+        }
+    }
+}

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -13,7 +13,6 @@ using FlaxEditor.Scripting;
 using FlaxEditor.States;
 using FlaxEngine;
 using FlaxEngine.GUI;
-using static FlaxEditor.GUI.ItemsListContextMenu;
 
 namespace FlaxEditor.Windows
 {
@@ -138,10 +137,24 @@ namespace FlaxEditor.Windows
         private void Rename()
         {
             var selection = Editor.SceneEditing.Selection;
-            if (selection.Count != 0 && selection[0] is ActorNode actor)
+            var selectionCount = selection.Count;
+
+            // Show a window with options to rename multiple actors.
+            if (selectionCount > 1)
             {
-                if (selection.Count != 0)
-                    Editor.SceneEditing.Select(actor);
+                var selectedActors = new Actor[selectionCount];
+
+                for (int i = 0; i < selectionCount; i++)
+                    if (selection[i] is ActorNode actorNode)
+                        selectedActors[i] = actorNode.Actor;
+
+                new RenameWindow(selectedActors, Editor).Show();
+                return;
+            }
+
+            if (selectionCount != 0 && selection[0] is ActorNode actor)
+            {
+                Editor.SceneEditing.Select(actor);
                 actor.TreeNode.StartRenaming(this, _sceneTreePanel);
             }
         }

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -148,7 +148,7 @@ namespace FlaxEditor.Windows
                     if (selection[i] is ActorNode actorNode)
                         selectedActors[i] = actorNode.Actor;
 
-                new RenameWindow(selectedActors, Editor).Show();
+                RenameWindow.Show(selectedActors, Editor);
                 return;
             }
 


### PR DESCRIPTION
This pr adds a window that have options to rename different actors.
This has inspiration of [this tool of unigine](https://developer.unigine.com/en/devlog/20231218-unigine-2.18#batch-rename).


https://github.com/FlaxEngine/FlaxEngine/assets/79365912/b098849c-a746-4e16-930b-93c5bf9a7493

