### PR TITLE
Skip empty layers for LayerMask Editor

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/LayersMaskEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/LayersMaskEditor.cs
@@ -31,7 +31,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 var layer = layers[i];
                 if (string.IsNullOrEmpty(layer))
                     continue;
-                var property = layout.AddPropertyItem(layer);
+                var property = layout.AddPropertyItem($"{i}: {layer}");
                 var checkbox = property.Checkbox().CheckBox;
                 UpdateCheckbox(checkbox, i);
                 checkbox.Tag = i;

--- a/Source/Editor/CustomEditors/Dedicated/LayersMaskEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/LayersMaskEditor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using System.Collections.Generic;
 using FlaxEditor.Content.Settings;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -12,7 +13,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
     [CustomEditor(typeof(LayersMask)), DefaultEditor]
     internal class LayersMaskEditor : CustomEditor
     {
-        private CheckBox[] _checkBoxes;
+        private List<CheckBox> _checkBoxes;
 
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
@@ -24,16 +25,18 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 return;
             }
 
-            _checkBoxes = new CheckBox[layers.Length];
+            _checkBoxes = new List<CheckBox>();
             for (int i = 0; i < layers.Length; i++)
             {
                 var layer = layers[i];
+                if (string.IsNullOrEmpty(layer))
+                    continue;
                 var property = layout.AddPropertyItem(layer);
                 var checkbox = property.Checkbox().CheckBox;
                 UpdateCheckbox(checkbox, i);
                 checkbox.Tag = i;
                 checkbox.StateChanged += OnCheckboxStateChanged;
-                _checkBoxes[i] = checkbox;
+                _checkBoxes.Add(checkbox);
             }
         }
 
@@ -50,9 +53,9 @@ namespace FlaxEditor.CustomEditors.Dedicated
         {
             if (_checkBoxes != null)
             {
-                for (int i = 0; i < _checkBoxes.Length; i++)
+                for (int i = 0; i < _checkBoxes.Count; i++)
                 {
-                    UpdateCheckbox(_checkBoxes[i], i);
+                    UpdateCheckbox(_checkBoxes[i], (int)_checkBoxes[i].Tag);
                 }
             }
 


### PR DESCRIPTION
Small QoL addition to not show any empty layers in the `LayerMaskEditor`


Example:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/cd2b7bb6-5d4a-46ba-a51b-2ba8a5af11a0)

![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/f6a26301-e04a-4761-812e-ec2c5ac563bb)
