### PR TITLE
Add drag drop controls to Actor Toolbox

### DIFF
--- a/Source/Editor/GUI/Drag/DragControlType.cs
+++ b/Source/Editor/GUI/Drag/DragControlType.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using FlaxEditor.SceneGraph;
+using FlaxEditor.Scripting;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using FlaxEngine.Utilities;
+
+namespace FlaxEditor.GUI.Drag;
+
+/// <summary>
+/// Control type drag handler.
+/// </summary>
+public sealed class DragControlType : DragActorType<DragEventArgs>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DragControlType"/> class.
+    /// </summary>
+    /// <param name="validateFunction">The validation function</param>
+    public DragControlType(Func<ScriptType, bool> validateFunction)
+    : base(validateFunction)
+    {
+    }
+}
+
+/// <summary>
+/// Helper class for handling control type drag and drop (for spawning).
+/// </summary>
+/// <seealso cref="Control" />
+/// <seealso cref="ActorNode" />
+public class DragControlType<U> : DragHelper<ScriptType, U> where U : DragEventArgs
+{
+    /// <summary>
+    /// The default prefix for drag data used for actor type drag and drop.
+    /// </summary>
+    public const string DragPrefix = "CTYPE!?";
+
+    /// <summary>
+    /// Creates a new DragHelper
+    /// </summary>
+    /// <param name="validateFunction">The validation function</param>
+    public DragControlType(Func<ScriptType, bool> validateFunction)
+    : base(validateFunction)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override DragData ToDragData(ScriptType item) => GetDragData(item);
+
+    /// <inheritdoc/>
+    public override DragData ToDragData(IEnumerable<ScriptType> items)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Gets the drag data.
+    /// </summary>
+    /// <param name="item">The control type.</param>
+    /// <returns>The data</returns>
+    public static DragData GetDragData(Type item)
+    {
+        if (item == null)
+            throw new ArgumentNullException();
+        return new DragDataText(DragPrefix + item.FullName);
+    }
+
+    /// <summary>
+    /// Gets the drag data.
+    /// </summary>
+    /// <param name="item">The control type.</param>
+    /// <returns>The data</returns>
+    public static DragData GetDragData(ScriptType item)
+    {
+        if (item == ScriptType.Null)
+            throw new ArgumentNullException();
+        return new DragDataText(DragPrefix + item.TypeName);
+    }
+
+    /// <summary>
+    /// Tries to parse the drag data to extract <see cref="Type"/> collection.
+    /// </summary>
+    /// <param name="data">The data.</param>
+    /// <returns>Gathered objects or empty array if cannot get any valid.</returns>
+    public override IEnumerable<ScriptType> FromDragData(DragData data)
+    {
+        if (data is DragDataText dataText)
+        {
+            if (dataText.Text.StartsWith(DragPrefix))
+            {
+                // Remove prefix and parse spitted names
+                var types = dataText.Text.Remove(0, DragPrefix.Length).Split('\n');
+                var results = new List<ScriptType>(types.Length);
+                for (int i = 0; i < types.Length; i++)
+                {
+                    // Find type
+                    var obj = TypeUtils.GetType(types[i]);
+                    if (obj)
+                        results.Add(obj);
+                }
+                return results;
+            }
+        }
+        return Utils.GetEmptyArray<ScriptType>();
+    }
+}
+

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -65,6 +65,7 @@ namespace FlaxEditor.Windows.Assets
             private PrefabWindow _window;
             private DragAssets _dragAssets;
             private DragActorType _dragActorType;
+            private DragControlType _dragControlType;
             private DragScriptItems _dragScriptItems;
             private DragHandlers _dragHandlers;
 
@@ -83,7 +84,12 @@ namespace FlaxEditor.Windows.Assets
 
             private static bool ValidateDragActorType(ScriptType actorType)
             {
-                return true;
+                return Editor.Instance.CodeEditing.Actors.Get().Contains(actorType);
+            }
+            
+            private static bool ValidateDragControlType(ScriptType controlType)
+            {
+                return Editor.Instance.CodeEditing.Controls.Get().Contains(controlType);
             }
 
             private static bool ValidateDragScriptItem(ScriptItem script)
@@ -113,6 +119,13 @@ namespace FlaxEditor.Windows.Assets
                     }
                     if (_dragActorType.OnDragEnter(data))
                         return _dragActorType.Effect;
+                    if (_dragControlType == null)
+                    {
+                        _dragControlType = new DragControlType(ValidateDragControlType);
+                        _dragHandlers.Add(_dragControlType);
+                    }
+                    if (_dragControlType.OnDragEnter(data))
+                        return _dragControlType.Effect;
                     if (_dragScriptItems == null)
                     {
                         _dragScriptItems = new DragScriptItems(ValidateDragScriptItem);
@@ -176,6 +189,27 @@ namespace FlaxEditor.Windows.Assets
                         }
                         result = DragDropEffect.Move;
                     }
+                    // Drag control type
+                    else if (_dragControlType != null && _dragControlType.HasValidDrag)
+                    {
+                        for (int i = 0; i < _dragControlType.Objects.Count; i++)
+                        {
+                            var item = _dragControlType.Objects[i];
+                            var control = item.CreateInstance() as Control;
+                            if (control == null)
+                            {
+                                Editor.LogWarning("Failed to spawn UIControl with control type " + item.TypeName);
+                                continue;
+                            }
+                            var uiControl = new UIControl
+                            {
+                                Control = control,
+                                Name = item.Name,
+                            };
+                            _window.Spawn(uiControl);
+                        }
+                        result = DragDropEffect.Move;
+                    }
                     // Drag script item
                     else if (_dragScriptItems != null && _dragScriptItems.HasValidDrag)
                     {
@@ -207,6 +241,7 @@ namespace FlaxEditor.Windows.Assets
                 _window = null;
                 _dragAssets = null;
                 _dragActorType = null;
+                _dragControlType = null;
                 _dragScriptItems = null;
                 _dragHandlers?.Clear();
                 _dragHandlers = null;

--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -191,6 +191,52 @@ namespace FlaxEditor.Windows
             CreateGroupWithList(_actorGroups, "GUI");
             CreateGroupWithList(_actorGroups, "Other");
 
+            // Add control types to tabs
+            foreach (var controlType in Editor.Instance.CodeEditing.Controls.Get())
+            {
+                if (controlType.IsAbstract)
+                    continue;
+                _groupSearch.AddChild(CreateControlItem(Utilities.Utils.GetPropertyNameUI(controlType.Name), controlType));
+                ActorToolboxAttribute attribute = null;
+                foreach (var e in controlType.GetAttributes(false))
+                {
+                    if (e is ActorToolboxAttribute actorToolboxAttribute)
+                    {
+                        attribute = actorToolboxAttribute;
+                        break;
+                    }
+                }
+                if (attribute == null)
+                    continue;
+                var groupName = attribute.Group.Trim();
+
+                // Check if tab already exists and add it to the tab
+                var actorTabExists = false;
+                foreach (var child in _actorGroups.Children)
+                {
+                    if (child is Tab tab)
+                    {
+                        if (string.Equals(tab.Text, groupName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var tree = tab.GetChild<Panel>().GetChild<Tree>();
+                            if (tree != null)
+                            {
+                                tree.AddChild(string.IsNullOrEmpty(attribute.Name) ? CreateControlItem(Utilities.Utils.GetPropertyNameUI(controlType.Name), controlType) : CreateControlItem(attribute.Name, controlType));
+                                tree.SortChildren();
+                            }
+                            actorTabExists = true;
+                            break;
+                        }
+                    }
+                }
+                if (actorTabExists)
+                    continue;
+
+                var group = CreateGroupWithList(_actorGroups, groupName);
+                group.AddChild(string.IsNullOrEmpty(attribute.Name) ? CreateControlItem(Utilities.Utils.GetPropertyNameUI(controlType.Name), controlType) : CreateControlItem(attribute.Name, controlType));
+                group.SortChildren();
+            }
+
             // Add other actor types to respective tab based on attribute
             foreach (var actorType in Editor.CodeEditing.Actors.Get())
             {
@@ -302,6 +348,11 @@ namespace FlaxEditor.Windows
         private Item CreateActorItem(string name, ScriptType type)
         {
             return new ScriptTypeItem(name, type, GUI.Drag.DragActorType.GetDragData(type));
+        }
+
+        private Item CreateControlItem(string name, ScriptType type)
+        {
+            return new ScriptTypeItem(name, type, GUI.Drag.DragControlType.GetDragData(type));
         }
 
         private ContainerControl CreateGroupWithList(Tabs parentTabs, string title, float topOffset = 0)

--- a/Source/Engine/UI/GUI/CanvasScaler.cs
+++ b/Source/Engine/UI/GUI/CanvasScaler.cs
@@ -7,6 +7,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// UI canvas scaling component for user interface that targets multiple different game resolutions (eg. mobile screens).
     /// </summary>
+    [ActorToolbox("GUI")]
     public class CanvasScaler : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/Border.cs
+++ b/Source/Engine/UI/GUI/Common/Border.cs
@@ -5,6 +5,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Border control that draws the border around the control edges (inner and outer sides).
     /// </summary>
+    [ActorToolbox("GUI")]
     public class Border : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/Button.cs
+++ b/Source/Engine/UI/GUI/Common/Button.cs
@@ -7,6 +7,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Button control
     /// </summary>
+    [ActorToolbox("GUI")]
     public class Button : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/CheckBox.cs
+++ b/Source/Engine/UI/GUI/Common/CheckBox.cs
@@ -29,6 +29,7 @@ namespace FlaxEngine.GUI
     /// Check box control.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.Control" />
+    [ActorToolbox("GUI")]
     public class CheckBox : Control
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/Dropdown.cs
+++ b/Source/Engine/UI/GUI/Common/Dropdown.cs
@@ -9,6 +9,7 @@ namespace FlaxEngine.GUI
     /// Dropdown menu control allows to choose one item from the provided collection of options.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class Dropdown : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/Image.cs
+++ b/Source/Engine/UI/GUI/Common/Image.cs
@@ -8,6 +8,7 @@ namespace FlaxEngine.GUI
     /// The basic GUI image control. Shows texture, sprite or render target.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class Image : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/Label.cs
+++ b/Source/Engine/UI/GUI/Common/Label.cs
@@ -8,6 +8,7 @@ namespace FlaxEngine.GUI
     /// The basic GUI label control.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class Label : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/ProgressBar.cs
+++ b/Source/Engine/UI/GUI/Common/ProgressBar.cs
@@ -8,6 +8,7 @@ namespace FlaxEngine.GUI
     /// Progress bar control shows visual progress of the action or set of actions.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.Control" />
+    [ActorToolbox("GUI")]
     public class ProgressBar : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/RenderToTextureControl.cs
+++ b/Source/Engine/UI/GUI/Common/RenderToTextureControl.cs
@@ -5,6 +5,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// UI container control that can render children to texture and display pre-cached texture instead of drawing children every frame. It can be also used to render part of UI to texture and use it in material or shader.
     /// </summary>
+    [ActorToolbox("GUI")]
     public class RenderToTextureControl : ContainerControl
     {
         private bool _invalid, _redrawRegistered, _isDuringTextureDraw;

--- a/Source/Engine/UI/GUI/Common/RichTextBox.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBox.cs
@@ -7,6 +7,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Rich text box control which can gather text input from the user and present text in highly formatted and stylized way.
     /// </summary>
+    [ActorToolbox("GUI")]
     public partial class RichTextBox : RichTextBoxBase
     {
         private TextBlockStyle _textStyle;

--- a/Source/Engine/UI/GUI/Common/Slider.cs
+++ b/Source/Engine/UI/GUI/Common/Slider.cs
@@ -7,6 +7,7 @@ namespace FlaxEngine.GUI;
 /// <summary>
 /// The slider control.
 /// </summary>
+[ActorToolbox("GUI")]
 public class Slider : ContainerControl
 {
     /// <summary>

--- a/Source/Engine/UI/GUI/Common/Spacer.cs
+++ b/Source/Engine/UI/GUI/Common/Spacer.cs
@@ -6,6 +6,7 @@ namespace FlaxEngine.GUI
     /// Helper control used to insert blank space into the layout.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public sealed class Spacer : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -5,6 +5,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Text box control which can gather text input from the user.
     /// </summary>
+    [ActorToolbox("GUI")]
     public class TextBox : TextBoxBase
     {
         private TextLayoutOptions _layout;

--- a/Source/Engine/UI/GUI/Panels/AlphaPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/AlphaPanel.cs
@@ -5,6 +5,7 @@ namespace FlaxEngine.GUI
     /// <summary>
     /// Changes alpha of all its children
     /// </summary>
+    [ActorToolbox("GUI")]
     public class AlphaPanel : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Panels/BlurPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/BlurPanel.cs
@@ -6,6 +6,7 @@ namespace FlaxEngine.GUI
     /// The blur panel that applied the Gaussian-blur to all content beneath the control.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class BlurPanel : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Panels/DropPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/DropPanel.cs
@@ -8,6 +8,7 @@ namespace FlaxEngine.GUI
     /// Drop Panel arranges control vertically and provides feature to collapse contents.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class DropPanel : ContainerControl
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Panels/GridPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/GridPanel.cs
@@ -8,6 +8,7 @@ namespace FlaxEngine.GUI
     /// A panel that divides up available space between all of its children.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class GridPanel : ContainerControl
     {
         private Margin _slotPadding;

--- a/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
@@ -6,6 +6,7 @@ namespace FlaxEngine.GUI
     /// This panel arranges child controls horizontally.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.PanelWithMargins" />
+    [ActorToolbox("GUI")]
     public class HorizontalPanel : PanelWithMargins
     {
         /// <summary>

--- a/Source/Engine/UI/GUI/Panels/Panel.cs
+++ b/Source/Engine/UI/GUI/Panels/Panel.cs
@@ -8,6 +8,7 @@ namespace FlaxEngine.GUI
     /// Panel UI control.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ScrollableControl" />
+    [ActorToolbox("GUI")]
     public class Panel : ScrollableControl
     {
         private bool _layoutChanged;

--- a/Source/Engine/UI/GUI/Panels/TilesPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/TilesPanel.cs
@@ -8,6 +8,7 @@ namespace FlaxEngine.GUI
     /// Panel that arranges child controls like tiles.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class TilesPanel : ContainerControl
     {
         private Margin _tileMargin;

--- a/Source/Engine/UI/GUI/Panels/UniformGridPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/UniformGridPanel.cs
@@ -6,6 +6,7 @@ namespace FlaxEngine.GUI
     /// A panel that evenly divides up available space between all of its children.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+    [ActorToolbox("GUI")]
     public class UniformGridPanel : ContainerControl
     {
         private Margin _slotPadding;

--- a/Source/Engine/UI/GUI/Panels/VerticalPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/VerticalPanel.cs
@@ -6,6 +6,7 @@ namespace FlaxEngine.GUI
     /// This panel arranges child controls vertically.
     /// </summary>
     /// <seealso cref="FlaxEngine.GUI.PanelWithMargins" />
+    [ActorToolbox("GUI")]
     public class VerticalPanel : PanelWithMargins
     {
         /// <summary>

--- a/Source/Engine/UI/SpriteRender.h
+++ b/Source/Engine/UI/SpriteRender.h
@@ -10,7 +10,7 @@
 /// <summary>
 /// Sprite rendering object.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/UI/Sprite Render\"), ActorToolbox(\"GUI\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/UI/Sprite Render\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API SpriteRender : public Actor
 {
     DECLARE_SCENE_OBJECT(SpriteRender);

--- a/Source/Engine/UI/TextRender.h
+++ b/Source/Engine/UI/TextRender.h
@@ -18,7 +18,7 @@
 /// <summary>
 /// Text rendering object.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/UI/Text Render\"), ActorToolbox(\"GUI\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/UI/Text Render\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API TextRender : public Actor
 {
     DECLARE_SCENE_OBJECT(TextRender);

--- a/Source/Engine/UI/UIControl.h
+++ b/Source/Engine/UI/UIControl.h
@@ -8,7 +8,7 @@
 /// <summary>
 /// Contains a single GUI control (on C# side).
 /// </summary>
-API_CLASS(Sealed, Attributes="ActorContextMenu(\"New/UI/UI Control\"), ActorToolbox(\"GUI\")")
+API_CLASS(Sealed, Attributes="ActorContextMenu(\"New/UI/UI Control\"), ActorToolbox(\"GUI\", \"Empty UIControl\")")
 class FLAXENGINE_API UIControl : public Actor
 {
     DECLARE_SCENE_OBJECT(UIControl);


### PR DESCRIPTION
Add controls to the ActorToolbox in the GUI tab. Add dragging and dropping controls from toolbox into scene and prefab trees.

This is great for quickly making UIControls of a specific type very quickly. I chose to bundle it in wit the actor toolbox so everything is in 1 spot.