### PR TITLE
Visject: Search and filter improvements

### DIFF
--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -307,7 +307,10 @@ namespace FlaxEditor.Surface.ContextMenu
                 if (!IsLayoutLocked)
                 {
                     group.UnlockChildrenRecursive();
-                    SortGroups();
+                    if(_contextSensitiveSearchEnabled && _selectedBox != null)
+                        UpdateFilters();
+                    else
+                        SortGroups();
                     if (ShowExpanded)
                         group.Open(false);
                     group.PerformLayout();
@@ -367,7 +370,10 @@ namespace FlaxEditor.Surface.ContextMenu
 
                 if (!isLayoutLocked)
                 {
-                    SortGroups();
+                    if(_contextSensitiveSearchEnabled && _selectedBox != null)
+                        UpdateFilters();
+                    else
+                        SortGroups();
                     Profiler.BeginEvent("Perform Layout");
                     UnlockChildrenRecursive();
                     foreach (var group in groups)
@@ -482,10 +488,11 @@ namespace FlaxEditor.Surface.ContextMenu
 
             // Update groups
             LockChildrenRecursive();
+            var contextSensitiveSelectedBox = _contextSensitiveSearchEnabled ? _selectedBox : null;
             for (int i = 0; i < _groups.Count; i++)
             {
-                _groups[i].UpdateFilter(_searchBox.Text, _contextSensitiveSearchEnabled ? _selectedBox : null);
-                _groups[i].UpdateItemSort(_selectedBox);
+                _groups[i].UpdateFilter(_searchBox.Text, contextSensitiveSelectedBox);
+                _groups[i].UpdateItemSort(contextSensitiveSelectedBox);
             }
             SortGroups();
             UnlockChildrenRecursive();
@@ -560,7 +567,10 @@ namespace FlaxEditor.Surface.ContextMenu
             }
             UnlockChildrenRecursive();
 
-            SortGroups();
+            if(_contextSensitiveSearchEnabled && _selectedBox != null)
+                UpdateFilters();
+            else
+                SortGroups();
             PerformLayout();
 
             Profiler.EndEvent();

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -88,6 +88,25 @@ namespace FlaxEditor.Surface.ContextMenu
         public void UpdateFilter(string filterText, Box selectedBox)
         {
             Profiler.BeginEvent("VisjectCMGroup.UpdateFilter");
+            
+            // Check if a dot is inside the filter text and split the string accordingly.
+            // Everything in front of the dot is for specifying a class/group name. And everything afterward is the actual item filter text
+            if (!string.IsNullOrEmpty(filterText))
+            {
+                int dotIndex = filterText.IndexOf('.');
+                if (dotIndex != -1)
+                {
+                    // Early out and make the group invisible if it doesn't start with the specified string
+                    string filterGroupName = filterText.Substring(0, dotIndex);
+                    if (!Name.StartsWith(filterGroupName, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        Visible = false;
+                        Profiler.EndEvent();
+                        return;
+                    }
+                    filterText = filterText.Substring(dotIndex + 1);
+                }
+            }
 
             // Update items
             bool isAnyVisible = false;
@@ -177,6 +196,13 @@ namespace FlaxEditor.Surface.ContextMenu
                         SortScore = item.SortScore;
                 }
             }
+
+            if (selectedBox != null)
+            {
+                if (string.Equals(Name, selectedBox.CurrentType.Name, StringComparison.InvariantCultureIgnoreCase))
+                    SortScore += 10;
+            }
+
             SortChildren();
 
             Profiler.EndEvent();

--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -88,7 +88,7 @@ namespace FlaxEditor.Surface.ContextMenu
         public void UpdateFilter(string filterText, Box selectedBox)
         {
             Profiler.BeginEvent("VisjectCMGroup.UpdateFilter");
-            
+
             // Check if a dot is inside the filter text and split the string accordingly.
             // Everything in front of the dot is for specifying a class/group name. And everything afterward is the actual item filter text
             if (!string.IsNullOrEmpty(filterText))


### PR DESCRIPTION
This PR aims to improve the UX of searching nodes in the visject context menu even more by adding 2 new features. 'Filter by group' and 'type sorting priority'.

Additionally minor fixes got applied where context sensitive node search would still filter through items while it was disabled. Turning off context sensitive node search should now turn it off for real.

**1) Filter by group**
Resolves #2305 
Users can now specify the group to search nodes in by using a '.' (dot) as a separator. This especially helps when there are a lot of nodes/methods with the same name. This is mainly helpful for visual scripting.

Before:
![GroupFilterBefore](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/a5f89418-3baf-4170-9cd2-82fbea3ff99d)

After:
![GroupFilterAfter](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/181d58a5-10e2-4979-9888-75fa69f6ce38)


**2) Type sorting priority**
Extending #1813 and #1522
When context sensitive node search is enabled and dragging out of a box, groups with the same type get higher priority when sorting. This feature is still not where i want it, but this is a good next step towards that goal.

Before:
![TypePriorityBefore](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/63b4fdb6-34d9-4c72-840f-524386a82ce9)

After:
![TypePriorityAfter](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/df024a4e-611c-4c45-9e02-8c121b8c17e5)
