### PR TITLE
Run control update even when UiCanvas skips events.

### DIFF
--- a/Source/Engine/UI/GUI/CanvasRootControl.cs
+++ b/Source/Engine/UI/GUI/CanvasRootControl.cs
@@ -200,6 +200,8 @@ namespace FlaxEngine.GUI
         /// <inheritdoc />
         public override void Update(float deltaTime)
         {
+            base.Update(deltaTime);
+
             // Update navigation
             if (SkipEvents)
             {
@@ -215,8 +217,6 @@ namespace FlaxEngine.GUI
                 UpdateNavigation(deltaTime, _canvas.NavigateRight.Name, NavDirection.Right, ref _navigationHeldTimeRight, ref _navigationRateTimeRight);
                 UpdateNavigation(deltaTime, _canvas.NavigateSubmit.Name, ref _navigationHeldTimeSubmit, ref _navigationRateTimeSubmit, SubmitFocused);
             }
-
-            base.Update(deltaTime);
         }
 
         private void ConditionalNavigate(NavDirection direction)


### PR DESCRIPTION
Fix <https://github.com/FlaxEngine/FlaxEngine/issues/2627>