### PR TITLE
Fix transform when re-parenting actor.

### DIFF
--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -170,7 +170,7 @@ namespace FlaxEditor.Windows
             if (parentActor != null)
             {
                 // Use the same location
-                actor.Transform = parentActor.Transform;
+                actor.LocalTransform = Transform.Identity;
 
                 // Rename actor to identify it easily
                 actor.Name = Utilities.Utils.IncrementNameNumber(type.Name, x => parentActor.GetChild(x) == null);

--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -317,12 +317,7 @@ void Actor::SetParent(Actor* value, bool worldPositionsStays, bool canBreakPrefa
 
     // Update the transform
     if (worldPositionsStays)
-    {
-        if (_parent)
-            _parent->_transform.WorldToLocal(prevTransform, _localTransform);
-        else
-            _localTransform = prevTransform;
-    }
+        _transform = prevTransform;
 
     // Fire events
     OnParentChanged();


### PR DESCRIPTION
Fix #2297 . Not sure if this causes other problems in different areas of the engine, but it does fix the issue... it seems like the code was trying to keep the exact world transform and not keep the local transform. it seems unintuitive to me and I would expect the code to keep the local transform when reparenting which is what this PR does. The issue did not seem to say what the desired outcome would be, so this would be my desired outcome. But it is interesting because Unity does something similar to the original code, so maybe I just want something different...