### PR TITLE
Make NavMesh initialize earlier.

### DIFF
--- a/Source/Engine/Navigation/NavMesh.cpp
+++ b/Source/Engine/Navigation/NavMesh.cpp
@@ -180,7 +180,7 @@ void NavMesh::Initialize()
     // Base
     Actor::Initialize();
 
-    if (!_navMeshActive)
+    if (!_navMeshActive && IsActiveInHierarchy())
     {
         GetScene()->Navigation.Meshes.Add(this);
         AddTiles();

--- a/Source/Engine/Navigation/NavMesh.cpp
+++ b/Source/Engine/Navigation/NavMesh.cpp
@@ -105,10 +105,8 @@ void NavMesh::OnDataAssetLoaded()
     if (Data.Tiles.HasItems())
         return;
 
-    const bool isEnabled = IsDuringPlay() && IsActiveInHierarchy();
-
     // Remove added tiles
-    if (isEnabled)
+    if (_navMeshActive)
     {
         RemoveTiles();
     }
@@ -120,7 +118,7 @@ void NavMesh::OnDataAssetLoaded()
     IsDataDirty = false;
 
     // Add loaded tiles
-    if (isEnabled)
+    if (_navMeshActive)
     {
         AddTiles();
     }
@@ -156,15 +154,36 @@ void NavMesh::OnEnable()
     // Base
     Actor::OnEnable();
 
-    GetScene()->Navigation.Meshes.Add(this);
-    AddTiles();
+    if (!_navMeshActive)
+    {
+        GetScene()->Navigation.Meshes.Add(this);
+        AddTiles();
+        _navMeshActive = true;
+    }
 }
 
 void NavMesh::OnDisable()
 {
-    RemoveTiles();
-    GetScene()->Navigation.Meshes.Remove(this);
+    if (_navMeshActive)
+    {
+        RemoveTiles();
+        GetScene()->Navigation.Meshes.Remove(this);
+        _navMeshActive = false;
+    }
 
     // Base
     Actor::OnDisable();
+}
+
+void NavMesh::Initialize()
+{
+    // Base
+    Actor::Initialize();
+
+    if (!_navMeshActive)
+    {
+        GetScene()->Navigation.Meshes.Add(this);
+        AddTiles();
+        _navMeshActive = true;
+    }
 }

--- a/Source/Engine/Navigation/NavMesh.h
+++ b/Source/Engine/Navigation/NavMesh.h
@@ -68,6 +68,9 @@ private:
     void RemoveTiles();
     void OnDataAssetLoaded();
 
+private:
+    bool _navMeshActive = false;
+
 public:
     // [Actor]
     void Serialize(SerializeStream& stream, const void* otherObj) override;
@@ -77,4 +80,5 @@ protected:
     // [Actor]
     void OnEnable() override;
     void OnDisable() override;
+    void Initialize() override;
 };


### PR DESCRIPTION
This PR makes navmeshes initialize earlier so the code example from the docs actually works reliably. Previously it would only work if `OnEnable()` for the navmesh ran before `OnEnable()` for the agent script, since the initialization for the `NavMesh` actor was previously done in `OnEnable()`. This PR makes an attempt to fix that, but I'm not sure if `Initialize()` is stable for this.