### PR TITLE
Extended math lib

### DIFF
--- a/Source/Engine/Core/Math/Quaternion.cpp
+++ b/Source/Engine/Core/Math/Quaternion.cpp
@@ -534,13 +534,13 @@ void Quaternion::RotationYawPitchRoll(float yaw, float pitch, float roll, Quater
     result.Z = cosYawOver2 * cosPitchOver2 * sinRollOver2 - sinYawOver2 * sinPitchOver2 * cosRollOver2;
 }
 
-Quaternion Quaternion::GetRotacionFromNormal(const Vector3& InNormal, const Transform& InRefrenceTransform)
+Quaternion Quaternion::GetRotationFromNormal(const Vector3& InNormal, const Transform& InReferenceTransform)
 {
-    Float3 up = InRefrenceTransform.GetUp();
+    Float3 up = InReferenceTransform.GetUp();
     auto dot = Vector3::Dot(InNormal, up);
     if (Math::NearEqual(Math::Abs(dot), 1))
     {
-        up = InRefrenceTransform.GetRight();
+        up = InReferenceTransform.GetRight();
     }
     return Quaternion::LookRotation(InNormal, up);
 }

--- a/Source/Engine/Core/Math/Quaternion.cpp
+++ b/Source/Engine/Core/Math/Quaternion.cpp
@@ -7,6 +7,7 @@
 #include "Matrix3x3.h"
 #include "Math.h"
 #include "../Types/String.h"
+#include "Engine/Core/Math/Transform.h"
 
 Quaternion Quaternion::Zero(0, 0, 0, 0);
 Quaternion Quaternion::One(1, 1, 1, 1);
@@ -531,4 +532,15 @@ void Quaternion::RotationYawPitchRoll(float yaw, float pitch, float roll, Quater
     result.X = cosYawOver2 * sinPitchOver2 * cosRollOver2 + sinYawOver2 * cosPitchOver2 * sinRollOver2;
     result.Y = sinYawOver2 * cosPitchOver2 * cosRollOver2 - cosYawOver2 * sinPitchOver2 * sinRollOver2;
     result.Z = cosYawOver2 * cosPitchOver2 * sinRollOver2 - sinYawOver2 * sinPitchOver2 * cosRollOver2;
+}
+
+Quaternion Quaternion::GetRotacionFromNormal(const Vector3& InNormal, const Transform& InRefrenceTransform)
+{
+    Float3 up = InRefrenceTransform.GetUp();
+    auto dot = Vector3::Dot(InNormal, up);
+    if (Math::NearEqual(Math::Abs(dot), 1))
+    {
+        up = InRefrenceTransform.GetRight();
+    }
+    return Quaternion::LookRotation(InNormal, up);
 }

--- a/Source/Engine/Core/Math/Quaternion.cs
+++ b/Source/Engine/Core/Math/Quaternion.cs
@@ -1480,13 +1480,13 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Gets rotacion for normal in relation to transform<br/>
-        /// Funcion especially created for aligned with axis aligned faces
-        /// use full with <seealso cref="Physics.RayCast"/>
+        /// Gets rotation from a normal in relation to a transform.<br/>
+        /// This function is especially useful for axis aligned faces,
+        /// and with <seealso cref="Physics.RayCast(Vector3, Vector3, out RayCastHit, float, uint, bool)"/>.
         /// 
         /// <example><para><b>Example code:</b></para>
         /// <code>
-        /// <see langword="public" /> <see langword="class" /> GetRotacionFromNormalExample : <see cref="Script"/><br/>
+        /// <see langword="public" /> <see langword="class" /> GetRotationFromNormalExample : <see cref="Script"/><br/>
         ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
         ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
         ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
@@ -1497,7 +1497,7 @@ namespace FlaxEngine
         ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
         ///             <see cref="Vector3"/> point = Hit.Point;
         ///             <see cref="Vector3"/> normal = Hit.Normal;
-        ///             <see cref="Quaternion"/> rot = <see cref="Quaternion"/>.GetRotacionFromNormal(normal,transform);
+        ///             <see cref="Quaternion"/> rot = <see cref="Quaternion"/>.GetRotationFromNormal(normal,transform);
         ///             SomeObject.Position = point;
         ///             SomeObject.Orientation = rot;
         ///         }
@@ -1506,18 +1506,18 @@ namespace FlaxEngine
         /// </code>
         /// </example>
         /// </summary>
-        /// <param name="InNormal">the normal vector</param>
-        /// <param name="InRefrenceTransform">relative to</param>
-        /// <returns>normal as rotacion</returns>
-        public static Quaternion GetRotacionFromNormal(Vector3 InNormal, Transform InRefrenceTransform)
+        /// <param name="InNormal">The normal vector.</param>
+        /// <param name="InReferenceTransform">The reference transform.</param>
+        /// <returns>The rotation from the normal vector.</returns>
+        public static Quaternion GetRotationFromNormal(Vector3 InNormal, Transform InReferenceTransform)
         {
-            Float3 up = InRefrenceTransform.Up;
+            Float3 up = InReferenceTransform.Up;
             var dot = Vector3.Dot(InNormal, up);
             if (Mathf.NearEqual(Math.Abs(dot), 1))
             {
-                up = InRefrenceTransform.Right;
+                up = InReferenceTransform.Right;
             }
-            return Quaternion.LookRotation(InNormal, up);
+            return LookRotation(InNormal, up);
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/Quaternion.cs
+++ b/Source/Engine/Core/Math/Quaternion.cs
@@ -1480,6 +1480,47 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Gets rotacion for normal in relation to transform<br/>
+        /// Funcion especially created for aligned with axis aligned faces
+        /// use full with <seealso cref="Physics.RayCast"/>
+        /// 
+        /// <example><para><b>Example code:</b></para>
+        /// <code>
+        /// <see langword="public" /> <see langword="class" /> GetRotacionFromNormalExample : <see cref="Script"/><br/>
+        ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
+        ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
+        ///     {<br/>
+        ///         <see langword="if" /> (<see cref="Physics"/>.RayCast(RayOrgin.Position, RayOrgin.Transform.Forward, out <see cref="RayCastHit"/> Hit)
+        ///         {<br/>
+        ///             <see cref="Vector3"/> position = Hit.Collider.Position;
+        ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
+        ///             <see cref="Vector3"/> point = Hit.Point;
+        ///             <see cref="Vector3"/> normal = Hit.Normal;
+        ///             <see cref="Quaternion"/> rot = <see cref="Quaternion"/>.GetRotacionFromNormal(normal,transform);
+        ///             SomeObject.Position = point;
+        ///             SomeObject.Orientation = rot;
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="InNormal">the normal vector</param>
+        /// <param name="InRefrenceTransform">relative to</param>
+        /// <returns>normal as rotacion</returns>
+        public static Quaternion GetRotacionFromNormal(Vector3 InNormal, Transform InRefrenceTransform)
+        {
+            Float3 up = InRefrenceTransform.Up;
+            var dot = Vector3.Dot(InNormal, up);
+            if (Mathf.NearEqual(Math.Abs(dot), 1))
+            {
+                up = InRefrenceTransform.Right;
+            }
+            return Quaternion.LookRotation(InNormal, up);
+        }
+
+        /// <summary>
         /// Adds two quaternions.
         /// </summary>
         /// <param name="left">The first quaternion to add.</param>

--- a/Source/Engine/Core/Math/Quaternion.h
+++ b/Source/Engine/Core/Math/Quaternion.h
@@ -663,14 +663,14 @@ public:
 
 
     /// <summary>
-    /// Gets rotacion for normal in relation to transform<br/>
-    /// Funcion especially created for aligned with axis aligned faces
-    /// use full with <seealso cref="Physics::RayCast"/>
+    /// Gets rotation from a normal in relation to a transform.<br/>
+    /// This function is especially useful for axis aligned faces,
+    /// and with <seealso cref="Physics::RayCast"/>.
     /// </summary>
-    /// <param name="InNormal">the normal vector</param>
-    /// <param name="InRefrenceTransform">relative to</param>
-    /// <returns>normal as rotacion</returns>
-    static Quaternion GetRotacionFromNormal(const Vector3& InNormal, const Transform& InRefrenceTransform);
+    /// <param name="InNormal">The normal vector.</param>
+    /// <param name="InReferenceTransform">The reference transform.</param>
+    /// <returns>The rotation from the normal vector.</returns>
+    static Quaternion GetRotationFromNormal(const Vector3& InNormal, const Transform& InReferenceTransform);
 };
 
 /// <summary>

--- a/Source/Engine/Core/Math/Quaternion.h
+++ b/Source/Engine/Core/Math/Quaternion.h
@@ -670,17 +670,7 @@ public:
     /// <param name="InNormal">the normal vector</param>
     /// <param name="InRefrenceTransform">relative to</param>
     /// <returns>normal as rotacion</returns>
-    static Quaternion GetRotacionFromNormal(const Vector3& InNormal, const Transform& InRefrenceTransform)
-    {
-        Float3 up = InRefrenceTransform.GetUp();
-        auto dot = Vector3::Dot(InNormal, up);
-        if (Math::NearEqual(Math::Abs(dot), 1))
-        {
-            up = InRefrenceTransform.GetRight();
-        }
-        return Quaternion::LookRotation(InNormal, up);
-    }
-
+    static Quaternion GetRotacionFromNormal(const Vector3& InNormal, const Transform& InRefrenceTransform);
 };
 
 /// <summary>

--- a/Source/Engine/Core/Math/Quaternion.h
+++ b/Source/Engine/Core/Math/Quaternion.h
@@ -660,6 +660,27 @@ public:
     // @param roll The roll of rotation (in radians)
     // @param result When the method completes, contains the newly created quaternion
     static void RotationYawPitchRoll(float yaw, float pitch, float roll, Quaternion& result);
+
+
+    /// <summary>
+    /// Gets rotacion for normal in relation to transform<br/>
+    /// Funcion especially created for aligned with axis aligned faces
+    /// use full with <seealso cref="Physics::RayCast"/>
+    /// </summary>
+    /// <param name="InNormal">the normal vector</param>
+    /// <param name="InRefrenceTransform">relative to</param>
+    /// <returns>normal as rotacion</returns>
+    static Quaternion GetRotacionFromNormal(const Vector3& InNormal, const Transform& InRefrenceTransform)
+    {
+        Float3 up = InRefrenceTransform.GetUp();
+        auto dot = Vector3::Dot(InNormal, up);
+        if (Math::NearEqual(Math::Abs(dot), 1))
+        {
+            up = InRefrenceTransform.GetRight();
+        }
+        return Quaternion::LookRotation(InNormal, up);
+    }
+
 };
 
 /// <summary>

--- a/Source/Engine/Core/Math/Transform.cpp
+++ b/Source/Engine/Core/Math/Transform.cpp
@@ -252,3 +252,9 @@ void Transform::Lerp(const Transform& t1, const Transform& t2, float amount, Tra
     Quaternion::Slerp(t1.Orientation, t2.Orientation, amount, result.Orientation);
     Float3::Lerp(t1.Scale, t2.Scale, amount, result.Scale);
 }
+
+inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const Vector3& InGridSize)
+{
+    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, InReturnScale);
+}

--- a/Source/Engine/Core/Math/Transform.cpp
+++ b/Source/Engine/Core/Math/Transform.cpp
@@ -253,26 +253,26 @@ void Transform::Lerp(const Transform& t1, const Transform& t2, float amount, Tra
     Float3::Lerp(t1.Scale, t2.Scale, amount, result.Scale);
 }
 
-inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const Vector3& InGridSize)
+inline Transform Transform::AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const Vector3& InGridSize)
 {
-    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    Quaternion rot = Quaternion::GetRotationFromNormal(InNormal, InRelativeTo);
     return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, InReturnScale);
 }
 
-inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Vector3& InGridSize)
+inline Transform Transform::AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Vector3& InGridSize)
 {
-    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    Quaternion rot = Quaternion::GetRotationFromNormal(InNormal, InRelativeTo);
     return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, Float3::One);
 }
 
-inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const Vector3& InGridSize)
+inline Transform Transform::AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const Vector3& InGridSize)
 {
-    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    Quaternion rot = Quaternion::GetRotationFromNormal(InNormal, InRelativeTo);
     return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, InReturnScale);
 }
 
-inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Vector3& InGridSize)
+inline Transform Transform::AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Vector3& InGridSize)
 {
-    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    Quaternion rot = Quaternion::GetRotationFromNormal(InNormal, InRelativeTo);
     return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, Float3::One);
 }

--- a/Source/Engine/Core/Math/Transform.cpp
+++ b/Source/Engine/Core/Math/Transform.cpp
@@ -258,3 +258,21 @@ inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& In
     Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
     return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, InReturnScale);
 }
+
+inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Vector3& InGridSize)
+{
+    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, Float3::One);
+}
+
+inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const Vector3& InGridSize)
+{
+    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, InReturnScale);
+}
+
+inline Transform Transform::AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Vector3& InGridSize)
+{
+    Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+    return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, Float3::One);
+}

--- a/Source/Engine/Core/Math/Transform.cs
+++ b/Source/Engine/Core/Math/Transform.cs
@@ -477,6 +477,187 @@ namespace FlaxEngine
             Quaternion.Slerp(ref start.Orientation, ref end.Orientation, amount, out result.Orientation);
             Float3.Lerp(ref start.Scale, ref end.Scale, amount, out result.Scale);
         }
+        /// <summary>
+        /// combines funcions <br/>
+        /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
+        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <example><para><b>Example code:</b></para>
+        /// <code>
+        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        ///     <see langword="public" /> <see cref="float"/> Offset = 50.0f;<br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
+        ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
+        ///     {<br/>
+        ///         <see langword="if" /> (<see cref="Physics"/>.RayCast(RayOrgin.Position, RayOrgin.Transform.Forward, out <see cref="RayCastHit"/> Hit)
+        ///         {<br/>
+        ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
+        ///             <see cref="Vector3"/> point = Hit.Point;
+        ///             <see cref="Vector3"/> normal = Hit.Normal;
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///                                     (
+        ///                                         point,
+        ///                                         normal,
+        ///                                         Offset,
+        ///                                         transform,
+        ///                                         SomeObject.Scale,
+        ///                                         GridSize
+        ///                                     );
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="InPoint">The position to snap.</param>
+        /// <param name="InGridSize">The size of the grid.</param>
+        /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
+        /// <param name="InNormal">Normal vector</param>
+        /// <param name="InRelativeTo">Realative transform</param>
+        /// <param name="InReturnScale">return scale</param>
+        /// InRefrenceTransform
+        /// <returns>rotated and snaped transform</returns>
+        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, float InNormalOffset, Transform InRelativeTo, Float3 InReturnScale, Vector3 InGridSize)
+        {
+            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, new Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, InReturnScale);
+        }
+        /// <summary>
+        /// combines funcions <br/>
+        /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
+        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <example><para><b>Example code:</b></para>
+        /// <code>
+        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        ///     <see langword="public" /> <see cref="float"/> Offset = 50.0f;<br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
+        ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
+        ///     {<br/>
+        ///         <see langword="if" /> (<see cref="Physics"/>.RayCast(RayOrgin.Position, RayOrgin.Transform.Forward, out <see cref="RayCastHit"/> Hit)
+        ///         {<br/>
+        ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
+        ///             <see cref="Vector3"/> point = Hit.Point;
+        ///             <see cref="Vector3"/> normal = Hit.Normal;
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///                                     (
+        ///                                         point,
+        ///                                         normal,
+        ///                                         Offset,
+        ///                                         transform,
+        ///                                         GridSize
+        ///                                     );
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="InPoint">The position to snap.</param>
+        /// <param name="InGridSize">The size of the grid.</param>
+        /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
+        /// <param name="InNormal">Normal vector</param>
+        /// <param name="InRelativeTo">Realative transform</param>
+        /// InRefrenceTransform
+        /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
+        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, float InNormalOffset, Transform InRelativeTo, Vector3 InGridSize)
+        {
+            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, new Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, Float3.One);
+        }
+        /// <summary>
+        /// combines funcions <br/>
+        /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
+        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <example><para><b>Example code:</b></para>
+        /// <code>
+        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> Offset = new Vector3(0, 0, 50f);<br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
+        ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
+        ///     {<br/>
+        ///         <see langword="if" /> (<see cref="Physics"/>.RayCast(RayOrgin.Position, RayOrgin.Transform.Forward, out <see cref="RayCastHit"/> Hit)
+        ///         {<br/>
+        ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
+        ///             <see cref="Vector3"/> point = Hit.Point;
+        ///             <see cref="Vector3"/> normal = Hit.Normal;
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///                                     (
+        ///                                         point,
+        ///                                         normal,
+        ///                                         Offset,
+        ///                                         transform,
+        ///                                         SomeObject.Scale,
+        ///                                         GridSize
+        ///                                     );
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="InPoint">The position to snap.</param>
+        /// <param name="InGridSize">The size of the grid.</param>
+        /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
+        /// <param name="InNormal">Normal vector</param>
+        /// <param name="InRelativeTo">Realative transform</param>
+        /// <param name="InReturnScale">return scale</param>
+        /// InRefrenceTransform
+        /// <returns>rotated and snaped transform</returns>
+        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, Vector3 InNormalOffset, Transform InRelativeTo, Float3 InReturnScale, Vector3 InGridSize)
+        {
+            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, InReturnScale);
+        }
+
+        /// <summary>
+        /// combines funcions <br/>
+        /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
+        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <example><para><b>Example code:</b></para>
+        /// <code>
+        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> Offset = new Vector3(0, 0, 50f);<br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
+        ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
+        ///     {<br/>
+        ///         <see langword="if" /> (<see cref="Physics"/>.RayCast(RayOrgin.Position, RayOrgin.Transform.Forward, out <see cref="RayCastHit"/> Hit)
+        ///         {<br/>
+        ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
+        ///             <see cref="Vector3"/> point = Hit.Point;
+        ///             <see cref="Vector3"/> normal = Hit.Normal;
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///                                     (
+        ///                                         point,
+        ///                                         normal,
+        ///                                         Offset,
+        ///                                         transform,
+        ///                                         GridSize
+        ///                                     );
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="InPoint">The position to snap.</param>
+        /// <param name="InGridSize">The size of the grid.</param>
+        /// <param name="InNormalOffset">The local grid offset to applay after snaping</param>
+        /// <param name="InNormal">Normal vector</param>
+        /// <param name="InRelativeTo">Realative transform</param>
+        /// InRefrenceTransform
+        /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
+        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, Vector3 InNormalOffset, Transform InRelativeTo, Vector3 InGridSize)
+        {
+            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, Float3.One);
+        }
 
         /// <summary>
         /// Tests for equality between two objects.

--- a/Source/Engine/Core/Math/Transform.cs
+++ b/Source/Engine/Core/Math/Transform.cs
@@ -478,12 +478,12 @@ namespace FlaxEngine
             Float3.Lerp(ref start.Scale, ref end.Scale, amount, out result.Scale);
         }
         /// <summary>
-        /// combines funcions <br/>
+        /// Combines the functions: <br/>
         /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
-        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <see cref="Quaternion.GetRotationFromNormal"/>.
         /// <example><para><b>Example code:</b></para>
         /// <code>
-        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        /// <see langword="public" /> <see langword="class" /> AlignRotationToObjectAndSnapToGridExample : <see cref="Script"/><br/>
         ///     <see langword="public" /> <see cref="float"/> Offset = 50.0f;<br/>
         ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
         ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
@@ -495,7 +495,7 @@ namespace FlaxEngine
         ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
         ///             <see cref="Vector3"/> point = Hit.Point;
         ///             <see cref="Vector3"/> normal = Hit.Normal;
-        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotationToNormalAndSnapToGrid
         ///                                     (
         ///                                         point,
         ///                                         normal,
@@ -512,24 +512,24 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="InPoint">The position to snap.</param>
         /// <param name="InGridSize">The size of the grid.</param>
-        /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
-        /// <param name="InNormal">Normal vector</param>
-        /// <param name="InRelativeTo">Realative transform</param>
-        /// <param name="InReturnScale">return scale</param>
-        /// InRefrenceTransform
-        /// <returns>rotated and snaped transform</returns>
-        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, float InNormalOffset, Transform InRelativeTo, Float3 InReturnScale, Vector3 InGridSize)
+        /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+        /// <param name="InNormal">The normal vector.</param>
+        /// <param name="InRelativeTo">The relative transform.</param>
+        /// <param name="InReturnScale">The scale to apply to the transform.</param>
+        /// <returns>The rotated and snapped transform.</returns>
+        public static Transform AlignRotationToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, float InNormalOffset, Transform InRelativeTo, Float3 InReturnScale, Vector3 InGridSize)
         {
-            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            Quaternion rot = Quaternion.GetRotationFromNormal(InNormal, InRelativeTo);
             return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, new Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, InReturnScale);
         }
+
         /// <summary>
-        /// combines funcions <br/>
+        /// Combines the functions: <br/>
         /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
-        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <see cref="Quaternion.GetRotationFromNormal"/>.
         /// <example><para><b>Example code:</b></para>
         /// <code>
-        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        /// <see langword="public" /> <see langword="class" /> AlignRotationToObjectAndSnapToGridExample : <see cref="Script"/><br/>
         ///     <see langword="public" /> <see cref="float"/> Offset = 50.0f;<br/>
         ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
         ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
@@ -541,7 +541,7 @@ namespace FlaxEngine
         ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
         ///             <see cref="Vector3"/> point = Hit.Point;
         ///             <see cref="Vector3"/> normal = Hit.Normal;
-        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotationToNormalAndSnapToGrid
         ///                                     (
         ///                                         point,
         ///                                         normal,
@@ -557,23 +557,23 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="InPoint">The position to snap.</param>
         /// <param name="InGridSize">The size of the grid.</param>
-        /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
-        /// <param name="InNormal">Normal vector</param>
-        /// <param name="InRelativeTo">Realative transform</param>
-        /// InRefrenceTransform
-        /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
-        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, float InNormalOffset, Transform InRelativeTo, Vector3 InGridSize)
+        /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+        /// <param name="InNormal">The normal vector.</param>
+        /// <param name="InRelativeTo">The relative transform.</param>
+        /// <returns>The rotated and snapped transform with scale <see cref="Float3.One"/>.</returns>
+        public static Transform AlignRotationToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, float InNormalOffset, Transform InRelativeTo, Vector3 InGridSize)
         {
-            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            Quaternion rot = Quaternion.GetRotationFromNormal(InNormal, InRelativeTo);
             return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, new Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, Float3.One);
         }
+
         /// <summary>
-        /// combines funcions <br/>
+        /// Combines the functions:<br/>
         /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
-        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <see cref="Quaternion.GetRotationFromNormal"/>.
         /// <example><para><b>Example code:</b></para>
         /// <code>
-        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        /// <see langword="public" /> <see langword="class" /> AlignRotationToObjectAndSnapToGridExample : <see cref="Script"/><br/>
         ///     <see langword="public" /> <see cref="Vector3"/> Offset = new Vector3(0, 0, 50f);<br/>
         ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
         ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
@@ -585,7 +585,7 @@ namespace FlaxEngine
         ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
         ///             <see cref="Vector3"/> point = Hit.Point;
         ///             <see cref="Vector3"/> normal = Hit.Normal;
-        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotationToNormalAndSnapToGrid
         ///                                     (
         ///                                         point,
         ///                                         normal,
@@ -602,25 +602,24 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="InPoint">The position to snap.</param>
         /// <param name="InGridSize">The size of the grid.</param>
-        /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
-        /// <param name="InNormal">Normal vector</param>
-        /// <param name="InRelativeTo">Realative transform</param>
-        /// <param name="InReturnScale">return scale</param>
-        /// InRefrenceTransform
-        /// <returns>rotated and snaped transform</returns>
-        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, Vector3 InNormalOffset, Transform InRelativeTo, Float3 InReturnScale, Vector3 InGridSize)
+        /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+        /// <param name="InNormal">The normal vector.</param>
+        /// <param name="InRelativeTo">The relative transform.</param>
+        /// <param name="InReturnScale">The scale to apply to the transform.</param>
+        /// <returns>The rotated and snapped transform.</returns>
+        public static Transform AlignRotationToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, Vector3 InNormalOffset, Transform InRelativeTo, Float3 InReturnScale, Vector3 InGridSize)
         {
-            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            Quaternion rot = Quaternion.GetRotationFromNormal(InNormal, InRelativeTo);
             return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, InReturnScale);
         }
 
         /// <summary>
-        /// combines funcions <br/>
+        /// Combines the functions:<br/>
         /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
-        /// <see cref="Quaternion.GetRotacionFromNormal"/>
+        /// <see cref="Quaternion.GetRotationFromNormal"/>.
         /// <example><para><b>Example code:</b></para>
         /// <code>
-        /// <see langword="public" /> <see langword="class" /> AlignRotacionToObjectAndSnapToGridExample : <see cref="Script"/><br/>
+        /// <see langword="public" /> <see langword="class" /> AlignRotationToObjectAndSnapToGridExample : <see cref="Script"/><br/>
         ///     <see langword="public" /> <see cref="Vector3"/> Offset = new Vector3(0, 0, 50f);<br/>
         ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
         ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
@@ -632,7 +631,7 @@ namespace FlaxEngine
         ///             <see cref="Transform"/> transform = Hit.Collider.Transform;
         ///             <see cref="Vector3"/> point = Hit.Point;
         ///             <see cref="Vector3"/> normal = Hit.Normal;
-        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotacionToNormalAndSnapToGrid
+        ///             SomeObject.Transform = <see cref="Transform"/>.AlignRotationToNormalAndSnapToGrid
         ///                                     (
         ///                                         point,
         ///                                         normal,
@@ -648,14 +647,13 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="InPoint">The position to snap.</param>
         /// <param name="InGridSize">The size of the grid.</param>
-        /// <param name="InNormalOffset">The local grid offset to applay after snaping</param>
-        /// <param name="InNormal">Normal vector</param>
-        /// <param name="InRelativeTo">Realative transform</param>
-        /// InRefrenceTransform
-        /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
-        public static Transform AlignRotacionToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, Vector3 InNormalOffset, Transform InRelativeTo, Vector3 InGridSize)
+        /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+        /// <param name="InNormal">The normal vector.</param>
+        /// <param name="InRelativeTo">The relative transform.</param>
+        /// <returns>The rotated and snapped transform with scale <see cref="Float3.One"/>.</returns>
+        public static Transform AlignRotationToNormalAndSnapToGrid(Vector3 InPoint, Vector3 InNormal, Vector3 InNormalOffset, Transform InRelativeTo, Vector3 InGridSize)
         {
-            Quaternion rot = Quaternion.GetRotacionFromNormal(InNormal, InRelativeTo);
+            Quaternion rot = Quaternion.GetRotationFromNormal(InNormal, InRelativeTo);
             return new Transform(Vector3.SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, Float3.One);
         }
 

--- a/Source/Engine/Core/Math/Transform.h
+++ b/Source/Engine/Core/Math/Transform.h
@@ -291,6 +291,77 @@ public:
         return result;
     }
 
+    /// <summary>
+    /// combines funcions <br/>
+    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
+    /// <see cref="GetRotacionFromNormal"/>
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
+    /// <param name="InNormal">Normal vector</param>
+    /// <param name="InRelativeTo">Realative transform</param>
+    /// <param name="InReturnScale">return scale</param>
+    /// InRefrenceTransform
+    /// <returns>rotated and snaped transform</returns>
+    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const  Vector3& InGridSize)
+    {
+        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, InReturnScale);
+    }
+    /// <summary>
+    /// combines funcions <br/>
+    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
+    /// <see cref="GetRotacionFromNormal"/>
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
+    /// <param name="InNormal">Normal vector</param>
+    /// <param name="InRelativeTo">Realative transform</param>
+    /// InRefrenceTransform
+    /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
+    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const  Vector3& InGridSize)
+    {
+        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, Float3::One);
+    }
+    /// <summary>
+    /// combines funcions <br/>
+    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
+    /// <see cref="GetRotacionFromNormal"/>
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
+    /// <param name="InNormal">Normal vector</param>
+    /// <param name="InRelativeTo">Realative transform</param>
+    /// <param name="InReturnScale">return scale</param>
+    /// InRefrenceTransform
+    /// <returns>rotated and snaped transform</returns>
+    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo,const Float3& InReturnScale,const Vector3& InGridSize)
+    {
+        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, InReturnScale);
+    }
+    /// <summary>
+    /// combines funcions <br/>
+    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
+    /// <see cref="GetRotacionFromNormal"/>
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InNormalOffset">The local grid offset to applay after snaping</param>
+    /// <param name="InNormal">Normal vector</param>
+    /// <param name="InRelativeTo">Realative transform</param>
+    /// InRefrenceTransform
+    /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
+    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint,const Vector3& InNormal,const Vector3& InNormalOffset, const Transform& InRelativeTo,const Vector3& InGridSize)
+    {
+        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
+        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, Float3::One);
+    }
+
 public:
     FORCE_INLINE Transform operator*(const Transform& other) const
     {

--- a/Source/Engine/Core/Math/Transform.h
+++ b/Source/Engine/Core/Math/Transform.h
@@ -18,20 +18,20 @@ API_STRUCT() struct FLAXENGINE_API Transform
     /// <summary>
     /// The translation vector of the transform.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(10), EditorDisplay(null, \"Position\"), ValueCategory(Utils.ValueCategory.Distance)")
-    Vector3 Translation;
+    API_FIELD(Attributes = "EditorOrder(10), EditorDisplay(null, \"Position\"), ValueCategory(Utils.ValueCategory.Distance)")
+        Vector3 Translation;
 
     /// <summary>
     /// The rotation of the transform.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(20), EditorDisplay(null, \"Rotation\"), ValueCategory(Utils.ValueCategory.Angle)")
-    Quaternion Orientation;
+    API_FIELD(Attributes = "EditorOrder(20), EditorDisplay(null, \"Rotation\"), ValueCategory(Utils.ValueCategory.Angle)")
+        Quaternion Orientation;
 
     /// <summary>
     /// The scale vector of the transform.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(30), Limit(float.MinValue, float.MaxValue, 0.01f)")
-    Float3 Scale;
+    API_FIELD(Attributes = "EditorOrder(30), Limit(float.MinValue, float.MaxValue, 0.01f)")
+        Float3 Scale;
 
 public:
     /// <summary>
@@ -291,63 +291,61 @@ public:
         return result;
     }
 
-    /// <summary>
-    /// combines funcions <br/>
-    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
-    /// <see cref="GetRotacionFromNormal"/>
-    /// </summary>
-    /// <param name="InPoint">The position to snap.</param>
-    /// <param name="InGridSize">The size of the grid.</param>
-    /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
-    /// <param name="InNormal">Normal vector</param>
-    /// <param name="InRelativeTo">Realative transform</param>
-    /// <param name="InReturnScale">return scale</param>
-    /// InRefrenceTransform
-    /// <returns>rotated and snaped transform</returns>
-    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const  Vector3& InGridSize);
-    
-    /// <summary>
-    /// combines funcions <br/>
-    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
-    /// <see cref="GetRotacionFromNormal"/>
-    /// </summary>
-    /// <param name="InPoint">The position to snap.</param>
-    /// <param name="InGridSize">The size of the grid.</param>
-    /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
-    /// <param name="InNormal">Normal vector</param>
-    /// <param name="InRelativeTo">Realative transform</param>
-    /// InRefrenceTransform
-    /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
-    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const  Vector3& InGridSize);
-    
-    /// <summary>
-    /// combines funcions <br/>
-    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
-    /// <see cref="GetRotacionFromNormal"/>
-    /// </summary>
-    /// <param name="InPoint">The position to snap.</param>
-    /// <param name="InGridSize">The size of the grid.</param>
-    /// <param name="InNormalOffset">The local Z grid offset to applay after snaping</param>
-    /// <param name="InNormal">Normal vector</param>
-    /// <param name="InRelativeTo">Realative transform</param>
-    /// <param name="InReturnScale">return scale</param>
-    /// InRefrenceTransform
-    /// <returns>rotated and snaped transform</returns>
-    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo,const Float3& InReturnScale,const Vector3& InGridSize);
 
     /// <summary>
-    /// combines funcions <br/>
+    /// Combines the functions: <br/>
     /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
-    /// <see cref="GetRotacionFromNormal"/>
+    /// <see cref="GetRotationFromNormal"/>.
     /// </summary>
     /// <param name="InPoint">The position to snap.</param>
     /// <param name="InGridSize">The size of the grid.</param>
-    /// <param name="InNormalOffset">The local grid offset to applay after snaping</param>
-    /// <param name="InNormal">Normal vector</param>
-    /// <param name="InRelativeTo">Realative transform</param>
-    /// InRefrenceTransform
-    /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
-    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint,const Vector3& InNormal,const Vector3& InNormalOffset, const Transform& InRelativeTo,const Vector3& InGridSize);
+    /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+    /// <param name="InNormal">The normal vector.</param>
+    /// <param name="InRelativeTo">The relative transform.</param>
+    /// <param name="InReturnScale">The scale to apply to the transform.</param>
+    /// <returns>The rotated and snapped transform.</returns>
+    static Transform AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const  Vector3& InGridSize);
+
+    /// <summary>
+    /// Combines the functions: <br/>
+    /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
+    /// <see cref="Quaternion.GetRotationFromNormal"/>.
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+    /// <param name="InNormal">The normal vector.</param>
+    /// <param name="InRelativeTo">The relative transform.</param>
+    /// <returns>The rotated and snapped transform with scale <see cref="Float3.One"/>.</returns>
+    static Transform AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const  Vector3& InGridSize);
+
+    /// <summary>
+    /// Combines the functions: <br/>
+    /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
+    /// <see cref="GetRotationFromNormal"/>.
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+    /// <param name="InNormal">The normal vector.</param>
+    /// <param name="InRelativeTo">The relative transform.</param>
+    /// <param name="InReturnScale">The scale to apply to the transform.</param>
+    /// <returns>The rotated and snapped transform.</returns>
+    static Transform AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const Vector3& InGridSize);
+
+    /// <summary>
+    /// Combines the functions: <br/>
+    /// <see cref="Vector3.SnapToRotatedGridWithOffset"/>,<br/>
+    /// <see cref="Quaternion.GetRotationFromNormal"/>.
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InNormalOffset">The local Z grid offset to apply after snapping.</param>
+    /// <param name="InNormal">The normal vector.</param>
+    /// <param name="InRelativeTo">The relative transform.</param>
+    /// <returns>The rotated and snapped transform with scale <see cref="Float3.One"/>.</returns>
+    static Transform AlignRotationToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo, const Vector3& InGridSize);
+
 
 public:
     FORCE_INLINE Transform operator*(const Transform& other) const

--- a/Source/Engine/Core/Math/Transform.h
+++ b/Source/Engine/Core/Math/Transform.h
@@ -304,11 +304,8 @@ public:
     /// <param name="InReturnScale">return scale</param>
     /// InRefrenceTransform
     /// <returns>rotated and snaped transform</returns>
-    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const  Vector3& InGridSize)
-    {
-        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
-        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, InReturnScale);
-    }
+    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const Float3& InReturnScale, const  Vector3& InGridSize);
+    
     /// <summary>
     /// combines funcions <br/>
     /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
@@ -321,11 +318,8 @@ public:
     /// <param name="InRelativeTo">Realative transform</param>
     /// InRefrenceTransform
     /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
-    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const  Vector3& InGridSize)
-    {
-        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
-        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, Vector3(0, 0, InNormalOffset), rot, InGridSize), rot, Float3::One);
-    }
+    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, float InNormalOffset, const Transform& InRelativeTo, const  Vector3& InGridSize);
+    
     /// <summary>
     /// combines funcions <br/>
     /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
@@ -339,11 +333,8 @@ public:
     /// <param name="InReturnScale">return scale</param>
     /// InRefrenceTransform
     /// <returns>rotated and snaped transform</returns>
-    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo,const Float3& InReturnScale,const Vector3& InGridSize)
-    {
-        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
-        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, InReturnScale);
-    }
+    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint, const Vector3& InNormal, const Vector3& InNormalOffset, const Transform& InRelativeTo,const Float3& InReturnScale,const Vector3& InGridSize);
+
     /// <summary>
     /// combines funcions <br/>
     /// <see cref="SnapToRotatedGridWithOffset"/>,<br/>
@@ -356,11 +347,7 @@ public:
     /// <param name="InRelativeTo">Realative transform</param>
     /// InRefrenceTransform
     /// <returns>rotated and snaped transform with scale <see cref="Float3.One"/> </returns>
-    static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint,const Vector3& InNormal,const Vector3& InNormalOffset, const Transform& InRelativeTo,const Vector3& InGridSize)
-    {
-        Quaternion rot = Quaternion::GetRotacionFromNormal(InNormal, InRelativeTo);
-        return Transform(Vector3::SnapToRotatedGridWithOffset(InPoint, InRelativeTo.Translation, InNormalOffset, rot, InGridSize), rot, Float3::One);
-    }
+    inline static Transform AlignRotacionToNormalAndSnapToGrid(const Vector3& InPoint,const Vector3& InNormal,const Vector3& InNormalOffset, const Transform& InRelativeTo,const Vector3& InGridSize);
 
 public:
     FORCE_INLINE Transform operator*(const Transform& other) const

--- a/Source/Engine/Core/Math/Vector3.cpp
+++ b/Source/Engine/Core/Math/Vector3.cpp
@@ -325,17 +325,17 @@ float Float3::Angle(const Float3& from, const Float3& to)
 }
 
 template<>
-Float3 Float3::SnapToRotatedGridWithOffset(const Float3& InPoint, const Float3& InCenterPoint, const Float3& InOffset, const Quaternion& InOrientation, const Float3& InGridSize)
-{
-    return (InOrientation * (InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
-}
-
-template<>
 Float3 Float3::SnapToGrid(const Float3& pos, const Float3& gridSize)
 {
     return Float3(Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X,
         Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y,
         Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z);
+}
+
+template<>
+Float3 Float3::SnapToRotatedGridWithOffset(const Float3& InPoint, const Float3& InCenterPoint, const Float3& InOffset, const Quaternion& InOrientation, const Float3& InGridSize)
+{
+    return (InOrientation * (InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
 }
 
 template<>
@@ -659,17 +659,17 @@ double Double3::Angle(const Double3& from, const Double3& to)
 }
 
 template<>
-Double3 Double3::SnapToRotatedGridWithOffset(const Double3& InPoint, const Double3& InCenterPoint, const Double3& InOffset, const Quaternion& InOrientation, const Double3& InGridSize)
-{
-    return (InOrientation * (InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
-}
-
-template<>
 Double3 Double3::SnapToGrid(const Double3& pos, const Double3& gridSize)
 {
     return Double3(Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X,
         Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y,
         Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z);
+}
+
+template<>
+Double3 Double3::SnapToRotatedGridWithOffset(const Double3& InPoint, const Double3& InCenterPoint, const Double3& InOffset, const Quaternion& InOrientation, const Double3& InGridSize)
+{
+    return (InOrientation * (InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
 }
 
 template<>
@@ -894,17 +894,17 @@ int32 Int3::Angle(const Int3& from, const Int3& to)
 }
 
 template<>
-Int3 Int3::SnapToRotatedGridWithOffset(const Int3& InPoint, const Int3& InCenterPoint, const Int3& InOffset, const Quaternion& InOrientation, const Int3& InGridSize)
-{
-    return (InOrientation * (InOrientation.Conjugated() * Int3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
-}
-
-template<>
 Int3 Int3::SnapToGrid(const Int3& pos, const Int3& gridSize)
 {
     return Double3(Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X,
         Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y,
         Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z);
+}
+
+template<>
+Int3 Int3::SnapToRotatedGridWithOffset(const Int3& InPoint, const Int3& InCenterPoint, const Int3& InOffset, const Quaternion& InOrientation, const Int3& InGridSize)
+{
+    return (InOrientation * (InOrientation.Conjugated() * Int3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
 }
 
 template<>

--- a/Source/Engine/Core/Math/Vector3.cpp
+++ b/Source/Engine/Core/Math/Vector3.cpp
@@ -324,6 +324,26 @@ float Float3::Angle(const Float3& from, const Float3& to)
     return Math::Acos(dot);
 }
 
+template<>
+Float3 Float3::SnapToRotatedGridWithOffset(const Float3& InPoint, const Float3& InCenterPoint, const Float3& InOffset, const Quaternion& InOrientation, const Float3& InGridSize)
+{
+    return (InOrientation * (InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
+}
+
+template<>
+Float3 Float3::SnapToGrid(const Float3& pos, const Float3& gridSize)
+{
+    return Float3(Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X,
+        Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y,
+        Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z);
+}
+
+template<>
+Float3 Float3::SnapToRotatedGrid(const Float3& InPoint, const Float3& InCenterPoint, const Quaternion& InOrientation, const Float3& InGridSize)
+{
+    return (InOrientation * InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize)) + InCenterPoint;
+}
+
 // Double
 
 static_assert(sizeof(Double3) == 24, "Invalid Double3 type size.");
@@ -638,6 +658,26 @@ double Double3::Angle(const Double3& from, const Double3& to)
     return Math::Acos(dot);
 }
 
+template<>
+Double3 Double3::SnapToRotatedGridWithOffset(const Double3& InPoint, const Double3& InCenterPoint, const Double3& InOffset, const Quaternion& InOrientation, const Double3& InGridSize)
+{
+    return (InOrientation * (InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
+}
+
+template<>
+Double3 Double3::SnapToGrid(const Double3& pos, const Double3& gridSize)
+{
+    return Double3(Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X,
+        Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y,
+        Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z);
+}
+
+template<>
+Double3 Double3::SnapToRotatedGrid(const Double3& InPoint, const Double3& InCenterPoint, const Quaternion& InOrientation, const Double3& InGridSize)
+{
+    return (InOrientation * InOrientation.Conjugated() * Float3::SnapToGrid((InPoint - InCenterPoint), InGridSize)) + InCenterPoint;
+}
+
 // Int
 
 static_assert(sizeof(Int3) == 12, "Invalid Int3 type size.");
@@ -851,4 +891,24 @@ template<>
 int32 Int3::Angle(const Int3& from, const Int3& to)
 {
     return 0;
+}
+
+template<>
+Int3 Int3::SnapToRotatedGridWithOffset(const Int3& InPoint, const Int3& InCenterPoint, const Int3& InOffset, const Quaternion& InOrientation, const Int3& InGridSize)
+{
+    return (InOrientation * (InOrientation.Conjugated() * Int3::SnapToGrid((InPoint - InCenterPoint), InGridSize) + InOffset)) + InCenterPoint;
+}
+
+template<>
+Int3 Int3::SnapToGrid(const Int3& pos, const Int3& gridSize)
+{
+    return Double3(Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X,
+        Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y,
+        Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z);
+}
+
+template<>
+Int3 Int3::SnapToRotatedGrid(const Int3& InPoint, const Int3& InCenterPoint, const Quaternion& InOrientation, const Int3& InGridSize)
+{
+    return (InOrientation * InOrientation.Conjugated() * Int3::SnapToGrid((InPoint - InCenterPoint), InGridSize)) + InCenterPoint;
 }

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -1769,7 +1769,7 @@ namespace FlaxEngine
         {
             Vector3 self = this;
             int FinalID = -1;
-            for (int i = 0; InArray.Length < 0; i++)
+            for (int i = 0; i < InArray.Length; i++)
             {
                 if (Distance(self, InArray[i]) <= Tolerance)
                 {
@@ -1790,7 +1790,7 @@ namespace FlaxEngine
         {
             Vector3 self = this;
             int FinalID = -1;
-            for (int i = 0; InList.Count < 0; i++)
+            for (int i = 0; i < InList.Count; i++)
             {
                 if (Distance(self, InList[i]) <= Tolerance)
                 {
@@ -1811,7 +1811,7 @@ namespace FlaxEngine
         {
             Vector3 self = this;
             Real LastDistance = Real.MaxValue;
-            for (int i = 0; InArray.Length < 0; i++)
+            for (int i = 0; i < InArray.Length; i++)
             {
                 var d = Distance(self, InArray[i]);
                 if (d <= LastDistance)
@@ -1834,9 +1834,9 @@ namespace FlaxEngine
         {
             Vector3 self = this;
             Real LastDistance = Real.MaxValue;
-            for (int i = 0; InList.Count < 0; i++)
+            for (int i = 0; i < InList.Count; i++)
             {
-                var d = Vector3.Distance(self, InList[i]);
+                var d = Distance(self, InList[i]);
                 if (d <= LastDistance)
                 {
                     self = InList[i];

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -1760,6 +1760,94 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Gets the closest vector id to <see langword="this" />
+        /// </summary>
+        /// <param name="InArray"></param>
+        /// <param name="Tolerance"></param>
+        /// <returns>index or -1 if all vectors in array are outside of <paramref name="Tolerance"/></returns>
+        private int GetClosest(ref Vector3[] InArray, float Tolerance)
+        {
+            Vector3 self = this;
+            int FinalID = -1;
+            for (int i = 0; InArray.Length < 0; i++)
+            {
+                if (Distance(self, InArray[i]) <= Tolerance)
+                {
+                    FinalID = i;
+                    self = InArray[i];
+                }
+            }
+            return FinalID;
+        }
+
+        /// <summary>
+        /// Gets the closest vector id to <see langword="this" />
+        /// </summary>
+        /// <param name="InList"></param>
+        /// <param name="Tolerance"></param>
+        /// <returns>index or -1 if all vectors in array are outside of <paramref name="Tolerance"/></returns>
+        private int GetClosest(ref System.Collections.Generic.List<Vector3> InList, float Tolerance)
+        {
+            Vector3 self = this;
+            int FinalID = -1;
+            for (int i = 0; InList.Count < 0; i++)
+            {
+                if (Distance(self, InList[i]) <= Tolerance)
+                {
+                    FinalID = i;
+                    self = InList[i];
+                }
+            }
+            return FinalID;
+        }
+
+        /// <summary>
+        /// Gets the closest vector to <see langword="this" />
+        /// </summary>
+        /// <param name="InArray"></param>
+        /// <param name="OutDistance"></param>
+        /// <param name="OutVector"></param>
+        private void GetClosest(ref Vector3[] InArray, ref Vector3 OutVector, ref float OutDistance)
+        {
+            Vector3 self = this;
+            float LastDistance = float.MaxValue;
+            for (int i = 0; InArray.Length < 0; i++)
+            {
+                var d = Distance(self, InArray[i]);
+                if (d <= LastDistance)
+                {
+                    self = InArray[i];
+                    LastDistance = d;
+                }
+            }
+            OutDistance = LastDistance;
+            OutVector = self;
+        }
+
+        /// <summary>
+        /// Gets the closest vector to <see langword="this" />
+        /// </summary>
+        /// <param name="InList"></param>
+        /// <param name="OutDistance"></param>
+        /// <param name="OutVector"></param>
+        private void GetClosest(ref System.Collections.Generic.List<Vector3> InList, ref Vector3 OutVector, ref float OutDistance)
+        {
+            Vector3 self = this;
+            float LastDistance = float.MaxValue;
+            for (int i = 0; InList.Count < 0; i++)
+            {
+                var d = Vector3.Distance(self, InList[i]);
+                if (d <= LastDistance)
+                {
+                    self = InList[i];
+                    LastDistance = d;
+                }
+            }
+            OutDistance = LastDistance;
+            OutVector = self;
+        }
+
+        /// <summary>
         /// Adds two vectors.
         /// </summary>
         /// <param name="left">The first vector to add.</param>

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -1686,6 +1686,80 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Snaps the <paramref name="InPoint"/> on to rotate grid.<br/>
+        /// for world aligned grid snapping use <b><see cref="Vector3.SnapToGrid"/></b> instead
+        /// <example><para><b>Example code:</b></para>
+        /// <code>
+        /// <see langword="public" /> <see langword="class" /> SnapToRotatedGridExample : <see cref="Script"/><br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
+        ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
+        ///     {<br/>
+        ///         <see langword="if" /> (<see cref="Physics"/>.RayCast(RayOrgin.Position, RayOrgin.Transform.Forward, out <see cref="RayCastHit"/> Hit)
+        ///         {<br/>
+        ///             <see cref="Vector3"/> position = Hit.Collider.Position;
+        ///             <see cref="FlaxEngine.Transform"/> transform = Hit.Collider.Transform;
+        ///             <see cref="Vector3"/> point = Hit.Point;
+        ///             <see cref="Vector3"/> normal = Hit.Normal;
+        ///             //Get rotation from normal relative to collider transform
+        ///             <see cref="Quaternion"/> rot = <see cref="Quaternion"/>.GetRotacionFromNormal(normal,transform);
+        ///             point = <see cref="Vector3"/>.SnapToRotatedGrid(point,position,rot,GridSize);
+        ///             SomeObject.Position = point;
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="InPoint">The position to snap.</param>
+        /// <param name="InCenterPoint">The center point.</param>
+        /// <param name="InOrientation">The rotation of the grid.</param>
+        /// <param name="InGridSize">The size of the grid.</param>
+        /// <returns>The position snapped to the grid.</returns>
+        public static Vector3 SnapToRotatedGrid(Vector3 InPoint, Vector3 InCenterPoint, Quaternion InOrientation, Vector3 InGridSize)
+        {
+            Vector3 p = (InPoint - InCenterPoint) * InOrientation.Conjugated();
+            return (SnapToGrid(p, InGridSize) * InOrientation) + InCenterPoint;
+        }
+        /// <summary>
+        /// The same as <see cref="SnapToRotatedGrid"/> but with local offset applied after point is spapend
+        /// <example><para><b>Example code:</b></para>
+        /// <code>
+        /// <see langword="public" /> <see langword="class" /> SnapToRotatedGridWithOffsetExample : <see cref="Script"/><br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> Offset = new Vector3(0, 0, 50f);<br/>
+        ///     <see langword="public" /> <see cref="Vector3"/> GridSize = <see cref="Vector3.One"/> * 20.0f;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> RayOrgin;<br/>
+        ///     <see langword="public" /> <see cref="Actor"/> SomeObject;<br/>
+        ///     <see langword="public" /> <see langword="override" /> <see langword="void" /> <see cref="Script.OnFixedUpdate"/><br/>
+        ///     {<br/>
+        ///         <see langword="if" /> (<see cref="Physics"/>.RayCast(RayOrgin.Position, RayOrgin.Transform.Forward, out <see cref="RayCastHit"/> Hit)
+        ///         {<br/>
+        ///             <see cref="Vector3"/> position = Hit.Collider.Position;
+        ///             <see cref="FlaxEngine.Transform"/> transform = Hit.Collider.Transform;
+        ///             <see cref="Vector3"/> point = Hit.Point;
+        ///             <see cref="Vector3"/> normal = Hit.Normal;
+        ///             <see cref="Quaternion"/> rot = <see cref="Quaternion"/>.GetRotacionFromNormal(normal,transform);
+        ///             point = <see cref="Vector3"/>.SnapToRotatedGridWithOffset(point,position,Offset,rot,GridSize);
+        ///             SomeObject.Position = point;
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="InPoint">The position to snap.</param>
+        /// <param name="InCenterPoint">The center point.</param>
+        /// <param name="InOrientation">The rotation of the grid.</param>
+        /// <param name="InGridSize">The size of the grid.</param>
+        /// <param name="InOffset">The local grid offset to applay after snaping</param>
+        /// <returns></returns>
+        public static Vector3 SnapToRotatedGridWithOffset(Vector3 InPoint, Vector3 InCenterPoint, Vector3 InOffset, Quaternion InOrientation, Vector3 InGridSize)
+        {
+            return ((SnapToGrid((InPoint - InCenterPoint) * InOrientation.Conjugated(), InGridSize) + InOffset) * InOrientation) + InCenterPoint;
+        }
+
+        /// <summary>
         /// Adds two vectors.
         /// </summary>
         /// <param name="left">The first vector to add.</param>

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -1765,7 +1765,7 @@ namespace FlaxEngine
         /// <param name="InArray"></param>
         /// <param name="Tolerance"></param>
         /// <returns>index or -1 if all vectors in array are outside of <paramref name="Tolerance"/></returns>
-        private int GetClosest(ref Vector3[] InArray, Real Tolerance)
+        public int GetClosest(ref Vector3[] InArray, Real Tolerance)
         {
             Vector3 self = this;
             int FinalID = -1;
@@ -1786,7 +1786,7 @@ namespace FlaxEngine
         /// <param name="InList"></param>
         /// <param name="Tolerance"></param>
         /// <returns>index or -1 if all vectors in array are outside of <paramref name="Tolerance"/></returns>
-        private int GetClosest(ref System.Collections.Generic.List<Vector3> InList, Real Tolerance)
+        public int GetClosest(ref System.Collections.Generic.List<Vector3> InList, Real Tolerance)
         {
             Vector3 self = this;
             int FinalID = -1;
@@ -1807,10 +1807,10 @@ namespace FlaxEngine
         /// <param name="InArray"></param>
         /// <param name="OutDistance"></param>
         /// <param name="OutVector"></param>
-        private void GetClosest(ref Vector3[] InArray, ref Vector3 OutVector, ref Real OutDistance)
+        public void GetClosest(ref Vector3[] InArray, ref Vector3 OutVector, ref Real OutDistance)
         {
             Vector3 self = this;
-            Real LastDistance = float.MaxValue;
+            Real LastDistance = Real.MaxValue;
             for (int i = 0; InArray.Length < 0; i++)
             {
                 var d = Distance(self, InArray[i]);
@@ -1830,10 +1830,10 @@ namespace FlaxEngine
         /// <param name="InList"></param>
         /// <param name="OutDistance"></param>
         /// <param name="OutVector"></param>
-        private void GetClosest(ref System.Collections.Generic.List<Vector3> InList, ref Vector3 OutVector, ref Real OutDistance)
+        public void GetClosest(ref System.Collections.Generic.List<Vector3> InList, ref Vector3 OutVector, ref Real OutDistance)
         {
             Vector3 self = this;
-            Real LastDistance = float.MaxValue;
+            Real LastDistance = Real.MaxValue;
             for (int i = 0; InList.Count < 0; i++)
             {
                 var d = Vector3.Distance(self, InList[i]);

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -1765,7 +1765,7 @@ namespace FlaxEngine
         /// <param name="InArray"></param>
         /// <param name="Tolerance"></param>
         /// <returns>index or -1 if all vectors in array are outside of <paramref name="Tolerance"/></returns>
-        private int GetClosest(ref Vector3[] InArray, float Tolerance)
+        private int GetClosest(ref Vector3[] InArray, Real Tolerance)
         {
             Vector3 self = this;
             int FinalID = -1;
@@ -1786,7 +1786,7 @@ namespace FlaxEngine
         /// <param name="InList"></param>
         /// <param name="Tolerance"></param>
         /// <returns>index or -1 if all vectors in array are outside of <paramref name="Tolerance"/></returns>
-        private int GetClosest(ref System.Collections.Generic.List<Vector3> InList, float Tolerance)
+        private int GetClosest(ref System.Collections.Generic.List<Vector3> InList, Real Tolerance)
         {
             Vector3 self = this;
             int FinalID = -1;
@@ -1807,7 +1807,7 @@ namespace FlaxEngine
         /// <param name="InArray"></param>
         /// <param name="OutDistance"></param>
         /// <param name="OutVector"></param>
-        private void GetClosest(ref Vector3[] InArray, ref Vector3 OutVector, ref float OutDistance)
+        private void GetClosest(ref Vector3[] InArray, ref Vector3 OutVector, ref Real OutDistance)
         {
             Vector3 self = this;
             float LastDistance = float.MaxValue;
@@ -1830,7 +1830,7 @@ namespace FlaxEngine
         /// <param name="InList"></param>
         /// <param name="OutDistance"></param>
         /// <param name="OutVector"></param>
-        private void GetClosest(ref System.Collections.Generic.List<Vector3> InList, ref Vector3 OutVector, ref float OutDistance)
+        private void GetClosest(ref System.Collections.Generic.List<Vector3> InList, ref Vector3 OutVector, ref Real OutDistance)
         {
             Vector3 self = this;
             float LastDistance = float.MaxValue;

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -1810,7 +1810,7 @@ namespace FlaxEngine
         private void GetClosest(ref Vector3[] InArray, ref Vector3 OutVector, ref Real OutDistance)
         {
             Vector3 self = this;
-            float LastDistance = float.MaxValue;
+            Real LastDistance = float.MaxValue;
             for (int i = 0; InArray.Length < 0; i++)
             {
                 var d = Distance(self, InArray[i]);
@@ -1833,7 +1833,7 @@ namespace FlaxEngine
         private void GetClosest(ref System.Collections.Generic.List<Vector3> InList, ref Vector3 OutVector, ref Real OutDistance)
         {
             Vector3 self = this;
-            float LastDistance = float.MaxValue;
+            Real LastDistance = float.MaxValue;
             for (int i = 0; InList.Count < 0; i++)
             {
                 var d = Vector3.Distance(self, InList[i]);

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -1672,7 +1672,7 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Snaps the input position into the grid.
+        /// Snaps the input position onto the grid.
         /// </summary>
         /// <param name="pos">The position to snap.</param>
         /// <param name="gridSize">The size of the grid.</param>
@@ -1686,8 +1686,8 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Snaps the <paramref name="InPoint"/> on to rotate grid.<br/>
-        /// for world aligned grid snapping use <b><see cref="Vector3.SnapToGrid"/></b> instead
+        /// Snaps the <paramref name="InPoint"/> onto the rotated grid.<br/>
+        /// For world aligned grid snapping use <b><see cref="SnapToGrid"/></b> instead.
         /// <example><para><b>Example code:</b></para>
         /// <code>
         /// <see langword="public" /> <see langword="class" /> SnapToRotatedGridExample : <see cref="Script"/><br/>
@@ -1723,7 +1723,7 @@ namespace FlaxEngine
             return (SnapToGrid(p, InGridSize) * InOrientation) + InCenterPoint;
         }
         /// <summary>
-        /// The same as <see cref="SnapToRotatedGrid"/> but with local offset applied after point is spapend
+        /// The same as <see cref="SnapToRotatedGrid"/> but with local offset applied after point is snapped.
         /// <example><para><b>Example code:</b></para>
         /// <code>
         /// <see langword="public" /> <see langword="class" /> SnapToRotatedGridWithOffsetExample : <see cref="Script"/><br/>
@@ -1739,7 +1739,7 @@ namespace FlaxEngine
         ///             <see cref="FlaxEngine.Transform"/> transform = Hit.Collider.Transform;
         ///             <see cref="Vector3"/> point = Hit.Point;
         ///             <see cref="Vector3"/> normal = Hit.Normal;
-        ///             <see cref="Quaternion"/> rot = <see cref="Quaternion"/>.GetRotacionFromNormal(normal,transform);
+        ///             <see cref="Quaternion"/> rot = <see cref="Quaternion"/>.GetRotationFromNormal(normal,transform);
         ///             point = <see cref="Vector3"/>.SnapToRotatedGridWithOffset(point,position,Offset,rot,GridSize);
         ///             SomeObject.Position = point;
         ///         }
@@ -1752,8 +1752,8 @@ namespace FlaxEngine
         /// <param name="InCenterPoint">The center point.</param>
         /// <param name="InOrientation">The rotation of the grid.</param>
         /// <param name="InGridSize">The size of the grid.</param>
-        /// <param name="InOffset">The local grid offset to applay after snaping</param>
-        /// <returns></returns>
+        /// <param name="InOffset">The local grid offset to apply after snapping.</param>
+        /// <returns>The position snapped to the grid, with offset applied.</returns>
         public static Vector3 SnapToRotatedGridWithOffset(Vector3 InPoint, Vector3 InCenterPoint, Vector3 InOffset, Quaternion InOrientation, Vector3 InGridSize)
         {
             return ((SnapToGrid((InPoint - InCenterPoint) * InOrientation.Conjugated(), InGridSize) + InOffset) * InOrientation) + InCenterPoint;

--- a/Source/Engine/Core/Math/Vector3.h
+++ b/Source/Engine/Core/Math/Vector3.h
@@ -927,6 +927,47 @@ public:
     /// <param name="to">The second vector.</param>
     /// <returns>The angle (in radians).</returns>
     static FLAXENGINE_API T Angle(const Vector3Base& from, const Vector3Base& to);
+
+    /// <summary>
+    /// Snaps the input position into the grid.
+    /// </summary>
+    /// <param name="pos">The position to snap.</param>
+    /// <param name="gridSize">The size of the grid.</param>
+    /// <returns>The position snapped to the grid.</returns>
+    static Vector3 SnapToGrid(const Vector3& pos, Vector3 gridSize)
+    {
+        pos.X = Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X;
+        pos.Y = Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y;
+        pos.Z = Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z;
+        return pos;
+    }
+
+    /// <summary>
+    /// Snaps the <paramref name="InPoint"/> on to rotate grid.<br/>
+    /// for world aligned grid snapping use <b><see cref="Vector3::SnapToGrid"/></b> instead
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InCenterPoint">The center point.</param>
+    /// <param name="InOrientation">The rotation of the grid.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <returns>The position snapped to the grid.</returns>
+    static Vector3 SnapToRotatedGrid(const Vector3& InPoint, const Vector3& InCenterPoint, const Quaternion& InOrientation, const Vector3& InGridSize)
+    {
+        return (Vector3::SnapToGrid((InPoint - InCenterPoint) * InOrientation.Conjugated(), InGridSize) * InOrientation) + InCenterPoint;
+    }
+    /// <summary>
+    /// The same as <see cref="SnapToRotatedGrid"/> but with local offset applied after point is spapend
+    /// </summary>
+    /// <param name="InPoint">The position to snap.</param>
+    /// <param name="InCenterPoint">The center point.</param>
+    /// <param name="InOrientation">The rotation of the grid.</param>
+    /// <param name="InGridSize">The size of the grid.</param>
+    /// <param name="InOffset">The local grid offset to applay after snaping</param>
+    /// <returns></returns>
+    static Vector3 SnapToRotatedGridWithOffset(const Vector3& InPoint, const Vector3& InCenterPoint, const Vector3& InOffset, const Quaternion& InOrientation, const Vector3& InGridSize)
+    {
+        return ((Vector3::SnapToGrid((InPoint - InCenterPoint) * InOrientation.Conjugated(), InGridSize) + InOffset) * InOrientation) + InCenterPoint;
+    }
 };
 
 template<typename T>

--- a/Source/Engine/Core/Math/Vector3.h
+++ b/Source/Engine/Core/Math/Vector3.h
@@ -934,13 +934,7 @@ public:
     /// <param name="pos">The position to snap.</param>
     /// <param name="gridSize">The size of the grid.</param>
     /// <returns>The position snapped to the grid.</returns>
-    static Vector3 SnapToGrid(const Vector3& pos, Vector3 gridSize)
-    {
-        pos.X = Math::Ceil((pos.X - (gridSize.X * 0.5f)) / gridSize.X) * gridSize.X;
-        pos.Y = Math::Ceil((pos.Y - (gridSize.Y * 0.5f)) / gridSize.Y) * gridSize.Y;
-        pos.Z = Math::Ceil((pos.Z - (gridSize.Z * 0.5f)) / gridSize.Z) * gridSize.Z;
-        return pos;
-    }
+    static Vector3Base SnapToGrid(const Vector3Base& pos,const Vector3Base& gridSize);
 
     /// <summary>
     /// Snaps the <paramref name="InPoint"/> on to rotate grid.<br/>
@@ -951,10 +945,7 @@ public:
     /// <param name="InOrientation">The rotation of the grid.</param>
     /// <param name="InGridSize">The size of the grid.</param>
     /// <returns>The position snapped to the grid.</returns>
-    static Vector3 SnapToRotatedGrid(const Vector3& InPoint, const Vector3& InCenterPoint, const Quaternion& InOrientation, const Vector3& InGridSize)
-    {
-        return (Vector3::SnapToGrid((InPoint - InCenterPoint) * InOrientation.Conjugated(), InGridSize) * InOrientation) + InCenterPoint;
-    }
+    static Vector3Base SnapToRotatedGrid(const Vector3Base& InPoint, const Vector3Base& InCenterPoint, const Quaternion& InOrientation, const Vector3Base& InGridSize);
     /// <summary>
     /// The same as <see cref="SnapToRotatedGrid"/> but with local offset applied after point is spapend
     /// </summary>
@@ -964,10 +955,7 @@ public:
     /// <param name="InGridSize">The size of the grid.</param>
     /// <param name="InOffset">The local grid offset to applay after snaping</param>
     /// <returns></returns>
-    static Vector3 SnapToRotatedGridWithOffset(const Vector3& InPoint, const Vector3& InCenterPoint, const Vector3& InOffset, const Quaternion& InOrientation, const Vector3& InGridSize)
-    {
-        return ((Vector3::SnapToGrid((InPoint - InCenterPoint) * InOrientation.Conjugated(), InGridSize) + InOffset) * InOrientation) + InCenterPoint;
-    }
+    static Vector3Base SnapToRotatedGridWithOffset(const Vector3Base& InPoint, const Vector3Base& InCenterPoint, const Vector3Base& InOffset, const Quaternion& InOrientation, const Vector3Base& InGridSize);
 };
 
 template<typename T>

--- a/Source/Engine/Core/Math/Vector3.h
+++ b/Source/Engine/Core/Math/Vector3.h
@@ -929,33 +929,34 @@ public:
     static FLAXENGINE_API T Angle(const Vector3Base& from, const Vector3Base& to);
 
     /// <summary>
-    /// Snaps the input position into the grid.
+    /// Snaps the input position onto the grid.
     /// </summary>
     /// <param name="pos">The position to snap.</param>
     /// <param name="gridSize">The size of the grid.</param>
     /// <returns>The position snapped to the grid.</returns>
-    static Vector3Base SnapToGrid(const Vector3Base& pos,const Vector3Base& gridSize);
+    static FLAXENGINE_API Vector3Base SnapToGrid(const Vector3Base& pos, const Vector3Base& gridSize);
 
     /// <summary>
-    /// Snaps the <paramref name="InPoint"/> on to rotate grid.<br/>
-    /// for world aligned grid snapping use <b><see cref="Vector3::SnapToGrid"/></b> instead
+    /// Snaps the <paramref name="InPoint"/> onto the rotated grid.<br/>
+    /// For world aligned grid snapping use <b><see cref="SnapToGrid"/></b> instead.
     /// </summary>
     /// <param name="InPoint">The position to snap.</param>
     /// <param name="InCenterPoint">The center point.</param>
     /// <param name="InOrientation">The rotation of the grid.</param>
     /// <param name="InGridSize">The size of the grid.</param>
     /// <returns>The position snapped to the grid.</returns>
-    static Vector3Base SnapToRotatedGrid(const Vector3Base& InPoint, const Vector3Base& InCenterPoint, const Quaternion& InOrientation, const Vector3Base& InGridSize);
+    static FLAXENGINE_API Vector3Base SnapToRotatedGrid(const Vector3Base& InPoint, const Vector3Base& InCenterPoint, const Quaternion& InOrientation, const Vector3Base& InGridSize);
+
     /// <summary>
-    /// The same as <see cref="SnapToRotatedGrid"/> but with local offset applied after point is spapend
+    /// The same as <see cref="SnapToRotatedGrid"/> but with local offset applied after point is snapped.
     /// </summary>
     /// <param name="InPoint">The position to snap.</param>
     /// <param name="InCenterPoint">The center point.</param>
     /// <param name="InOrientation">The rotation of the grid.</param>
     /// <param name="InGridSize">The size of the grid.</param>
-    /// <param name="InOffset">The local grid offset to applay after snaping</param>
-    /// <returns></returns>
-    static Vector3Base SnapToRotatedGridWithOffset(const Vector3Base& InPoint, const Vector3Base& InCenterPoint, const Vector3Base& InOffset, const Quaternion& InOrientation, const Vector3Base& InGridSize);
+    /// <param name="InOffset">The local grid offset to apply after snapping.</param>
+    /// <returns>The position snapped to the grid, with offset applied.</returns>
+    static FLAXENGINE_API Vector3Base SnapToRotatedGridWithOffset(const Vector3Base& InPoint, const Vector3Base& InCenterPoint, const Vector3Base& InOffset, const Quaternion& InOrientation, const Vector3Base& InGridSize);
 };
 
 template<typename T>


### PR DESCRIPTION
Added
C# and c++

**Quaternion.GetRotationFromNormal**
A special function for converting normal from ray cast to the rotation
When normal is axis-aligned, the Quaternion. Direction is not enough

**Transform. AlignRotationToNormalAndSnapToGrid**
Advanced function for snapping to grid with is in local space and aligning to normal vector

**Vector3. SnapToRotatedGrid**
function for snapping to grid with is in local space

**Vector3. SnapToRotatedGridWithOffset**
function for snapping to grid with is in local space with offset in local space

added missing
C++ was missing snap to grid function