### PR TITLE
Remove redundant asset waiting and reloading when saving materials

### DIFF
--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -459,8 +459,7 @@ namespace FlaxEditor.Windows.Assets
         /// <returns>True if failed, otherwise false.</returns>
         protected virtual bool SaveToOriginal()
         {
-            // Wait until temporary asset file be fully loaded
-            if (_asset.WaitForLoaded())
+            if (_asset.LastLoadFailed)
             {
                 Editor.LogError(string.Format("Cannot save asset {0}. Wait for temporary asset loaded failed.", _item.Path));
                 return true;
@@ -492,12 +491,6 @@ namespace FlaxEditor.Windows.Assets
             {
                 Editor.LogError(string.Format("Cannot copy asset \'{0}\' to \'{1}\'", sourcePath, destinationPath));
                 return true;
-            }
-
-            // Reload original asset
-            if (originalAsset)
-            {
-                originalAsset.Reload();
             }
 
             // Refresh thumbnail

--- a/Source/Editor/Windows/Assets/MaterialWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialWindow.cs
@@ -355,7 +355,6 @@ namespace FlaxEditor.Windows.Assets
                     Editor.LogError("Failed to save surface data");
                 }
                 _asset.Reload();
-                _asset.WaitForLoaded();
             }
         }
 


### PR DESCRIPTION
Fixes the editor stalling while saving the material in #2604

We don't need to wait for the temporary asset to be fully loaded from the disk when cloning the file, and the original asset is constantly being reloaded when nodes have been edited in the surface, so this reload is also not needed.