### PR TITLE
Remove import UI on Animation not created by an import.

### DIFF
--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -186,6 +186,10 @@ namespace FlaxEditor.Windows.Assets
 
                     base.Initialize(layout);
 
+                    // Ignore import settings GUI if the type is not animation. This removes the import UI if the animation asset was not created using an import.
+                    if (proxy.ImportSettings.Settings.Type != FlaxEngine.Tools.ModelTool.ModelType.Animation)
+                        return;
+
                     // Import Settings
                     {
                         var group = layout.Group("Import Settings");


### PR DESCRIPTION
There is most likely a better way to do this, but because animations keep the type of Animation when they are imported and an animation created form the content menu does not, this way seems to work well.