### PR TITLE
Force windows cursor to show or hide based on cursor hidden value

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -770,13 +770,23 @@ void WindowsWindow::CheckForWindowResize()
     }
 }
 
-void WindowsWindow::UpdateCursor() const
+void WindowsWindow::UpdateCursor()
 {
     // Don't hide cursor when window is not focused
     if (_cursor == CursorType::Hidden && _focused)
     {
+        if (!_lastCursorHidden)
+        {
+            _lastCursorHidden = true;
+            ::ShowCursor(FALSE);
+        }
         ::SetCursor(nullptr);
         return;
+    }
+    else if (_lastCursorHidden)
+    {
+        _lastCursorHidden = false;
+        ::ShowCursor(TRUE);
     }
 
     int32 index = 0;

--- a/Source/Engine/Platform/Windows/WindowsWindow.h
+++ b/Source/Engine/Platform/Windows/WindowsWindow.h
@@ -28,6 +28,7 @@ private:
     bool _isSwitchingFullScreen = false;
     bool _trackingMouse = false;
     bool _clipCursorSet = false;
+    bool _lastCursorHidden = false;
     bool _isDuringMaximize = false;
     Windows::HANDLE _monitor = nullptr;
     Windows::LONG _clipCursorRect[4];
@@ -90,7 +91,7 @@ public:
 private:
 
     void CheckForWindowResize();
-    void UpdateCursor() const;
+    void UpdateCursor();
     void UpdateRegion();
 
 public:


### PR DESCRIPTION
Fix #2531 

This was only tested in the editor and not a cooked game but I dont see why it wouldn't work.