### PR TITLE
Focus prefab window on item spawn.

### DIFF
--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -450,6 +450,7 @@ namespace FlaxEditor.Windows.Assets
             // Create undo action
             var action = new CustomDeleteActorsAction(new List<SceneGraphNode>(1) { actorNode }, true);
             Undo.AddAction(action);
+            Focus();
             Select(actorNode);
         }
 


### PR DESCRIPTION
This fixes the appearance that undo does not work because the prefab window does not receive focus when an item is spawned. Fix <https://discord.com/channels/437989205315158016/1231709429838250115/1233056699653554188>