### PR TITLE
Fix Editor not launching if custom interface fonts are missing

### DIFF
--- a/Source/Editor/Options/OptionsModule.cs
+++ b/Source/Editor/Options/OptionsModule.cs
@@ -255,6 +255,17 @@ namespace FlaxEditor.Options
                 }
             }
 
+            // Ensure custom fonts are valid, reset if not
+            var defaultInterfaceOptions = new InterfaceOptions();
+            if (Style.Current.FontTitle == null)
+                Style.Current.FontTitle = defaultInterfaceOptions.TitleFont.GetFont();
+            if (Style.Current.FontSmall == null)
+                Style.Current.FontSmall = defaultInterfaceOptions.SmallFont.GetFont();
+            if (Style.Current.FontMedium == null)
+                Style.Current.FontMedium = defaultInterfaceOptions.MediumFont.GetFont();
+            if (Style.Current.FontLarge == null)
+                Style.Current.FontLarge = defaultInterfaceOptions.LargeFont.GetFont();
+
             // Set fallback fonts
             var fallbackFonts = Options.Interface.FallbackFonts;
             if (fallbackFonts == null || fallbackFonts.Length == 0 || fallbackFonts.All(x => x == null))


### PR DESCRIPTION
If user has selected interface fonts that were valid at one point and can no longer be found on startup, reset the fonts in current editor style back to defaults to avoid crashing at startup.