### PR TITLE
Visject: Spawn parameter setter node when holding ALT during drag and drop

### DIFF
--- a/Source/Editor/Surface/VisjectSurface.DragDrop.cs
+++ b/Source/Editor/Surface/VisjectSurface.DragDrop.cs
@@ -129,7 +129,12 @@ namespace FlaxEditor.Surface
         /// <param name="args">The drag drop arguments data.</param>
         protected virtual void HandleDragDropParameters(List<string> objects, DragDropEventArgs args)
         {
-            var arch = GetParameterGetterNodeArchetype(out var groupId);
+            // Try to get the setter node when holding the ALT key, otherwise get the getter node
+            if (!Input.GetKey(KeyboardKeys.Alt) || !TryGetParameterSetterNodeArchetype(out var groupId, out var arch))
+            {
+                arch = GetParameterGetterNodeArchetype(out groupId);
+            }
+
             for (int i = 0; i < objects.Count; i++)
             {
                 var parameter = GetParameter(objects[i]);
@@ -155,6 +160,19 @@ namespace FlaxEditor.Surface
         {
             groupId = 6;
             return Archetypes.Parameters.Nodes[0];
+        }
+
+        /// <summary>
+        /// Tries to get the parameter setter node archetype to use.
+        /// </summary>
+        /// <param name="groupId">The group ID.</param>
+        /// <param name="archetype">The node archetype.</param>
+        /// <returns>True if a setter node exists.</returns>
+        protected virtual bool TryGetParameterSetterNodeArchetype(out ushort groupId, out NodeArchetype archetype)
+        {
+            groupId = 0;
+            archetype = null;
+            return false;
         }
     }
 }

--- a/Source/Editor/Surface/VisualScriptSurface.cs
+++ b/Source/Editor/Surface/VisualScriptSurface.cs
@@ -188,6 +188,14 @@ namespace FlaxEditor.Surface
         }
 
         /// <inheritdoc />
+        protected override bool TryGetParameterSetterNodeArchetype(out ushort groupId, out NodeArchetype archetype)
+        {
+            groupId = 6;
+            archetype = Archetypes.Parameters.Nodes[3];
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override void OnShowPrimaryMenu(VisjectCM activeCM, Float2 location, Box startBox)
         {
             // Update nodes for method overrides


### PR DESCRIPTION
This PR adds the ability to easily drag and drop a parameter setter node while holding the alt key. This mimics the functionality of other visual scripting tools like Bolt. Requested in the discord server, no related issue found.

Note: This only works for visual scripting, since the visual scripting graph is the only tool that has a setter node defined.

In both gifs i hold the ALT key for the 2nd node.

Before:
![ParametersAltDragSetterBefore](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/5e4e3685-1df3-4299-9ea4-9afa0c1c132f)

After:
![ParametersAltDragSetterAfter](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/12081961-c8cb-45e3-be8a-158152d87e90)
