### PR TITLE
Fix `PhysicsScene` change not working in physics actors

### DIFF
--- a/Source/Engine/Physics/Actors/RigidBody.cpp
+++ b/Source/Engine/Physics/Actors/RigidBody.cpp
@@ -569,7 +569,7 @@ void RigidBody::OnTransformChanged()
 
 void RigidBody::OnPhysicsSceneChanged(PhysicsScene* previous)
 {
-    PhysicsBackend::RemoveSceneActor(previous->GetPhysicsScene(), _actor);
+    PhysicsBackend::RemoveSceneActor(previous->GetPhysicsScene(), _actor, true);
     void* scene = GetPhysicsScene()->GetPhysicsScene();
     PhysicsBackend::AddSceneActor(scene, _actor);
     const bool putToSleep = !_startAwake && GetEnableSimulation() && !GetIsKinematic() && IsActiveInHierarchy();

--- a/Source/Engine/Physics/Colliders/Collider.cpp
+++ b/Source/Engine/Physics/Colliders/Collider.cpp
@@ -438,7 +438,7 @@ void Collider::OnPhysicsSceneChanged(PhysicsScene* previous)
 
     if (_staticActor != nullptr)
     {
-        PhysicsBackend::RemoveSceneActor(previous->GetPhysicsScene(), _staticActor);
+        PhysicsBackend::RemoveSceneActor(previous->GetPhysicsScene(), _staticActor, true);
         void* scene = GetPhysicsScene()->GetPhysicsScene();
         PhysicsBackend::AddSceneActor(scene, _staticActor);
     }

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -1998,11 +1998,14 @@ void PhysicsBackend::AddSceneActor(void* scene, void* actor)
     FlushLocker.Unlock();
 }
 
-void PhysicsBackend::RemoveSceneActor(void* scene, void* actor)
+void PhysicsBackend::RemoveSceneActor(void* scene, void* actor, bool immediately)
 {
     auto scenePhysX = (ScenePhysX*)scene;
     FlushLocker.Lock();
-    scenePhysX->RemoveActors.Add((PxActor*)actor);
+    if (immediately)
+        scenePhysX->Scene->removeActor(*(PxActor*)actor);
+    else
+        scenePhysX->RemoveActors.Add((PxActor*)actor);
     FlushLocker.Unlock();
 }
 

--- a/Source/Engine/Physics/PhysicsBackend.h
+++ b/Source/Engine/Physics/PhysicsBackend.h
@@ -113,7 +113,7 @@ public:
     static void SetSceneBounceThresholdVelocity(void* scene, float value);
     static void SetSceneOrigin(void* scene, const Vector3& oldOrigin, const Vector3& newOrigin);
     static void AddSceneActor(void* scene, void* actor);
-    static void RemoveSceneActor(void* scene, void* actor);
+    static void RemoveSceneActor(void* scene, void* actor, bool immediately = false);
     static void AddSceneActorAction(void* scene, void* actor, ActionType action);
 #if COMPILE_WITH_PROFILER
     static void GetSceneStatistics(void* scene, PhysicsStatistics& result);

--- a/Source/Engine/Physics/PhysicsBackendEmpty.cpp
+++ b/Source/Engine/Physics/PhysicsBackendEmpty.cpp
@@ -115,7 +115,7 @@ void PhysicsBackend::AddSceneActor(void* scene, void* actor)
 {
 }
 
-void PhysicsBackend::RemoveSceneActor(void* scene, void* actor)
+void PhysicsBackend::RemoveSceneActor(void* scene, void* actor, bool immediately)
 {
 }
 

--- a/Source/Engine/Terrain/TerrainPatch.cpp
+++ b/Source/Engine/Terrain/TerrainPatch.cpp
@@ -2580,7 +2580,7 @@ void TerrainPatch::Deserialize(DeserializeStream& stream, ISerializeModifier* mo
 
 void TerrainPatch::OnPhysicsSceneChanged(PhysicsScene* previous)
 {
-    PhysicsBackend::RemoveSceneActor(previous->GetPhysicsScene(), _physicsActor);
+    PhysicsBackend::RemoveSceneActor(previous->GetPhysicsScene(), _physicsActor, true);
     void* scene = _terrain->GetPhysicsScene()->GetPhysicsScene();
     PhysicsBackend::AddSceneActor(scene, _physicsActor);
 }


### PR DESCRIPTION
The change fails due to actor removal being batched and PhysX backend expecting the actor to not belong any scenes at the moment of the change request. 