### PR TITLE
Fix bindings code generation for nested types

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/ApiTypeInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/ApiTypeInfo.cs
@@ -98,7 +98,7 @@ namespace Flax.Build.Bindings
             {
                 var result = NativeName;
                 if (Parent != null && !(Parent is FileInfo))
-                    result = Parent.FullNameNative + '_' + result;
+                    result = Parent.FullNameNative.Replace("::", "_") + '_' + result;
                 return result;
             }
         }

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -1641,8 +1641,9 @@ namespace Flax.Build.Bindings
                             if (internalType)
                             {
                                 // Marshal blittable array elements back to original non-blittable elements
-                                string originalElementTypeMarshaller = originalElementType + "Marshaller";
-                                string internalElementType = $"{originalElementTypeMarshaller}.{originalElementType}Internal";
+                                string originalElementTypeMarshaller = $"{originalElementType}Marshaller";
+                                string originalElementTypeName = originalElementType.Substring(originalElementType.LastIndexOf('.') + 1); // Strip namespace
+                                string internalElementType = $"{originalElementTypeMarshaller}.{originalElementTypeName}Internal";
                                 toManagedContent.AppendLine($"unmanaged.{fieldInfo.Name} != IntPtr.Zero ? NativeInterop.ConvertArray((Unsafe.As<ManagedArray>(ManagedHandle.FromIntPtr(unmanaged.{fieldInfo.Name}).Target)).ToSpan<{internalElementType}>(), {originalElementTypeMarshaller}.ToManaged) : null;");
                                 toNativeContent.AppendLine($"managed.{fieldInfo.Name}?.Length > 0 ? ManagedHandle.ToIntPtr(ManagedArray.WrapNewArray(NativeInterop.ConvertArray(managed.{fieldInfo.Name}, {originalElementTypeMarshaller}.ToNative)), GCHandleType.Weak) : IntPtr.Zero;");
                                 freeContents.AppendLine($"if (unmanaged.{fieldInfo.Name} != IntPtr.Zero) {{ ManagedHandle handle = ManagedHandle.FromIntPtr(unmanaged.{fieldInfo.Name}); Span<{internalElementType}> values = (Unsafe.As<ManagedArray>(handle.Target)).ToSpan<{internalElementType}>(); foreach (var value in values) {{ {originalElementTypeMarshaller}.Free(value); }} (Unsafe.As<ManagedArray>(handle.Target)).Free(); handle.Free(); }}");


### PR DESCRIPTION
Fixes #2582, and has better fix for #2590 to avoid conflicting names in following scenarios:
```cpp
API_CLASS() class GAME_API Item : public Script
{
    // ...
    API_STRUCT() struct GAME_API Attribute
    {
        // ...
        API_ENUM() enum MyEnum
        {
            E1, E2,
        };
    };
    // ...
};
API_CLASS() class GAME_API DifferentItem : public Script
{
    // ...
    API_STRUCT() struct GAME_API Attribute
    {
        // ...
        API_ENUM() enum MyEnum
        {
            E3, E4,
        };
    };
    // ...
};
```