### PR TITLE
Add locking actor selection in properties and prefab windows

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FlaxEditor.Actions;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.CustomEditors.Elements;
@@ -9,6 +10,7 @@ using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Tree;
 using FlaxEditor.Scripting;
+using FlaxEditor.Windows;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Json;
@@ -111,6 +113,22 @@ namespace FlaxEditor.CustomEditors.Dedicated
             var actor = (Actor)Values[0];
             var scriptType = TypeUtils.GetType(actor.TypeName);
             var item = scriptType.ContentItem;
+            if (Presenter.Owner is PropertiesWindow pw)
+            {
+                var lockButton = cm.AddButton(pw.LockObjects ? "Unlock" : "Lock");
+                lockButton.ButtonClicked += button =>
+                {
+                    pw.LockObjects = !pw.LockObjects;
+
+                    // Reselect current selection
+                    if (!pw.LockObjects && Editor.Instance.SceneEditing.SelectionCount > 0)
+                    {
+                        var cachedSelection = Editor.Instance.SceneEditing.Selection.ToArray();
+                        Editor.Instance.SceneEditing.Select(null);
+                        Editor.Instance.SceneEditing.Select(cachedSelection);
+                    }
+                };
+            }
             cm.AddButton("Copy ID", OnClickCopyId);
             cm.AddButton("Edit actor type", OnClickEditActorType).Enabled = item != null;
             var showButton = cm.AddButton("Show in content window", OnClickShowActorType);

--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -11,6 +11,7 @@ using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Tree;
 using FlaxEditor.Scripting;
 using FlaxEditor.Windows;
+using FlaxEditor.Windows.Assets;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Json;
@@ -113,19 +114,35 @@ namespace FlaxEditor.CustomEditors.Dedicated
             var actor = (Actor)Values[0];
             var scriptType = TypeUtils.GetType(actor.TypeName);
             var item = scriptType.ContentItem;
-            if (Presenter.Owner is PropertiesWindow pw)
+            if (Presenter.Owner is PropertiesWindow propertiesWindow)
             {
-                var lockButton = cm.AddButton(pw.LockObjects ? "Unlock" : "Lock");
+                var lockButton = cm.AddButton(propertiesWindow.LockObjects ? "Unlock" : "Lock");
                 lockButton.ButtonClicked += button =>
                 {
-                    pw.LockObjects = !pw.LockObjects;
+                    propertiesWindow.LockObjects = !propertiesWindow.LockObjects;
 
                     // Reselect current selection
-                    if (!pw.LockObjects && Editor.Instance.SceneEditing.SelectionCount > 0)
+                    if (!propertiesWindow.LockObjects && Editor.Instance.SceneEditing.SelectionCount > 0)
                     {
                         var cachedSelection = Editor.Instance.SceneEditing.Selection.ToArray();
                         Editor.Instance.SceneEditing.Select(null);
                         Editor.Instance.SceneEditing.Select(cachedSelection);
+                    }
+                };
+            }
+            else if (Presenter.Owner is PrefabWindow prefabWindow)
+            {
+                var lockButton = cm.AddButton(prefabWindow.LockSelectedObjects ? "Unlock" : "Lock");
+                lockButton.ButtonClicked += button =>
+                {
+                    prefabWindow.LockSelectedObjects = !prefabWindow.LockSelectedObjects;
+
+                    // Reselect current selection
+                    if (!prefabWindow.LockSelectedObjects && prefabWindow.Selection.Count > 0)
+                    {
+                        var cachedSelection = prefabWindow.Selection.ToList();
+                        prefabWindow.Select(null);
+                        prefabWindow.Select(cachedSelection);
                     }
                 };
             }

--- a/Source/Editor/Windows/Assets/PrefabWindow.Selection.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Selection.cs
@@ -54,6 +54,9 @@ namespace FlaxEditor.Windows.Assets
         /// <param name="before">The selection before the change.</param>
         public void OnSelectionChanged(SceneGraphNode[] before)
         {
+            if (LockSelectedObjects)
+                return;
+
             Undo.AddAction(new SelectionChangeAction(before, Selection.ToArray(), OnSelectionUndo));
 
             OnSelectionChanges();

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -69,6 +69,11 @@ namespace FlaxEditor.Windows.Assets
         public readonly LocalSceneGraph Graph;
 
         /// <summary>
+        /// Indication of if the prefab window selection is locked on specific objects.
+        /// </summary>
+        public bool LockSelectedObjects = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether use live reloading for the prefab changes (applies prefab changes on modification by auto).
         /// </summary>
         public bool LiveReload

--- a/Source/Editor/Windows/PropertiesWindow.cs
+++ b/Source/Editor/Windows/PropertiesWindow.cs
@@ -38,6 +38,11 @@ namespace FlaxEditor.Windows
         public bool UIPivotRelative = true;
 
         /// <summary>
+        /// Indication of if the properties window is locked on specific objects.
+        /// </summary>
+        public bool LockObjects = false;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PropertiesWindow"/> class.
         /// </summary>
         /// <param name="editor">The editor.</param>
@@ -62,6 +67,9 @@ namespace FlaxEditor.Windows
 
         private void OnSelectionChanged()
         {
+            if (LockObjects)
+                return;
+
             // Update selected objects
             // TODO: use cached collection for less memory allocations
             undoRecordObjects = Editor.SceneEditing.Selection.ConvertAll(x => x.UndoRecordObject).Distinct();


### PR DESCRIPTION
This adds the option to lock and unlock the selection in the scene and prefab windows through the actor options dropdown. it is very useful if needing to drag actors into a reference. 

I did not address in this PR unlocking the locked selection if the selected actor is deleted.