### PR TITLE
Patch numpad enter to normal enter on Linux

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxPlatform.cpp
+++ b/Source/Engine/Platform/Linux/LinuxPlatform.cpp
@@ -2253,6 +2253,9 @@ bool LinuxPlatform::Init()
 		}
 	}
 
+	//Patch in numpad enter to normal enter, just like on windows.
+	KeyCodeMap[104] = KeyboardKeys::Return;
+
     Input::Mouse = Impl::Mouse = New<LinuxMouse>();
     Input::Keyboard = Impl::Keyboard = New<LinuxKeyboard>();
 	LinuxInput::Init();


### PR DESCRIPTION
I was getting highly annoyed by not being able to finalize changes by hitting the numpad enter, so I did some digging around, and it turns out on Windows "return" and "kp_enter" are treated the same, but under Linux they are treated separate.

Following is a snippet from running `xev` and hitting both return keys:
```
KeyPress event, serial 47, synthetic NO, window 0x7a00001,
    root 0x1e4, subw 0x0, time 117356896, (241,-13), root:(1807,397),
    state 0x0, keycode 36 (keysym 0xff0d, Return), same_screen YES,
"   XLookupString gives 1 bytes: (0d) "
"   XmbLookupString gives 1 bytes: (0d) "
    XFilterEvent returns: False

KeyRelease event, serial 47, synthetic NO, window 0x7a00001,
    root 0x1e4, subw 0x0, time 117357019, (241,-13), root:(1807,397),
    state 0x0, keycode 36 (keysym 0xff0d, Return), same_screen YES,
"   XLookupString gives 1 bytes: (0d) "
    XFilterEvent returns: False

KeyPress event, serial 47, synthetic NO, window 0x7a00001,
    root 0x1e4, subw 0x0, time 117357342, (241,-13), root:(1807,397),
    state 0x0, keycode 104 (keysym 0xff8d, KP_Enter), same_screen YES,
"   XLookupString gives 1 bytes: (0d) "
"   XmbLookupString gives 1 bytes: (0d) "
    XFilterEvent returns: False

KeyRelease event, serial 47, synthetic NO, window 0x7a00001,
    root 0x1e4, subw 0x0, time 117357464, (240,-10), root:(1806,400),
    state 0x0, keycode 104 (keysym 0xff8d, KP_Enter), same_screen YES,
"   XLookupString gives 1 bytes: (0d) "
    XFilterEvent returns: False
```

As you can see enter returns keycode 36 and  numpad enter returns keycode 104.
By default flax seems to map enter on its own, but as it has no `KeyboardKeys` definition for numpad enter it fails to map it to `KeyboardKeys.Return` properly.
The solve I did was just crudely add in the mapping manually with a magic value after the automatic mapping, and this fixes the issue.

