### PR TITLE
[Android] Add basic Android version settings to editor

### DIFF
--- a/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
@@ -266,9 +266,33 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
         }
     }
 
+    String versionCode = platformSettings->VersionCode;
+    if (versionCode.IsEmpty())
+    {
+        LOG(Error, "AndroidSettings: Invalid version code");
+        return true;
+    }
+
+    String minimumSdk = platformSettings->MinimumAPILevel;
+    if (minimumSdk.IsEmpty())
+    {
+        LOG(Error, "AndroidSettings: Invalid minimum API level");
+        return true;
+    }
+
+    String targetSdk = platformSettings->TargetAPILevel;
+    if (targetSdk.IsEmpty())
+    {
+        LOG(Error, "AndroidSettings: Invalid target API level");
+        return true;
+    }
+
     // Format project template files
     const String buildGradlePath = data.OriginalOutputPath / TEXT("app/build.gradle");
     EditorUtilities::ReplaceInFile(buildGradlePath, TEXT("${PackageName}"), packageName);
+    EditorUtilities::ReplaceInFile(buildGradlePath, TEXT("${VersionCode}"), versionCode);
+    EditorUtilities::ReplaceInFile(buildGradlePath, TEXT("${MinimumSdk}"), minimumSdk);
+    EditorUtilities::ReplaceInFile(buildGradlePath, TEXT("${TargetSdk}"), targetSdk);
     EditorUtilities::ReplaceInFile(buildGradlePath, TEXT("${ProjectVersion}"), projectVersion);
     EditorUtilities::ReplaceInFile(buildGradlePath, TEXT("${PackageAbi}"), abi);
     const String manifestPath = data.OriginalOutputPath / TEXT("app/src/main/AndroidManifest.xml");

--- a/Source/Engine/Platform/Android/AndroidPlatformSettings.h
+++ b/Source/Engine/Platform/Android/AndroidPlatformSettings.h
@@ -73,6 +73,24 @@ API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API 
     String PackageName = TEXT("com.${COMPANY_NAME}.${PROJECT_NAME}");
 
     /// <summary>
+    /// The application version code (eg. 1, 12, 123).
+    /// </summary>
+    API_FIELD(Attributes="EditorOrder(10), EditorDisplay(\"General\")")
+    String VersionCode = TEXT("1");
+
+    /// <summary>
+    /// The minimum Android API level(eg. 20, 28, 34).
+    /// </summary>
+    API_FIELD(Attributes = "EditorOrder(20), EditorDisplay(\"General\")")
+    String MinimumAPILevel = TEXT("23");
+
+    /// <summary>
+    /// The target Android API level(eg. 20, 28, 34).
+    /// </summary>
+    API_FIELD(Attributes = "EditorOrder(30), EditorDisplay(\"General\")")
+    String TargetAPILevel = TEXT("33");
+
+    /// <summary>
     /// The application permissions list (eg. android.media.action.IMAGE_CAPTURE). Added to the generated manifest file.
     /// </summary>
     API_FIELD(Attributes="EditorOrder(100), EditorDisplay(\"General\")")

--- a/Source/Platforms/Android/Binaries/Project/app/build.gradle
+++ b/Source/Platforms/Android/Binaries/Project/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 android {
-    compileSdkVersion 24
+    compileSdk ${TargetSdk}
     namespace "${PackageName}"
     defaultConfig {
         applicationId "${PackageName}"
-        minSdkVersion 24
-        targetSdkVersion 24
-        versionCode 1
+        minSdk ${MinimumSdk}
+        targetSdk ${TargetSdk}
+        versionCode ${VersionCode}
         versionName "${ProjectVersion}"
         ndk {
             abiFilter "${PackageAbi}"


### PR DESCRIPTION
#### Issue #2476 
When exporting to Android, the minimum and target API level in `build.gralde`  are automatically set to API level 24.
The Google Play store has very specific requirements for the API level a game/app need to support in order to be published. For instance, since August 2023 apps need to target API level 33 or later to be accepted.

#### Solution
Expose the following settings to the Android settings editor

- Version code
- Minimum API Level
- Target API Level (same as Compile Sdk Version)

![image](https://github.com/FlaxEngine/FlaxEngine/assets/11413364/7a623603-58e6-4a54-870b-a85ed23163d1)
