### PR TITLE
Visject: Improved UX for disabled boxes

### DIFF
--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -71,20 +71,20 @@ namespace FlaxEditor.Surface.Archetypes
                 // Layered material
                 if (GetBox(MaterialNodeBoxes.Layer).HasAnyConnection)
                 {
-                    GetBox(MaterialNodeBoxes.Color).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Mask).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Emissive).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Metalness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Specular).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Roughness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.AmbientOcclusion).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Normal).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Opacity).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Refraction).Enabled = false;
-                    GetBox(MaterialNodeBoxes.PositionOffset).Enabled = false;
-                    GetBox(MaterialNodeBoxes.TessellationMultiplier).Enabled = false;
-                    GetBox(MaterialNodeBoxes.WorldDisplacement).Enabled = false;
-                    GetBox(MaterialNodeBoxes.SubsurfaceColor).Enabled = false;
+                    GetBox(MaterialNodeBoxes.Color).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Mask).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Emissive).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Metalness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Specular).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Roughness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.AmbientOcclusion).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Normal).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Opacity).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Refraction).IsActive = false;
+                    GetBox(MaterialNodeBoxes.PositionOffset).IsActive = false;
+                    GetBox(MaterialNodeBoxes.TessellationMultiplier).IsActive = false;
+                    GetBox(MaterialNodeBoxes.WorldDisplacement).IsActive = false;
+                    GetBox(MaterialNodeBoxes.SubsurfaceColor).IsActive = false;
                     return;
                 }
 
@@ -102,94 +102,94 @@ namespace FlaxEditor.Surface.Archetypes
                     bool isNotUnlit = info.ShadingModel != MaterialShadingModel.Unlit;
                     bool withTess = info.TessellationMode != TessellationMethod.None;
 
-                    GetBox(MaterialNodeBoxes.Color).Enabled = isNotUnlit;
-                    GetBox(MaterialNodeBoxes.Mask).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Emissive).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Metalness).Enabled = isNotUnlit;
-                    GetBox(MaterialNodeBoxes.Specular).Enabled = isNotUnlit;
-                    GetBox(MaterialNodeBoxes.Roughness).Enabled = isNotUnlit;
-                    GetBox(MaterialNodeBoxes.AmbientOcclusion).Enabled = isNotUnlit;
-                    GetBox(MaterialNodeBoxes.Normal).Enabled = isNotUnlit;
-                    GetBox(MaterialNodeBoxes.Opacity).Enabled = info.ShadingModel == MaterialShadingModel.Subsurface || info.ShadingModel == MaterialShadingModel.Foliage || info.BlendMode != MaterialBlendMode.Opaque;
-                    GetBox(MaterialNodeBoxes.Refraction).Enabled = info.BlendMode != MaterialBlendMode.Opaque;
-                    GetBox(MaterialNodeBoxes.PositionOffset).Enabled = true;
-                    GetBox(MaterialNodeBoxes.TessellationMultiplier).Enabled = withTess;
-                    GetBox(MaterialNodeBoxes.WorldDisplacement).Enabled = withTess;
-                    GetBox(MaterialNodeBoxes.SubsurfaceColor).Enabled = info.ShadingModel == MaterialShadingModel.Subsurface || info.ShadingModel == MaterialShadingModel.Foliage;
+                    GetBox(MaterialNodeBoxes.Color).IsActive = isNotUnlit;
+                    GetBox(MaterialNodeBoxes.Mask).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Emissive).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Metalness).IsActive = isNotUnlit;
+                    GetBox(MaterialNodeBoxes.Specular).IsActive = isNotUnlit;
+                    GetBox(MaterialNodeBoxes.Roughness).IsActive = isNotUnlit;
+                    GetBox(MaterialNodeBoxes.AmbientOcclusion).IsActive = isNotUnlit;
+                    GetBox(MaterialNodeBoxes.Normal).IsActive = isNotUnlit;
+                    GetBox(MaterialNodeBoxes.Opacity).IsActive = info.ShadingModel == MaterialShadingModel.Subsurface || info.ShadingModel == MaterialShadingModel.Foliage || info.BlendMode != MaterialBlendMode.Opaque;
+                    GetBox(MaterialNodeBoxes.Refraction).IsActive = info.BlendMode != MaterialBlendMode.Opaque;
+                    GetBox(MaterialNodeBoxes.PositionOffset).IsActive = true;
+                    GetBox(MaterialNodeBoxes.TessellationMultiplier).IsActive = withTess;
+                    GetBox(MaterialNodeBoxes.WorldDisplacement).IsActive = withTess;
+                    GetBox(MaterialNodeBoxes.SubsurfaceColor).IsActive = info.ShadingModel == MaterialShadingModel.Subsurface || info.ShadingModel == MaterialShadingModel.Foliage;
                     break;
                 }
                 case MaterialDomain.PostProcess:
                 {
-                    GetBox(MaterialNodeBoxes.Color).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Mask).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Emissive).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Metalness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Specular).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Roughness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.AmbientOcclusion).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Normal).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Opacity).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Refraction).Enabled = false;
-                    GetBox(MaterialNodeBoxes.PositionOffset).Enabled = false;
-                    GetBox(MaterialNodeBoxes.TessellationMultiplier).Enabled = false;
-                    GetBox(MaterialNodeBoxes.WorldDisplacement).Enabled = false;
-                    GetBox(MaterialNodeBoxes.SubsurfaceColor).Enabled = false;
+                    GetBox(MaterialNodeBoxes.Color).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Mask).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Emissive).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Metalness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Specular).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Roughness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.AmbientOcclusion).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Normal).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Opacity).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Refraction).IsActive = false;
+                    GetBox(MaterialNodeBoxes.PositionOffset).IsActive = false;
+                    GetBox(MaterialNodeBoxes.TessellationMultiplier).IsActive = false;
+                    GetBox(MaterialNodeBoxes.WorldDisplacement).IsActive = false;
+                    GetBox(MaterialNodeBoxes.SubsurfaceColor).IsActive = false;
                     break;
                 }
                 case MaterialDomain.Decal:
                 {
                     var mode = info.DecalBlendingMode;
 
-                    GetBox(MaterialNodeBoxes.Color).Enabled = mode == MaterialDecalBlendingMode.Translucent || mode == MaterialDecalBlendingMode.Stain;
-                    GetBox(MaterialNodeBoxes.Mask).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Emissive).Enabled = mode == MaterialDecalBlendingMode.Translucent || mode == MaterialDecalBlendingMode.Emissive;
-                    GetBox(MaterialNodeBoxes.Metalness).Enabled = mode == MaterialDecalBlendingMode.Translucent;
-                    GetBox(MaterialNodeBoxes.Specular).Enabled = mode == MaterialDecalBlendingMode.Translucent;
-                    GetBox(MaterialNodeBoxes.Roughness).Enabled = mode == MaterialDecalBlendingMode.Translucent;
-                    GetBox(MaterialNodeBoxes.AmbientOcclusion).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Normal).Enabled = mode == MaterialDecalBlendingMode.Translucent || mode == MaterialDecalBlendingMode.Normal;
-                    GetBox(MaterialNodeBoxes.Opacity).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Refraction).Enabled = false;
-                    GetBox(MaterialNodeBoxes.PositionOffset).Enabled = false;
-                    GetBox(MaterialNodeBoxes.TessellationMultiplier).Enabled = false;
-                    GetBox(MaterialNodeBoxes.WorldDisplacement).Enabled = false;
-                    GetBox(MaterialNodeBoxes.SubsurfaceColor).Enabled = false;
+                    GetBox(MaterialNodeBoxes.Color).IsActive = mode == MaterialDecalBlendingMode.Translucent || mode == MaterialDecalBlendingMode.Stain;
+                    GetBox(MaterialNodeBoxes.Mask).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Emissive).IsActive = mode == MaterialDecalBlendingMode.Translucent || mode == MaterialDecalBlendingMode.Emissive;
+                    GetBox(MaterialNodeBoxes.Metalness).IsActive = mode == MaterialDecalBlendingMode.Translucent;
+                    GetBox(MaterialNodeBoxes.Specular).IsActive = mode == MaterialDecalBlendingMode.Translucent;
+                    GetBox(MaterialNodeBoxes.Roughness).IsActive = mode == MaterialDecalBlendingMode.Translucent;
+                    GetBox(MaterialNodeBoxes.AmbientOcclusion).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Normal).IsActive = mode == MaterialDecalBlendingMode.Translucent || mode == MaterialDecalBlendingMode.Normal;
+                    GetBox(MaterialNodeBoxes.Opacity).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Refraction).IsActive = false;
+                    GetBox(MaterialNodeBoxes.PositionOffset).IsActive = false;
+                    GetBox(MaterialNodeBoxes.TessellationMultiplier).IsActive = false;
+                    GetBox(MaterialNodeBoxes.WorldDisplacement).IsActive = false;
+                    GetBox(MaterialNodeBoxes.SubsurfaceColor).IsActive = false;
                     break;
                 }
                 case MaterialDomain.GUI:
                 {
-                    GetBox(MaterialNodeBoxes.Color).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Mask).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Emissive).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Metalness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Specular).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Roughness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.AmbientOcclusion).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Normal).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Opacity).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Refraction).Enabled = false;
-                    GetBox(MaterialNodeBoxes.PositionOffset).Enabled = false;
-                    GetBox(MaterialNodeBoxes.TessellationMultiplier).Enabled = false;
-                    GetBox(MaterialNodeBoxes.WorldDisplacement).Enabled = false;
-                    GetBox(MaterialNodeBoxes.SubsurfaceColor).Enabled = false;
+                    GetBox(MaterialNodeBoxes.Color).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Mask).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Emissive).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Metalness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Specular).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Roughness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.AmbientOcclusion).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Normal).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Opacity).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Refraction).IsActive = false;
+                    GetBox(MaterialNodeBoxes.PositionOffset).IsActive = false;
+                    GetBox(MaterialNodeBoxes.TessellationMultiplier).IsActive = false;
+                    GetBox(MaterialNodeBoxes.WorldDisplacement).IsActive = false;
+                    GetBox(MaterialNodeBoxes.SubsurfaceColor).IsActive = false;
                     break;
                 }
                 case MaterialDomain.VolumeParticle:
                 {
-                    GetBox(MaterialNodeBoxes.Color).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Mask).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Emissive).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Metalness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Specular).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Roughness).Enabled = false;
-                    GetBox(MaterialNodeBoxes.AmbientOcclusion).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Normal).Enabled = false;
-                    GetBox(MaterialNodeBoxes.Opacity).Enabled = true;
-                    GetBox(MaterialNodeBoxes.Refraction).Enabled = false;
-                    GetBox(MaterialNodeBoxes.PositionOffset).Enabled = false;
-                    GetBox(MaterialNodeBoxes.TessellationMultiplier).Enabled = false;
-                    GetBox(MaterialNodeBoxes.WorldDisplacement).Enabled = false;
-                    GetBox(MaterialNodeBoxes.SubsurfaceColor).Enabled = false;
+                    GetBox(MaterialNodeBoxes.Color).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Mask).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Emissive).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Metalness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Specular).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Roughness).IsActive = false;
+                    GetBox(MaterialNodeBoxes.AmbientOcclusion).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Normal).IsActive = false;
+                    GetBox(MaterialNodeBoxes.Opacity).IsActive = true;
+                    GetBox(MaterialNodeBoxes.Refraction).IsActive = false;
+                    GetBox(MaterialNodeBoxes.PositionOffset).IsActive = false;
+                    GetBox(MaterialNodeBoxes.TessellationMultiplier).IsActive = false;
+                    GetBox(MaterialNodeBoxes.WorldDisplacement).IsActive = false;
+                    GetBox(MaterialNodeBoxes.SubsurfaceColor).IsActive = false;
                     break;
                 }
                 default: throw new ArgumentOutOfRangeException();

--- a/Source/Editor/Surface/Archetypes/ParticleModules.cs
+++ b/Source/Editor/Surface/Archetypes/ParticleModules.cs
@@ -399,7 +399,7 @@ namespace FlaxEditor.Surface.Archetypes
             private void UpdateInputBox()
             {
                 var facingMode = (ParticleSpriteFacingMode)Values[2];
-                GetBox(0).Enabled = facingMode == ParticleSpriteFacingMode.CustomFacingVector || facingMode == ParticleSpriteFacingMode.FixedAxis;
+                GetBox(0).IsActive = facingMode == ParticleSpriteFacingMode.CustomFacingVector || facingMode == ParticleSpriteFacingMode.FixedAxis;
             }
         }
 

--- a/Source/Editor/Surface/Elements/Box.cs
+++ b/Source/Editor/Surface/Elements/Box.cs
@@ -42,6 +42,11 @@ namespace FlaxEditor.Surface.Elements
         protected bool _isSelected;
 
         /// <summary>
+        /// The is active flag for the box. Unlike <see cref="FlaxEngine.GUI.Control.Enabled"/>, inactive boxes can still be interacted with, they just will be drawn like disabled boxes
+        /// </summary>
+        protected bool _isActive = true;
+
+        /// <summary>
         /// Unique box ID within single node.
         /// </summary>
         public int ID => Archetype.BoxID;
@@ -178,6 +183,15 @@ namespace FlaxEditor.Surface.Elements
                 _isSelected = value;
                 OnSelectionChanged();
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the active state of the box. Unlike <see cref="FlaxEngine.GUI.Control.Enabled"/>, inactive boxes can still be interacted with, they just will be drawn like disabled boxes
+        /// </summary>
+        public bool IsActive
+        {
+            get => _isActive;
+            set => _isActive = value;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -152,7 +152,8 @@ namespace FlaxEditor.Surface.Elements
                 Box targetBox = Connections[i];
                 var endPos = targetBox.ConnectionOrigin;
                 var highlight = 1 + Mathf.Max(startHighlight, targetBox.ConnectionsHighlightIntensity);
-                var color = _currentTypeColor * highlight;
+                var alpha = targetBox.Enabled && targetBox.IsActive ? 1.0f : 0.6f;
+                var color = _currentTypeColor * highlight * alpha;
 
                 // TODO: Figure out how to only draw the topmost connection
                 if (IntersectsConnection(ref startPos, ref endPos, ref mousePosition, mouseOverDistance))
@@ -172,7 +173,9 @@ namespace FlaxEditor.Surface.Elements
             // Draw all the connections
             var startPos = ConnectionOrigin;
             var endPos = targetBox.ConnectionOrigin;
-            DrawConnection(Surface.Style, ref startPos, ref endPos, ref _currentTypeColor, 2.5f);
+            var alpha = targetBox.Enabled && targetBox.IsActive ? 1.0f : 0.6f;
+            var color = _currentTypeColor * alpha;
+            DrawConnection(Surface.Style, ref startPos, ref endPos, ref color, 2.5f);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/SurfaceStyle.cs
+++ b/Source/Editor/Surface/SurfaceStyle.cs
@@ -228,7 +228,7 @@ namespace FlaxEditor.Surface
 
             // Draw icon
             bool hasConnections = box.HasAnyConnection;
-            float alpha = box.Enabled ? 1.0f : 0.6f;
+            float alpha = box.Enabled && box.IsActive ? 1.0f : 0.6f;
             Color color = box.CurrentTypeColor * alpha;
             var style = box.Surface.Style;
             SpriteHandle icon;


### PR DESCRIPTION
When a box in a node in visject gets disabled it is no longer possible to disconnect from that box via dragging with the mouse. Additionally it is not possible to just connect or swap connections to that box. See #2611 for more information.

This PR adds an active flag to boxes. Unlike the enabled flag of the control class, boxes can still be interacted with when set to inactive. This allows to connect and disconnect from inactive boxes.

Also a minor UI improvement: Connections that lead to a disabled/inactive box will now also get rendered with a lower alpha value. This makes it easier to see if a box is connected to a box that is inactive and therefor is not getting utilized.

Additionally i went through all archetypes and replaced cases where boxes would get disabled by some condition with just getting set to inactive. E.g. in the OrientSprite node.
In some cases i left the logic where boxes got disabled entirely. E.g. some nodes for visual scripting which disabled their ports when a class or enum they referenced was set to null.

As discussed in the aforementioned issue, i might build upon this in the future and make inactive nodes disappear completely. But for now this is sufficient to fix the issue.

Interacting with disabled/inactive nodes before:
![DisabledBoxesBefore](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/bf4e6d99-bd1e-403b-8faa-0f8f41b42501)

Interacting with disabled/inactive nodes after:
![DisabledBoxesAfter](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/976c0867-5398-4297-ad35-cd9b86a5c348)

Resolves #2611 