### PR TITLE
Add checkerboard background to color picker dialog color.

### DIFF
--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -389,7 +389,7 @@ namespace FlaxEditor.GUI.Dialogs
                     }
                 }
             }
-            Render2D.FillRectangle(newRect, _value * _value.A);
+            Render2D.FillRectangle(newRect, _value);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -371,8 +371,24 @@ namespace FlaxEditor.GUI.Dialogs
             Render2D.DrawText(style.FontMedium, "Hex", hex, textColor, TextAlignment.Near, TextAlignment.Center);
 
             // Color difference
-            var newRect = new Rectangle(_cOK.X, _cHex.Bottom + PickerMargin, _cCancel.Right - _cOK.Left, 0);
-            newRect.Size.Y = _cValue.Bottom - newRect.Y;
+            var newRect = new Rectangle(_cOK.X - 3, _cHex.Bottom + PickerMargin, 130, 0);
+            newRect.Size.Y = 50;
+            Render2D.FillRectangle(newRect, Color.White);
+            var smallRectSize = 10;
+            var numHor = Mathf.FloorToInt(newRect.Width / smallRectSize);
+            var numVer = Mathf.FloorToInt(newRect.Height / smallRectSize);
+            // Draw checkerboard for background of color to help with transparency
+            for (int i = 0; i < numHor; i++)
+            {
+                for (int j = 0; j < numVer; j++)
+                {
+                    if ((i + j) % 2 == 0 )
+                    {
+                        var rect = new Rectangle(newRect.X + smallRectSize * i, newRect.Y + smallRectSize * j, new Float2(smallRectSize));
+                        Render2D.FillRectangle(rect, Color.Gray);
+                    }
+                }
+            }
             Render2D.FillRectangle(newRect, _value * _value.A);
         }
 


### PR DESCRIPTION
Adds a checkboard to the main color in the color picker for easier time seeing alpha changes.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/c16ac110-0cd1-4e89-adb9-b6f928ff32ea)
