### PR TITLE
Add shift scroll for panels and textbox

### DIFF
--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -281,7 +281,7 @@ namespace FlaxEditor.Windows
             if (IsLayoutLocked)
                 return;
 
-            _hScroll.Maximum = _output.TextSize.X;
+            _hScroll.Maximum = Mathf.Max(_output.TextSize.X, _hScroll.Minimum);
             _vScroll.Maximum = Mathf.Max(_output.TextSize.Y - _output.Height, _vScroll.Minimum);
         }
 

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1269,7 +1269,11 @@ namespace FlaxEngine.GUI
             // Multiline scroll
             if (IsMultiline && _text.Length != 0 && IsMultilineScrollable)
             {
-                TargetViewOffset = Float2.Clamp(_targetViewOffset - new Float2(0, delta * 10.0f), Float2.Zero, new Float2(_targetViewOffset.X, _textSize.Y - Height));
+                if (Input.GetKey(KeyboardKeys.Shift))
+                    TargetViewOffset = Float2.Clamp(_targetViewOffset - new Float2(delta * 20.0f, 0), Float2.Zero, new Float2(_textSize.X, _targetViewOffset.Y));
+                else
+                    TargetViewOffset = Float2.Clamp(_targetViewOffset - new Float2(0, delta * 10.0f), Float2.Zero, new Float2(_targetViewOffset.X, _textSize.Y - Height));
+                
                 return true;
             }
 

--- a/Source/Engine/UI/GUI/Panels/Panel.cs
+++ b/Source/Engine/UI/GUI/Panels/Panel.cs
@@ -292,10 +292,14 @@ namespace FlaxEngine.GUI
             if (base.OnMouseWheel(location, delta))
                 return true;
 
+            if (Input.GetKey(KeyboardKeys.Shift))
+            {
+                if (HScrollBar != null && HScrollBar.Enabled && HScrollBar.OnMouseWheel(HScrollBar.PointFromParent(ref location), delta))
+                    return true;
+            }
+
             // Roll back to scroll bars
             if (VScrollBar != null && VScrollBar.Enabled && VScrollBar.OnMouseWheel(VScrollBar.PointFromParent(ref location), delta))
-                return true;
-            if (HScrollBar != null && HScrollBar.Enabled && HScrollBar.OnMouseWheel(HScrollBar.PointFromParent(ref location), delta))
                 return true;
 
             // No event handled


### PR DESCRIPTION
Add holding shift to scroll horizontally in panels and textbox. this works in the output log as well.