### PR TITLE
Visject: Improved comment renaming + visual fix

### DIFF
--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -20,11 +20,17 @@ namespace FlaxEditor.Surface
         private Rectangle _colorButtonRect;
         private Rectangle _resizeButtonRect;
         private Float2 _startResizingSize;
+        private readonly TextBox _renameTextBox;
 
         /// <summary>
         /// True if sizing tool is in use.
         /// </summary>
         protected bool _isResizing;
+
+        /// <summary>
+        /// True if rename textbox is active in order to rename comment
+        /// </summary>
+        protected bool _isRenaming;
 
         /// <summary>
         /// Gets or sets the color of the comment.
@@ -63,6 +69,13 @@ namespace FlaxEditor.Surface
         public SurfaceComment(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
         : base(id, context, nodeArch, groupArch)
         {
+            _renameTextBox = new TextBox(false, 0,0, Width)
+            {
+                Height = Constants.NodeHeaderSize,
+                Visible = false,
+                Parent = this,
+                EndEditOnClick = false, // We have to handle this ourselves, otherwise the textbox instantly loses focus when double-clicking the header
+            };
         }
 
         /// <inheritdoc />
@@ -149,6 +162,20 @@ namespace FlaxEditor.Surface
             _closeButtonRect = new Rectangle(Width - buttonSize - buttonMargin, buttonMargin, buttonSize, buttonSize);
             _colorButtonRect = new Rectangle(_closeButtonRect.Left - buttonSize - buttonMargin, buttonMargin, buttonSize, buttonSize);
             _resizeButtonRect = new Rectangle(_closeButtonRect.Left, Height - buttonSize - buttonMargin, buttonSize, buttonSize);
+            _renameTextBox.Width = Width;
+            _renameTextBox.Height = headerSize;
+        }
+
+        /// <inheritdoc />
+        public override void Update(float deltaTime)
+        {
+            if (_isRenaming && (!_renameTextBox.IsFocused || !RootWindow.IsFocused))
+            {
+                Rename(_renameTextBox.Text);
+                StopRenaming();
+            }
+
+            base.Update(deltaTime);
         }
 
         /// <inheritdoc />
@@ -158,7 +185,7 @@ namespace FlaxEditor.Surface
             var color = Color;
             var backgroundRect = new Rectangle(Float2.Zero, Size);
             var headerColor = new Color(Mathf.Clamp(color.R, 0.1f, 0.3f), Mathf.Clamp(color.G, 0.1f, 0.3f), Mathf.Clamp(color.B, 0.1f, 0.3f), 0.4f);
-            if (IsSelected)
+            if (IsSelected && !_isRenaming)
                 headerColor *= 2.0f;
 
             // Paint background
@@ -169,7 +196,8 @@ namespace FlaxEditor.Surface
 
             // Header
             Render2D.FillRectangle(_headerRect, headerColor);
-            Render2D.DrawText(style.FontLarge, Title, _headerRect, style.Foreground, TextAlignment.Center, TextAlignment.Center);
+            if(!_isRenaming)
+                Render2D.DrawText(style.FontLarge, Title, _headerRect, style.Foreground, TextAlignment.Center, TextAlignment.Center);
 
             // Close button
             Render2D.DrawSprite(style.Cross, _closeButtonRect, _closeButtonRect.Contains(_mousePosition) && Surface.CanEdit ? style.Foreground : style.ForegroundGrey);
@@ -211,6 +239,13 @@ namespace FlaxEditor.Surface
             if (_isResizing)
             {
                 EndResizing();
+            }
+
+            // Check if was renaming
+            if (_isRenaming)
+            {
+                Rename(_renameTextBox.Text);
+                StopRenaming();
             }
 
             // Base
@@ -294,15 +329,45 @@ namespace FlaxEditor.Surface
         /// </summary>
         public void StartRenaming()
         {
-            Surface.Select(this);
-            var dialog = RenamePopup.Show(this, _headerRect, Title, false);
-            dialog.Renamed += OnRenamed;
+            _isRenaming = true;
+            _renameTextBox.Visible = true;
+            _renameTextBox.SetText(Title);
+            _renameTextBox.Focus();
+            _renameTextBox.SelectAll();
         }
 
-        private void OnRenamed(RenamePopup renamePopup)
+        private void StopRenaming()
         {
-            Title = TitleValue = renamePopup.Text;
+            _isRenaming = false;
+            _renameTextBox.Visible = false;
+        }
+
+        private void Rename(string newTitle)
+        {
+            if(string.Equals(Title, newTitle, StringComparison.Ordinal))
+                return;
+
+            Title = TitleValue = newTitle;
             Surface.MarkAsEdited(false);
+        }
+
+        /// <inheritdoc />
+        public override bool OnKeyDown(KeyboardKeys key)
+        {
+            if (key == KeyboardKeys.Return)
+            {
+                Rename(_renameTextBox.Text);
+                StopRenaming();
+                return true;
+            }
+
+            if(key == KeyboardKeys.Escape)
+            {
+                StopRenaming();
+                return true;
+            }
+
+            return base.OnKeyDown(key);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
When renaming a comment in visject and the comment happens to not be fully visible in the visject window, the rename popup will be drawn outside the window.

This PR replaces the RenamePopup with a textbox inside the comment header itself. This is more in line with how other graph tools handle this case.
Fixes #2006 

Additionally pressing ESC now will no longer apply the new name.

Note: I actually wanted the textbox text to align with the title. In the center. But this is currently buggy. See #2653. When the issue gets fixed i might change the alignment here as well.

**Preview**

Renaming before
![CommentRenamingBefore](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/fa2c6602-388e-4724-a777-9c5db5a2a42d)

Renaming after
![CommentRenamingAfter](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/4bc64d1d-522a-40be-84b6-22c404fe69c9)


Of course this means, that the textbox will now be cut off when renaming a comment that is outside the window. But i would argue that this is the expected behaviour. I also checked and other graph tools seem to just do the same.
![FlaxEditor_Hoi06StfMA](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/dbf8b659-43d5-47e0-83e3-96ed90fb5136)




