### PR TITLE
Visject: Connection curvature option

### DIFF
--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -312,6 +312,13 @@ namespace FlaxEditor.Options
         [EditorDisplay("Cook & Run"), EditorOrder(500)]
         public int NumberOfGameClientsToLaunch = 1;
 
+        /// <summary>
+        /// Gets or sets the visject connection curvature.
+        /// </summary>
+        [DefaultValue(1.0f), Range(0.0f, 2.0f)]
+        [EditorDisplay("Visject"), EditorOrder(550)]
+        public float ConnectionCurvature { get; set; } = 1.0f;
+
         private static FontAsset DefaultFont => FlaxEngine.Content.LoadAsyncInternal<FontAsset>(EditorAssets.PrimaryFont);
         private static FontAsset ConsoleFont => FlaxEngine.Content.LoadAsyncInternal<FontAsset>(EditorAssets.InconsolataRegularFont);
 

--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -3,6 +3,7 @@
 using FlaxEngine;
 using FlaxEngine.GUI;
 using System;
+using FlaxEditor.Options;
 
 namespace FlaxEditor.Surface.Elements
 {
@@ -57,8 +58,8 @@ namespace FlaxEditor.Surface.Elements
         private static void CalculateBezierControlPoints(Float2 start, Float2 end, out Float2 control1, out Float2 control2)
         {
             // Control points parameters
-            const float minControlLength = 100f;
-            const float maxControlLength = 150f;
+            const float minControlLength = 50f;
+            const float maxControlLength = 120f;
             var dst = (end - start).Length;
             var yDst = Mathf.Abs(start.Y - end.Y);
 
@@ -66,6 +67,7 @@ namespace FlaxEditor.Surface.Elements
             var minControlDst = dst * 0.5f;
             var maxControlDst = Mathf.Max(Mathf.Min(maxControlLength, dst), minControlLength);
             var controlDst = Mathf.Lerp(minControlDst, maxControlDst, Mathf.Clamp(yDst / minControlLength, 0f, 1f));
+            controlDst *= Editor.Instance.Options.Options.Interface.ConnectionCurvature;
 
             control1 = new Float2(start.X + controlDst, start.Y);
             control2 = new Float2(end.X - controlDst, end.Y);


### PR DESCRIPTION
Not everyone is a fan of the curvy connections in visject. Esepecially in larger graphs this can become a readibility issue. Also requested in #1821 
This PR adds an entry to the editor interface options to change said curvature.
Additionally the default curvature got decreased a little bit.

Note: In discord i asked if interface/visject is the correct place for this option. So depending on the feedback there, the option might change it's location.

**Preview**

Curvature Option. Can be a value between 0 and 2
![FlaxEditor_GFmLlmn6hy](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/10de5ae7-f3c0-4e91-86fa-fc788ed8aab1)

For people that like straight lines more
![FlaxEditor_hSLCb8mG64](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/a73bff09-b61e-4636-872f-417d1f5c553f)

For people that like curves... less curvy
![FlaxEditor_ur9ceGPUKN](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/3c4195e7-dbf6-4ea9-b0c9-0bf8aaa49a1b)

For people that like it extreme... i mean sure go for it
![FlaxEditor_RTFoLlcMew](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/fe45dda4-69e9-4aca-b9c9-976998c3018b)
