### PR TITLE
added IAssetFactory::Get().ContainsKey cheak

### DIFF
--- a/Source/Engine/Content/Factories/JsonAssetFactory.h
+++ b/Source/Engine/Content/Factories/JsonAssetFactory.h
@@ -49,7 +49,20 @@ protected:
 	class CONCAT_MACROS(Factory, type) : public JsonAssetFactory<type> \
 	{ \
 		public: \
-		CONCAT_MACROS(Factory, type)() { IAssetFactory::Get().Add(type::TypeName, this); } \
+		CONCAT_MACROS(Factory, type)() \
+        { \
+            if (IAssetFactory::Get().ContainsKey(type::TypeName)) \
+            { \
+                if (Platform::IsDebuggerPresent()) \
+                { \
+                    PLATFORM_DEBUG_BREAK; \
+                } \
+                Platform::Assert("[IAssetFactory] Can't Register "#type \
+                " it is already registered", __FILE__, __LINE__); \
+                return; \
+            } \
+            IAssetFactory::Get().Add(type::TypeName, this); \
+        } \
 		~CONCAT_MACROS(Factory, type)() { IAssetFactory::Get().Remove(type::TypeName); } \
 		bool SupportsVirtualAssets() const override { return supportsVirtualAssets; } \
 	}; \


### PR DESCRIPTION
gives more info what went wrong instead of empty call stack and crash
![image](https://github.com/FlaxEngine/FlaxEngine/assets/53096989/77ad6ee5-8982-42b3-ae16-ffc7d30ed585)
