### PR TITLE
Initial AGX Impl

### DIFF
--- a/Source/Engine/Graphics/PostProcessSettings.h
+++ b/Source/Engine/Graphics/PostProcessSettings.h
@@ -52,6 +52,11 @@ API_ENUM() enum class ToneMappingMode
     /// The ACES Filmic reference tonemapper (approximation).
     /// </summary>
     ACES = 2,
+
+    /// <summary>
+    /// The AGX tonemapper.
+    /// </summary>
+    AGX = 3,
 };
 
 /// <summary>

--- a/Source/Shaders/ColorGrading.shader
+++ b/Source/Shaders/ColorGrading.shader
@@ -238,9 +238,11 @@ float3 TonemapAGX(float3 linearColor)
             + 0.1191    * color
             - 0.00232;
 
-    color = agxAscCdl(color, float3(1.0, 1.0, 1.0), float3(0.0, 0.0, 0.0), float3(1.35, 1.35, 1.35), 1.4);
+    // color = agxAscCdl(color, float3(1.0, 1.0, 1.0), float3(0.0, 0.0, 0.0), float3(1.35, 1.35, 1.35), 1.4);
 
     color = mul(color, AgXOutsetMatrix);
+
+    color = pow(max(float3(0.0, 0.0, 0.0), color), float3(2.2, 2.2, 2.2));
 
     color = clamp(color, 0.0, 1.0);
 

--- a/Source/Shaders/ColorGrading.shader
+++ b/Source/Shaders/ColorGrading.shader
@@ -191,6 +191,60 @@ float3 TonemapACES(float3 linearColor)
 	return saturate(color);
 }
 
+#ifdef TONE_MAPPING_MODE_AGX
+
+float3 agxAscCdl(float3 color, float3 slope, float3 offset, float3 power, float sat) {
+    const float3 lw = float3(0.2126, 0.7152, 0.0722);
+    float luma = dot(color, lw);
+    float3 c = pow(color * slope + offset, power);
+    return luma + sat * (c - luma);
+}
+
+float3 TonemapAGX(float3 linearColor)
+{
+    static const float3x3 AgXInsetMatrix = {
+        0.8566, 0.1373, 0.1119,
+        0.0951, 0.7612, 0.0768,
+        0.0483, 0.1014, 0.8113
+    };
+
+    static const float3x3 AgXOutsetMatrix = {
+        1.1271, -0.1413, -0.1413,
+        -0.1106, 1.1578, -0.1106,
+        -0.0165, -0.0165, 1.2519
+    };
+
+    static const float AgxMinEv = -12.47393;
+    static const float AgxMaxEv = 4.026069;
+
+	float3 color = linearColor;
+    color = mul(color, AgXInsetMatrix);
+    color = max(color, 1e-10);
+    color = clamp(log2(color), AgxMinEv, AgxMaxEv);
+    color = (color - AgxMinEv) / (AgxMaxEv - AgxMinEv);
+
+    color = clamp(color, 0.0, 1.0);
+
+    float3 x2 = color * color;
+    float3 x4 = x2 * x2;    
+
+    color = + 15.5      * x4 * x2
+            - 40.14     * x4 * color
+            + 31.96     * x4
+            - 6.868     * x2 * color
+            + 0.4298    * x2
+            + 0.1191    * color
+            - 0.00232;
+
+    color = agxAscCdl(color, float3(1.0, 1.0, 1.0), float3(0.0, 0.0, 0.0), float3(1.35, 1.35, 1.35), 1.4);
+
+    color = mul(color, AgXOutsetMatrix);
+
+    color = clamp(color, 0.0, 1.0);
+
+	return color;
+}
+
 #endif
 
 // Perfoms the tonemapping on the input linear color
@@ -202,6 +256,8 @@ float3 Tonemap(float3 linearColor)
 	return TonemapNeutral(linearColor);
 #elif defined(TONE_MAPPING_MODE_ACES)
 	return TonemapACES(linearColor);
+#elif defined(TONE_MAPPING_MODE_AGX)
+    return TonemapAGX(linearColor);
 #else
 	return float3(0, 0, 0);
 #endif
@@ -292,6 +348,7 @@ META_PS(true, FEATURE_LEVEL_ES2)
 META_PERMUTATION_1(TONE_MAPPING_MODE_NONE=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_NEUTRAL=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_ACES=1)
+META_PERMUTATION_1(TONE_MAPPING_MODE_AGX=1)
 float4 PS_Lut2D(Quad_VS2PS input) : SV_Target
 {
 	return CombineLUTs(input.TexCoord, 0);
@@ -301,6 +358,7 @@ META_PS(true, FEATURE_LEVEL_ES2)
 META_PERMUTATION_1(TONE_MAPPING_MODE_NONE=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_NEUTRAL=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_ACES=1)
+META_PERMUTATION_1(TONE_MAPPING_MODE_AGX=1)
 float4 PS_Lut3D(Quad_GS2PS input) : SV_Target
 {
 	return CombineLUTs(input.Vertex.TexCoord, input.LayerIndex);

--- a/Source/Shaders/ColorGrading.shader
+++ b/Source/Shaders/ColorGrading.shader
@@ -191,7 +191,9 @@ float3 TonemapACES(float3 linearColor)
 	return saturate(color);
 }
 
-#ifdef TONE_MAPPING_MODE_AGX
+#endif
+
+#ifdef TONE_MAPPING_MODE_NEUTRAL
 
 float3 agxAscCdl(float3 color, float3 slope, float3 offset, float3 power, float sat) {
     const float3 lw = float3(0.2126, 0.7152, 0.0722);


### PR DESCRIPTION
An initial implementation of AGX tonemapping as an alternative to neutral and ACES. The result is a desaturated look that better preserves colors at higher exposures, intended to be used with color grading to achieve a desired vibrant look.

The current branch does not work, but the example image below is a result of ad-hoc replacing the ACES tonemapping function with AGX. Additional work needs to be done to properly integrate the shader permutations, as currently the device hangs on selection of the new AGX ToneMappingMode.

 ![image](https://github.com/FlaxEngine/FlaxEngine/assets/52535319/0898b92d-3f8e-4fa9-8a7f-07c86e770fad)
