### PR TITLE
Force camera model to load in prefabs.

### DIFF
--- a/Source/Engine/Level/Actors/Camera.cpp
+++ b/Source/Engine/Level/Actors/Camera.cpp
@@ -349,6 +349,11 @@ void Camera::Draw(RenderContext& renderContext)
             _previewModel->Draw(renderContext, draw);
         }
     }
+    // Load preview model if it doesnt exist. Ex: prefabs
+    else if (EnumHasAnyFlags(renderContext.View.Flags, ViewFlags::EditorSprites) && !_previewModel)
+    {
+        _previewModel = Content::LoadAsyncInternal<Model>(TEXT("Editor/Camera/O_Camera"));
+    }
 }
 
 #include "Engine/Debug/DebugDraw.h"


### PR DESCRIPTION
Because begin play does not run in prefabs it seems, added some extra code to load the preview model if it does not exist.