### PR TITLE
[Minor] Fix thumb of H scrollbar not showing up until dragged by user

### DIFF
--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -100,6 +100,7 @@ namespace FlaxEngine.GUI
                 if (value > _maximum)
                     throw new ArgumentOutOfRangeException();
                 _minimum = value;
+                UpdateThumb();
                 if (Value < _minimum)
                     Value = _minimum;
             }
@@ -116,6 +117,7 @@ namespace FlaxEngine.GUI
                 if (value < _minimum)
                     throw new ArgumentOutOfRangeException();
                 _maximum = value;
+                UpdateThumb();
                 if (Value > _maximum)
                     Value = _maximum;
             }


### PR DESCRIPTION
Fixes a minor bug where the horizontal thumb doesn't show up until clicked by user.  

![a02a32c0aa3ac2bbd173856eaa16d7e](https://github.com/FlaxEngine/FlaxEngine/assets/33123710/f0ade8c1-07a1-4d15-8f8b-68561530f7cd)

This is because that `UpdateThumb` doesn't get called when text are appended into the textbox. 