### PR TITLE
Trade minor optimizations in MSVC Development builds for compile speed

### DIFF
--- a/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchainBase.cs
+++ b/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchainBase.cs
@@ -484,12 +484,6 @@ namespace Flax.Build.Platforms
                 // Remove unreferenced COMDAT
                 commonArgs.Add("/Zc:inline");
 
-                // Favor Small Code, Favor Fast Code
-                if (compileEnvironment.FavorSizeOrSpeed == FavorSizeOrSpeed.FastCode)
-                    commonArgs.Add("/Ot");
-                else if (compileEnvironment.FavorSizeOrSpeed == FavorSizeOrSpeed.SmallCode)
-                    commonArgs.Add("/Os");
-
                 // Run-Time Error Checks
                 if (compileEnvironment.RuntimeChecks && !compileEnvironment.CompileAsWinRT)
                     commonArgs.Add("/RTC1");
@@ -510,10 +504,16 @@ namespace Flax.Build.Platforms
                     commonArgs.Add("/Zo");
                 }
 
+                // Favor Small Code, Favor Fast Code
+                if (compileEnvironment.FavorSizeOrSpeed == FavorSizeOrSpeed.FastCode)
+                    commonArgs.Add("/Ot");
+                else if (compileEnvironment.FavorSizeOrSpeed == FavorSizeOrSpeed.SmallCode)
+                    commonArgs.Add("/Os");
                 if (compileEnvironment.Optimization)
                 {
                     // Enable Most Speed Optimizations
-                    commonArgs.Add("/Ox");
+                    // Commented out due to /Og causing slow build times without /GL in development builds
+                    //commonArgs.Add("/Ox");
 
                     // Generate Intrinsic Functions
                     commonArgs.Add("/Oi");
@@ -523,6 +523,9 @@ namespace Flax.Build.Platforms
 
                     if (compileEnvironment.WholeProgramOptimization)
                     {
+                        // Enable Most Speed Optimizations
+                        commonArgs.Add("/Ox");
+
                         // Whole Program Optimization
                         commonArgs.Add("/GL");
                     }
@@ -908,7 +911,7 @@ namespace Flax.Build.Platforms
                         }
                         else
                         {
-                            args.Add("/DEBUG");
+                            args.Add("/DEBUG"); // Same as /DEBUG:FULL
                         }
 
                         // Use Program Database


### PR DESCRIPTION
The overall performance doesn't seem to be affected in any noticeable way in development builds with these changes. However full compilation of the editor is reduced from around 3:30 down to 1min in this system, landing right between the build times in debug (~50sec) and release configurations (~1:10). The root cause of this seems to be the `/Og` compile flag (comes with `/Ox` flag) combined with debug symbol generation flags.

The disabled flag is enabled in release builds to not cause any changes in performance or binary file sizes.