### PR TITLE
Fix scripting AssemblyLoadContext not getting unloaded

### DIFF
--- a/Source/Editor/CustomEditors/CustomEditorPresenter.cs
+++ b/Source/Editor/CustomEditors/CustomEditorPresenter.cs
@@ -196,6 +196,15 @@ namespace FlaxEditor.CustomEditors
             }
 
             /// <inheritdoc />
+            protected override void Deinitialize()
+            {
+                Editor = null;
+                _overrideEditor = null;
+
+                base.Deinitialize();
+            }
+
+            /// <inheritdoc />
             protected override void OnModified()
             {
                 Presenter.OnModified();

--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -206,7 +206,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
             if (_linkedPrefabId != Guid.Empty)
             {
                 _linkedPrefabId = Guid.Empty;
-                Editor.Instance.Prefabs.PrefabApplied -= OnPrefabApplying;
+                Editor.Instance.Prefabs.PrefabApplying -= OnPrefabApplying;
                 Editor.Instance.Prefabs.PrefabApplied -= OnPrefabApplied;
             }
         }

--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -1057,6 +1057,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
         protected override void Deinitialize()
         {
             _scriptToggles = null;
+            _scripts.Clear();
 
             base.Deinitialize();
         }

--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -819,6 +819,14 @@ namespace FlaxEditor.CustomEditors.Editors
             OnGroupsEnd();
         }
 
+        protected override void Deinitialize()
+        {
+            _visibleIfCaches = null;
+            _visibleIfPropertiesListsCache = null;
+
+            base.Deinitialize();
+        }
+
         /// <inheritdoc />
         public override void Refresh()
         {

--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -819,6 +819,7 @@ namespace FlaxEditor.CustomEditors.Editors
             OnGroupsEnd();
         }
 
+        /// <inheritdoc />
         protected override void Deinitialize()
         {
             _visibleIfCaches = null;

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -464,7 +464,7 @@ namespace FlaxEditor.GUI.Docking
         {
             base.Focus();
 
-            SelectTab();
+            SelectTab(false);
             BringToFront();
         }
 

--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -21,6 +21,7 @@ namespace FlaxEditor.Modules
         private bool _enableEvents;
         private bool _isDuringFastSetup;
         private bool _rebuildFlag;
+        private bool _rebuildInitFlag;
         private int _itemsCreated;
         private int _itemsDeleted;
         private readonly HashSet<MainContentTreeNode> _dirtyNodes = new HashSet<MainContentTreeNode>();
@@ -820,6 +821,7 @@ namespace FlaxEditor.Modules
             Profiler.BeginEvent("ContentDatabase.Rebuild");
             var startTime = Platform.TimeSeconds;
             _rebuildFlag = false;
+            _rebuildInitFlag = false;
             _enableEvents = false;
 
             // Load all folders
@@ -1240,6 +1242,15 @@ namespace FlaxEditor.Modules
                     FlaxEngine.Scripting.InvokeOnUpdate(() => OnImportFileDone(path));
             };
             _enableEvents = true;
+            _rebuildInitFlag = true;
+        }
+
+        /// <inheritdoc />
+        public override void OnEndInit()
+        {
+            // Handle init when project was loaded without scripts loading ()
+            if (_rebuildInitFlag)
+                RebuildInternal();
         }
 
         private void OnImportFileDone(string path)

--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -90,6 +90,7 @@ namespace FlaxEditor.Modules
             FlaxEngine.Json.JsonSerializer.Settings.Converters.Add(new AssetItemConverter());
 
             ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+            ScriptsBuilder.ScriptsReloadEnd += OnScriptsReloadEnd;
         }
 
         private void OnContentAssetDisposing(Asset asset)
@@ -1232,8 +1233,6 @@ namespace FlaxEditor.Modules
                 LoadProjects(Game.Project);
             }
 
-            RebuildInternal();
-
             Editor.ContentImporting.ImportFileEnd += (obj, failed) =>
             {
                 var path = obj.ResultUrl;
@@ -1354,6 +1353,11 @@ namespace FlaxEditor.Modules
 
             _isDuringFastSetup = false;
             _enableEvents = enabledEvents;
+        }
+
+        private void OnScriptsReloadEnd()
+        {
+            RebuildInternal();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -61,7 +61,7 @@ namespace FlaxEditor.Modules
         public event Action WorkspaceModified;
 
         /// <summary>
-        /// Occurs when workspace has will be rebuilt.
+        /// Occurs when workspace will be rebuilt.
         /// </summary>
         public event Action WorkspaceRebuilding;
 
@@ -89,7 +89,7 @@ namespace FlaxEditor.Modules
             // Register AssetItems serialization helper (serialize ref ID only)
             FlaxEngine.Json.JsonSerializer.Settings.Converters.Add(new AssetItemConverter());
 
-            ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+            ScriptsBuilder.ScriptsReload += OnScriptsReload;
             ScriptsBuilder.ScriptsReloadEnd += OnScriptsReloadEnd;
         }
 
@@ -1314,7 +1314,7 @@ namespace FlaxEditor.Modules
             }
         }
 
-        private void OnScriptsReloadBegin()
+        private void OnScriptsReload()
         {
             var enabledEvents = _enableEvents;
             _enableEvents = false;
@@ -1387,7 +1387,8 @@ namespace FlaxEditor.Modules
         public override void OnExit()
         {
             FlaxEngine.Content.AssetDisposing -= OnContentAssetDisposing;
-            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
+            ScriptsBuilder.ScriptsReload -= OnScriptsReload;
+            ScriptsBuilder.ScriptsReloadEnd -= OnScriptsReloadEnd;
 
             // Disable events
             _enableEvents = false;

--- a/Source/Editor/Modules/ContentImportingModule.cs
+++ b/Source/Editor/Modules/ContentImportingModule.cs
@@ -391,6 +391,20 @@ namespace FlaxEditor.Modules
         public override void OnInit()
         {
             ImportFileEntry.RegisterDefaultTypes();
+            ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+        }
+
+        private void OnScriptsReloadBegin()
+        {
+            // Remove import file types from scripting assemblies
+            List<string> removeFileTypes = new List<string>();
+            foreach (var pair in ImportFileEntry.FileTypes)
+            {
+                if (pair.Value.Method.IsCollectible || (pair.Value.Target != null && pair.Value.Target.GetType().IsCollectible))
+                    removeFileTypes.Add(pair.Key);
+            }
+            foreach (var fileType in removeFileTypes)
+                ImportFileEntry.FileTypes.Remove(fileType);
         }
 
         /// <inheritdoc />
@@ -451,6 +465,7 @@ namespace FlaxEditor.Modules
         /// <inheritdoc />
         public override void OnExit()
         {
+            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
             EndWorker();
         }
     }

--- a/Source/Editor/Modules/SceneModule.cs
+++ b/Source/Editor/Modules/SceneModule.cs
@@ -58,7 +58,7 @@ namespace FlaxEditor.Modules
         : base(editor)
         {
             // After editor cache but before the windows
-            InitOrder = -900;
+            InitOrder = -800;
         }
 
         /// <summary>

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -160,7 +160,7 @@ namespace FlaxEditor.Modules
         internal UIModule(Editor editor)
         : base(editor)
         {
-            InitOrder = -90;
+            InitOrder = -70;
             VisjectSurfaceBackground = FlaxEngine.Content.LoadAsyncInternal<Texture>("Editor/VisjectSurface");
             ColorValueBox.ShowPickColorDialog += ShowPickColorDialog;
         }

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -1004,6 +1004,11 @@ namespace FlaxEditor.Modules
                     Editor.LogWarning(string.Format("Failed to restore window {0} (assembly: {1})", winData.TypeName, winData.AssemblyName));
                 }
             }
+
+            // Restored windows stole the focus from Editor
+            if (_restoreWindows.Count > 0)
+                Editor.Instance.Windows.MainWindow.Focus();
+
             _restoreWindows.Clear();
         }
 

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -5,10 +5,12 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Xml;
 using FlaxEditor.Content;
 using FlaxEditor.GUI.Dialogs;
+using FlaxEditor.GUI.Docking;
 using FlaxEditor.Windows;
 using FlaxEditor.Windows.Assets;
 using FlaxEditor.Windows.Profiler;
@@ -39,6 +41,7 @@ namespace FlaxEditor.Modules
             
             public DockState DockState;
             public DockPanel DockedTo;
+            public int DockedTabIndex;
             public float? SplitterValue = null;
 
             public bool SelectOnShow = false;
@@ -47,6 +50,9 @@ namespace FlaxEditor.Modules
             public bool Minimize;
             public Float2 FloatSize;
             public Float2 FloatPosition;
+
+            public AssetItem Item;
+            public AssetItem Item2;
 
             // Constructor, to allow for default values
             public WindowRestoreData()
@@ -807,6 +813,56 @@ namespace FlaxEditor.Modules
             Editor.StateMachine.StateChanged += OnEditorStateChanged;
         }
 
+        internal void AddToRestore(PrefabWindow win)
+        {
+            var type = win.GetType();
+            var winData = new WindowRestoreData();
+            var panel = win.ParentDockPanel;
+
+            // Ensure that this window is only selected following recompilation
+            // if it was the active tab in its dock panel. Otherwise, there is a
+            // risk of interrupting the user's workflow by potentially selecting
+            // background tabs.
+            var window = win.RootWindow?.Window;
+            winData.SelectOnShow = panel.SelectedTab == win;
+            winData.DockedTabIndex = 0;
+            if (panel is FloatWindowDockPanel && window != null && panel.TabsCount == 1)
+            {
+                winData.DockState = DockState.Float;
+                winData.FloatPosition = window.Position;
+                winData.FloatSize = window.ClientSize;
+                winData.Maximize = window.IsMaximized;
+                winData.Minimize = window.IsMinimized;
+                winData.DockedTo = panel;
+            }
+            else
+            {
+                for (int i = 0; i < panel.Tabs.Count; i++)
+                {
+                    if (panel.Tabs[i] == win)
+                    {
+                        winData.DockedTabIndex = i;
+                        break;
+                    }
+                }
+                if (panel.TabsCount > 1)
+                {
+                    winData.DockState = DockState.DockFill;
+                    winData.DockedTo = panel;
+                }
+                else
+                {
+                    winData.DockState = panel.TryGetDockState(out var splitterValue);
+                    winData.DockedTo = panel.ParentDockPanel;
+                    winData.SplitterValue = splitterValue;
+                }
+            }
+            winData.AssemblyName = type.Assembly.GetName().Name;
+            winData.TypeName = type.FullName;
+            winData.Item = win.Item;
+            _restoreWindows.Add(winData);
+        }
+
         internal void AddToRestore(CustomEditorWindow win)
         {
             var type = win.GetType();
@@ -839,7 +895,8 @@ namespace FlaxEditor.Modules
                 {
                     winData.DockState = DockState.DockFill;
                     winData.DockedTo = panel;
-                }else
+                }
+                else
                 {
                     winData.DockState = panel.TryGetDockState(out var splitterValue);
                     winData.DockedTo = panel.ParentDockPanel;
@@ -853,36 +910,89 @@ namespace FlaxEditor.Modules
 
         private void OnScriptsReloadEnd()
         {
-            for (int i = 0; i < _restoreWindows.Count; i++)
+            // Go in reverse order to create floating Prefab windows first before docked windows
+            for (int i = _restoreWindows.Count - 1; i >= 0; i--)
             {
                 var winData = _restoreWindows[i];
 
                 try
                 {
                     var assembly = Utils.GetAssemblyByName(winData.AssemblyName);
-                    if (assembly != null)
+                    if (assembly == null)
+                        continue;
+                    
+                    var type = assembly.GetType(winData.TypeName);
+                    if (type == null)
+                        continue;
+
+                    if (type == typeof(PrefabWindow))
                     {
-                        var type = assembly.GetType(winData.TypeName);
-                        if (type != null)
+                        var win = new PrefabWindow(Editor.Instance, winData.Item);
+                        win.Show(winData.DockState, winData.DockState != DockState.Float ? winData.DockedTo : null, winData.SelectOnShow, winData.SplitterValue);
+                        if (winData.DockState == DockState.Float)
                         {
-                            var win = (CustomEditorWindow)Activator.CreateInstance(type);
-                            win.Show(winData.DockState, winData.DockedTo, winData.SelectOnShow, winData.SplitterValue);
-                            if (winData.DockState == DockState.Float)
+                            var window = win.RootWindow.Window;
+                            window.Position = winData.FloatPosition;
+                            if (winData.Maximize)
                             {
-                                var window = win.Window.RootWindow.Window;
-                                window.Position = winData.FloatPosition;
-                                if (winData.Maximize)
-                                {
-                                    window.Maximize();
-                                }
-                                else if (winData.Minimize)
-                                {
-                                    window.Minimize();
-                                }
-                                else 
-                                {
-                                    window.ClientSize = winData.FloatSize;
-                                }
+                                window.Maximize();
+                            }
+                            else if (winData.Minimize)
+                            {
+                                window.Minimize();
+                            }
+                            else
+                            {
+                                window.ClientSize = winData.FloatSize;
+                            }
+
+                            // Update panel reference in other windows docked to this panel
+                            foreach (ref var otherData in CollectionsMarshal.AsSpan(_restoreWindows))
+                            {
+                                if (otherData.DockedTo == winData.DockedTo)
+                                    otherData.DockedTo = win.ParentDockPanel;
+                            }
+                        }
+                        var panel = win.ParentDockPanel;
+                        int currentTabIndex = 0;
+                        for (int pi = 0; pi < panel.TabsCount; pi++)
+                        {
+                            if (panel.Tabs[pi] == win)
+                            {
+                                currentTabIndex = pi;
+                                break;
+                            }
+                        }
+                        while (currentTabIndex > winData.DockedTabIndex)
+                        {
+                            win.ParentDockPanel.MoveTabLeft(currentTabIndex);
+                            currentTabIndex--;
+                        }
+                        while (currentTabIndex < winData.DockedTabIndex)
+                        {
+                            win.ParentDockPanel.MoveTabRight(currentTabIndex);
+                            currentTabIndex++;
+                        }
+                    }
+                    else
+                    {
+                        var win = (CustomEditorWindow)Activator.CreateInstance(type);
+                        win.Show(winData.DockState, winData.DockedTo, winData.SelectOnShow, winData.SplitterValue);
+                        if (winData.DockState == DockState.Float)
+                        {
+                            var window = win.Window.RootWindow.Window;
+                            window.Position = winData.FloatPosition;
+                            if (winData.Maximize)
+                            {
+                                window.Maximize();
+                            }
+                            else if (winData.Minimize)
+                            {
+                                window.Minimize();
+                            }
+                            else
+                            {
+                                window.ClientSize = winData.FloatSize;
                             }
                         }
                     }

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -52,7 +52,6 @@ namespace FlaxEditor.Modules
             public Float2 FloatPosition;
 
             public AssetItem Item;
-            public AssetItem Item2;
 
             // Constructor, to allow for default values
             public WindowRestoreData()

--- a/Source/Editor/SceneGraph/SceneGraphNode.cs
+++ b/Source/Editor/SceneGraph/SceneGraphNode.cs
@@ -469,6 +469,7 @@ namespace FlaxEditor.SceneGraph
             {
                 ChildNodes[i].OnDispose();
             }
+            ChildNodes.Clear();
 
             SceneGraphFactory.Nodes.Remove(ID);
         }

--- a/Source/Editor/Surface/AnimGraphSurface.cs
+++ b/Source/Editor/Surface/AnimGraphSurface.cs
@@ -161,6 +161,8 @@ namespace FlaxEditor.Surface
 
         private void OnScriptsReloadBegin()
         {
+            _nodesCache.Clear();
+
             // Check if any of the nodes comes from the game scripts - those can be reloaded at runtime so prevent crashes
             bool hasTypeFromGameScripts = Editor.Instance.CodeEditing.AnimGraphNodes.HasTypeFromGameScripts;
 

--- a/Source/Editor/Surface/BehaviorTreeSurface.cs
+++ b/Source/Editor/Surface/BehaviorTreeSurface.cs
@@ -24,6 +24,7 @@ namespace FlaxEditor.Surface
         public BehaviorTreeSurface(IVisjectSurfaceOwner owner, Action onSave, FlaxEditor.Undo undo)
         : base(owner, onSave, undo, CreateStyle())
         {
+            ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
         }
 
         private static SurfaceStyle CreateStyle()
@@ -33,6 +34,11 @@ namespace FlaxEditor.Surface
             style.DrawBox = DrawBox;
             style.DrawConnection = SurfaceStyle.DrawStraightConnection;
             return style;
+        }
+
+        private void OnScriptsReloadBegin()
+        {
+            _nodesCache.Clear();
         }
 
         private static void DrawBox(Box box)
@@ -186,6 +192,7 @@ namespace FlaxEditor.Surface
         {
             if (IsDisposing)
                 return;
+            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
             _nodesCache.Wait();
 
             base.OnDestroy();

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -415,6 +415,15 @@ namespace FlaxEditor.Surface
             // Init drag handlers
             DragHandlers.Add(_dragAssets = new DragAssets<DragDropEventArgs>(ValidateDragItem));
             DragHandlers.Add(_dragParameters = new DragNames<DragDropEventArgs>(SurfaceParameter.DragPrefix, ValidateDragParameter));
+
+            ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+        }
+
+        private void OnScriptsReloadBegin()
+        {
+            _activeVisjectCM = null;
+            _cmPrimaryMenu?.Dispose();
+            _cmPrimaryMenu = null;
         }
 
         /// <summary>
@@ -1022,6 +1031,8 @@ namespace FlaxEditor.Surface
             // Cleanup
             _activeVisjectCM = null;
             _cmPrimaryMenu?.Dispose();
+
+            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
 
             base.OnDestroy();
         }

--- a/Source/Editor/Surface/VisualScriptSurface.cs
+++ b/Source/Editor/Surface/VisualScriptSurface.cs
@@ -62,6 +62,12 @@ namespace FlaxEditor.Surface
         {
             _supportsImplicitCastFromObjectToBoolean = true;
             DragHandlers.Add(_dragActors = new DragActors(ValidateDragActor));
+            ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+        }
+
+        private void OnScriptsReloadBegin()
+        {
+            _nodesCache.Clear();
         }
 
         private bool ValidateDragActor(ActorNode actor)
@@ -631,6 +637,7 @@ namespace FlaxEditor.Surface
         {
             if (IsDisposing)
                 return;
+            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
             _nodesCache.Wait();
 
             base.OnDestroy();

--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -58,6 +58,8 @@ namespace FlaxEditor.Windows.Assets
             InputActions.Add(options => options.Save, Save);
 
             UpdateTitle();
+
+            ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
         }
 
         /// <summary>
@@ -151,6 +153,8 @@ namespace FlaxEditor.Windows.Assets
         /// <inheritdoc />
         public override void OnDestroy()
         {
+            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
+
             if (_item != null)
             {
                 // Ensure to remove linkage to the item
@@ -158,6 +162,15 @@ namespace FlaxEditor.Windows.Assets
             }
 
             base.OnDestroy();
+        }
+
+        /// <inheritdoc />
+        protected virtual void OnScriptsReloadBegin()
+        {
+            if (!IsHidden)
+            {
+                Editor.Instance.Windows.AddToRestore(this);
+            }
         }
 
         #region IEditable Implementation

--- a/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
+++ b/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
@@ -268,8 +268,11 @@ namespace FlaxEditor.Windows.Assets
             UpdateKnowledge();
         }
 
-        private void OnScriptsReloadBegin()
+        /// <inheritdoc />
+        protected override void OnScriptsReloadBegin()
         {
+            base.OnScriptsReloadBegin();
+
             // TODO: impl hot-reload for BT to nicely refresh state (save asset, clear undo/properties, reload surface)
             Close();
         }

--- a/Source/Editor/Windows/Assets/JsonAssetWindow.cs
+++ b/Source/Editor/Windows/Assets/JsonAssetWindow.cs
@@ -124,8 +124,10 @@ namespace FlaxEditor.Windows.Assets
             UpdateToolstrip();
         }
 
-        private void OnScriptsReloadBegin()
+        /// <inheritdoc />
+        protected override void OnScriptsReloadBegin()
         {
+            base.OnScriptsReloadBegin();
             Close();
         }
 

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -194,7 +194,6 @@ namespace FlaxEditor.Windows.Assets
 
             Editor.Prefabs.PrefabApplied += OnPrefabApplied;
             ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
-            ScriptsBuilder.ScriptsReloadEnd += OnScriptsReloadEnd;
 
             // Setup input actions
             InputActions.Add(options => options.Undo, () =>
@@ -311,24 +310,18 @@ namespace FlaxEditor.Windows.Assets
                 }
             }
 
+            if (!IsHidden)
+            {
+                Editor.Instance.Windows.AddToRestore(this);
+            }
+
             // Cleanup
             Deselect();
             Graph.MainActor = null;
             _viewport.Prefab = null;
             _undo?.Clear(); // TODO: maybe don't clear undo?
-        }
 
-        private void OnScriptsReloadEnd()
-        {
-            _isScriptsReloading = false;
-
-            if (_asset == null || !_asset.IsLoaded)
-                return;
-
-            // Restore
-            OnPrefabOpened();
-            _undo.Clear();
-            ClearEditedFlag();
+            Close();
         }
 
         private void OnUndoEvent(IUndoAction action)
@@ -547,7 +540,6 @@ namespace FlaxEditor.Windows.Assets
         {
             Editor.Prefabs.PrefabApplied -= OnPrefabApplied;
             ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
-            ScriptsBuilder.ScriptsReloadEnd -= OnScriptsReloadEnd;
 
             _undo.Dispose();
             Graph.Dispose();

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -286,8 +286,10 @@ namespace FlaxEditor.Windows.Assets
             return false;
         }
 
-        private void OnScriptsReloadBegin()
+        /// <inheritdoc />
+        protected override void OnScriptsReloadBegin()
         {
+            base.OnScriptsReloadBegin();
             _isScriptsReloading = true;
 
             if (_asset == null || !_asset.IsLoaded)
@@ -308,11 +310,6 @@ namespace FlaxEditor.Windows.Assets
                 {
                     Save();
                 }
-            }
-
-            if (!IsHidden)
-            {
-                Editor.Instance.Windows.AddToRestore(this);
             }
 
             // Cleanup

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -144,26 +144,6 @@ namespace FlaxEditor.Windows
 
             FlaxEditor.Utilities.Utils.SetupCommonInputActions(this);
 
-            // Content database events
-            editor.ContentDatabase.WorkspaceModified += () => _isWorkspaceDirty = true;
-            editor.ContentDatabase.ItemRemoved += OnContentDatabaseItemRemoved;
-            editor.ContentDatabase.WorkspaceRebuilding += () => { _workspaceRebuildLocation = SelectedNode?.Path; };
-            editor.ContentDatabase.WorkspaceRebuilt += () =>
-            {
-                var selected = Editor.ContentDatabase.Find(_workspaceRebuildLocation);
-                if (selected is ContentFolder selectedFolder)
-                {
-                    _navigationUnlocked = false;
-                    RefreshView(selectedFolder.Node);
-                    _tree.Select(selectedFolder.Node);
-                    UpdateItemsSearch();
-                    _navigationUnlocked = true;
-                    UpdateUI();
-                }
-                else
-                    ShowRoot();
-            };
-
             var options = Editor.Options;
             options.OptionsChanged += OnOptionsChanged;
 
@@ -1037,6 +1017,26 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override void OnInit()
         {
+            // Content database events
+            Editor.ContentDatabase.WorkspaceModified += () => _isWorkspaceDirty = true;
+            Editor.ContentDatabase.ItemRemoved += OnContentDatabaseItemRemoved;
+            Editor.ContentDatabase.WorkspaceRebuilding += () => { _workspaceRebuildLocation = SelectedNode?.Path; };
+            Editor.ContentDatabase.WorkspaceRebuilt += () =>
+            {
+                var selected = Editor.ContentDatabase.Find(_workspaceRebuildLocation);
+                if (selected is ContentFolder selectedFolder)
+                {
+                    _navigationUnlocked = false;
+                    RefreshView(selectedFolder.Node);
+                    _tree.Select(selectedFolder.Node);
+                    UpdateItemsSearch();
+                    _navigationUnlocked = true;
+                    UpdateUI();
+                }
+                else if (_root != null)
+                    ShowRoot();
+            };
+
             // Setup content root node
             _root = new RootContentTreeNode
             {

--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -150,6 +150,22 @@ namespace FlaxEditor.Windows
             _searchBox.Clear();
             _groupSearch.DisposeChildren();
             _groupSearch.PerformLayout();
+
+            // Remove tabs
+            var tabs = new List<Tab>();
+            foreach (var child in _actorGroups.Children)
+            {
+                if (child is Tab tab)
+                {
+                    if (tab.Text != "Search")
+                        tabs.Add(tab);
+                }
+            }
+            foreach (var tab in tabs)
+            {
+                var group = _actorGroups.Children.Find(T => T == tab);
+                group.Dispose();
+            }
         }
 
         private void OnScriptsReloadEnd()

--- a/Source/Engine/Engine/NativeInterop.Managed.cs
+++ b/Source/Engine/Engine/NativeInterop.Managed.cs
@@ -176,6 +176,7 @@ namespace FlaxEngine.Interop
                 _managedHandle.Free();
                 _unmanagedData = IntPtr.Zero;
             }
+            _arrayType = _elementType = null;
             ManagedArrayPool.Put(this);
         }
 
@@ -442,22 +443,25 @@ namespace FlaxEngine.Interop
             /// <summary>
             /// Tries to free all references to old weak handles so GC can collect them.
             /// </summary>
-            internal static void TryCollectWeakHandles()
+            internal static void TryCollectWeakHandles(bool force = false)
             {
-                if (weakHandleAccumulator < nextWeakPoolCollection)
-                    return;
+                if (!force)
+                {
+                    if (weakHandleAccumulator < nextWeakPoolCollection)
+                        return;
 
-                nextWeakPoolCollection = weakHandleAccumulator + 1000;
+                    nextWeakPoolCollection = weakHandleAccumulator + 1000;
 
-                // Try to swap pools after garbage collection or whenever the pool gets too large
-                var gc0CollectionCount = GC.CollectionCount(0);
-                if (gc0CollectionCount < nextWeakPoolGCCollection && weakPool.Count < WeakPoolCollectionSizeThreshold)
-                    return;
-                nextWeakPoolGCCollection = gc0CollectionCount + 1;
+                    // Try to swap pools after garbage collection or whenever the pool gets too large
+                    var gc0CollectionCount = GC.CollectionCount(0);
+                    if (gc0CollectionCount < nextWeakPoolGCCollection && weakPool.Count < WeakPoolCollectionSizeThreshold)
+                        return;
+                    nextWeakPoolGCCollection = gc0CollectionCount + 1;
 
-                // Prevent huge allocations from swapping the pools in the middle of the operation
-                if (System.Diagnostics.Stopwatch.GetElapsedTime(lastWeakPoolCollectionTime).TotalMilliseconds < WeakPoolCollectionTimeThreshold)
-                    return;
+                    // Prevent huge allocations from swapping the pools in the middle of the operation
+                    if (System.Diagnostics.Stopwatch.GetElapsedTime(lastWeakPoolCollectionTime).TotalMilliseconds < WeakPoolCollectionTimeThreshold)
+                        return;
+                }
                 lastWeakPoolCollectionTime = System.Diagnostics.Stopwatch.GetTimestamp();
 
                 // Swap the pools and release the oldest pool for GC

--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -1054,7 +1054,49 @@ namespace FlaxEngine.Interop
         }
 
         [UnmanagedCallersOnly]
-        internal static void ReloadScriptingAssemblyLoadContext()
+        internal static void CreateScriptingAssemblyLoadContext()
+        {
+#if FLAX_EDITOR
+            if (scriptingAssemblyLoadContext != null)
+            {
+                // Wait for previous ALC to finish unloading, track it without holding strong references to it
+                GCHandle weakRef = GCHandle.Alloc(scriptingAssemblyLoadContext, GCHandleType.WeakTrackResurrection);
+                scriptingAssemblyLoadContext = null;
+#if true
+                // In case the ALC doesn't unload properly: https://learn.microsoft.com/en-us/dotnet/standard/assembly/unloadability#debug-unloading-issues
+                while (true)
+#else
+                for (int attempts = 5; attempts > 0; attempts--)
+#endif
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+
+                    if (!IsHandleAlive(weakRef))
+                        break;
+                    System.Threading.Thread.Sleep(1);
+                }
+                if (IsHandleAlive(weakRef))
+                    Debug.LogWarning("Scripting AssemblyLoadContext was not unloaded.");
+                weakRef.Free();
+
+                static bool IsHandleAlive(GCHandle weakRef)
+                {
+                    // Checking the target in scope somehow holds a reference to it...?
+                    return weakRef.Target != null;
+                }
+            }
+
+            scriptingAssemblyLoadContext = new AssemblyLoadContext("Flax", isCollectible: true);
+            scriptingAssemblyLoadContext.Resolving += OnScriptingAssemblyLoadContextResolving;
+#else
+            scriptingAssemblyLoadContext = new AssemblyLoadContext("Flax", isCollectible: false);
+#endif
+            DelegateHelpers.InitMethods();
+        }
+
+        [UnmanagedCallersOnly]
+        internal static void UnloadScriptingAssemblyLoadContext()
         {
 #if FLAX_EDITOR
             // Clear all caches which might hold references to assemblies in collectible ALC
@@ -1072,24 +1114,73 @@ namespace FlaxEngine.Interop
                 handle.Free();
             propertyHandleCacheCollectible.Clear();
 
+            foreach (var key in assemblyHandles.Keys.Where(x => x.IsCollectible))
+                assemblyHandles.Remove(key);
+            foreach (var key in assemblyOwnedNativeLibraries.Keys.Where(x => x.IsCollectible))
+                assemblyOwnedNativeLibraries.Remove(key);
+
             _typeSizeCache.Clear();
 
             foreach (var pair in classAttributesCacheCollectible)
                 pair.Value.Free();
             classAttributesCacheCollectible.Clear();
 
+            ArrayFactory.marshalledTypes.Clear();
+            ArrayFactory.arrayTypes.Clear();
+            ArrayFactory.createArrayDelegates.Clear();
+
             FlaxEngine.Json.JsonSerializer.ResetCache();
+            DelegateHelpers.Release();
+
+            // Ensure both pools are empty
+            ManagedHandle.ManagedHandlePool.TryCollectWeakHandles(true);
+            ManagedHandle.ManagedHandlePool.TryCollectWeakHandles(true);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            {
+                // HACK: Workaround for TypeDescriptor holding references to collectible types (https://github.com/dotnet/runtime/issues/30656)
+
+                Type TypeDescriptionProviderType = typeof(System.ComponentModel.TypeDescriptionProvider);
+                MethodInfo clearCacheMethod = TypeDescriptionProviderType?.Assembly.GetType("System.ComponentModel.ReflectionCachesUpdateHandler")?.GetMethod("ClearCache");
+                if (clearCacheMethod != null)
+                    clearCacheMethod.Invoke(null, new object[] { null });
+                else
+                {
+                    MethodInfo beforeUpdateMethod = TypeDescriptionProviderType?.Assembly.GetType("System.ComponentModel.ReflectionCachesUpdateHandler")?.GetMethod("BeforeUpdate");
+                    if (beforeUpdateMethod != null)
+                        beforeUpdateMethod.Invoke(null, new object[] { null });
+                }
+
+                Type TypeDescriptorType = typeof(System.ComponentModel.TypeDescriptor);
+
+                object s_internalSyncObject = TypeDescriptorType?.GetField("s_internalSyncObject", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)?.GetValue(null);
+                System.Collections.Hashtable s_defaultProviders = (System.Collections.Hashtable)TypeDescriptorType?.GetField("s_defaultProviders", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)?.GetValue(null);
+                if (s_internalSyncObject != null && s_defaultProviders != null)
+                {
+                    lock (s_internalSyncObject)
+                        s_defaultProviders.Clear();
+                }
+
+                object s_providerTable = TypeDescriptorType?.GetField("s_providerTable", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)?.GetValue(null);
+                System.Collections.Hashtable s_providerTypeTable = (System.Collections.Hashtable)TypeDescriptorType?.GetField("s_providerTypeTable", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)?.GetValue(null);
+                if (s_providerTable != null && s_providerTypeTable != null)
+                {
+                    lock (s_providerTable)
+                        s_providerTypeTable.Clear();
+                    TypeDescriptorType.GetField("s_providerTable", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
+                        ?.FieldType.GetMethods(BindingFlags.Instance | BindingFlags.Public).FirstOrDefault(x => x.Name == "Clear")
+                        ?.Invoke(s_providerTable, new object[] { });
+                }
+            }
 
             // Unload the ALC
-            bool unloading = true;
-            scriptingAssemblyLoadContext.Unloading += (alc) => { unloading = false; };
             scriptingAssemblyLoadContext.Unload();
+            scriptingAssemblyLoadContext.Resolving -= OnScriptingAssemblyLoadContextResolving;
 
-            while (unloading)
-                System.Threading.Thread.Sleep(1);
-
-            InitScriptingAssemblyLoadContext();
-            DelegateHelpers.InitMethods();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
 #endif
         }
 

--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -1146,12 +1146,6 @@ namespace FlaxEngine.Interop
                 MethodInfo clearCacheMethod = TypeDescriptionProviderType?.Assembly.GetType("System.ComponentModel.ReflectionCachesUpdateHandler")?.GetMethod("ClearCache");
                 if (clearCacheMethod != null)
                     clearCacheMethod.Invoke(null, new object[] { null });
-                else
-                {
-                    MethodInfo beforeUpdateMethod = TypeDescriptionProviderType?.Assembly.GetType("System.ComponentModel.ReflectionCachesUpdateHandler")?.GetMethod("BeforeUpdate");
-                    if (beforeUpdateMethod != null)
-                        beforeUpdateMethod.Invoke(null, new object[] { null });
-                }
 
                 Type TypeDescriptorType = typeof(System.ComponentModel.TypeDescriptor);
 

--- a/Source/Engine/Engine/NativeInterop.cs
+++ b/Source/Engine/Engine/NativeInterop.cs
@@ -73,19 +73,6 @@ namespace FlaxEngine.Interop
             return nativeLibrary;
         }
 
-        private static void InitScriptingAssemblyLoadContext()
-        {
-#if FLAX_EDITOR
-            var isCollectible = true;
-#else
-            var isCollectible = false;
-#endif
-            scriptingAssemblyLoadContext = new AssemblyLoadContext("Flax", isCollectible);
-#if FLAX_EDITOR
-            scriptingAssemblyLoadContext.Resolving += OnScriptingAssemblyLoadContextResolving;
-#endif
-        }
-
         [UnmanagedCallersOnly]
         internal static unsafe void Init()
         {
@@ -97,8 +84,6 @@ namespace FlaxEngine.Interop
             System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
-            InitScriptingAssemblyLoadContext();
-            DelegateHelpers.InitMethods();
         }
 
 #if FLAX_EDITOR
@@ -1475,11 +1460,11 @@ namespace FlaxEngine.Interop
 
         internal static class ArrayFactory
         {
-            private delegate Array CreateArrayDelegate(long size);
+            internal delegate Array CreateArrayDelegate(long size);
 
-            private static ConcurrentDictionary<Type, Type> marshalledTypes = new ConcurrentDictionary<Type, Type>(1, 3);
-            private static ConcurrentDictionary<Type, Type> arrayTypes = new ConcurrentDictionary<Type, Type>(1, 3);
-            private static ConcurrentDictionary<Type, CreateArrayDelegate> createArrayDelegates = new ConcurrentDictionary<Type, CreateArrayDelegate>(1, 3);
+            internal static ConcurrentDictionary<Type, Type> marshalledTypes = new ConcurrentDictionary<Type, Type>(1, 3);
+            internal static ConcurrentDictionary<Type, Type> arrayTypes = new ConcurrentDictionary<Type, Type>(1, 3);
+            internal static ConcurrentDictionary<Type, CreateArrayDelegate> createArrayDelegates = new ConcurrentDictionary<Type, CreateArrayDelegate>(1, 3);
 
             internal static Type GetMarshalledType(Type elementType)
             {
@@ -1645,17 +1630,6 @@ namespace FlaxEngine.Interop
             return RegisterType(type, true).typeHolder;
         }
 
-        internal static (TypeHolder typeHolder, ManagedHandle handle) GetTypeHolderAndManagedHandle(Type type)
-        {
-            if (managedTypes.TryGetValue(type, out (TypeHolder typeHolder, ManagedHandle handle) tuple))
-                return tuple;
-#if FLAX_EDITOR
-            if (managedTypesCollectible.TryGetValue(type, out tuple))
-                return tuple;
-#endif
-            return RegisterType(type, true);
-        }
-
         /// <summary>
         /// Returns a static ManagedHandle to TypeHolder for given Type, and caches it if needed.
         /// </summary>
@@ -1778,6 +1752,14 @@ namespace FlaxEngine.Interop
                     using var ctx = scriptingAssemblyLoadContext.EnterContextualReflection();
                     MakeNewCustomDelegateFuncCollectible(new[] { typeof(void) });
                 }
+#endif
+            }
+
+            internal static void Release()
+            {
+                MakeNewCustomDelegateFunc = null;
+#if FLAX_EDITOR
+                MakeNewCustomDelegateFuncCollectible = null;
 #endif
             }
 

--- a/Source/Engine/Scripting/ManagedCLR/MCore.h
+++ b/Source/Engine/Scripting/ManagedCLR/MCore.h
@@ -45,9 +45,16 @@ public:
     /// </summary>
     static void UnloadEngine();
 
+    /// <summary>
+    /// Creates the assembly load context for assemblies used by Scripting.
+    /// </summary>
+    static void CreateScriptingAssemblyLoadContext();
+
 #if USE_EDITOR
-    // Called by Scripting in a middle of hot-reload (after unloading modules but before loading them again).
-    static void ReloadScriptingAssemblyLoadContext();
+    /// <summary>
+    /// Called by Scripting in a middle of hot-reload (after unloading modules but before loading them again).
+    /// </summary>
+    static void UnloadScriptingAssemblyLoadContext();
 #endif
 
 public:

--- a/Source/Engine/Scripting/Runtime/DotNet.cpp
+++ b/Source/Engine/Scripting/Runtime/DotNet.cpp
@@ -330,9 +330,15 @@ void MCore::UnloadEngine()
     ShutdownHostfxr();
 }
 
+void MCore::CreateScriptingAssemblyLoadContext()
+{
+    static void* CreateScriptingAssemblyLoadContextPtr = GetStaticMethodPointer(TEXT("CreateScriptingAssemblyLoadContext"));
+    CallStaticMethod<void>(CreateScriptingAssemblyLoadContextPtr);
+}
+
 #if USE_EDITOR
 
-void MCore::ReloadScriptingAssemblyLoadContext()
+void MCore::UnloadScriptingAssemblyLoadContext()
 {
     // Clear any cached class attributes (see https://github.com/FlaxEngine/FlaxEngine/issues/1108)
     for (auto e : CachedClassHandles)
@@ -377,8 +383,8 @@ void MCore::ReloadScriptingAssemblyLoadContext()
         }
     }
 
-    static void* ReloadScriptingAssemblyLoadContextPtr = GetStaticMethodPointer(TEXT("ReloadScriptingAssemblyLoadContext"));
-    CallStaticMethod<void>(ReloadScriptingAssemblyLoadContextPtr);
+    static void* UnloadScriptingAssemblyLoadContextPtr = GetStaticMethodPointer(TEXT("UnloadScriptingAssemblyLoadContext"));
+    CallStaticMethod<void>(UnloadScriptingAssemblyLoadContextPtr);
 }
 
 #endif

--- a/Source/Engine/Scripting/Runtime/Mono.cpp
+++ b/Source/Engine/Scripting/Runtime/Mono.cpp
@@ -715,9 +715,13 @@ void MCore::UnloadEngine()
 #endif
 }
 
+void MCore::CreateScriptingAssemblyLoadContext()
+{
+}
+
 #if USE_EDITOR
 
-void MCore::ReloadScriptingAssemblyLoadContext()
+void MCore::UnloadScriptingAssemblyLoadContext()
 {
 }
 

--- a/Source/Engine/Scripting/Runtime/None.cpp
+++ b/Source/Engine/Scripting/Runtime/None.cpp
@@ -58,9 +58,13 @@ void MCore::UnloadEngine()
     MRootDomain = nullptr;
 }
 
+void MCore::CreateScriptingAssemblyLoadContext()
+{
+}
+
 #if USE_EDITOR
 
-void MCore::ReloadScriptingAssemblyLoadContext()
+void MCore::UnloadScriptingAssemblyLoadContext()
 {
 }
 

--- a/Source/Engine/Scripting/Scripting.cpp
+++ b/Source/Engine/Scripting/Scripting.cpp
@@ -182,6 +182,8 @@ bool ScriptingService::Init()
         return true;
     }
 
+    MCore::CreateScriptingAssemblyLoadContext();
+
     // Cache root domain
     _rootDomain = MCore::GetRootDomain();
 
@@ -710,7 +712,8 @@ void Scripting::Reload(bool canTriggerSceneReload)
     _hasGameModulesLoaded = false;
 
     // Release and create a new assembly load context for user assemblies
-    MCore::ReloadScriptingAssemblyLoadContext();
+    MCore::UnloadScriptingAssemblyLoadContext();
+    MCore::CreateScriptingAssemblyLoadContext();
 
     // Give GC a try to cleanup old user objects and the other mess
     MCore::GC::Collect();

--- a/Source/Engine/Scripting/Scripting.cs
+++ b/Source/Engine/Scripting/Scripting.cs
@@ -170,6 +170,10 @@ namespace FlaxEngine
             AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
             Localization.LocalizationChanged += OnLocalizationChanged;
+#if FLAX_EDITOR
+            FlaxEditor.ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+            FlaxEditor.ScriptsBuilder.ScriptsReloadEnd += OnScriptsReloadEnd;
+#endif
 
             OnLocalizationChanged();
             if (!Engine.IsEditor)
@@ -177,6 +181,19 @@ namespace FlaxEngine
                 CreateGuiStyle();
             }
         }
+
+#if FLAX_EDITOR
+        private static void OnScriptsReloadBegin()
+        {
+            // Tooltip might hold references to scripting assemblies
+            Style.Current.SharedTooltip = null;
+        }
+
+        private static void OnScriptsReloadEnd()
+        {
+            Style.Current.SharedTooltip = new Tooltip();
+        }
+#endif
 
         private static void OnLocalizationChanged()
         {
@@ -359,6 +376,10 @@ namespace FlaxEngine
 
             MainThreadTaskScheduler.Dispose();
             Json.JsonSerializer.Dispose();
+#if FLAX_EDITOR
+            FlaxEditor.ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
+            FlaxEditor.ScriptsBuilder.ScriptsReloadEnd -= OnScriptsReloadEnd;
+#endif
         }
 
         /// <summary>

--- a/Source/Engine/UI/GUI/Tooltip.cs
+++ b/Source/Engine/UI/GUI/Tooltip.cs
@@ -120,6 +120,7 @@ namespace FlaxEngine.GUI
             // Unlink
             IsLayoutLocked = true;
             Parent = null;
+            _showTarget = null;
 
             // Close window
             if (_window)


### PR DESCRIPTION
Refactor the ALC unload and creation process while also attempt to fix the unloading properly. The local variables in previous `ReloadScriptingAssemblyLoadContext` method were keeping the assemblies alive by holding references to the collectible types, so splitting the unloading and recreation into separate methods also fixes most of these issues. 

Requires also fixing in Newtonsoft.Json: https://github.com/FlaxEngine/Newtonsoft.Json/pull/1