### PR TITLE
Add slot spacing to uniform grid panel.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -41,6 +41,13 @@ namespace FlaxEditor.CustomEditors.Editors
             public override void Initialize(LayoutElementsContainer layout)
             {
                 base.Initialize(layout);
+                
+                if (XElement.ValueBox.Parent is UniformGridPanel ug)
+                {
+                    ug.Height += 2;
+                    ug.SlotSpacing = new Float2(4);
+                    ug.SlotPadding = new Margin(0, 0, 1, 1);
+                }
 
                 // Override colors
                 var back = FlaxEngine.GUI.Style.Current.TextBoxBackground;
@@ -66,6 +73,13 @@ namespace FlaxEditor.CustomEditors.Editors
             public override void Initialize(LayoutElementsContainer layout)
             {
                 base.Initialize(layout);
+                
+                if (XElement.ValueBox.Parent is UniformGridPanel ug)
+                {
+                    ug.Height += 2;
+                    ug.SlotSpacing = new Float2(4);
+                    ug.SlotPadding = new Margin(0, 0, 1, 1);
+                }
 
                 // Override colors
                 var back = FlaxEngine.GUI.Style.Current.TextBoxBackground;
@@ -121,6 +135,13 @@ namespace FlaxEditor.CustomEditors.Editors
                         else
                             menu.AddButton("Link", ToggleLink).LinkTooltip("Links scale components for uniform scaling");
                     };
+                }
+                
+                if (XElement.ValueBox.Parent is UniformGridPanel ug)
+                {
+                    ug.Height += 2;
+                    ug.SlotSpacing = new Float2(4);
+                    ug.SlotPadding = new Margin(0, 0, 1, 1);
                 }
 
                 // Override colors

--- a/Source/Editor/GUI/Input/ColorValueBox.cs
+++ b/Source/Editor/GUI/Input/ColorValueBox.cs
@@ -130,7 +130,7 @@ namespace FlaxEditor.GUI.Input
             base.Draw();
 
             var style = Style.Current;
-            var r = new Rectangle(2, 2, Width - 4, Height - 4);
+            var r = new Rectangle(0, 0, Width, Height);
 
             Render2D.FillRectangle(r, _value);
             Render2D.DrawRectangle(r, IsMouseOver || IsNavFocused ? style.BackgroundSelected : Color.Black);

--- a/Source/Engine/UI/GUI/Panels/UniformGridPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/UniformGridPanel.cs
@@ -11,6 +11,7 @@ namespace FlaxEngine.GUI
     {
         private Margin _slotPadding;
         private int _slotsV, _slotsH;
+        private Float2 _slotSpacing;
 
         /// <summary>
         /// Gets or sets the padding given to each slot.
@@ -63,10 +64,24 @@ namespace FlaxEngine.GUI
         }
 
         /// <summary>
+        /// Gets or sets grid slot spacing.
+        /// </summary>
+        [EditorOrder(30), Limit(0), Tooltip("The Grid slot spacing.")]
+        public Float2 SlotSpacing
+        {
+            get => _slotSpacing;
+            set
+            {
+                _slotSpacing = value;
+                PerformLayout();
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UniformGridPanel"/> class.
         /// </summary>
         public UniformGridPanel()
-        : this(2)
+        : this(0)
         {
         }
 
@@ -74,10 +89,11 @@ namespace FlaxEngine.GUI
         /// Initializes a new instance of the <see cref="UniformGridPanel"/> class.
         /// </summary>
         /// <param name="slotPadding">The slot padding.</param>
-        public UniformGridPanel(float slotPadding = 2)
+        public UniformGridPanel(float slotPadding = 0)
         {
             AutoFocus = false;
             SlotPadding = new Margin(slotPadding);
+            SlotSpacing = new Float2(2);
             _slotsH = _slotsV = 5;
         }
 
@@ -121,6 +137,42 @@ namespace FlaxEngine.GUI
                 {
                     var slotBounds = new Rectangle(slotSize.X * x, slotSize.Y * y, slotSize.X, slotSize.Y);
                     _slotPadding.ShrinkRectangle(ref slotBounds);
+
+                    if (slotsV > 1)
+                    {
+                        if (y == 0)
+                        {
+                            slotBounds.Height -= _slotSpacing.Y * 0.5f * slotsV;
+                        }
+                        else if (y == slotsV - 1)
+                        {
+                            slotBounds.Height -= _slotSpacing.Y * 0.5f * slotsV;
+                            slotBounds.Y += _slotSpacing.Y * 0.5f * slotsV;
+                        }
+                        else
+                        {
+                            slotBounds.Height -= _slotSpacing.Y * 0.5f * slotsV;
+                            slotBounds.Y += _slotSpacing.Y * 0.5f;
+                        }
+                    }
+                   
+                    if (slotsH > 1)
+                    {
+                        if (x == 0)
+                        {
+                            slotBounds.Width -= _slotSpacing.X * 0.5f * slotsH;
+                        }
+                        else if (x == slotsH - 1)
+                        {
+                            slotBounds.Width -= _slotSpacing.X * 0.5f * slotsH;
+                            slotBounds.X += _slotSpacing.X * 0.5f * slotsH;
+                        }
+                        else
+                        {
+                            slotBounds.Width -= _slotSpacing.X * 0.5f * slotsH;
+                            slotBounds.X += _slotSpacing.X * 0.5f;
+                        }
+                    }
 
                     var c = _children[i++];
                     c.Bounds = slotBounds;

--- a/Source/Engine/UI/GUI/Panels/UniformGridPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/UniformGridPanel.cs
@@ -142,16 +142,16 @@ namespace FlaxEngine.GUI
                     {
                         if (y == 0)
                         {
-                            slotBounds.Height -= _slotSpacing.Y * 0.5f * slotsV;
+                            slotBounds.Height -= _slotSpacing.Y * 0.5f;
                         }
                         else if (y == slotsV - 1)
                         {
-                            slotBounds.Height -= _slotSpacing.Y * 0.5f * slotsV;
-                            slotBounds.Y += _slotSpacing.Y * 0.5f * slotsV;
+                            slotBounds.Height -= _slotSpacing.Y * 0.5f;
+                            slotBounds.Y += _slotSpacing.Y * 0.5f;
                         }
                         else
                         {
-                            slotBounds.Height -= _slotSpacing.Y * 0.5f * slotsV;
+                            slotBounds.Height -= _slotSpacing.Y;
                             slotBounds.Y += _slotSpacing.Y * 0.5f;
                         }
                     }
@@ -160,16 +160,16 @@ namespace FlaxEngine.GUI
                     {
                         if (x == 0)
                         {
-                            slotBounds.Width -= _slotSpacing.X * 0.5f * slotsH;
+                            slotBounds.Width -= _slotSpacing.X * 0.5f;
                         }
                         else if (x == slotsH - 1)
                         {
-                            slotBounds.Width -= _slotSpacing.X * 0.5f * slotsH;
-                            slotBounds.X += _slotSpacing.X * 0.5f * slotsH;
+                            slotBounds.Width -= _slotSpacing.X * 0.5f;
+                            slotBounds.X += _slotSpacing.X * 0.5f;
                         }
                         else
                         {
-                            slotBounds.Width -= _slotSpacing.X * 0.5f * slotsH;
+                            slotBounds.Width -= _slotSpacing.X;
                             slotBounds.X += _slotSpacing.X * 0.5f;
                         }
                     }


### PR DESCRIPTION
Using this makes everything look a little better in the editor when using the uniform grid and lets you control the x and y spacing between the grid items. This adds slot spacing which only affects the control size by controlling the space between the controls in the grid instead of just the control's size like the padding does.

Before:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/98a825ab-a3c8-464b-a1d6-83aee3c57a11)
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/796c5c1d-21fa-47ab-a771-1923a3d03f14)


After:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/8b3fb5aa-81df-410b-995c-e412dcb5a9cc)
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/d8c4bf96-0e2c-483e-8998-c868dba55b0c)
