### PR TITLE
Allow multiple collision actors to be created from context menu.

### DIFF
--- a/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
+++ b/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
@@ -89,71 +89,87 @@ namespace FlaxEditor.SceneGraph.Actors
 
         private void OnAddMeshCollider()
         {
-            var model = ((StaticModel)Actor).Model;
-            if (!model)
-                return;
+            // Allow collider to be added to evey static model selection
+            var selection = Editor.Instance.SceneEditing.Selection.ToArray();
+            var createdNodes = new List<SceneGraphNode>();
+            foreach (var node in selection)
+            {
+                if (node is not StaticModelNode staticModelNode)
+                    continue;
 
-            // Special case for in-built Editor models that can use analytical collision
-            var modelPath = model.Path;
-            if (modelPath.EndsWith("/Primitives/Cube.flax", StringComparison.Ordinal))
-            {
-                var actor = new BoxCollider
-                {
-                    StaticFlags = Actor.StaticFlags,
-                    Transform = Actor.Transform,
-                };
-                Root.Spawn(actor, Actor);
-                return;
-            }
-            if (modelPath.EndsWith("/Primitives/Sphere.flax", StringComparison.Ordinal))
-            {
-                var actor = new SphereCollider
-                {
-                    StaticFlags = Actor.StaticFlags,
-                    Transform = Actor.Transform,
-                };
-                Root.Spawn(actor, Actor);
-                return;
-            }
-            if (modelPath.EndsWith("/Primitives/Plane.flax", StringComparison.Ordinal))
-            {
-                var actor = new BoxCollider
-                {
-                    StaticFlags = Actor.StaticFlags,
-                    Transform = Actor.Transform,
-                    Size = new Float3(100.0f, 100.0f, 1.0f),
-                };
-                Root.Spawn(actor, Actor);
-                return;
-            }
-            if (modelPath.EndsWith("/Primitives/Capsule.flax", StringComparison.Ordinal))
-            {
-                var actor = new CapsuleCollider
-                {
-                    StaticFlags = Actor.StaticFlags,
-                    Transform = Actor.Transform,
-                    Radius = 25.0f,
-                    Height = 50.0f,
-                };
-                Editor.Instance.SceneEditing.Spawn(actor, Actor);
-                actor.LocalPosition = new Vector3(0, 50.0f, 0);
-                actor.LocalOrientation = Quaternion.Euler(0, 0, 90.0f);
-                return;
-            }
+                var model = ((StaticModel)staticModelNode.Actor).Model;
+                if (!model)
+                    continue;
 
-            // Create collision data (or reuse) and add collision actor
-            Action<CollisionData> created = collisionData =>
-            {
-                var actor = new MeshCollider
+                // Special case for in-built Editor models that can use analytical collision
+                var modelPath = model.Path;
+                if (modelPath.EndsWith("/Primitives/Cube.flax", StringComparison.Ordinal))
                 {
-                    StaticFlags = Actor.StaticFlags,
-                    Transform = Actor.Transform,
-                    CollisionData = collisionData,
+                    var actor = new BoxCollider
+                    {
+                        StaticFlags = staticModelNode.Actor.StaticFlags,
+                        Transform = staticModelNode.Actor.Transform,
+                    };
+                    staticModelNode.Root.Spawn(actor, staticModelNode.Actor);
+                    createdNodes.Add(Editor.Instance.Scene.GetActorNode(actor));
+                    continue;
+                }
+                if (modelPath.EndsWith("/Primitives/Sphere.flax", StringComparison.Ordinal))
+                {
+                    var actor = new SphereCollider
+                    {
+                        StaticFlags = staticModelNode.Actor.StaticFlags,
+                        Transform = staticModelNode.Actor.Transform,
+                    };
+                    staticModelNode.Root.Spawn(actor, staticModelNode.Actor);
+                    createdNodes.Add(Editor.Instance.Scene.GetActorNode(actor));
+                    continue;
+                }
+                if (modelPath.EndsWith("/Primitives/Plane.flax", StringComparison.Ordinal))
+                {
+                    var actor = new BoxCollider
+                    {
+                        StaticFlags = staticModelNode.Actor.StaticFlags,
+                        Transform = staticModelNode.Actor.Transform,
+                        Size = new Float3(100.0f, 100.0f, 1.0f),
+                    };
+                    staticModelNode.Root.Spawn(actor, staticModelNode.Actor);
+                    createdNodes.Add(Editor.Instance.Scene.GetActorNode(actor));
+                    continue;
+                }
+                if (modelPath.EndsWith("/Primitives/Capsule.flax", StringComparison.Ordinal))
+                {
+                    var actor = new CapsuleCollider
+                    {
+                        StaticFlags = staticModelNode.Actor.StaticFlags,
+                        Transform = staticModelNode.Actor.Transform,
+                        Radius = 25.0f,
+                        Height = 50.0f,
+                    };
+                    Editor.Instance.SceneEditing.Spawn(actor, staticModelNode.Actor);
+                    actor.LocalPosition = new Vector3(0, 50.0f, 0);
+                    actor.LocalOrientation = Quaternion.Euler(0, 0, 90.0f);
+                    createdNodes.Add(Editor.Instance.Scene.GetActorNode(actor));
+                    continue;
+                }
+
+                // Create collision data (or reuse) and add collision actor
+                Action<CollisionData> created = collisionData =>
+                {
+                    var actor = new MeshCollider
+                    {
+                        StaticFlags = staticModelNode.Actor.StaticFlags,
+                        Transform = staticModelNode.Actor.Transform,
+                        CollisionData = collisionData,
+                    };
+                    staticModelNode.Root.Spawn(actor, staticModelNode.Actor);
+                    createdNodes.Add(Editor.Instance.Scene.GetActorNode(actor));
                 };
-                Root.Spawn(actor, Actor);
-            };
-            var collisionDataProxy = (CollisionDataProxy)Editor.Instance.ContentDatabase.GetProxy<CollisionData>();
-            collisionDataProxy.CreateCollisionDataFromModel(model, created);
+                var collisionDataProxy = (CollisionDataProxy)Editor.Instance.ContentDatabase.GetProxy<CollisionData>();
+                collisionDataProxy.CreateCollisionDataFromModel(model, created);
+            }
+            // Select all created nodes
+            Editor.Instance.SceneEditing.Select(createdNodes);
         }
     }
 }


### PR DESCRIPTION
A nice QoL addition that allows for multiple collision actors to be created if multiple staticmodels are selected and the context menu is used to add colliders.