### PR TITLE
Remove drop down image on scripts if no objects are in the group.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -880,6 +880,13 @@ namespace FlaxEditor.CustomEditors.Dedicated
 
                 group.Panel.HeaderTextMargin = new Margin(scriptDrag.Right - 12, 15, 2, 2);
                 group.Object(values, editor);
+                // Remove drop down arrows and containment lines if no objects in the group
+                if (group.Children.Count == 0)
+                {
+                    group.Panel.ArrowImageOpened = null;
+                    group.Panel.ArrowImageClosed = null;
+                    group.Panel.EnableContainmentLines = false;
+                }
 
                 // Scripts arrange bar
                 dragBar = layout.Custom<ScriptArrangeBar>();


### PR DESCRIPTION
Makes it clear on scripts that there are no properties to edit.

![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/d403e766-8459-40fc-9cb8-6999b2e9e246)
