### PR TITLE
replaced cheeks with generic message found a way to hard crash the engine (Actor.cpp)

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -26,6 +26,8 @@
 #include "Engine/Serialization/MemoryReadStream.h"
 #include "Engine/Serialization/MemoryWriteStream.h"
 
+#include "Engine/Debug/DebugLog.h"
+
 #if USE_EDITOR
 #include "Editor/Editor.h"
 #define CHECK_EXECUTE_IN_EDITOR if (Editor::IsPlayMode || script->_executeInEditor)
@@ -614,7 +616,21 @@ void Actor::SetStaticFlags(StaticFlags value)
 
 void Actor::SetTransform(const Transform& value)
 {
-    CHECK(!value.IsNanOrInfinity());
+    if (value.IsNanOrInfinity() || Math::NearEqual(value.Orientation.W, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.Orientation.X, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.Orientation.Y, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.Orientation.Z, ACTOR_ORIENTATION_EPSILON))
+    {
+        LOG(Error,
+                        "Invalid Transform Component('s) passed to Actor::SetTransform"
+            "\n"        "Value's:"
+            "\n""\t"    "Translation:{0}"
+            "\n""\t"    "Orientation:{1}"
+            "\n""\t"    "Scale:{2}"
+            "\n"        
+            "\n"        "StackTrace:"
+            "\n"        "{3}",
+            value.Translation, value.Orientation, value.Scale, DebugLog::GetStackTrace());
+        return;
+    }
+
     if (!(Vector3::NearEqual(_transform.Translation, value.Translation) && Quaternion::NearEqual(_transform.Orientation, value.Orientation, ACTOR_ORIENTATION_EPSILON) && Float3::NearEqual(_transform.Scale, value.Scale)))
     {
         if (_parent)
@@ -640,7 +656,19 @@ void Actor::SetPosition(const Vector3& value)
 
 void Actor::SetOrientation(const Quaternion& value)
 {
-    CHECK(!value.IsNanOrInfinity());
+    if (value.IsNanOrInfinity() || Math::NearEqual(value.W, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.X, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.Y, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.Z, ACTOR_ORIENTATION_EPSILON))
+    {
+        LOG(Error,
+                        "Invalid Quaternion passed to Actor::SetOrientation"
+            "\n"        "Value:"
+            "\n""\t"    "{0}"
+            "\n"        
+            "\n"        "StackTrace:"
+            "\n"        "{2}",
+            value, DebugLog::GetStackTrace());
+        return;
+    }
+
     if (!Quaternion::NearEqual(_transform.Orientation, value, ACTOR_ORIENTATION_EPSILON))
     {
         if (_parent)

--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -664,7 +664,7 @@ void Actor::SetOrientation(const Quaternion& value)
             "\n""\t"    "{0}"
             "\n"        
             "\n"        "StackTrace:"
-            "\n"        "{2}",
+            "\n"        "{1}",
             value, DebugLog::GetStackTrace());
         return;
     }


### PR DESCRIPTION
Passing Quaterion
x 0
y 0
z 0
w -0
creates nan or inf in internal code and hard crashes the editor 
cheeks has been replaced with generic massage with will catch nan or inf and if all quaternion components are neer zero

Efected funcions:
**SetTransfom**
**SetOrientation**
massange given to user

SetTransfom:
```cs
[ 00:00:33.913 ]: [Error] Invalid Transform Component('s) passed to Actor::SetTransform
Value's:
	Translation:X:-42.768875 Y:60 Z:-830.78723
	Orientation:X:0 Y:0 Z:0 W:-0
	Scale:X:1 Y:1 Z:1

StackTrace:
 ...
 ```
 
 SetOrientation:
 ```cs
[ 00:00:21.672 ]: [Error] Invalid Quaternion passed to Actor::SetOrientation
Value:
	X:0 Y:0 Z:0 W:-0

StackTrace:
 ...
```
alternative is to use "Check" but it creates this message with is hard to read
```
Expression: !(value.IsNanOrInfinity() || Math::NearEqual(value.W, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.X, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.Y, ACTOR_ORIENTATION_EPSILON) && Math::NearEqual(value.Z, ACTOR_ORIENTATION_EPSILON))
```
[edit] the Quaternion::NearEqual is not detecting it, so is not used