### PR TITLE
Remove ui postfx render task on canvas disable.

### DIFF
--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -843,6 +843,13 @@ namespace FlaxEngine
 
             if (_renderer)
             {
+#if FLAX_EDITOR
+                if (_editorTask != null)
+                {
+                    _editorTask.RemoveCustomPostFx(_renderer);
+                    return;
+                }
+#endif
                 SceneRenderTask.RemoveGlobalCustomPostFx(_renderer);
             }
         }


### PR DESCRIPTION
Working on something and noticed that the canvas renderer is added to customPostFx in the editor on enable, but is not removed on disable which did not seem right... so this removes it on disable.