### PR TITLE
Visual Scripting CM: Fixed no available Getter/Setter node and item for private parameters

### DIFF
--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -583,7 +583,7 @@ namespace FlaxEditor.Surface.ContextMenu
 
             // Check if surface has any parameters
             var parameters = _parametersGetter?.Invoke();
-            int count = parameters?.Count(x => x.IsPublic) ?? 0;
+            int count = parameters?.Count ?? 0;
             if (count > 0)
             {
                 // TODO: cache the allocated memory to reduce dynamic allocations
@@ -596,8 +596,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 for (int i = 0; i < parameters.Count; i++)
                 {
                     var param = parameters[i];
-                    if (!param.IsPublic)
-                        continue;
 
                     var node = (NodeArchetype)_parameterGetNodeArchetype.Clone();
                     node.Title = "Get " + param.Name;
@@ -629,10 +627,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 archetypeIndex = 0;
                 for (int i = 0; i < parameters.Count; i++)
                 {
-                    var param = parameters[i];
-                    if (!param.IsPublic)
-                        continue;
-
                     var item = new VisjectCMItem(group, groupArchetype, archetypes[archetypeIndex++])
                     {
                         Parent = group

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -592,26 +592,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 var archetypes = new NodeArchetype[count];
                 int archetypeIndex = 0;
 
-                // ReSharper disable once PossibleNullReferenceException
-                for (int i = 0; i < parameters.Count; i++)
-                {
-                    var param = parameters[i];
-
-                    var node = (NodeArchetype)_parameterGetNodeArchetype.Clone();
-                    node.Title = "Get " + param.Name;
-                    node.DefaultValues[0] = param.ID;
-                    archetypes[archetypeIndex++] = node;
-
-                    if (_parameterSetNodeArchetype != null)
-                    {
-                        node = (NodeArchetype)_parameterSetNodeArchetype.Clone();
-                        node.Title = "Set " + param.Name;
-                        node.DefaultValues[0] = param.ID;
-                        node.DefaultValues[1] = TypeUtils.GetDefaultValue(param.Type);
-                        archetypes[archetypeIndex++] = node;
-                    }
-                }
-
                 var groupArchetype = new GroupArchetype
                 {
                     GroupID = 6,
@@ -624,22 +604,39 @@ namespace FlaxEditor.Surface.ContextMenu
                 group.ArrowImageOpened = new SpriteBrush(Style.Current.ArrowDown);
                 group.ArrowImageClosed = new SpriteBrush(Style.Current.ArrowRight);
                 group.Close(false);
-                archetypeIndex = 0;
+
+                // ReSharper disable once PossibleNullReferenceException
                 for (int i = 0; i < parameters.Count; i++)
                 {
-                    var item = new VisjectCMItem(group, groupArchetype, archetypes[archetypeIndex++])
+                    var param = parameters[i];
+
+                    // Define Getter node and create CM item
+                    var node = (NodeArchetype)_parameterGetNodeArchetype.Clone();
+                    node.Title = "Get " + param.Name;
+                    node.DefaultValues[0] = param.ID;
+                    archetypes[archetypeIndex++] = node;
+
+                    var item = new VisjectCMItem(group, groupArchetype, node)
                     {
                         Parent = group
                     };
 
+                    // Define Setter node and create CM item if parameter has a setter
                     if (_parameterSetNodeArchetype != null)
                     {
-                        item = new VisjectCMItem(group, groupArchetype, archetypes[archetypeIndex++])
+                        node = (NodeArchetype)_parameterSetNodeArchetype.Clone();
+                        node.Title = "Set " + param.Name;
+                        node.DefaultValues[0] = param.ID;
+                        node.DefaultValues[1] = TypeUtils.GetDefaultValue(param.Type);
+                        archetypes[archetypeIndex++] = node;
+
+                        item = new VisjectCMItem(group, groupArchetype, node)
                         {
                             Parent = group
                         };
                     }
                 }
+
                 group.SortChildren();
                 group.UnlockChildrenRecursive();
                 group.Parent = _groupsPanel;


### PR DESCRIPTION
When making a visual scripting parameter private, it no longer can be accessed by the visual script via getters/setters, atleast that is what it looks like. It turns out that the context menu filters out private parameters, so i removed that.
I checked if other VS can now access the private parameters after removing the filters. No they cannot (see after gif). 
So it looks fixed to me :)

Fixes #2231 

**Note**

- Only my first commit really fixes the problem. It basically just removes the param.IsPublic checks.
- My second commit refactors the whole 'UpdateSurfaceParametersGroup' method a bit, basically removing the unnecessary second for loop. So if the refactoring is not wanted only the first commit can be used.

Before:
![BeforePrivateParamFix](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/c7570672-88cf-42d4-975d-d0caabdf91eb)

After:
![AfterPrivateParamFix](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/ea029408-0051-4775-8a31-88cfda686251)
