### PR TITLE
Hide TAA settings if TAA isn't enabled.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/PostProcessSettingsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/PostProcessSettingsEditor.cs
@@ -37,6 +37,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 return;
             }
 
+            EvaluateVisibleIf(itemLayout, item, GetLabelIndex(itemLayout, item));
+
             // Add labels with a check box
             var label = new CheckablePropertyNameLabel(item.DisplayName);
             label.CheckBox.Tag = setting.Bit;

--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -582,55 +582,13 @@ namespace FlaxEditor.CustomEditors.Editors
         }
 
         /// <summary>
-        /// Spawns the property for the given item.
+        /// Evaluate the visible if cache.
         /// </summary>
         /// <param name="itemLayout">The item layout.</param>
-        /// <param name="itemValues">The item values.</param>
         /// <param name="item">The item.</param>
-        protected virtual void SpawnProperty(LayoutElementsContainer itemLayout, ValueContainer itemValues, ItemInfo item)
+        /// <param name="labelIndex">The label index.</param>
+        protected virtual void EvaluateVisibleIf(LayoutElementsContainer itemLayout, ItemInfo item, int labelIndex)
         {
-            int labelIndex = 0;
-            if ((item.IsReadOnly || item.VisibleIfs.Length > 0) &&
-                itemLayout.Children.Count > 0 &&
-                itemLayout.Children[itemLayout.Children.Count - 1] is PropertiesListElement propertiesListElement)
-            {
-                labelIndex = propertiesListElement.Labels.Count;
-            }
-
-            itemLayout.Property(item.DisplayName, itemValues, item.OverrideEditor, item.TooltipText);
-
-            if (item.IsReadOnly && itemLayout.Children.Count > 0)
-            {
-                PropertiesListElement list = null;
-                int firstChildControlIndex = 0;
-                bool disableSingle = true;
-                var control = itemLayout.Children[itemLayout.Children.Count - 1];
-                if (control is GroupElement group && group.Children.Count > 0)
-                {
-                    list = group.Children[0] as PropertiesListElement;
-                    disableSingle = false; // Disable all nested editors
-                }
-                else if (control is PropertiesListElement list1)
-                {
-                    list = list1;
-                    firstChildControlIndex = list.Labels[labelIndex].FirstChildControlIndex;
-                }
-
-                if (list != null)
-                {
-                    // Disable controls added to the editor
-                    var count = list.Properties.Children.Count;
-                    for (int j = firstChildControlIndex; j < count; j++)
-                    {
-                        var child = list.Properties.Children[j];
-                        if (disableSingle && child is PropertyNameLabel)
-                            break;
-
-                        if (child != null)
-                            child.Enabled = false;
-                    }
-                }
-            }
             if (item.VisibleIfs.Length > 0 && itemLayout.Children.Count > 0)
             {
                 PropertiesListElement list = null;
@@ -667,6 +625,73 @@ namespace FlaxEditor.CustomEditors.Editors
                     InversionList = item.VisibleIfs.Select((x, i) => x.Invert).ToArray(),
                 };
             }
+        }
+
+        /// <summary>
+        /// Get the label index.
+        /// </summary>
+        /// <param name="itemLayout">The item layout.</param>
+        /// <param name="item">The item.</param>
+        /// <returns>The label index.</returns>
+        protected virtual int GetLabelIndex(LayoutElementsContainer itemLayout, ItemInfo item)
+        {
+            int labelIndex = 0;
+            if ((item.IsReadOnly || item.VisibleIfs.Length > 0) &&
+                itemLayout.Children.Count > 0 &&
+                itemLayout.Children[itemLayout.Children.Count - 1] is PropertiesListElement propertiesListElement)
+            {
+                labelIndex = propertiesListElement.Labels.Count;
+            }
+
+            return labelIndex;
+        }
+
+        /// <summary>
+        /// Spawns the property for the given item.
+        /// </summary>
+        /// <param name="itemLayout">The item layout.</param>
+        /// <param name="itemValues">The item values.</param>
+        /// <param name="item">The item.</param>
+        protected virtual void SpawnProperty(LayoutElementsContainer itemLayout, ValueContainer itemValues, ItemInfo item)
+        {
+            int labelIndex = GetLabelIndex(itemLayout, item);
+
+            itemLayout.Property(item.DisplayName, itemValues, item.OverrideEditor, item.TooltipText);
+
+            if (item.IsReadOnly && itemLayout.Children.Count > 0)
+            {
+                PropertiesListElement list = null;
+                int firstChildControlIndex = 0;
+                bool disableSingle = true;
+                var control = itemLayout.Children[itemLayout.Children.Count - 1];
+                if (control is GroupElement group && group.Children.Count > 0)
+                {
+                    list = group.Children[0] as PropertiesListElement;
+                    disableSingle = false; // Disable all nested editors
+                }
+                else if (control is PropertiesListElement list1)
+                {
+                    list = list1;
+                    firstChildControlIndex = list.Labels[labelIndex].FirstChildControlIndex;
+                }
+
+                if (list != null)
+                {
+                    // Disable controls added to the editor
+                    var count = list.Properties.Children.Count;
+                    for (int j = firstChildControlIndex; j < count; j++)
+                    {
+                        var child = list.Properties.Children[j];
+                        if (disableSingle && child is PropertyNameLabel)
+                            break;
+
+                        if (child != null)
+                            child.Enabled = false;
+                    }
+                }
+            }
+
+            EvaluateVisibleIf(itemLayout, item, labelIndex);
         }
 
         /// <inheritdoc />

--- a/Source/Engine/Graphics/PostProcessSettings.cs
+++ b/Source/Engine/Graphics/PostProcessSettings.cs
@@ -13,4 +13,12 @@ namespace FlaxEngine
             Bit = bit;
         }
     }
+
+    public partial struct AntiAliasingSettings
+    {
+        /// <summary>
+        /// Whether or not to show the TAA settings.
+        /// </summary>
+        public bool ShowTAASettings => (Mode == AntialiasingMode.TemporalAntialiasing);
+    }
 }

--- a/Source/Engine/Graphics/PostProcessSettings.h
+++ b/Source/Engine/Graphics/PostProcessSettings.h
@@ -1888,25 +1888,25 @@ API_STRUCT() struct FLAXENGINE_API AntiAliasingSettings : ISerializable
     /// <summary>
     /// The diameter (in texels) inside which jitter samples are spread. Smaller values result in crisper but more aliased output, while larger values result in more stable but blurrier output.
     /// </summary>
-    API_FIELD(Attributes="Limit(0.1f, 1f, 0.001f), EditorOrder(1), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_JitterSpread), EditorDisplay(null, \"TAA Jitter Spread\")")
+    API_FIELD(Attributes="Limit(0.1f, 1f, 0.001f), EditorOrder(1), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_JitterSpread), EditorDisplay(null, \"TAA Jitter Spread\"), VisibleIf(nameof(ShowTAASettings))")
     float TAA_JitterSpread = 1.0f;
 
     /// <summary>
     /// Controls the amount of sharpening applied to the color buffer. TAA can induce a slight loss of details in high frequency regions. Sharpening alleviates this issue. High values may introduce dark-border artifacts.
     /// </summary>
-    API_FIELD(Attributes="Limit(0, 3f, 0.001f), EditorOrder(2), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_Sharpness), EditorDisplay(null, \"TAA Sharpness\")")
+    API_FIELD(Attributes="Limit(0, 3f, 0.001f), EditorOrder(2), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_Sharpness), EditorDisplay(null, \"TAA Sharpness\"), VisibleIf(nameof(ShowTAASettings))")
     float TAA_Sharpness = 0.1f;
 
     /// <summary>
     /// The blend coefficient for stationary fragments. Controls the percentage of history samples blended into the final color for fragments with minimal active motion.
     /// </summary>
-    API_FIELD(Attributes="Limit(0, 0.99f, 0.001f), EditorOrder(3), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_StationaryBlending), EditorDisplay(null, \"TAA Stationary Blending\")")
+    API_FIELD(Attributes="Limit(0, 0.99f, 0.001f), EditorOrder(3), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_StationaryBlending), EditorDisplay(null, \"TAA Stationary Blending\"), VisibleIf(nameof(ShowTAASettings))")
     float TAA_StationaryBlending = 0.95f;
 
     /// <summary>
     /// The blending coefficient for moving fragments. Controls the percentage of history samples blended into the final color for fragments with significant active motion.
     /// </summary>
-    API_FIELD(Attributes="Limit(0, 0.99f, 0.001f), EditorOrder(4), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_MotionBlending), EditorDisplay(null, \"TAA Motion Blending\")")
+    API_FIELD(Attributes="Limit(0, 0.99f, 0.001f), EditorOrder(4), PostProcessSetting((int)AntiAliasingSettingsOverride.TAA_MotionBlending), EditorDisplay(null, \"TAA Motion Blending\"), VisibleIf(nameof(ShowTAASettings))")
     float TAA_MotionBlending = 0.85f;
 
 public:


### PR DESCRIPTION
This PR fixes the specific case mentioned in #2422. It also adds support for `VisibleIf()` in post process settings.