### PR TITLE
Quick Fix To Progress Bar Min/Max

### DIFF
--- a/Source/Engine/UI/GUI/Common/ProgressBar.cs
+++ b/Source/Engine/UI/GUI/Common/ProgressBar.cs
@@ -220,7 +220,7 @@ namespace FlaxEngine.GUI
         {
             base.DrawSelf();
 
-            float progressNormalized = (_current - _minimum) / _maximum;
+            float progressNormalized = Mathf.InverseLerp(_minimum, _maximum, _current);
             if (progressNormalized > 0.001f)
             {
                 Rectangle barRect = new Rectangle(0, 0, Width * progressNormalized, Height);


### PR DESCRIPTION
Currently if you set the min/max of the progress bar to a different value outside of 0-100 the visual aspect of the bar does not update appropriately due to the normalization formula to be off.

This changes the formula to just use a simple InverseLerp to simplify things.