### PR TITLE
Fix error when previewing animation timeline values after reimport

### DIFF
--- a/Source/Editor/GUI/Timeline/Tracks/MemberTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/MemberTrack.cs
@@ -363,6 +363,8 @@ namespace FlaxEditor.GUI.Timeline.Tracks
         /// <inheritdoc />
         public override void OnDestroy()
         {
+            if (_previewValue != null)
+                Timeline.ShowPreviewValuesChanged -= OnTimelineShowPreviewValuesChanged;
             _previewValue = null;
             _rightKey = null;
             _addKey = null;


### PR DESCRIPTION
The editor crashes when animation track preview values is enabled after animation is reimported.