### PR TITLE
Infinite Grid

### DIFF
--- a/Content/Shaders/Grid.flax
+++ b/Content/Shaders/Grid.flax
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67be5a9207994cdb858b65d9c06d763e0cb51f532e8ef37c18b24c17c216c0cd
-size 4575
+oid sha256:ff8ecc01befe7149ce3ad7e5de37503b7acc0ef25a8ba13a316aa4047b8ff6d1
+size 4882

--- a/Content/Shaders/Grid.flax
+++ b/Content/Shaders/Grid.flax
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff8ecc01befe7149ce3ad7e5de37503b7acc0ef25a8ba13a316aa4047b8ff6d1
-size 4882
+oid sha256:cb31a3dd32db9a9c2de3ad1debaf7be3091ee890fecfbc39e85701335135c7ae
+size 4675

--- a/Content/Shaders/Grid.flax
+++ b/Content/Shaders/Grid.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb31a3dd32db9a9c2de3ad1debaf7be3091ee890fecfbc39e85701335135c7ae
-size 4675

--- a/Content/Shaders/Grid.flax
+++ b/Content/Shaders/Grid.flax
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67be5a9207994cdb858b65d9c06d763e0cb51f532e8ef37c18b24c17c216c0cd
+size 4575

--- a/Source/Editor/Gizmo/GridGizmo.cs
+++ b/Source/Editor/Gizmo/GridGizmo.cs
@@ -64,9 +64,8 @@ namespace FlaxEditor.Gizmo
 
             public unsafe Renderer()
             {
-                Order = -100;
                 UseSingleTarget = true;
-                Location = PostProcessEffectLocation.BeforeForwardPass;
+                Location = PostProcessEffectLocation.Default;
 
                 // Create index buffer for custom geometry drawing
                 _indexBuffer = new GPUBuffer();
@@ -123,7 +122,7 @@ namespace FlaxEditor.Gizmo
                 }
 
                 // Setup missing resources
-                if (!_psCustom)
+                if (_psCustom == null)
                 {
                     _psCustom = new GPUPipelineState();
                     var desc = GPUPipelineState.Description.Default;
@@ -148,16 +147,16 @@ namespace FlaxEditor.Gizmo
                     data.GridColor = options.Viewport.ViewportGridColor;
                     data.Far = renderContext.View.Far;
                     data.GridSize = options.Viewport.ViewportGridViewDistance;
+
                     context.UpdateCB(cb, new IntPtr(&data));
                 }
 
                 // // Draw geometry using custom Pixel Shader and Vertex Shader
                 context.BindCB(0, cb);
-                context.BindSR(0, input);
                 context.BindIB(_indexBuffer);
                 context.BindVB(new[] { _vertexBuffer });
                 context.SetState(_psCustom);
-                context.SetRenderTarget(input.View());
+                context.SetRenderTarget(renderContext.Buffers.DepthBuffer.View(), input.View());
                 context.DrawIndexed((uint)_triangles.Length);
 
                 Profiler.EndEventGPU();

--- a/Source/Editor/Gizmo/GridGizmo.cs
+++ b/Source/Editor/Gizmo/GridGizmo.cs
@@ -2,6 +2,8 @@
 
 using System;
 using FlaxEngine;
+using System.Runtime.InteropServices;
+using static FlaxEditor.Surface.Archetypes.Animation.StateMachineTransition;
 
 namespace FlaxEditor.Gizmo
 {
@@ -15,13 +17,65 @@ namespace FlaxEditor.Gizmo
         [HideInEditor]
         private sealed class Renderer : PostProcessEffect
         {
+            [StructLayout(LayoutKind.Sequential)]
+            private struct Data
+            {
+                public Matrix WorldMatrix;
+                public Matrix ViewProjectionMatrix;
+                public Float4 GridColor;
+                public Float3 ViewPos;
+                public float Far;
+                public float GridSize;
+            }
+
+            private Float3[] _vertices =
+            {
+                new Float3(0, 0, 0),
+                new Float3(100, 0, 0),
+                new Float3(100, 100, 0),
+                new Float3(0, 100, 0),
+            };
+
+            private static readonly uint[] _triangles =
+            {
+                0, 2, 1, // Face front
+                1, 3, 0,
+            };
+
+            private GPUBuffer _vertexBuffer;
+            private GPUBuffer _indexBuffer;
+            private GPUPipelineState _psCustom;
+            private Shader _shader;
+
+            public Shader Shader
+            {
+                get => _shader;
+                set
+                {
+                    if (_shader != value)
+                    {
+                        _shader = value;
+                        ReleaseShader();
+                    }
+                }
+            }
+
             private IntPtr _debugDrawContext;
 
-            public Renderer()
+            public unsafe Renderer()
             {
                 Order = -100;
                 UseSingleTarget = true;
                 Location = PostProcessEffectLocation.BeforeForwardPass;
+
+                // Create index buffer for custom geometry drawing
+                _indexBuffer = new GPUBuffer();
+                fixed (uint* ptr = _triangles)
+                {
+                    var desc = GPUBufferDescription.Index(sizeof(uint), _triangles.Length, new IntPtr(ptr));
+                    _indexBuffer.Init(ref desc);
+                }
+                Shader = FlaxEngine.Content.LoadAsyncInternal<Shader>("Shaders/Grid");
             }
 
             ~Renderer()
@@ -31,75 +85,80 @@ namespace FlaxEditor.Gizmo
                     DebugDraw.FreeContext(_debugDrawContext);
                     _debugDrawContext = IntPtr.Zero;
                 }
+
+                ReleaseShader();
+                Destroy(ref _vertexBuffer);
+                Destroy(ref _indexBuffer);
             }
 
-            public override void Render(GPUContext context, ref RenderContext renderContext, GPUTexture input, GPUTexture output)
+            private void ReleaseShader()
+            {
+                // Release resources using shader
+                Destroy(ref _psCustom);
+            }
+
+            public override unsafe void Render(GPUContext context, ref RenderContext renderContext, GPUTexture input, GPUTexture output)
             {
                 Profiler.BeginEventGPU("Editor Grid");
 
-                if (_debugDrawContext == IntPtr.Zero)
-                    _debugDrawContext = DebugDraw.AllocateContext();
-                DebugDraw.SetContext(_debugDrawContext);
-                DebugDraw.UpdateContext(_debugDrawContext, 1.0f / Mathf.Max(Engine.FramesPerSecond, 1));
+                if (Shader == null) return;
 
-                var viewPos = (Vector3)renderContext.View.Position;
-                var plane = new Plane(Vector3.Zero, Vector3.UnitY);
-                var dst = CollisionsHelper.DistancePlanePoint(ref plane, ref viewPos);
+                // Here we perform custom rendering on top of the in-build drawing
+                Vector3 camPos = renderContext.View.WorldPosition;
+                float gridSize = renderContext.View.Far + 20000;
+                _vertices = new Float3[]
+                {
+                    new Float3(-gridSize + camPos.X, 0, -gridSize + camPos.Z),
+                    new Float3(gridSize + camPos.X, 0, gridSize + camPos.Z),
+                    new Float3(-gridSize + camPos.X, 0, gridSize + camPos.Z),
+                    new Float3(gridSize + camPos.X, 0, -gridSize + camPos.Z),
+                };
+
+                // Create vertex buffer for custom geometry drawing
+                _vertexBuffer = new GPUBuffer();
+                fixed (Float3* ptr = _vertices)
+                {
+                    var desc = GPUBufferDescription.Vertex(sizeof(Float3), _vertices.Length, new IntPtr(ptr));
+                    _vertexBuffer.Init(ref desc);
+                }
+
+                // Setup missing resources
+                if (!_psCustom)
+                {
+                    _psCustom = new GPUPipelineState();
+                    var desc = GPUPipelineState.Description.Default;
+                    desc.BlendMode = BlendingMode.AlphaBlend;
+                    desc.CullMode = CullMode.TwoSided;
+                    desc.VS = Shader.GPU.GetVS("VS_Custom");
+                    desc.PS = Shader.GPU.GetPS("PS_Custom");
+                    _psCustom.Init(ref desc);
+                }
 
                 var options = Editor.Instance.Options.Options;
-                float space = options.Viewport.ViewportGridScale, size;
-                if (dst <= 500.0f)
-                {
-                    size = 8000;
-                }
-                else if (dst <= 2000.0f)
-                {
-                    space *= 2;
-                    size = 8000;
-                }
-                else
-                {
-                    space *= 20;
-                    size = 100000;
-                }
 
-                float bigLineIntensity = 0.8f;
-                Color bigColor = Color.Gray * bigLineIntensity;
-                Color color = bigColor * 0.8f;
-                int count = (int)(size / space);
-                int midLine = count / 2;
-                int bigLinesMod = count / 8;
-
-                Vector3 start = new Vector3(0, 0, size * -0.5f);
-                Vector3 end = new Vector3(0, 0, size * 0.5f);
-
-                for (int i = 0; i <= count; i++)
+                // Set constant buffer data (memory copy is used under the hood to copy raw data from CPU to GPU memory)
+                var cb = Shader.GPU.GetCB(0);
+                if (cb != IntPtr.Zero)
                 {
-                    start.X = end.X = i * space + start.Z;
-                    Color lineColor = color;
-                    if (i == midLine)
-                        lineColor = Color.Blue * bigLineIntensity;
-                    else if (i % bigLinesMod == 0)
-                        lineColor = bigColor;
-                    DebugDraw.DrawLine(start, end, lineColor);
+                    var data = new Data();
+                    Matrix.Multiply(ref renderContext.View.View, ref renderContext.View.Projection, out var viewProjection);
+                    data.WorldMatrix = Matrix.Identity;
+                    Matrix.Transpose(ref viewProjection, out data.ViewProjectionMatrix);
+                    data.ViewPos = renderContext.View.WorldPosition;
+                    data.GridColor = options.Viewport.ViewportGridColor;
+                    data.Far = renderContext.View.Far;
+                    data.GridSize = options.Viewport.ViewportGridViewDistance;
+                    context.UpdateCB(cb, new IntPtr(&data));
                 }
 
-                start = new Vector3(size * -0.5f, 0, 0);
-                end = new Vector3(size * 0.5f, 0, 0);
-
-                for (int i = 0; i <= count; i++)
-                {
-                    start.Z = end.Z = i * space + start.X;
-                    Color lineColor = color;
-                    if (i == midLine)
-                        lineColor = Color.Red * bigLineIntensity;
-                    else if (i % bigLinesMod == 0)
-                        lineColor = bigColor;
-                    DebugDraw.DrawLine(start, end, lineColor);
-                }
-
-                DebugDraw.Draw(ref renderContext, input.View(), null, true);
-                DebugDraw.SetContext(IntPtr.Zero);
+                // // Draw geometry using custom Pixel Shader and Vertex Shader
+                context.BindCB(0, cb);
+                context.BindSR(0, input);
+                context.BindIB(_indexBuffer);
+                context.BindVB(new[] { _vertexBuffer });
+                context.SetState(_psCustom);
+                context.SetRenderTarget(input.View());
+                context.DrawIndexed((uint)_triangles.Length);
 
                 Profiler.EndEventGPU();
             }

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -129,5 +129,19 @@ namespace FlaxEditor.Options
         [DefaultValue(50.0f), Limit(25.0f, 500.0f, 5.0f)]
         [EditorDisplay("Defaults"), EditorOrder(220), Tooltip("The default editor viewport grid scale.")]
         public float ViewportGridScale { get; set; } = 50.0f;
+
+        /// <summary>
+        /// Gets or sets the view distance you can see the grid.
+        /// </summary>
+        [DefaultValue(2500.0f)]
+        [EditorDisplay("Grid"), EditorOrder(300), Tooltip("The maximum distance you will be able to see the grid.")]
+        public float ViewportGridViewDistance { get; set; } = 2500.0f;
+
+        /// <summary>
+        /// Gets or sets the grid color.
+        /// </summary>
+        [DefaultValue(typeof(Color), "0.5,0.5,0.5")]
+        [EditorDisplay("Grid"), EditorOrder(310), Tooltip("The color for the viewport grid.")]
+        public Color ViewportGridColor { get; set; } = Color.Gray;
     }
 }

--- a/Source/Shaders/Grid.shader
+++ b/Source/Shaders/Grid.shader
@@ -1,4 +1,9 @@
-﻿#define USE_FORWARD true;
+﻿// Implementation based on:
+// "The Best Darn Grid Shader (Yet)", Medium, Oct 2023
+// Ben Golus
+// https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8#3e73
+
+#define USE_FORWARD true;
 
 #include "./Flax/Common.hlsl"
 

--- a/Source/Shaders/Grid.shader
+++ b/Source/Shaders/Grid.shader
@@ -1,18 +1,15 @@
-﻿#define NO_GBUFFER_SAMPLING
-#define USE_FORWARD true;
+﻿#define USE_FORWARD true;
 
 #include "./Flax/Common.hlsl"
 
 META_CB_BEGIN(0, Data)
 float4x4 WorldMatrix;
 float4x4 ViewProjectionMatrix;
+float4 GridColor;
 float3 ViewPos;
-float3 GridColor;
 float Far;
 float GridSize;
 META_CB_END
-
-Texture2D Input : register(t0);
 
 // Geometry data passed to the vertex shader
 struct ModelInput
@@ -24,19 +21,22 @@ struct ModelInput
 struct VertexOutput
 {
     float4 Position : SV_Position;
-    float3 WorldPosition : TEXCOORD0;
+    float2 TexCoord : TEXCOORD0;
+    float3 WorldPosition : TEXCOORD1;
 };
 
 // Interpolants passed to the pixel shader
 struct PixelInput
 {
     float4 Position : SV_Position;
-    float3 WorldPosition : TEXCOORD0;
+    noperspective float2 TexCoord : TEXCOORD0;
+    float3 WorldPosition : TEXCOORD1;
 };
 
 // Vertex shader function for custom geometry processing
 META_VS(true, FEATURE_LEVEL_ES2)
-META_VS_IN_ELEMENT(POSITION, 0, R32G32B32_FLOAT, 0, 0, PER_VERTEX, 0, true)
+META_VS_IN_ELEMENT(POSITION, 0, R32G32B32_FLOAT, 0, ALIGN, PER_VERTEX, 0, true)
+META_VS_IN_ELEMENT(TEXCOORD, 0, R16G16_FLOAT, 1, ALIGN, PER_VERTEX, 0, true)
 VertexOutput VS_Custom(ModelInput input)
 {
     VertexOutput output;

--- a/Source/Shaders/Grid.shader
+++ b/Source/Shaders/Grid.shader
@@ -1,0 +1,151 @@
+﻿#define NO_GBUFFER_SAMPLING
+#define USE_FORWARD true;
+
+#include "./Flax/Common.hlsl"
+
+META_CB_BEGIN(0, Data)
+float4x4 WorldMatrix;
+float4x4 ViewProjectionMatrix;
+float3 ViewPos;
+float3 GridColor;
+float Far;
+float GridSize;
+META_CB_END
+
+Texture2D Input : register(t0);
+
+// Geometry data passed to the vertex shader
+struct ModelInput
+{
+    float3 Position : POSITION;
+};
+
+// Interpolants passed from the vertex shader
+struct VertexOutput
+{
+    float4 Position : SV_Position;
+    float3 WorldPosition : TEXCOORD0;
+};
+
+// Interpolants passed to the pixel shader
+struct PixelInput
+{
+    float4 Position : SV_Position;
+    float3 WorldPosition : TEXCOORD0;
+};
+
+// Vertex shader function for custom geometry processing
+META_VS(true, FEATURE_LEVEL_ES2)
+META_VS_IN_ELEMENT(POSITION, 0, R32G32B32_FLOAT, 0, 0, PER_VERTEX, 0, true)
+VertexOutput VS_Custom(ModelInput input)
+{
+    VertexOutput output;
+    output.WorldPosition = mul(float4(input.Position.xyz, 1), WorldMatrix).xyz;
+    output.Position = mul(float4(input.Position.xyz, 1), ViewProjectionMatrix);
+    return output;
+}
+
+float invLerp(float from, float to, float value){
+  return (value - from) / (to - from);
+}
+
+float remap(float origFrom, float origTo, float targetFrom, float targetTo, float value){
+  float rel = invLerp(origFrom, origTo, value);
+  return lerp(targetFrom, targetTo, rel);
+}
+
+float ddLength(float a)
+{
+  return length(float2(ddx(a), ddy(a)));
+}
+
+float GetLine(float pos, float scale, float thickness)
+{
+    float lineWidth = thickness;
+    float coord = (pos * 0.01) * scale;
+    
+    float2 uvDDXY = float2(ddx(coord), ddy(coord));
+    
+    float deriv = float(length(uvDDXY.xy));
+    float drawWidth = clamp(lineWidth, deriv, 0.5);
+    float lineAA = deriv * 1.5;
+    float gridUV = abs(coord);
+    float grid2 = smoothstep(drawWidth + lineAA, drawWidth - lineAA, gridUV);
+    grid2 *= saturate(lineWidth / drawWidth);
+    grid2 = lerp(grid2, lineWidth, saturate(deriv * 2.0 - 1.0));
+    
+    float grid = lerp(grid2, 1.0, grid2);
+    
+    return grid; 
+}
+
+float GetGrid(float3 pos, float scale, float thickness)
+{
+    float lineWidth = thickness;
+    float2 coord = (pos.xz * 0.01) * scale;
+    
+    float4 uvDDXY = float4(ddx(coord), ddy(coord));
+    
+    float2 deriv = float2(length(uvDDXY.xz), length(uvDDXY.yw));
+    float2 drawWidth = clamp(lineWidth, deriv, 0.5);
+    float2 lineAA = deriv * 1.5;
+    float2 gridUV = 1.0 - abs(frac(coord) * 2.0 - 1.0);
+    float2 grid2 = smoothstep(drawWidth + lineAA, drawWidth - lineAA, gridUV);
+    grid2 *= saturate(lineWidth / drawWidth);
+    grid2 = lerp(grid2, lineWidth, saturate(deriv * 2.0 - 1.0));
+    
+    float grid = lerp(grid2.x, 1.0, grid2.y);
+    
+    return grid;
+}
+
+
+float4 GetColor(float3 pos, float scale)
+{
+    float dist = 1-saturate(distance(float3(ViewPos.x, 0, ViewPos.z), pos) / GridSize);
+    
+    // Line width
+    float g1LW = 0.01;
+    // Major line Z
+    float l1 = GetLine(pos.x, 1, g1LW * 2);
+    // Major line X
+    float l2 = GetLine(pos.z, 1, g1LW);
+    
+    // Main grid
+    float g1 = GetGrid(pos, 1, g1LW * 0.8);
+    
+    float g2 = GetGrid(pos, 2, g1LW * 0.4);
+    
+    float g3 = GetGrid(pos, 0.1, g1LW * 2);
+    float camFadeLarge = clamp(invLerp(2500, 4000, abs(ViewPos.y)),0, g3);
+    g3 *= camFadeLarge;
+    
+    float g4 = GetGrid(pos, 10, g1LW);
+    float camFadeTiny = clamp(invLerp(150, 100, abs(ViewPos.y)), 0, g4);
+    g4 *= camFadeTiny;
+
+    float grid = 0;
+    
+    grid = max(l1, l2);
+    grid = max(grid, g1);
+    grid = max(grid, g2);
+    grid = max(grid, g3);
+    grid = max(grid, g4);
+    
+    float4 color = grid * GridColor;
+    
+    color = lerp(color, float4(1,0,0,1), l1);
+    color = lerp(color, float4(0,0,1,1), l2);
+    
+    color *= dist;
+    
+    return color;
+}
+
+// Pixel shader function for custom geoemtry drawing on a screen
+META_PS(true, FEATURE_LEVEL_ES2)
+float4 PS_Custom(PixelInput input) : SV_Target
+{ 
+    float4 color = GetColor(input.WorldPosition, 1);
+    return color;
+}

--- a/Source/Shaders/Grid.shader
+++ b/Source/Shaders/Grid.shader
@@ -134,8 +134,8 @@ float4 GetColor(float3 pos, float scale)
     
     float4 color = grid * GridColor;
     
-    color = lerp(color, float4(1,0,0,1), l1);
-    color = lerp(color, float4(0,0,1,1), l2);
+    color = lerp(color, float4(1,0,0,1), l2);
+    color = lerp(color, float4(0,0,1,1), l1);
     
     color *= dist;
     


### PR DESCRIPTION
An update to make the grid look much nicer. No longer uses debug lines and instead a shader on a large quad that follows the camera around. Configurable color and viewable distance for the main grid,

How it looks by default:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/38583668/c65fbbd4-d75d-4bf4-9496-ba0d7c7d9f96)

Options configurable in Viewport options:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/38583668/c8588852-c036-4d0e-9579-6af5bc9f4536)

Notes;
- Wasn't sure if Viewport options was the best place to put the settings for this but it also seemed like the most relevant.
- The default distance is 2500, this can feel a bit small and still considering if doubling it to 5000 would be better.
- The X and Z axis lines can be a bit difficult to see when far away. 
- At a later point I could also make it so you can configure the Y position of the grid through the View dropdown menu on the Editor window.

Despite those notes I think it's still a rather large improvement.