### PR TITLE
Fix Variant getters returning already freed managed handles

### DIFF
--- a/Source/Editor/Managed/ManagedEditor.cpp
+++ b/Source/Editor/Managed/ManagedEditor.cpp
@@ -223,6 +223,19 @@ void ManagedEditor::Init()
     {
         LOG(Info, "Loading managed assemblies (due to disabled compilation on startup)");
         Scripting::Load();
+
+        const auto endInitMethod = mclass->GetMethod("EndInit");
+        if (endInitMethod == nullptr)
+        {
+            LOG(Fatal, "Invalid Editor assembly! Missing EndInit method.");
+        }
+        endInitMethod->Invoke(instance, nullptr, &exception);
+        if (exception)
+        {
+            MException ex(exception);
+            ex.Log(LogType::Warning, TEXT("ManagedEditor::EndInit"));
+            LOG_STR(Fatal, TEXT("Failed to initialize editor during EndInit! ") + ex.Message);
+        }
     }
 
     // Call building if need to (based on CL)

--- a/Source/Editor/States/LoadingState.cs
+++ b/Source/Editor/States/LoadingState.cs
@@ -71,7 +71,6 @@ namespace FlaxEditor.States
             {
                 // Skip compilation on startup
                 OnCompilationEnd(true);
-                Editor.EndInit();
             }
         }
 

--- a/Source/Engine/AI/BehaviorKnowledge.cpp
+++ b/Source/Engine/AI/BehaviorKnowledge.cpp
@@ -212,7 +212,7 @@ bool BehaviorKnowledge::HasGoal(ScriptingTypeHandle type) const
     return false;
 }
 
-Variant BehaviorKnowledge::GetGoal(ScriptingTypeHandle type)
+const Variant& BehaviorKnowledge::GetGoal(ScriptingTypeHandle type) const
 {
     for (const Variant& goal : Goals)
     {

--- a/Source/Engine/AI/BehaviorKnowledge.h
+++ b/Source/Engine/AI/BehaviorKnowledge.h
@@ -101,7 +101,7 @@ public:
     /// </summary>
     /// <param name="type">The goal type.</param>
     /// <returns>The goal value or null if not found.</returns>
-    API_FUNCTION() Variant GetGoal(ScriptingTypeHandle type);
+    API_FUNCTION() const Variant& GetGoal(ScriptingTypeHandle type) const;
 
     /// <summary>
     /// Adds the goal to the knowledge. If goal of that type already exists then it's value is updated.

--- a/Source/Engine/Engine/GameplayGlobals.cpp
+++ b/Source/Engine/Engine/GameplayGlobals.cpp
@@ -124,7 +124,7 @@ void GameplayGlobals::SetDefaultValues(const Dictionary<String, Variant>& values
     }
 }
 
-Variant GameplayGlobals::GetValue(const StringView& name) const
+const Variant& GameplayGlobals::GetValue(const StringView& name) const
 {
     ScopeLock lock(Locker);
     auto e = Variables.TryGet(name);

--- a/Source/Engine/Engine/GameplayGlobals.h
+++ b/Source/Engine/Engine/GameplayGlobals.h
@@ -66,7 +66,7 @@ public:
     /// </summary>
     /// <param name="name">The variable name.</param>
     /// <returns>The value.</returns>
-    API_FUNCTION() Variant GetValue(const StringView& name) const;
+    API_FUNCTION() const Variant& GetValue(const StringView& name) const;
 
     /// <summary>
     /// Sets the value of the global variable (it must be added first).

--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -273,7 +273,7 @@ AnimGraphParameter* AnimatedModel::GetParameter(const StringView& name)
     return nullptr;
 }
 
-Variant AnimatedModel::GetParameterValue(const StringView& name)
+const Variant& AnimatedModel::GetParameterValue(const StringView& name) const
 {
     CHECK_ANIM_GRAPH_PARAM_ACCESS_RESULT(Variant::Null);
     for (auto& param : GraphInstance.Parameters)
@@ -299,7 +299,7 @@ void AnimatedModel::SetParameterValue(const StringView& name, const Variant& val
     LOG(Warning, "Failed to set animated model '{0}' missing parameter '{1}'", ToString(), name);
 }
 
-Variant AnimatedModel::GetParameterValue(const Guid& id)
+const Variant& AnimatedModel::GetParameterValue(const Guid& id) const
 {
     CHECK_ANIM_GRAPH_PARAM_ACCESS_RESULT(Variant::Null);
     for (auto& param : GraphInstance.Parameters)

--- a/Source/Engine/Level/Actors/AnimatedModel.h
+++ b/Source/Engine/Level/Actors/AnimatedModel.h
@@ -308,7 +308,7 @@ public:
     /// </summary>
     /// <param name="name">The parameter name.</param>
     /// <returns>The value.</returns>
-    API_FUNCTION() Variant GetParameterValue(const StringView& name);
+    API_FUNCTION() const Variant& GetParameterValue(const StringView& name) const;
 
     /// <summary>
     /// Sets the anim graph instance parameter value.
@@ -322,7 +322,7 @@ public:
     /// </summary>
     /// <param name="id">The parameter id.</param>
     /// <returns>The value.</returns>
-    API_FUNCTION() Variant GetParameterValue(const Guid& id);
+    API_FUNCTION() const Variant& GetParameterValue(const Guid& id) const;
 
     /// <summary>
     /// Sets the anim graph instance parameter value.

--- a/Source/Engine/Particles/ParticleEffect.cpp
+++ b/Source/Engine/Particles/ParticleEffect.cpp
@@ -91,14 +91,14 @@ Variant ParticleEffectParameter::GetDefaultValue() const
     return paramValue;
 }
 
-Variant ParticleEffectParameter::GetDefaultEmitterValue() const
+const Variant& ParticleEffectParameter::GetDefaultEmitterValue() const
 {
     CHECK_RETURN(IsValid(), Variant::False);
     const ParticleSystemParameter& param = _effect->ParticleSystem->Emitters[_emitterIndex]->Graph.Parameters[_paramIndex];
     return param.Value;
 }
 
-Variant ParticleEffectParameter::GetValue() const
+const Variant& ParticleEffectParameter::GetValue() const
 {
     CHECK_RETURN(IsValid(), Variant::False);
     const Variant& paramValue = _effect->Instance.Emitters[_emitterIndex].Parameters[_paramIndex];
@@ -205,7 +205,7 @@ ParticleEffectParameter* ParticleEffect::GetParameter(const StringView& emitterT
     return nullptr;
 }
 
-Variant ParticleEffect::GetParameterValue(const StringView& emitterTrackName, const StringView& paramName)
+const Variant& ParticleEffect::GetParameterValue(const StringView& emitterTrackName, const StringView& paramName)
 {
     const auto param = GetParameter(emitterTrackName, paramName);
     CHECK_RETURN(param, Variant::Null);

--- a/Source/Engine/Particles/ParticleEffect.h
+++ b/Source/Engine/Particles/ParticleEffect.h
@@ -109,13 +109,13 @@ public:
     /// Gets the default value of the parameter (set in particle emitter asset).
     /// </summary>
     /// <returns>The default value.</returns>
-    API_PROPERTY() Variant GetDefaultEmitterValue() const;
+    API_PROPERTY() const Variant& GetDefaultEmitterValue() const;
 
     /// <summary>
     /// Gets the value of the parameter.
     /// </summary>
     /// <returns>The value.</returns>
-    API_PROPERTY() Variant GetValue() const;
+    API_PROPERTY() const Variant& GetValue() const;
 
     /// <summary>
     /// Sets the value of the parameter.
@@ -293,7 +293,7 @@ public:
     /// <param name="emitterTrackName">The emitter track name (in particle system asset).</param>
     /// <param name="paramName">The emitter parameter name (in particle emitter asset).</param>
     /// <returns>The value.</returns>
-    API_FUNCTION() Variant GetParameterValue(const StringView& emitterTrackName, const StringView& paramName);
+    API_FUNCTION() const Variant& GetParameterValue(const StringView& emitterTrackName, const StringView& paramName);
 
     /// <summary>
     /// Set the particle parameter value.


### PR DESCRIPTION
Possibly fix for #2620

Delayed loading of `Editor.EndInit` fixes Animation Graph Preview tab parameters containing missing values initially when Animation Graph window is getting shown on Editor startup. The Variant data in the Animation Graph assets can't be loaded properly if the Variants contains managed data in types from scripting assemblies, so the opening of the asset windows should be delayed until the scripting assemblies have been loaded.