### PR TITLE
Visject: Minor QoL change for moving reroute nodes

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1032,7 +1032,8 @@ namespace FlaxEditor.Surface.Archetypes
             private Rectangle _localBounds;
             private InputBox _input;
             private OutputBox _output;
-            private bool _isMouseDown, _isConnecting;
+            private bool _isMouseDown, _isConnecting, _isMouseInConnectingBounds;
+            private const float ConnectingBounds = -12.0f;
 
             /// <inheritdoc />
             public RerouteNode(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
@@ -1170,7 +1171,7 @@ namespace FlaxEditor.Surface.Archetypes
                 if (button == MouseButton.Left)
                 {
                     _isMouseDown = true;
-                    _isConnecting = _localBounds.MakeExpanded(-10.0f).Contains(ref location); // Inner area for connecting, outer area for moving
+                    _isConnecting = _isMouseInConnectingBounds;
                     if (_isConnecting)
                     {
                         Focus();
@@ -1189,12 +1190,22 @@ namespace FlaxEditor.Surface.Archetypes
                     if (Surface.CanEdit && _isConnecting)
                         Surface.ConnectingStart(this);
                 }
+
+                _isMouseInConnectingBounds = false;
+                Cursor = CursorType.Default;
+                
                 base.OnMouseLeave();
             }
 
             /// <inheritdoc />
             public override void OnMouseMove(Float2 location)
             {
+                _isMouseInConnectingBounds = IsMouseOver && _localBounds.MakeExpanded(ConnectingBounds).Contains(ref location); // Inner area for connecting, outer area for moving
+                if (!_isMouseInConnectingBounds && !_isMouseDown)
+                    Cursor = CursorType.SizeAll;
+                else
+                    Cursor = CursorType.Default;
+
                 Surface.ConnectingOver(this);
                 base.OnMouseMove(location);
             }


### PR DESCRIPTION
Reroute nodes can be a bit fiddely. Sometimes you want to create a connection but you suddenly move the node. Or you want to move the node but suddenly create a connection...

This PR increases the padding of the bounds check that detemines if a reroute node should be moved or create a connection slightly. Additionally it also changes the cursor now when hovering outside of the connecting bounds to make it more obvious that the user is about to move the node. See Gifs.

**Preview**

Before
![RerouteMoveBefore](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/ae0ae3af-d11c-430f-9d48-2eca68e9df37)

After
![RerouteMoveAfter](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/a8410502-0f49-4d51-899d-3bbeee433d6e)

