### PR TITLE
Add NextUnitCircleVector2 extension method

### DIFF
--- a/Source/Engine/Utilities/Extensions.cs
+++ b/Source/Engine/Utilities/Extensions.cs
@@ -309,8 +309,8 @@ namespace FlaxEngine.Utilities
         /// <returns>A random <see cref="Vector2"/>.</returns>
         public static Vector2 NextUnitCircleVector2(this Random random, float radius = 1.0f)
         {
-            double randomDegree = random.NextDouble() * 360;
-            return new Vector2((float)Math.Cos(randomDegree) * radius, (float)Math.Sin(randomDegree) * radius);
+            double randomRadian = random.NextDouble() * Mathf.RevolutionsToRadians;
+            return new Vector2((float)Math.Cos(randomRadian) * radius, (float)Math.Sin(randomRadian) * radius);
         }
 
         /// <summary>

--- a/Source/Engine/Utilities/Extensions.cs
+++ b/Source/Engine/Utilities/Extensions.cs
@@ -300,6 +300,18 @@ namespace FlaxEngine.Utilities
             var randomRadius = (float)random.NextDouble() * radius;
             return new Vector2((float)Math.Cos(random.NextDouble()) * randomRadius, (float)Math.Sin(random.NextDouble()) * randomRadius);
         }
+        
+        /// <summary>
+        /// Generates a random <see cref="Vector2"/> point on a circle of a given radius.
+        /// </summary>
+        /// <param name="random">An instance of <see cref="Random"/>.</param>
+        /// <param name="radius">Radius of circle. Default 1.0f./>.</param>
+        /// <returns>A random <see cref="Vector2"/>.</returns>
+        public static Vector2 NextUnitCircleVector2(this Random random, float radius = 1.0f)
+        {
+            double randomDegree = random.NextDouble() * 360;
+            return new Vector2((float)Math.Cos(randomDegree) * radius, (float)Math.Sin(randomDegree) * radius);
+        }
 
         /// <summary>
         /// Generates a uniformly distributed random unit length vector point on a unit sphere.


### PR DESCRIPTION
Adds the NextUnitCircleVector2 extension method which produces a Vector2 on a unit circle with a magnitude equal to the radius.