### PR TITLE
Clamp location of multiblend data to fix last animation edge case.

### DIFF
--- a/Source/Editor/Surface/Archetypes/Animation.MultiBlend.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.MultiBlend.cs
@@ -617,8 +617,9 @@ namespace FlaxEditor.Surface.Archetypes
                 public override void SetLocation(int index, Float2 location)
                 {
                     var dataA = (Float4)_node.Values[4 + index * 2];
+                    var ranges = (Float4)_node.Values[0];
 
-                    dataA.X = location.X;
+                    dataA.X = Mathf.Clamp(location.X, ranges.X, ranges.Y);
 
                     _node.Values[4 + index * 2] = dataA;
                     _node.Surface.MarkAsEdited();
@@ -750,9 +751,10 @@ namespace FlaxEditor.Surface.Archetypes
                 public override void SetLocation(int index, Float2 location)
                 {
                     var dataA = (Float4)_node.Values[4 + index * 2];
+                    var ranges = (Float4)_node.Values[0];
 
-                    dataA.X = location.X;
-                    dataA.Y = location.Y;
+                    dataA.X = Mathf.Clamp(location.X, ranges.X, ranges.Y);
+                    dataA.Y = Mathf.Clamp(location.Y, ranges.Z, ranges.W);
 
                     _node.Values[4 + index * 2] = dataA;
                     _node.Surface.MarkAsEdited();


### PR DESCRIPTION
There was an issue of the edge case of the bAnim of a multiblend node to not trigger because the x value could be larger than the point because it could be "dragged" further which increased the value (even without moving the ui). This fixes that issue.