### PR TITLE
LODIndexFence

### DIFF
--- a/Source/Engine/Content/Assets/Model.cpp
+++ b/Source/Engine/Content/Assets/Model.cpp
@@ -782,7 +782,7 @@ Check_Again:
         else
         {
             int i = 0;
-            LOG_STR(Warning, TEXT("Can't get LOD Model is not initialized awaiting..."));
+            LOG_STR(Warning, TEXT("Can't get Model LODs, Model is not initialized yet. awaiting..."));
             while (!IsInitialized()) //Wait for a model
             {
                 Platform::Sleep(1);

--- a/Source/Engine/Content/Assets/Model.cpp
+++ b/Source/Engine/Content/Assets/Model.cpp
@@ -781,18 +781,40 @@ Check_Again:
         }
         else
         {
+            
             int i = 0;
             LOG_STR(Warning, TEXT("Can't get Model LODs, Model is not initialized yet. awaiting..."));
-            while (!IsInitialized()) //Wait for a model
+            const double startTime = Platform::GetTimeSeconds();
+            if (!WaitForLoaded())
             {
-                Platform::Sleep(1);
-                i++;
-                if (i == 1000) {//give it 1000 try's
-                    LOG(Error, "Timeout Model is now initialized in expected time of 1000ms ""\nStackTrace:\n{ 0 }", DebugLog::GetStackTrace());
+                auto timespan = (Platform::GetTimeSeconds() - startTime);
+
+                
+                //{ToDo] move this to StringUtils:: ? and do somfing like const String& StringUtils::TimeFrom(double timespan) with will return {0}{1}
+                // or replace it with existing funcion with is doing the same think 
+                {
+                    //conver it to s,ms,μs,ns
+                    String v = String("s");
+                    if (timespan < 1.0) // ms 1 / 1 000
+                    {
+                        timespan *= 1000;
+                        v = "ms";
+                        if (timespan < 1.0) // μs 1 / 1 000 000
+                        {
+                            timespan *= 1000;
+                            v = "μs";
+                            if (timespan < 1.0) // ns  1 / 1 000 000 000
+                            {
+                                timespan *= 1000;
+                                v = "ns";
+                            }
+                        }
+                    }
+                    timespan = Math::RoundToInt(timespan);
+                    LOG(Info, "Model is now initialized... took ~{0}{1}", timespan, v);
                 }
+                goto Check_Again; // in case the lodIndex is invalid any way
             }
-            LOG(Info, "Model is now initialized... took ~{0}ms", i);
-            goto Check_Again; // in case the lodIndex is invalid any way
         }
     }
 

--- a/Source/Engine/Content/Assets/Model.cpp
+++ b/Source/Engine/Content/Assets/Model.cpp
@@ -776,18 +776,18 @@ Check_Again:
     {
         if (IsInitialized())
         {
-            LOG_STR(Error, L"Invalid LOD index"); // [TODO] it misght be use full to incude a stack trace in this place
+            LOG_STR(Error, TEXT("Invalid LOD index")); // [TODO] it misght be use full to incude a stack trace in this place
         }
         else
         {
             int i = 0;
-            LOG_STR(Warning, L"Can't get LOD Model is not initialized awaiting...");
+            LOG_STR(Warning, TEXT("Can't get LOD Model is not initialized awaiting..."));
             while (!IsInitialized()) //Wait for a model
             {
                 Platform::Sleep(1);
                 i++;
                 if (i == 1000) {//give it 1000 try's
-                    LOG_STR(Error, L"Timeout Model is now initialized in expected time of 1000ms");
+                    LOG_STR(Error, TEXT("Timeout Model is now initialized in expected time of 1000ms"));
                 }
             }
             LOG(Info, "Model is now initialized... took ~{0}ms", i);

--- a/Source/Engine/Content/Assets/Model.cpp
+++ b/Source/Engine/Content/Assets/Model.cpp
@@ -8,6 +8,7 @@
 #include "Engine/Content/Upgraders/ModelAssetUpgrader.h"
 #include "Engine/Content/Factories/BinaryAssetFactory.h"
 #include "Engine/Debug/DebugDraw.h"
+#include "Engine/Debug/DebugLog.h"
 #include "Engine/Graphics/RenderTools.h"
 #include "Engine/Graphics/RenderTask.h"
 #include "Engine/Graphics/Models/ModelInstanceEntry.h"
@@ -776,7 +777,7 @@ Check_Again:
     {
         if (IsInitialized())
         {
-            LOG_STR(Error, TEXT("Invalid LOD index")); // [TODO] it misght be use full to incude a stack trace in this place
+            LOG(Error, "Invalid LOD index ""\nStackTrace:\n{0}", DebugLog::GetStackTrace());
         }
         else
         {
@@ -787,7 +788,7 @@ Check_Again:
                 Platform::Sleep(1);
                 i++;
                 if (i == 1000) {//give it 1000 try's
-                    LOG_STR(Error, TEXT("Timeout Model is now initialized in expected time of 1000ms"));
+                    LOG(Error, "Timeout Model is now initialized in expected time of 1000ms ""\nStackTrace:\n{ 0 }", DebugLog::GetStackTrace());
                 }
             }
             LOG(Info, "Model is now initialized... took ~{0}ms", i);

--- a/Source/Engine/Content/Assets/Model.h
+++ b/Source/Engine/Content/Assets/Model.h
@@ -150,10 +150,7 @@ public:
     /// <param name="transform">The instance transformation.</param>
     /// <param name="lodIndex">The Level Of Detail index.</param>
     /// <returns>The bounding box.</returns>
-    API_FUNCTION() BoundingBox GetBox(const Transform& transform, int32 lodIndex = 0) const
-    {
-        return LODs[lodIndex].GetBox(transform);
-    }
+    API_FUNCTION() BoundingBox GetBox(const Transform& transform, int32 lodIndex = 0) const;
 
     /// <summary>
     /// Gets the model bounding box in local space.
@@ -242,6 +239,13 @@ private:
     /// <param name="meshesCountPerLod">The meshes count per lod array (amount of meshes per LOD).</param>
     /// <returns>True if failed, otherwise false.</returns>
     bool Init(const Span<int32>& meshesCountPerLod);
+
+    /// <summary>
+    /// Cheaks the LODIndex if is valid and if object is not ready for use it will wait maximum 1000ms
+    /// </summary>
+    /// <param name="lodIndex">The Level Of Detail index.</param>
+    /// <returns>if index valid.</returns>
+    bool LODIndexFence(int32 lodIndex) const;
 
 public:
     // [ModelBase]


### PR DESCRIPTION
fixes 2 cases
case 1 index was invalid
case 2 model was not ready for use
this this case the code with wait it will print a information about this
```
[ 00:00:26.749 ]: [Warning] Can't get Model LODs, Model is not initialized yet. awaiting...
[ 00:00:26.751 ]: [Info] Model is now initialized... took ~1ms
```
it not always triggered looks like it is something to do with async loading of the asset its 90% time triggering when model is first loaded and is not existing the the scene

awaiting time is dependent on model complexity