### PR TITLE
vertex snapping refactor corrections

### DIFF
--- a/Source/Editor/Gizmo/TransformGizmo.cs
+++ b/Source/Editor/Gizmo/TransformGizmo.cs
@@ -263,6 +263,8 @@ namespace FlaxEditor.Gizmo
             // Note: because selection may contain objects and their children we have to split them and get only parents.
             // Later during transformation we apply translation/scale/rotation only on them (children inherit transformations)
             SceneGraphTools.BuildNodesParents(_selection, _selectionParents);
+
+            base.OnSelectionChanged(newSelection);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
+++ b/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
@@ -23,20 +23,23 @@ namespace FlaxEditor.SceneGraph.Actors
         : base(actor)
         {
         }
+        
 
         /// <inheritdoc />
-        public override bool OnVertexSnap(ref Vector3 point, out Vector3 result)
+        public override bool OnVertexSnap(ref Ray ray, float hitDistance, out Vector3 result)
         {
-            result = point;
+            // Find the closest vertex to bounding box point (collision detection approximation)
+
+            result = ray.GetPoint(hitDistance);
             var model = ((StaticModel)Actor).Model;
             if (model && !model.WaitForLoaded())
             {
                 // TODO: move to C++ and use cached vertex buffer internally inside the Mesh
                 if (_vertices == null)
                     _vertices = new();
-                var pointLocal = (Float3)Actor.Transform.WorldToLocal(point);
+                var pointLocal = (Float3)Actor.Transform.WorldToLocal(result);
                 var minDistance = float.MaxValue;
-                foreach (var lod in model.LODs)
+                foreach (var lod in model.LODs) //[ToDo] fix it [Nori_SC note] this is wrong it should get current lod level going it throw all lods will create ghost snaping points
                 {
                     var hit = false;
                     foreach (var mesh in lod.Meshes)

--- a/Source/Editor/SceneGraph/SceneGraphNode.cs
+++ b/Source/Editor/SceneGraph/SceneGraphNode.cs
@@ -95,18 +95,6 @@ namespace FlaxEditor.SceneGraph
         public virtual bool CanTransform => true;
 
         /// <summary>
-        /// Gets a value indicating whether this node can be used for the vertex snapping feature.
-        /// </summary>
-        public bool CanVertexSnap
-        {
-            get
-            {
-                var v = Vector3.Zero;
-                return OnVertexSnap(ref v, out _);
-            }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether this <see cref="SceneGraphNode"/> is active.
         /// </summary>
         public abstract bool IsActive { get; }
@@ -365,14 +353,15 @@ namespace FlaxEditor.SceneGraph
         }
 
         /// <summary>
-        /// Performs the vertex snapping of a given point on the object surface that is closest to a given location.
+        /// Performs the vertex snapping for a given ray and hitDistance.
         /// </summary>
-        /// <param name="point">The position to snap.</param>
+        /// <param name="ray">Raycasted ray</param>
+        /// <param name="hitDistance">Hit distance from ray to object bounding box</param>
         /// <param name="result">The result point on the object mesh that is closest to the specified location.</param>
         /// <returns>True if got a valid result value, otherwise false (eg. if missing data or not initialized).</returns>
-        public virtual bool OnVertexSnap(ref Vector3 point, out Vector3 result)
+        public virtual bool OnVertexSnap(ref Ray ray,float hitDistance, out Vector3 result) // [NoriSC note] ray and hit Distance will be needed for a future use, in mesh types for proper collision detection
         {
-            result = point;
+            result = Vector3.Zero;
             return false;
         }
 


### PR DESCRIPTION
fixed selecting other object the selected transform tool was staying in the same place

removed
public bool CanVertexSnap was calling too many times to heavy function (wrong implementacion)

removed `Find the closest object in selection (in case ray didn't hit anything)`
part because it is an edge case and has weird behavior with selection

move comment to correct place 
changed some stuff for a future
added to do in [StaticModelNode.cs](https://github.com/FlaxEngine/FlaxEngine/pull/2299/files#diff-e4f80873cfa59fec67cdaf216e3f9d844ff60b5c6c5f259eefb484e8fa13d87c) because it will cause the problem if is not fixed at some point