### PR TITLE
[Android] Add more useful orientation settings

### DIFF
--- a/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
@@ -203,16 +203,16 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
     switch (defaultOrienation)
     {
     case AndroidPlatformSettings::ScreenOrientation::Portrait:
-        orientation = String("portrait");
+        orientation = String("userPortrait");
         break;
-    case AndroidPlatformSettings::ScreenOrientation::PortraitReverse:
-        orientation = String("reversePortrait");
+    case AndroidPlatformSettings::ScreenOrientation::Landscape:
+        orientation = String("userLandscape");
         break;
-    case AndroidPlatformSettings::ScreenOrientation::LandscapeRight:
-        orientation = String("landscape");
+    case AndroidPlatformSettings::ScreenOrientation::SensorPortrait:
+        orientation = String("sensorPortrait");
         break;
-    case AndroidPlatformSettings::ScreenOrientation::LandscapeLeft:
-        orientation = String("reverseLandscape");
+    case AndroidPlatformSettings::ScreenOrientation::SensorLandscape:
+        orientation = String("sensorLandscape");
         break;
     case AndroidPlatformSettings::ScreenOrientation::AutoRotation:
         orientation = String("fullSensor");

--- a/Source/Engine/Platform/Android/AndroidPlatformSettings.h
+++ b/Source/Engine/Platform/Android/AndroidPlatformSettings.h
@@ -23,24 +23,24 @@ API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API 
     API_ENUM() enum class FLAXENGINE_API ScreenOrientation
     {
         /// <summary>
-        /// "portrait" mode
+        /// "userPortrait" mode
         /// </summary>
         Portrait,
 
         /// <summary>
-        /// "reversePortrait" mode
+        /// "userLandscape" mode
         /// </summary>
-        PortraitReverse,
+        Landscape,
 
         /// <summary>
-        /// "landscape" mode
+        /// "sensorPortrait" mode
         /// </summary>
-        LandscapeRight,
+        SensorPortrait,
 
         /// <summary>
-        /// "reverseLandscape" mode
+        /// "sensorLandscape" mode
         /// </summary>
-        LandscapeLeft,
+        SensorLandscape,
 
         /// <summary>
         /// "fullSensor" mode


### PR DESCRIPTION
#### Issue #2475 
The current orientation settings are not offering the best experience for an app.
To decide between, for instance, landscape or reverseLandscape is going to frustrate the user of the app (and this developer!)

#### Solution
Change the current orientation settings with more useful (modern?) ones:

- userPortrat (portrait orientation fixed by the user or default)
- userLandscape (landscape orientation fixed by the user or default)
- sensorPortart (let sensor decide if portaitUp or portraitDown)
- sensorLandscape (let sensor decide if landscapeLeft or landscapeRight)
- fullSensor (automatic rotation)

![image](https://github.com/FlaxEngine/FlaxEngine/assets/11413364/bc2e91f2-af2d-41cd-a158-0830e5610127)
