### PR TITLE
Fix underline being in wrong spot on different DPIs

### DIFF
--- a/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
@@ -290,7 +290,7 @@ namespace FlaxEngine.GUI
                 {
                     var leftEdge = selection.StartIndex <= textBlock.Range.StartIndex ? textBlock.Bounds.UpperLeft : font.GetCharPosition(_text, selection.StartIndex);
                     var rightEdge = selection.EndIndex >= textBlock.Range.EndIndex ? textBlock.Bounds.UpperRight : font.GetCharPosition(_text, selection.EndIndex);
-                    float height = font.Height / DpiScale;
+                    float height = font.Height;
                     float alpha = Mathf.Min(1.0f, Mathf.Cos(_animateTime * BackgroundSelectedFlashSpeed) * 0.5f + 1.3f);
                     alpha *= alpha;
                     Color selectionColor = Color.White * alpha;

--- a/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
@@ -340,7 +340,7 @@ namespace FlaxEngine.GUI
                 if (textBlock.Style.UnderlineBrush != null)
                 {
                     var underLineHeight = 2.0f;
-                    var height = font.Height / DpiScale;
+                    var height = font.Height;
                     var underlineRect = new Rectangle(textBlock.Bounds.Location.X, textBlock.Bounds.Location.Y + height - underLineHeight * 0.5f, textBlock.Bounds.Width, underLineHeight);
                     textBlock.Style.UnderlineBrush.Draw(underlineRect, textBlock.Style.Color);
                 }


### PR DESCRIPTION
Fix #2401 

Fix underline to be in correct spot. Fix selection to scale correctly with dpi.