### PR TITLE
Fix issue with CharacterController initialization

### DIFF
--- a/Source/Engine/Physics/Colliders/CharacterController.cpp
+++ b/Source/Engine/Physics/Colliders/CharacterController.cpp
@@ -210,7 +210,7 @@ void CharacterController::CreateController()
 
     // Setup
     PhysicsBackend::SetControllerUpDirection(_controller, _upDirection);
-    PhysicsBackend::SetShapeLocalPose(_shape, _center, Quaternion::Identity);
+    PhysicsBackend::SetShapeLocalPose(_shape, Vector3.Zero, Quaternion::Identity);
     UpdateLayerBits();
     UpdateBounds();
 }


### PR DESCRIPTION
I've noticed for some time that the position of my CharacterController's collider was incorrect in my project, but hoped a fix for one of the existing reported bugs would also resolve my issue.  I also commented on a previous ticket, though I had identified the behavior incorrectly there. (https://github.com/FlaxEngine/FlaxEngine/issues/1935)

In a test scene, I created a series of CharacterControllers and a grid of raycsts to indicate when they were detecting collisions.

In each image attached below:
- the orange sphere identifies the CharacterController origin
- the text above each test indicates the `Center` value provided for each CharacterController
- the blue capsule indicates where the collider should be when taking the configured `Center` position into account
- the green circles indicate raycasts that detected contact

Before:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/17469837/99efe182-ef7c-42ee-95bc-e48578e111db)

After:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/17469837/02460fba-6458-4af3-b1ee-36316c485ca5)