### PR TITLE
Move control transform to under "General" group

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
@@ -466,27 +466,35 @@ namespace FlaxEditor.CustomEditors.Dedicated
             // Setup transform
             if (Presenter is LayoutElementsContainer l)
             {
-                var group = l.Group("Transform");
-                VerticalPanelElement mainHor = VerticalPanelWithoutMargin(group);
+                var transformGroup = l.Group("Transform");
+                VerticalPanelElement mainHor = VerticalPanelWithoutMargin(transformGroup);
                 CreateTransformElements(mainHor, ValuesTypes);
                 
                 ScriptMemberInfo scaleInfo = ValuesTypes[0].GetProperty("Scale");
                 ItemInfo scaleItem = new ItemInfo(scaleInfo);
-                group.Property("Scale", scaleItem.GetValues(Values));
+                transformGroup.Property("Scale", scaleItem.GetValues(Values));
                 
                 ScriptMemberInfo pivotInfo = ValuesTypes[0].GetProperty("Pivot");
                 ItemInfo pivotItem = new ItemInfo(pivotInfo);
-                group.Property("Pivot", pivotItem.GetValues(Values));
+                transformGroup.Property("Pivot", pivotItem.GetValues(Values));
                 
                 ScriptMemberInfo shearInfo = ValuesTypes[0].GetProperty("Shear");
                 ItemInfo shearItem = new ItemInfo(shearInfo);
-                group.Property("Shear", shearItem.GetValues(Values));
+                transformGroup.Property("Shear", shearItem.GetValues(Values));
                 
                 ScriptMemberInfo rotationInfo = ValuesTypes[0].GetProperty("Rotation");
                 ItemInfo rotationItem = new ItemInfo(rotationInfo);
-                group.Property("Rotation", rotationItem.GetValues(Values));
+                transformGroup.Property("Rotation", rotationItem.GetValues(Values));
                 
-                Presenter.ContainerControl.ChangeChildIndex(group.Control, 1);
+                // Get position of general tab
+                for (int i = 0; i < l.Children.Count; i++)
+                {
+                    if (l.Children[i] is GroupElement g && g.Panel.HeaderText == "General" && i + 1 <= l.Children.Count)
+                    {
+                        Presenter.ContainerControl.ChangeChildIndex(transformGroup.Control, i + 1);
+                        break;
+                    }
+                }
             }
         }
 

--- a/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
@@ -678,7 +678,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
         {
             var grid = UniformGridTwoByOne(el);
             grid.CustomControl.SlotPadding = new Margin(5, 5, 1, 1);
-            var label = grid.Label(text);
+            var label = grid.Label(text, TextAlignment.Far);
             var editor = grid.Object(values);
             if (editor is FloatEditor floatEditor && floatEditor.Element is FloatValueElement floatEditorElement)
             {

--- a/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
@@ -458,11 +458,35 @@ namespace FlaxEditor.CustomEditors.Dedicated
             {
                 if (layout.Children[i] is GroupElement group && group.Panel.HeaderText == "Transform")
                 {
-                    VerticalPanelElement mainHor = VerticalPanelWithoutMargin(group);
-                    CreateTransformElements(mainHor, ValuesTypes);
-                    group.ContainerControl.ChangeChildIndex(mainHor.Control, 0);
+                    layout.Children.Remove(group);
                     break;
                 }
+            }
+
+            // Setup transform
+            if (Presenter is LayoutElementsContainer l)
+            {
+                var group = l.Group("Transform");
+                VerticalPanelElement mainHor = VerticalPanelWithoutMargin(group);
+                CreateTransformElements(mainHor, ValuesTypes);
+                
+                ScriptMemberInfo scaleInfo = ValuesTypes[0].GetProperty("Scale");
+                ItemInfo scaleItem = new ItemInfo(scaleInfo);
+                group.Property("Scale", scaleItem.GetValues(Values));
+                
+                ScriptMemberInfo pivotInfo = ValuesTypes[0].GetProperty("Pivot");
+                ItemInfo pivotItem = new ItemInfo(pivotInfo);
+                group.Property("Pivot", pivotItem.GetValues(Values));
+                
+                ScriptMemberInfo shearInfo = ValuesTypes[0].GetProperty("Shear");
+                ItemInfo shearItem = new ItemInfo(shearInfo);
+                group.Property("Shear", shearItem.GetValues(Values));
+                
+                ScriptMemberInfo rotationInfo = ValuesTypes[0].GetProperty("Rotation");
+                ItemInfo rotationItem = new ItemInfo(rotationInfo);
+                group.Property("Rotation", rotationItem.GetValues(Values));
+                
+                Presenter.ContainerControl.ChangeChildIndex(group.Control, 1);
             }
         }
 

--- a/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/UIControlEditor.cs
@@ -456,9 +456,10 @@ namespace FlaxEditor.CustomEditors.Dedicated
 
             for (int i = 0; i < layout.Children.Count; i++)
             {
-                if (layout.Children[i] is GroupElement group && group.Panel.HeaderText == "Transform")
+                if (layout.Children[i] is GroupElement group && group.Panel.HeaderText.Equals("Transform", StringComparison.Ordinal))
                 {
                     layout.Children.Remove(group);
+                    layout.ContainerControl.Children.Remove(group.Panel);
                     break;
                 }
             }
@@ -489,7 +490,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 // Get position of general tab
                 for (int i = 0; i < l.Children.Count; i++)
                 {
-                    if (l.Children[i] is GroupElement g && g.Panel.HeaderText == "General" && i + 1 <= l.Children.Count)
+                    if (l.Children[i] is GroupElement g && g.Panel.HeaderText.Equals("General", StringComparison.Ordinal) && i + 1 <= l.Children.Count)
                     {
                         Presenter.ContainerControl.ChangeChildIndex(transformGroup.Control, i + 1);
                         break;


### PR DESCRIPTION
A nice QoL addition to bring the transform of the control to where the regular actor transform is.

Before:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/75d93d5a-1d88-453a-b452-8caa76a6d3b3)


After:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/37d4045a-aa84-4049-a82e-aebc6264df49)
