### PR TITLE
Add watermark attribute to add watermark to string fields in editor.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/StringEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/StringEditor.cs
@@ -13,6 +13,9 @@ namespace FlaxEditor.CustomEditors.Editors
     public sealed class StringEditor : CustomEditor
     {
         private TextBoxElement _element;
+        private string _watermarkText;
+        private Color _watermarkColor;
+        private Color _defaultWatermarkColor;
 
         /// <inheritdoc />
         public override DisplayStyle Style => DisplayStyle.Inline;
@@ -21,15 +24,26 @@ namespace FlaxEditor.CustomEditors.Editors
         public override void Initialize(LayoutElementsContainer layout)
         {
             bool isMultiLine = false;
+            _watermarkText = string.Empty;
 
             var attributes = Values.GetAttributes();
             var multiLine = attributes?.FirstOrDefault(x => x is MultilineTextAttribute);
+            var watermarkAttribute = attributes?.FirstOrDefault(x => x is WatermarkAttribute);
             if (multiLine != null)
             {
                 isMultiLine = true;
             }
 
             _element = layout.TextBox(isMultiLine);
+            _defaultWatermarkColor = _element.TextBox.WatermarkTextColor;
+            if (watermarkAttribute is WatermarkAttribute watermark)
+            {
+                _watermarkText = watermark.WatermarkText;
+                var watermarkColor = watermark.WatermarkColor > 0 ? Color.FromRGBA(watermark.WatermarkColor) : FlaxEngine.GUI.Style.Current.ForegroundDisabled;
+                _watermarkColor = watermarkColor;
+                _element.TextBox.WatermarkText = watermark.WatermarkText;
+                _element.TextBox.WatermarkTextColor = watermarkColor;
+            }
             _element.TextBox.EditEnd += () => SetValue(_element.Text);
         }
 
@@ -41,12 +55,14 @@ namespace FlaxEditor.CustomEditors.Editors
             if (HasDifferentValues)
             {
                 _element.TextBox.Text = string.Empty;
+                _element.TextBox.WatermarkTextColor = _defaultWatermarkColor;
                 _element.TextBox.WatermarkText = "Different values";
             }
             else
             {
                 _element.TextBox.Text = (string)Values[0];
-                _element.TextBox.WatermarkText = string.Empty;
+                _element.TextBox.WatermarkTextColor = _watermarkColor;
+                _element.TextBox.WatermarkText = _watermarkText;
             }
         }
     }

--- a/Source/Engine/Scripting/Attributes/Editor/WatermarkAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/WatermarkAttribute.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using FlaxEngine.GUI;
+
+namespace FlaxEngine;
+
+/// <summary>
+/// Used to add a watermark to a string textbox in the editor field
+/// </summary>
+[Serializable]
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public class WatermarkAttribute : Attribute
+{
+    /// <summary>
+    /// The watermark text.
+    /// </summary>
+    public string WatermarkText;
+
+    /// <summary>
+    /// The watermark color.
+    /// </summary>
+    public uint WatermarkColor;
+
+    /// <summary>
+    /// Initializes a new instance of the  <see cref="WatermarkAttribute"/> class.
+    /// </summary>
+    /// <param name="text">The watermark text.</param>
+    public WatermarkAttribute(string text)
+    {
+        WatermarkText = text;
+        WatermarkColor = 0; // default color of watermark in textbox
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the  <see cref="WatermarkAttribute"/> class.
+    /// </summary>
+    /// <param name="text">The watermark text.</param>
+    /// <param name="color">The watermark color. 0 to use default.</param>
+    public WatermarkAttribute(string text, uint color)
+    {
+        WatermarkText = text;
+        WatermarkColor = color;
+    }
+}

--- a/Source/Engine/Scripting/Attributes/Editor/WatermarkAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/WatermarkAttribute.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using FlaxEngine.GUI;
 
 namespace FlaxEngine;
 

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -213,7 +213,7 @@ namespace FlaxEngine.GUI
                     color *= 0.6f;
                 Render2D.DrawText(font, _text, color, ref _layout, TextMaterial);
             }
-            else if (!string.IsNullOrEmpty(_watermarkText) && !IsFocused)
+            else if (!string.IsNullOrEmpty(_watermarkText))
             {
                 Render2D.DrawText(font, _watermarkText, WatermarkTextColor, ref _layout, TextMaterial);
             }


### PR DESCRIPTION
This is a nice QoL feature for prompting what the user should enter into the text box by allowing the user to add an attribute that lets a watermark be added. This also changes the watermark to show even when textbox is focused as long as there is no text entered.