### PR TITLE
Fix playing from first scene with invalid asset id.…

### DIFF
--- a/Source/Editor/Modules/SimulationModule.cs
+++ b/Source/Editor/Modules/SimulationModule.cs
@@ -132,6 +132,7 @@ namespace FlaxEditor.Modules
             var firstScene = Content.Settings.GameSettings.Load().FirstScene;
             if (firstScene == Guid.Empty)
             {
+                Editor.LogWarning("No First Scene assigned in Game Settings.");
                 if (Level.IsAnySceneLoaded)
                     Editor.Simulation.RequestStartPlayScenes();
                 return;

--- a/Source/Editor/Modules/SimulationModule.cs
+++ b/Source/Editor/Modules/SimulationModule.cs
@@ -127,9 +127,7 @@ namespace FlaxEditor.Modules
         public void RequestStartPlayGame()
         {
             if (!Editor.StateMachine.IsEditMode)
-            {
                 return;
-            }
 
             var firstScene = Content.Settings.GameSettings.Load().FirstScene;
             if (firstScene == Guid.Empty)
@@ -141,6 +139,9 @@ namespace FlaxEditor.Modules
             if (!FlaxEngine.Content.GetAssetInfo(firstScene.ID, out var info))
             {
                 Editor.LogWarning("Invalid First Scene in Game Settings.");
+                if (Level.IsAnySceneLoaded)
+                    Editor.Simulation.RequestStartPlayScenes();
+                return;
             }
 
             // Load scenes after entering the play mode


### PR DESCRIPTION
 Play scene if invalid first scene data in editor while selected to play game from first scene.