### PR TITLE
Draw impulse/ execution lines slightly thicker than data ones

### DIFF
--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -198,15 +198,11 @@ namespace FlaxEditor.Surface.Elements
 
                 // TODO: Figure out how to only draw the topmost connection
                 if (IntersectsConnection(ref startPos, ref endPos, ref mousePosition, mouseOverDistance))
-                {
                     highlight += DefaultConnectionThickness * 0.5f;
-                }
 
                 // Increase thickness on impulse/ execution lines
                 if (targetBox.CurrentType.IsVoid)
-                {
                     highlight += 1.25f;
-                }
                 
                 DrawConnection(style, ref startPos, ref endPos, ref color, highlight);
             }

--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -202,6 +202,12 @@ namespace FlaxEditor.Surface.Elements
                     highlight += DefaultConnectionThickness * 0.5f;
                 }
 
+                // Increase thickness on impulse/ execution lines
+                if (targetBox.CurrentType.IsVoid)
+                {
+                    highlight += 1.25f;
+                }
+                
                 DrawConnection(style, ref startPos, ref endPos, ref color, highlight);
             }
         }

--- a/Source/Editor/Surface/Elements/OutputBox.cs
+++ b/Source/Editor/Surface/Elements/OutputBox.cs
@@ -202,7 +202,7 @@ namespace FlaxEditor.Surface.Elements
 
                 // Increase thickness on impulse/ execution lines
                 if (targetBox.CurrentType.IsVoid)
-                    highlight += 1.25f;
+                    highlight *= 2;
                 
                 DrawConnection(style, ref startPos, ref endPos, ref color, highlight);
             }


### PR DESCRIPTION
_This is my first pr so if there are any issue with code quality or stuff like that let me know :)_

Slightly increases the thickness of impulse/ execution lines for node editors to make it easier for the user to follow execution flow (and indirectly also data flow). This is the same thing Unreal Engine does.

Before:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/111653551/66cf8ea8-8868-4c6c-a1da-10fe9938d929)

After:
![image](https://github.com/FlaxEngine/FlaxEngine/assets/111653551/43c1f150-d216-4363-bc7b-bc5b43ba8ee3)
