### PR TITLE
Color picker improvements

### DIFF
--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -34,7 +34,10 @@ namespace FlaxEditor.GUI.Dialogs
         private const float ChannelTextWidth = 12.0f;
         private const float SavedColorButtonWidth = 20.0f;
         private const float SavedColorButtonHeight = 20.0f;
+        private const float ColorPreviewWidth = 120.0f;
+        private const float ColorPreviewHeight = 50.0f;
         private const float RGBAHexSeparator = 10.0f;
+        private const float OldNewColorPreviewDisplayRatio = 0.3335f;
 
         private Color _initialValue;
         private Color _value;
@@ -369,9 +372,15 @@ namespace FlaxEditor.GUI.Dialogs
             var hex = new Rectangle(_cHex.Left - 26, _cHex.Y, 10000, _cHex.Height);
             Render2D.DrawText(style.FontMedium, "Hex", hex, textColor, TextAlignment.Near, TextAlignment.Center);
 
-            // Color difference
-            var newRect = new Rectangle(_cOK.X - 3, _cHex.Bottom + PickerMargin, 130, 0);
-            newRect.Size.Y = 50;
+            // Old and New Color preview
+            var colorPickerYPosition = _cOK.Top - ColorPreviewHeight - PickerMargin;
+
+            var oldColorRect = new Rectangle(_cOK.X - 3, colorPickerYPosition, ColorPreviewWidth * OldNewColorPreviewDisplayRatio, 0);
+            oldColorRect.Size.Y = ColorPreviewHeight;
+
+            var newColorRect = new Rectangle(_cOK.X - 3 + oldColorRect.Size.X, colorPickerYPosition, ColorPreviewWidth * (1 - OldNewColorPreviewDisplayRatio), 0);
+            newColorRect.Size.Y = ColorPreviewHeight;
+
             var smallRectSize = 10;
             var numHor = Mathf.FloorToInt(newRect.Width / smallRectSize);
             var numVer = Mathf.FloorToInt(newRect.Height / smallRectSize);
@@ -387,7 +396,13 @@ namespace FlaxEditor.GUI.Dialogs
                     }
                 }
             }
-            Render2D.FillRectangle(newRect, _value);
+            Vector2 textOffset = new Vector2(0, -15);
+            Render2D.DrawText(style.FontMedium, "Old", Color.White, oldColorRect.UpperLeft + textOffset);
+            Render2D.DrawText(style.FontMedium, "New", Color.White, newColorRect.UpperLeft + textOffset);
+
+            Render2D.FillRectangle(oldColorRect, _initialValue);
+            Render2D.FillRectangle(newColorRect, _value);
+
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -383,6 +383,7 @@ namespace FlaxEditor.GUI.Dialogs
 
             // Draw checkerboard for background of color preview to help with transparency
             Render2D.FillRectangle(new Rectangle(_cOK.X - 3, colorPickerYPosition, ColorPreviewWidth, ColorPreviewHeight), Color.White);
+
             var smallRectSize = 10;
             var numHor = Mathf.FloorToInt(ColorPreviewWidth / smallRectSize);
             var numVer = Mathf.FloorToInt(oldColorRect.Height / smallRectSize);
@@ -405,6 +406,11 @@ namespace FlaxEditor.GUI.Dialogs
             Render2D.FillRectangle(oldColorRect, _initialValue);
             Render2D.FillRectangle(newColorRect, _value);
 
+            // Small separators between Old and New
+            Float2 separatorOffset = new Vector2(0, smallRectSize);
+            // TODO: Fix color to not be black but color picker background
+            Render2D.DrawLine(oldColorRect.UpperRight, oldColorRect.UpperRight + separatorOffset / 2, Color.Black, 2);
+            Render2D.DrawLine(oldColorRect.BottomRight, oldColorRect.BottomRight - separatorOffset / 2, Color.Black, 2);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -348,7 +348,7 @@ namespace FlaxEditor.GUI.Dialogs
             rgbaR.Location.Y = _cAlpha.Y;
             Render2D.DrawText(style.FontMedium, "A", rgbaR, textColor, TextAlignment.Near, TextAlignment.Center);
 
-            // HSV left
+            // HSV letters (left)
             var hsvHl = new Rectangle(_cHue.Left - ChannelTextWidth, _cHue.Y, 10000, _cHue.Height);
             Render2D.DrawText(style.FontMedium, "H", hsvHl, textColor, TextAlignment.Near, TextAlignment.Center);
             hsvHl.Location.Y = _cSaturation.Y;
@@ -356,7 +356,7 @@ namespace FlaxEditor.GUI.Dialogs
             hsvHl.Location.Y = _cValue.Y;
             Render2D.DrawText(style.FontMedium, "V", hsvHl, textColor, TextAlignment.Near, TextAlignment.Center);
 
-            // HSV right
+            // HSV math symbols (right)
             var hsvHr = new Rectangle(_cHue.Right + 2, _cHue.Y, 10000, _cHue.Height);
             Render2D.DrawText(style.FontMedium, "°", hsvHr, textColor, TextAlignment.Near, TextAlignment.Center);
             hsvHr.Location.Y = _cSaturation.Y;

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -34,6 +34,7 @@ namespace FlaxEditor.GUI.Dialogs
         private const float ChannelTextWidth = 12.0f;
         private const float SavedColorButtonWidth = 20.0f;
         private const float SavedColorButtonHeight = 20.0f;
+        private const float RGBAHexSeparator = 10.0f;
 
         private Color _initialValue;
         private Color _value;
@@ -184,7 +185,7 @@ namespace FlaxEditor.GUI.Dialogs
 
             // Hex
             const float hexTextBoxWidth = 80;
-            _cHex = new TextBox(false, Width - hexTextBoxWidth - PickerMargin, _cSelector.Bottom + PickerMargin, hexTextBoxWidth)
+            _cHex = new TextBox(false, Width - hexTextBoxWidth - PickerMargin, _cAlpha.Bottom + RGBAHexSeparator, hexTextBoxWidth)
             {
                 Parent = this
             };

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -381,21 +381,23 @@ namespace FlaxEditor.GUI.Dialogs
             var newColorRect = new Rectangle(_cOK.X - 3 + oldColorRect.Size.X, colorPickerYPosition, ColorPreviewWidth * (1 - OldNewColorPreviewDisplayRatio), 0);
             newColorRect.Size.Y = ColorPreviewHeight;
 
+            // Draw checkerboard for background of color preview to help with transparency
+            Render2D.FillRectangle(new Rectangle(_cOK.X - 3, colorPickerYPosition, ColorPreviewWidth, ColorPreviewHeight), Color.White);
             var smallRectSize = 10;
-            var numHor = Mathf.FloorToInt(newRect.Width / smallRectSize);
-            var numVer = Mathf.FloorToInt(newRect.Height / smallRectSize);
-            // Draw checkerboard for background of color to help with transparency
+            var numHor = Mathf.FloorToInt(ColorPreviewWidth / smallRectSize);
+            var numVer = Mathf.FloorToInt(oldColorRect.Height / smallRectSize);
             for (int i = 0; i < numHor; i++)
             {
                 for (int j = 0; j < numVer; j++)
                 {
                     if ((i + j) % 2 == 0 )
                     {
-                        var rect = new Rectangle(newRect.X + smallRectSize * i, newRect.Y + smallRectSize * j, new Float2(smallRectSize));
+                        var rect = new Rectangle(oldColorRect.X + smallRectSize * i, oldColorRect.Y + smallRectSize * j, new Float2(smallRectSize));
                         Render2D.FillRectangle(rect, Color.Gray);
                     }
                 }
             }
+
             Vector2 textOffset = new Vector2(0, -15);
             Render2D.DrawText(style.FontMedium, "Old", Color.White, oldColorRect.UpperLeft + textOffset);
             Render2D.DrawText(style.FontMedium, "New", Color.White, newColorRect.UpperLeft + textOffset);

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -215,7 +215,7 @@ namespace FlaxEditor.GUI.Dialogs
 
             // Eyedropper button
             var style = Style.Current;
-            _cEyedropper = new Button(_cOK.X - EyedropperMargin, _cHex.Bottom + PickerMargin)
+            _cEyedropper = new Button(_cSelector.BottomLeft.X, _cSelector.BottomLeft.Y)
             {
                 TooltipText = "Eyedropper tool to pick a color directly from the screen",
                 BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Search32),
@@ -226,9 +226,8 @@ namespace FlaxEditor.GUI.Dialogs
                 Parent = this,
             };
             _cEyedropper.Clicked += OnEyedropStart;
-            _cEyedropper.Height = (_cValue.Bottom - _cEyedropper.Y) * 0.5f;
             _cEyedropper.Width = _cEyedropper.Height;
-            _cEyedropper.X -= _cEyedropper.Width;
+            _cEyedropper.Location = new Float2(_cEyedropper.Location.X, _cEyedropper.Location.Y - _cEyedropper.Height);
 
             // Set initial color
             SelectedColor = initialValue;

--- a/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
+++ b/Source/Editor/GUI/Dialogs/ColorPickerDialog.cs
@@ -371,7 +371,6 @@ namespace FlaxEditor.GUI.Dialogs
             // Color difference
             var newRect = new Rectangle(_cOK.X - 3, _cHex.Bottom + PickerMargin, 130, 0);
             newRect.Size.Y = 50;
-            Render2D.FillRectangle(newRect, Color.White);
             var smallRectSize = 10;
             var numHor = Mathf.FloorToInt(newRect.Width / smallRectSize);
             var numVer = Mathf.FloorToInt(newRect.Height / smallRectSize);

--- a/Source/Editor/GUI/Dialogs/ColorSelector.cs
+++ b/Source/Editor/GUI/Dialogs/ColorSelector.cs
@@ -172,8 +172,15 @@ namespace FlaxEditor.GUI.Dialogs
             float hAngle = hsv.X * Mathf.DegreesToRadians;
             float hRadius = hsv.Y * _wheelRect.Width * 0.5f;
             var hsPos = new Float2(hRadius * Mathf.Cos(hAngle), -hRadius * Mathf.Sin(hAngle));
-            const float wheelBoxSize = 4.0f;
-            Render2D.DrawRectangle(new Rectangle(hsPos - (wheelBoxSize * 0.5f) + _wheelRect.Center, new Float2(wheelBoxSize)), _isMouseDownWheel ? Color.Gray : Color.Black);
+            // Wheel selection box
+            Float2 selectionBoxSize = new Float2(_isMouseDownWheel ? wheelSelectionBoxEdgeLenght * 2 : wheelSelectionBoxEdgeLenght);
+            Rectangle selectionBoxFill = new Rectangle(hsPos - (selectionBoxSize * 0.5f) + _wheelRect.Center, selectionBoxSize);
+
+            Color rawWheelColor = Color.FromHSV(new Float3(Color.ToHSV().X, 1, 1));
+
+            Render2D.FillRectangle(selectionBoxFill, rawWheelColor);
+            Render2D.DrawRectangle(selectionBoxFill, Color.Black);
+
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Dialogs/ColorSelector.cs
+++ b/Source/Editor/GUI/Dialogs/ColorSelector.cs
@@ -176,7 +176,7 @@ namespace FlaxEditor.GUI.Dialogs
             Float2 selectionBoxSize = new Float2(_isMouseDownWheel ? wheelSelectionBoxEdgeLenght * 2 : wheelSelectionBoxEdgeLenght);
             Rectangle selectionBoxFill = new Rectangle(hsPos - (selectionBoxSize * 0.5f) + _wheelRect.Center, selectionBoxSize);
 
-            Color rawWheelColor = Color.FromHSV(new Float3(Color.ToHSV().X, 1, 1));
+            Color rawWheelColor = Color.FromHSV(new Float3(Color.ToHSV().X, Color.ToHSV().Y, 1));
 
             Render2D.FillRectangle(selectionBoxFill, rawWheelColor);
             Render2D.DrawRectangle(selectionBoxFill, Color.Black);

--- a/Source/Editor/GUI/Dialogs/ColorSelector.cs
+++ b/Source/Editor/GUI/Dialogs/ColorSelector.cs
@@ -172,14 +172,18 @@ namespace FlaxEditor.GUI.Dialogs
             float hAngle = hsv.X * Mathf.DegreesToRadians;
             float hRadius = hsv.Y * _wheelRect.Width * 0.5f;
             var hsPos = new Float2(hRadius * Mathf.Cos(hAngle), -hRadius * Mathf.Sin(hAngle));
+            const float wheelSelectionBoxEdgeLenght = 5f;
+
             // Wheel selection box
             Float2 selectionBoxSize = new Float2(_isMouseDownWheel ? wheelSelectionBoxEdgeLenght * 2 : wheelSelectionBoxEdgeLenght);
             Rectangle selectionBoxFill = new Rectangle(hsPos - (selectionBoxSize * 0.5f) + _wheelRect.Center, selectionBoxSize);
+            Rectangle selectionSecondOutline = new Rectangle(hsPos - ((selectionBoxSize - Float2.One) * 0.5f) + _wheelRect.Center, selectionBoxSize - Float2.One);
 
             Color rawWheelColor = Color.FromHSV(new Float3(Color.ToHSV().X, Color.ToHSV().Y, 1));
 
             Render2D.FillRectangle(selectionBoxFill, rawWheelColor);
             Render2D.DrawRectangle(selectionBoxFill, Color.Black);
+            Render2D.DrawRectangle(selectionSecondOutline, Color.White, 0.5f);
 
         }
 


### PR DESCRIPTION
This pr aims to make multiple improvements to the color picker. Mostly UX stuff and polish but also a few new features.
I'm planing to get this ready for so that it can be merged for 1.9 but no promises on that :)

**If you have the time please try this out and give me some feedback, I don't wanna make things worse by trying to make them better :)**

There are several mockups for a new layout [here](https://www.figma.com/design/g7w9SI7RFP18CJHVonIPV3/FlaxColorPicker?node-id=0-1&t=13KdiP5tRbNXUsz2-1).

This is the current state of the color picker with all of the progress made so far:

https://github.com/FlaxEngine/FlaxEngine/assets/111653551/3c12eb00-f412-4bee-b69b-b1a76ecb32a6

*Tasks marked with " * " are tasks where I need help or don't know how to approach them atm*
### Todo

- [ ] BUG: Fix bug where you can't drag the wheel when *HSV = 0, 0, 0* and *Alpha > 1*
- [ ] BUG: After exiting eye dropper with right click you need to click on the editor once for it to register mouse events again
- [ ] Include A and S slider handles in calculation if clicked
- [ ] Get rid of *Ok* and *Cancel* buttons (see #2446)
- [ ] Checkerboard background for A slider similar to color preview
- [ ] A way to reset color to Old color from color preview
- [ ] Multiple improvements to A and S sliders
- [ ] Try drawing previews on sliders similar to Unreal (see if it looks good)
- [ ] Tint HV wheel to reflect current Saturation *
- [ ] Try to counteract fuzzy edges on HV wheel by drawing an outline (I can't get bezier curves to work like I wanna atm) *

### Todo if there is enough time

- [ ] Add SV square and H slider
- [ ] Rework saved colors system
- [ ] Procedurally draw HV wheel *

### Done

- [x] Old and new color preview
- [x] Resizing HV wheel selection box that shows the currently selected color
- [x] Hide mouse cursor when dragging on HV wheel and AS sliders 