### PR TITLE
Allow adding script via drag drop on actor

### DIFF
--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -620,12 +620,12 @@ namespace FlaxEditor.Viewport
 
         private static bool ValidateDragActorType(ScriptType actorType)
         {
-            return Level.IsAnySceneLoaded;
+            return Level.IsAnySceneLoaded && Editor.Instance.CodeEditing.Actors.Get().Contains(actorType);
         }
 
         private static bool ValidateDragScriptItem(ScriptItem script)
         {
-            return Editor.Instance.CodeEditing.Actors.Get(script) != ScriptType.Null;
+            return Level.IsAnySceneLoaded && Editor.Instance.CodeEditing.Actors.Get(script) != ScriptType.Null;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -498,7 +498,7 @@ namespace FlaxEditor.Viewport
 
         private static bool ValidateDragActorType(ScriptType actorType)
         {
-            return true;
+            return Editor.Instance.CodeEditing.Actors.Get().Contains(actorType);
         }
 
         private static bool ValidateDragScriptItem(ScriptItem script)


### PR DESCRIPTION
Allow adding a script to an actor via drag and drop from the content menu.

Small fixes to validating drag drop in viewport.