### PR TITLE
Attempt to fix `IAssetFactory::Get()` in plugins on Linux.

### DIFF
--- a/Source/Engine/Content/Content.cpp
+++ b/Source/Engine/Content/Content.cpp
@@ -912,6 +912,8 @@ bool Content::IsAssetTypeIdInvalid(const ScriptingTypeHandle& type, const Script
     return true;
 }
 
+Dictionary<StringView, IAssetFactory*> IAssetFactory::Factories;
+
 Asset* Content::LoadAsync(const Guid& id, const ScriptingTypeHandle& type)
 {
     if (!id.IsValid())

--- a/Source/Engine/Content/Factories/IAssetFactory.h
+++ b/Source/Engine/Content/Factories/IAssetFactory.h
@@ -16,13 +16,13 @@ class FLAXENGINE_API IAssetFactory
 {
 public:
     typedef Dictionary<StringView, IAssetFactory*> Collection;
+    static Collection Factories;
 
     /// <summary>
     /// Gets the all registered assets factories. Key is asset typename, value is the factory object.
     /// </summary>
     static Collection& Get()
     {
-        static Collection Factories(1024);
         return Factories;
     }
 


### PR DESCRIPTION
Previously, on Linux, any use of `IAssetFactory::Get()` in another module, such as a plugin, created a new `Dictionary` which prevents external asset factories from being registered. This fixes that by moving `static Collection Factories;` into the class itself instead of in a function, 
and adding a `Dictionary<StringView, IAssetFactory*> IAssetFactory::Factories;` in `Content.cpp`, but maybe there is a better place for it, feel free to move it.

Currently this breaks for `CollisionData` assets, but I'm not sure why as seemingly every other data type works perfectly.