### PR TITLE
.NET8: Move generated marshallers into separate namespace

### DIFF
--- a/Source/Engine/Animations/AnimationGraph.cs
+++ b/Source/Engine/Animations/AnimationGraph.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
+using FlaxEngine.Interop;
 
 namespace FlaxEngine
 {

--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -1019,9 +1019,6 @@ namespace FlaxEngine.Interop
         {
 #if FLAX_EDITOR
             // Clear all caches which might hold references to assemblies in collectible ALC
-            typeCache.Clear();
-
-            // Release all references in collectible ALC
             cachedDelegatesCollectible.Clear();
             foreach (var pair in managedTypesCollectible)
                 pair.Value.handle.Free();

--- a/Source/Engine/Engine/NativeInterop.cs
+++ b/Source/Engine/Engine/NativeInterop.cs
@@ -388,7 +388,7 @@ namespace FlaxEngine.Interop
                 className = className.Substring(parentClassName.Length);
             }
             string marshallerName = className + "Marshaller";
-            string internalAssemblyQualifiedName = $"{@namespace}.{parentClassName}{marshallerName}+{className}Internal,{String.Join(',', splits.Skip(1))}";
+            string internalAssemblyQualifiedName = $"{@namespace}.Interop.{parentClassName}{marshallerName}+{className}Internal,{String.Join(',', splits.Skip(1))}";
             return FindType(internalAssemblyQualifiedName);
         }
 

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -1585,7 +1585,7 @@ namespace Flax.Build.Bindings
                             }
                             //else if (type == "Guid")
                             //    type = "GuidNative";
-                            structContents.Append(type).Append(' ').Append(fieldInfo.Name).Append(';').AppendLine();
+                            structContents.Append($"{type} {fieldInfo.Name};").Append(type == "IntPtr" ? $" // {originalType}" : "").AppendLine();
                         }
 
                         // Generate struct constructor/getter and deconstructor/setter function


### PR DESCRIPTION
Avoid polluting the `FlaxEngine` namespace with interop related marshallers, move those to nested namespace called `Interop` where most of the common marshallers are placed already. Also includes few minor refactoring in the touched areas.