### PR TITLE
Prevent creating new project into non-empty folder

### DIFF
--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -406,11 +406,26 @@ int32 Editor::LoadProduct()
     if (CommandLine::Options.NewProject)
     {
         Array<String> projectFiles;
-        FileSystem::DirectoryGetFiles(projectFiles, projectPath, TEXT("*"), DirectorySearchOption::TopDirectoryOnly);
-        if (projectFiles.Count() > 0)
+        FileSystem::DirectoryGetFiles(projectFiles, projectPath, TEXT("*.flaxproj"), DirectorySearchOption::TopDirectoryOnly);
+        if (projectFiles.Count() > 1)
         {
-            Platform::Fatal(String::Format(TEXT("Target project folder '{0}' is not empty."), projectPath));
-            return -1;
+            Platform::Fatal(TEXT("Too many project files."));
+            return -2;
+        }
+        else if (projectFiles.Count() == 1)
+        {
+            LOG(Info, "Skip creating new project because it already exists");
+            CommandLine::Options.NewProject.Reset();
+        }
+        else
+        {
+            Array<String> files;
+            FileSystem::DirectoryGetFiles(files, projectPath, TEXT("*"), DirectorySearchOption::TopDirectoryOnly);
+            if (files.Count() > 0)
+            {
+                Platform::Fatal(String::Format(TEXT("Target project folder '{0}' is not empty."), projectPath));
+                return -1;
+            }
         }
     }
     if (CommandLine::Options.NewProject)

--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -406,12 +406,11 @@ int32 Editor::LoadProduct()
     if (CommandLine::Options.NewProject)
     {
         Array<String> projectFiles;
-        FileSystem::DirectoryGetFiles(projectFiles, projectPath, TEXT("*.flaxproj"), DirectorySearchOption::TopDirectoryOnly);
-        if (projectFiles.Count() == 1)
+        FileSystem::DirectoryGetFiles(projectFiles, projectPath, TEXT("*"), DirectorySearchOption::TopDirectoryOnly);
+        if (projectFiles.Count() > 0)
         {
-            // Skip creating new project if it already exists
-            LOG(Info, "Skip creatinng new project because it already exists");
-            CommandLine::Options.NewProject.Reset();
+            Platform::Fatal(String::Format(TEXT("Target project folder '{0}' is not empty."), projectPath));
+            return -1;
         }
     }
     if (CommandLine::Options.NewProject)

--- a/Source/Engine/Platform/Win32/Win32FileSystem.h
+++ b/Source/Engine/Platform/Win32/Win32FileSystem.h
@@ -16,12 +16,12 @@ class FLAXENGINE_API Win32FileSystem : public FileSystemBase
 public:
 
     // Creates a new directory
-    // @param path Drectory path
+    // @param path Directory path
     // @returns True if cannot create directory, otherwise false
     static bool CreateDirectory(const StringView& path);
 
     // Deletes an existing directory
-    // @param path Drectory path
+    // @param path Directory path
     // @param deleteSubdirectories True if delete all subdirectories and files, otherwise false
     // @returns True if cannot delete directory, otherwise false
     static bool DeleteDirectory(const String& path, bool deleteContents = true);
@@ -32,15 +32,15 @@ public:
     static bool DirectoryExists(const StringView& path);
 
     // Finds the names of files (including their paths) that match the specified search pattern in the specified directory, using a value to determine whether to search subdirectories
-    // @param results When this metod completes, this list contains list of all filenames that match the specified search pattern
+    // @param results When this method completes, this list contains list of all filenames that match the specified search pattern
     // @param path Path of the directory to search in it
-    // @param searchPattern Custo msearch pattern to use during that operation
-    // @param option Addidtional search options
+    // @param searchPattern Custom search pattern to use during that operation
+    // @param option Additional search options
     // @returns True if an error occurred, otherwise false
     static bool DirectoryGetFiles(Array<String, HeapAllocation>& results, const String& path, const Char* searchPattern, DirectorySearchOption option = DirectorySearchOption::AllDirectories);
 
     // Finds the names of directories (including their paths) that are inside the specified directory
-    // @param results When this metod completes, this list contains list of all filenames that match the specified search pattern
+    // @param results When this method completes, this list contains list of all filenames that match the specified search pattern
     // @param directory Path of the directory to search in it
     // @returns True if an error occurred, otherwise false
     static bool GetChildDirectories(Array<String, HeapAllocation>& results, const String& directory);


### PR DESCRIPTION
Error is now thrown if the new project folder is not empty. This prevents a case where user tries to create project following way: `FlaxEditor -new <path_to_project_folder>`

The command is interpret as `FlaxEditor -new` because project path is expected to be specified with `-project <path_to_project_folder>` in addition to the `-new` switch, and the project is thus accidentally created on the current working directory.