### PR TITLE
initialize the bool _isHorizontalFlippingMouse to false

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxWindow.cpp
+++ b/Source/Engine/Platform/Linux/LinuxWindow.cpp
@@ -55,6 +55,8 @@ LinuxWindow::LinuxWindow(const CreateWindowSettings& settings)
         return;
 	auto screen = XDefaultScreen(display);
 
+    // default to false
+    _isHorizontalFlippingMouse = false;
     // Cache data
 	int32 width = Math::TruncToInt(settings.Size.X);
 	int32 height = Math::TruncToInt(settings.Size.Y);


### PR DESCRIPTION
fixes #2226 
The boolean flag was not initialized at all for non-Windows platform.