### PR TITLE
Remove Editor viewport aspect ratio scaling from camera mouse movement

### DIFF
--- a/Source/Editor/Viewport/EditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/EditorGizmoViewport.cs
@@ -76,7 +76,7 @@ namespace FlaxEditor.Viewport
         public bool SnapToVertex => ContainsFocus && Editor.Instance.Options.Options.Input.SnapToVertex.Process(Root);
 
         /// <inheritdoc />
-        public Float2 MouseDelta => _mouseDelta * 1000;
+        public Float2 MouseDelta => _mouseDelta;
 
         /// <inheritdoc />
         public bool UseSnapping => Root?.GetKey(KeyboardKeys.Control) ?? false;

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1663,8 +1663,7 @@ namespace FlaxEditor.Viewport
                 {
                     offset.X = offset.X > 0 ? Mathf.Floor(offset.X) : Mathf.Ceil(offset.X);
                     offset.Y = offset.Y > 0 ? Mathf.Floor(offset.Y) : Mathf.Ceil(offset.Y);
-                    _mouseDelta = offset / size;
-                    _mouseDelta.Y *= size.Y / size.X;
+                    _mouseDelta = offset;
 
                     // Update delta filtering buffer
                     _deltaFilteringBuffer[_deltaFilteringStep] = _mouseDelta;
@@ -1682,8 +1681,7 @@ namespace FlaxEditor.Viewport
                 }
                 else
                 {
-                    _mouseDelta = offset / size;
-                    _mouseDelta.Y *= size.Y / size.X;
+                    _mouseDelta = offset;
                     mouseDelta = _mouseDelta;
                 }
 
@@ -1697,7 +1695,7 @@ namespace FlaxEditor.Viewport
 
                 // Update
                 moveDelta *= dt * (60.0f * 4.0f);
-                mouseDelta *= 200.0f * MouseSpeed * _mouseSensitivity;
+                mouseDelta *= 0.1833f * MouseSpeed * _mouseSensitivity;
                 UpdateView(dt, ref moveDelta, ref mouseDelta, out var centerMouse);
 
                 // Move mouse back to the root position
@@ -1723,7 +1721,7 @@ namespace FlaxEditor.Viewport
                     var offset = _viewMousePos - _startPos;
                     offset.X = offset.X > 0 ? Mathf.Floor(offset.X) : Mathf.Ceil(offset.X);
                     offset.Y = offset.Y > 0 ? Mathf.Floor(offset.Y) : Mathf.Ceil(offset.Y);
-                    _mouseDelta = offset / size;
+                    _mouseDelta = offset;
                     _startPos = _viewMousePos;
                 }
                 else

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -291,7 +291,7 @@ namespace FlaxEditor.Viewport
         public bool SnapToVertex => ContainsFocus && Editor.Instance.Options.Options.Input.SnapToVertex.Process(Root);
 
         /// <inheritdoc />
-        public Float2 MouseDelta => _mouseDelta * 1000;
+        public Float2 MouseDelta => _mouseDelta;
 
         /// <inheritdoc />
         public bool UseSnapping => Root.GetKey(KeyboardKeys.Control);


### PR DESCRIPTION
Rescaled the final mouse delta values to roughly matching default viewport width in 1080p resolution.