### PR TITLE
Fix scale gizmo to correctly do 2 axis

### DIFF
--- a/Source/Editor/Gizmo/TransformGizmoBase.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.cs
@@ -257,7 +257,7 @@ namespace FlaxEditor.Gizmo
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
                         var maxDelta = Mathf.Max(tDeltaAbs.Y, tDeltaAbs.Z);
-                        float sign = Mathf.Sign(tDeltaAbs.Y > tDeltaAbs.Z ? _tDelta.Y : _tDelta.Z);
+                        var sign = Mathf.Sign(tDeltaAbs.Y > tDeltaAbs.Z ? _tDelta.Y : _tDelta.Z);
                         delta = new Vector3(0, maxDelta * sign, maxDelta * sign);
                     }
                     else
@@ -278,7 +278,7 @@ namespace FlaxEditor.Gizmo
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
                         var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Y);
-                        float sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Y ? _tDelta.X : _tDelta.Y);
+                        var sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Y ? _tDelta.X : _tDelta.Y);
                         delta = new Vector3(maxDelta * sign, maxDelta * sign, 0);
                     }
                     else
@@ -299,7 +299,7 @@ namespace FlaxEditor.Gizmo
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
                         var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Z);
-                        float sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Z ? _tDelta.X : _tDelta.Z);
+                        var sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Z ? _tDelta.X : _tDelta.Z);
                         delta = new Vector3(maxDelta * sign, 0, maxDelta * sign);
                     }
                     else
@@ -323,7 +323,7 @@ namespace FlaxEditor.Gizmo
                 {
                     var tDeltaAbs = Vector3.Abs(_tDelta);
                     var maxDelta = Mathf.Max(new[] { tDeltaAbs.X, tDeltaAbs.Y, tDeltaAbs.Z });
-                    float sign = 0;
+                    Real sign = 0;
                     if (Mathf.NearEqual(maxDelta, tDeltaAbs.X))
                         sign = Mathf.Sign(_tDelta.X);
                     else if (Mathf.NearEqual(maxDelta, tDeltaAbs.Y))

--- a/Source/Editor/Gizmo/TransformGizmoBase.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.cs
@@ -256,8 +256,8 @@ namespace FlaxEditor.Gizmo
                     if (isScaling)
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
-                        var maxDelta = Mathf.Max(tDeltaAbs.Y, tDeltaAbs.Z);
-                        var sign = Mathf.Sign(tDeltaAbs.Y > tDeltaAbs.Z ? _tDelta.Y : _tDelta.Z);
+                        var maxDelta = Math.Max(tDeltaAbs.Y, tDeltaAbs.Z);
+                        var sign = Math.Sign(tDeltaAbs.Y > tDeltaAbs.Z ? _tDelta.Y : _tDelta.Z);
                         delta = new Vector3(0, maxDelta * sign, maxDelta * sign);
                     }
                     else
@@ -277,8 +277,8 @@ namespace FlaxEditor.Gizmo
                     if (isScaling)
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
-                        var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Y);
-                        var sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Y ? _tDelta.X : _tDelta.Y);
+                        var maxDelta = Math.Max(tDeltaAbs.X, tDeltaAbs.Y);
+                        var sign = Math.Sign(tDeltaAbs.X > tDeltaAbs.Y ? _tDelta.X : _tDelta.Y);
                         delta = new Vector3(maxDelta * sign, maxDelta * sign, 0);
                     }
                     else
@@ -298,8 +298,8 @@ namespace FlaxEditor.Gizmo
                     if (isScaling)
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
-                        var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Z);
-                        var sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Z ? _tDelta.X : _tDelta.Z);
+                        var maxDelta = Math.Max(tDeltaAbs.X, tDeltaAbs.Z);
+                        var sign = Math.Sign(tDeltaAbs.X > tDeltaAbs.Z ? _tDelta.X : _tDelta.Z);
                         delta = new Vector3(maxDelta * sign, 0, maxDelta * sign);
                     }
                     else
@@ -322,14 +322,15 @@ namespace FlaxEditor.Gizmo
                 if (isScaling)
                 {
                     var tDeltaAbs = Vector3.Abs(_tDelta);
-                    var maxDelta = Mathf.Max(new[] { tDeltaAbs.X, tDeltaAbs.Y, tDeltaAbs.Z });
+                    var maxDelta = Math.Max(tDeltaAbs.X, tDeltaAbs.Y);
+                    maxDelta = Math.Max(maxDelta, tDeltaAbs.Z);
                     Real sign = 0;
                     if (Mathf.NearEqual(maxDelta, tDeltaAbs.X))
-                        sign = Mathf.Sign(_tDelta.X);
+                        sign = Math.Sign(_tDelta.X);
                     else if (Mathf.NearEqual(maxDelta, tDeltaAbs.Y))
-                        sign = Mathf.Sign(_tDelta.Y);
+                        sign = Math.Sign(_tDelta.Y);
                     else if (Mathf.NearEqual(maxDelta, tDeltaAbs.Z))
-                        sign = Mathf.Sign(_tDelta.Z);
+                        sign = Math.Sign(_tDelta.Z);
                     delta = new Vector3(maxDelta * sign);
                 }
                 else

--- a/Source/Editor/Gizmo/TransformGizmoBase.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.cs
@@ -257,11 +257,7 @@ namespace FlaxEditor.Gizmo
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
                         var maxDelta = Mathf.Max(tDeltaAbs.Y, tDeltaAbs.Z);
-                        float sign = 0;
-                        if (tDeltaAbs.Y > tDeltaAbs.Z)
-                            sign = Mathf.Sign(_tDelta.Y);
-                        else if (tDeltaAbs.Z > tDeltaAbs.Y)
-                            sign = Mathf.Sign(_tDelta.Z);
+                        float sign = Mathf.Sign(tDeltaAbs.Y > tDeltaAbs.Z ? _tDelta.Y : _tDelta.Z);
                         delta = new Vector3(0, maxDelta * sign, maxDelta * sign);
                     }
                     else
@@ -282,11 +278,7 @@ namespace FlaxEditor.Gizmo
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
                         var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Y);
-                        float sign = 0;
-                        if (tDeltaAbs.X > tDeltaAbs.Y)
-                            sign = Mathf.Sign(_tDelta.X);
-                        else if (tDeltaAbs.Y > tDeltaAbs.X)
-                            sign = Mathf.Sign(_tDelta.Y);
+                        float sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Y ? _tDelta.X : _tDelta.Y);
                         delta = new Vector3(maxDelta * sign, maxDelta * sign, 0);
                     }
                     else
@@ -307,11 +299,7 @@ namespace FlaxEditor.Gizmo
                     {
                         var tDeltaAbs = Vector3.Abs(_tDelta);
                         var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Z);
-                        float sign = 0;
-                        if (tDeltaAbs.X > tDeltaAbs.Z)
-                            sign = Mathf.Sign(_tDelta.X);
-                        else if (tDeltaAbs.Z > tDeltaAbs.X)
-                            sign = Mathf.Sign(_tDelta.Z);
+                        float sign = Mathf.Sign(tDeltaAbs.X > tDeltaAbs.Z ? _tDelta.X : _tDelta.Z);
                         delta = new Vector3(maxDelta * sign, 0, maxDelta * sign);
                     }
                     else

--- a/Source/Editor/Gizmo/TransformGizmoBase.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.cs
@@ -253,7 +253,21 @@ namespace FlaxEditor.Gizmo
                     _intersectPosition = ray.Position + ray.Direction * intersection;
                     if (_lastIntersectionPosition != Vector3.Zero)
                         _tDelta = _intersectPosition - _lastIntersectionPosition;
-                    delta = new Vector3(0, _tDelta.Y, _tDelta.Z);
+                    if (isScaling)
+                    {
+                        var tDeltaAbs = Vector3.Abs(_tDelta);
+                        var maxDelta = Mathf.Max(tDeltaAbs.Y, tDeltaAbs.Z);
+                        float sign = 0;
+                        if (tDeltaAbs.Y > tDeltaAbs.Z)
+                            sign = Mathf.Sign(_tDelta.Y);
+                        else if (tDeltaAbs.Z > tDeltaAbs.Y)
+                            sign = Mathf.Sign(_tDelta.Z);
+                        delta = new Vector3(0, maxDelta * sign, maxDelta * sign);
+                    }
+                    else
+                    {
+                        delta = new Vector3(0, _tDelta.Y, _tDelta.Z);
+                    }
                 }
                 break;
             }
@@ -264,7 +278,21 @@ namespace FlaxEditor.Gizmo
                     _intersectPosition = ray.Position + ray.Direction * intersection;
                     if (_lastIntersectionPosition != Vector3.Zero)
                         _tDelta = _intersectPosition - _lastIntersectionPosition;
-                    delta = new Vector3(_tDelta.X, _tDelta.Y, 0);
+                    if (isScaling)
+                    {
+                        var tDeltaAbs = Vector3.Abs(_tDelta);
+                        var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Y);
+                        float sign = 0;
+                        if (tDeltaAbs.X > tDeltaAbs.Y)
+                            sign = Mathf.Sign(_tDelta.X);
+                        else if (tDeltaAbs.Y > tDeltaAbs.X)
+                            sign = Mathf.Sign(_tDelta.Y);
+                        delta = new Vector3(maxDelta * sign, maxDelta * sign, 0);
+                    }
+                    else
+                    {
+                        delta = new Vector3(_tDelta.X, _tDelta.Y, 0);
+                    }
                 }
                 break;
             }
@@ -275,7 +303,21 @@ namespace FlaxEditor.Gizmo
                     _intersectPosition = ray.Position + ray.Direction * intersection;
                     if (_lastIntersectionPosition != Vector3.Zero)
                         _tDelta = _intersectPosition - _lastIntersectionPosition;
-                    delta = new Vector3(_tDelta.X, 0, _tDelta.Z);
+                    if (isScaling)
+                    {
+                        var tDeltaAbs = Vector3.Abs(_tDelta);
+                        var maxDelta = Mathf.Max(tDeltaAbs.X, tDeltaAbs.Z);
+                        float sign = 0;
+                        if (tDeltaAbs.X > tDeltaAbs.Z)
+                            sign = Mathf.Sign(_tDelta.X);
+                        else if (tDeltaAbs.Z > tDeltaAbs.X)
+                            sign = Mathf.Sign(_tDelta.Z);
+                        delta = new Vector3(maxDelta * sign, 0, maxDelta * sign);
+                    }
+                    else
+                    {
+                        delta = new Vector3(_tDelta.X, 0, _tDelta.Z);
+                    }
                 }
                 break;
             }
@@ -289,7 +331,23 @@ namespace FlaxEditor.Gizmo
                     if (_lastIntersectionPosition != Vector3.Zero)
                         _tDelta = _intersectPosition - _lastIntersectionPosition;
                 }
-                delta = _tDelta;
+                if (isScaling)
+                {
+                    var tDeltaAbs = Vector3.Abs(_tDelta);
+                    var maxDelta = Mathf.Max(new[] { tDeltaAbs.X, tDeltaAbs.Y, tDeltaAbs.Z });
+                    float sign = 0;
+                    if (Mathf.NearEqual(maxDelta, tDeltaAbs.X))
+                        sign = Mathf.Sign(_tDelta.X);
+                    else if (Mathf.NearEqual(maxDelta, tDeltaAbs.Y))
+                        sign = Mathf.Sign(_tDelta.Y);
+                    else if (Mathf.NearEqual(maxDelta, tDeltaAbs.Z))
+                        sign = Mathf.Sign(_tDelta.Z);
+                    delta = new Vector3(maxDelta * sign);
+                }
+                else
+                {
+                    delta = _tDelta;
+                }
                 break;
             }
             }


### PR DESCRIPTION
The scale gizmo will now scale the 2 axis in the same way instead of individually to bring it in line with how other engines handle this.

Before:

https://github.com/FlaxEngine/FlaxEngine/assets/71274967/2572d6d7-b98b-4647-9897-ee843de7808c

After: 

https://github.com/FlaxEngine/FlaxEngine/assets/71274967/24bd2b24-ddcc-4b54-a2a5-6ecfa876614d

