### PR TITLE
Dont unfocus game window while cursor is not visible unless the lock mode is none.

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -470,6 +470,10 @@ namespace FlaxEditor.Windows
             IsMaximized = false;
             IsBorderless = false;
             Cursor = CursorType.Default;
+            Screen.CursorLock = CursorLockMode.None;
+            if (Screen.MainWindow.IsMouseTracking)
+                Screen.MainWindow.EndTrackingMouse();
+            RootControl.GameRoot.EndMouseCapture();
         }
 
         /// <inheritdoc />
@@ -478,7 +482,7 @@ namespace FlaxEditor.Windows
             base.OnMouseLeave();
 
             // Remove focus from game window when mouse moves out and the cursor is hidden during game
-            if ((IsFocused || ContainsFocus) && Parent != null && Editor.IsPlayMode && !Screen.CursorVisible)
+            if (ContainsFocus && Parent != null && Editor.IsPlayMode && !Screen.CursorVisible && Screen.CursorLock == CursorLockMode.None)
             {
                 Parent.Focus();
             }


### PR DESCRIPTION
Fixes the focus issue part of #2510 but not the visibility issues. I also added some extra code to OnPlayEnd to move a few setting back to default because of a couple of issues I ran into.