### PR TITLE
Expose colors of `ScrollBar`s

### DIFF
--- a/Source/Editor/GUI/Tabs/Tabs.cs
+++ b/Source/Editor/GUI/Tabs/Tabs.cs
@@ -418,9 +418,19 @@ namespace FlaxEditor.GUI.Tabs
             {
                 // If scroll bar is visible it covers part of the tab header so include this in tab size to improve usability
                 if (_orientation == Orientation.Horizontal && TabsPanel.HScrollBar.Visible)
+                {
                     tabsSize.Y += TabsPanel.HScrollBar.Height;
+                    var style = Style.Current;
+                    TabsPanel.HScrollBar.TrackColor = style.Background;
+                    TabsPanel.HScrollBar.ThumbColor = style.ForegroundGrey;
+                }
                 else if (_orientation == Orientation.Vertical && TabsPanel.VScrollBar.Visible)
+                {
                     tabsSize.X += TabsPanel.VScrollBar.Width;
+                    var style = Style.Current;
+                    TabsPanel.VScrollBar.TrackColor = style.Background;
+                    TabsPanel.VScrollBar.ThumbColor = style.ForegroundGrey;
+                }
             }
 
             // Fit the tabs panel

--- a/Source/Engine/UI/GUI/Panels/Panel.cs
+++ b/Source/Engine/UI/GUI/Panels/Panel.cs
@@ -17,6 +17,9 @@ namespace FlaxEngine.GUI
         private ScrollBars _scrollBars;
         private float _scrollBarsSize = ScrollBar.DefaultSize;
         private Margin _scrollMargin;
+        private Color _scrollbarTrackColor;
+        private Color _scrollbarThumbColor;
+        private Color _scrollbarThumbSelectedColor;
 
         /// <summary>
         /// The cached scroll area bounds. Used to scroll contents of the panel control. Cached during performing layout.
@@ -49,7 +52,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets the scroll bars usage by this panel.
         /// </summary>
-        [EditorOrder(0), Tooltip("The scroll bars usage.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(0), Tooltip("The scroll bars usage.")]
         public ScrollBars ScrollBars
         {
             get => _scrollBars;
@@ -73,6 +76,12 @@ namespace FlaxEngine.GUI
                         //VScrollBar.X += VScrollBar.Width;
                         VScrollBar.ValueChanged += () => SetViewOffset(Orientation.Vertical, VScrollBar.Value);
                     }
+                    if (VScrollBar != null)
+                    {
+                        VScrollBar.TrackColor = _scrollbarTrackColor;
+                        VScrollBar.ThumbColor = _scrollbarThumbColor;
+                        VScrollBar.ThumbSelectedColor = _scrollbarThumbSelectedColor;
+                    }
                 }
                 else if (VScrollBar != null)
                 {
@@ -94,6 +103,12 @@ namespace FlaxEngine.GUI
                         //HScrollBar.Offsets += new Margin(0, 0, HScrollBar.Height * 0.5f, 0);
                         HScrollBar.ValueChanged += () => SetViewOffset(Orientation.Horizontal, HScrollBar.Value);
                     }
+                    if (HScrollBar != null)
+                    {
+                        HScrollBar.TrackColor = _scrollbarTrackColor;
+                        HScrollBar.ThumbColor = _scrollbarThumbColor;
+                        HScrollBar.ThumbSelectedColor = _scrollbarThumbSelectedColor;
+                    }
                 }
                 else if (HScrollBar != null)
                 {
@@ -108,7 +123,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets the size of the scroll bars.
         /// </summary>
-        [EditorOrder(5), Tooltip("Scroll bars size.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(5), Tooltip("Scroll bars size.")]
         public float ScrollBarsSize
         {
             get => _scrollBarsSize;
@@ -124,7 +139,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets a value indicating whether always show scrollbars. Otherwise show them only if scrolling is available.
         /// </summary>
-        [EditorOrder(10), Tooltip("Whether always show scrollbars. Otherwise show them only if scrolling is available.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(10), Tooltip("Whether always show scrollbars. Otherwise show them only if scrolling is available.")]
         public bool AlwaysShowScrollbars
         {
             get => _alwaysShowScrollbars;
@@ -157,7 +172,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets the scroll margin applies to the child controls area. Can be used to expand the scroll area bounds by adding a margin.
         /// </summary>
-        [EditorOrder(20), Tooltip("Scroll margin applies to the child controls area. Can be used to expand the scroll area bounds by adding a margin.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(20), Tooltip("Scroll margin applies to the child controls area. Can be used to expand the scroll area bounds by adding a margin.")]
         public Margin ScrollMargin
         {
             get => _scrollMargin;
@@ -168,6 +183,57 @@ namespace FlaxEngine.GUI
                     _scrollMargin = value;
                     PerformLayout();
                 }
+            }
+        }
+
+        /// <summary>
+        /// The color of the scroll bar track.
+        /// </summary>
+        [EditorDisplay("Scrollbar Style"), EditorOrder(30), ExpandGroups]
+        public Color ScrollbarTrackColor
+        {
+            get => _scrollbarTrackColor;
+            set
+            {
+                _scrollbarTrackColor = value;
+                if (VScrollBar != null)
+                    VScrollBar.TrackColor = _scrollbarTrackColor;
+                if (HScrollBar != null)
+                    HScrollBar.TrackColor = _scrollbarTrackColor;
+            }
+        }
+
+        /// <summary>
+        /// The color of the scroll bar thumb.
+        /// </summary>
+        [EditorDisplay("Scrollbar Style"), EditorOrder(31)]
+        public Color ScrollbarThumbColor
+        {
+            get => _scrollbarThumbColor;
+            set
+            {
+                _scrollbarThumbColor = value;
+                if (VScrollBar != null)
+                    VScrollBar.ThumbColor = _scrollbarThumbColor;
+                if (HScrollBar != null)
+                    HScrollBar.ThumbColor = _scrollbarThumbColor;
+            }
+        }
+
+        /// <summary>
+        /// The color of the scroll bar thumb when selected.
+        /// </summary>
+        [EditorDisplay("Scrollbar Style"), EditorOrder(32)]
+        public Color ScrollbarThumbSelectedColor
+        {
+            get => _scrollbarThumbSelectedColor;
+            set
+            {
+                _scrollbarThumbSelectedColor = value;
+                if (VScrollBar != null)
+                    VScrollBar.ThumbSelectedColor = _scrollbarThumbSelectedColor;
+                if (HScrollBar != null)
+                    HScrollBar.ThumbSelectedColor = _scrollbarThumbSelectedColor;
             }
         }
 
@@ -187,6 +253,10 @@ namespace FlaxEngine.GUI
         public Panel(ScrollBars scrollBars, bool autoFocus = false)
         {
             AutoFocus = autoFocus;
+            var style = Style.Current;
+            _scrollbarTrackColor = style.BackgroundHighlighted;
+            _scrollbarThumbColor = style.BackgroundNormal;
+            _scrollbarThumbSelectedColor = style.BackgroundSelected;
             ScrollBars = scrollBars;
         }
 

--- a/Source/Engine/UI/GUI/Panels/Panel.cs
+++ b/Source/Engine/UI/GUI/Panels/Panel.cs
@@ -52,7 +52,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets the scroll bars usage by this panel.
         /// </summary>
-        [EditorDisplay("Scrollbar Style"), EditorOrder(0), Tooltip("The scroll bars usage.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(1500), Tooltip("The scroll bars usage.")]
         public ScrollBars ScrollBars
         {
             get => _scrollBars;
@@ -123,7 +123,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets the size of the scroll bars.
         /// </summary>
-        [EditorDisplay("Scrollbar Style"), EditorOrder(5), Tooltip("Scroll bars size.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(1501), Tooltip("Scroll bars size.")]
         public float ScrollBarsSize
         {
             get => _scrollBarsSize;
@@ -139,7 +139,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets a value indicating whether always show scrollbars. Otherwise show them only if scrolling is available.
         /// </summary>
-        [EditorDisplay("Scrollbar Style"), EditorOrder(10), Tooltip("Whether always show scrollbars. Otherwise show them only if scrolling is available.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(1502), Tooltip("Whether always show scrollbars. Otherwise show them only if scrolling is available.")]
         public bool AlwaysShowScrollbars
         {
             get => _alwaysShowScrollbars;
@@ -172,7 +172,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets the scroll margin applies to the child controls area. Can be used to expand the scroll area bounds by adding a margin.
         /// </summary>
-        [EditorDisplay("Scrollbar Style"), EditorOrder(20), Tooltip("Scroll margin applies to the child controls area. Can be used to expand the scroll area bounds by adding a margin.")]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(1503), Tooltip("Scroll margin applies to the child controls area. Can be used to expand the scroll area bounds by adding a margin.")]
         public Margin ScrollMargin
         {
             get => _scrollMargin;
@@ -189,7 +189,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// The color of the scroll bar track.
         /// </summary>
-        [EditorDisplay("Scrollbar Style"), EditorOrder(30), ExpandGroups]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(1600), ExpandGroups]
         public Color ScrollbarTrackColor
         {
             get => _scrollbarTrackColor;
@@ -206,7 +206,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// The color of the scroll bar thumb.
         /// </summary>
-        [EditorDisplay("Scrollbar Style"), EditorOrder(31)]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(1601)]
         public Color ScrollbarThumbColor
         {
             get => _scrollbarThumbColor;
@@ -223,7 +223,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// The color of the scroll bar thumb when selected.
         /// </summary>
-        [EditorDisplay("Scrollbar Style"), EditorOrder(32)]
+        [EditorDisplay("Scrollbar Style"), EditorOrder(1602)]
         public Color ScrollbarThumbSelectedColor
         {
             get => _scrollbarThumbSelectedColor;

--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -75,6 +75,21 @@ namespace FlaxEngine.GUI
         public bool EnableSmoothing { get; set; } = true;
 
         /// <summary>
+        /// The track color.
+        /// </summary>
+        public Color TrackColor;
+
+        /// <summary>
+        /// The thumb color.
+        /// </summary>
+        public Color ThumbColor;
+
+        /// <summary>
+        /// The selected thumb color.
+        /// </summary>
+        public Color ThumbSelectedColor;
+
+        /// <summary>
         /// Gets or sets the minimum value.
         /// </summary>
         public float Minimum
@@ -209,6 +224,10 @@ namespace FlaxEngine.GUI
             AutoFocus = false;
 
             _orientation = orientation;
+            var style = Style.Current;
+            TrackColor = style.BackgroundHighlighted;
+            ThumbColor = style.BackgroundNormal;
+            ThumbSelectedColor = style.BackgroundSelected;
         }
 
         /// <summary>
@@ -377,8 +396,8 @@ namespace FlaxEngine.GUI
             base.Draw();
 
             var style = Style.Current;
-            Render2D.FillRectangle(_trackRect, style.BackgroundHighlighted * _thumbOpacity);
-            Render2D.FillRectangle(_thumbRect, (_thumbClicked ? style.BackgroundSelected : style.BackgroundNormal) * _thumbOpacity);
+            Render2D.FillRectangle(_trackRect, TrackColor * _thumbOpacity);
+            Render2D.FillRectangle(_thumbRect, (_thumbClicked ? ThumbSelectedColor : ThumbColor) * _thumbOpacity);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This exposes the ability to change a scroll bars color in a panel and through code.

This also changes to colors of the scroll bar in tabs to be more easily seen. If there are better colors to be used, let me know (see image below for colors used).
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/d18f1e78-a3d9-4a17-9b4b-f3c9cc2ed7f5)
