### PR TITLE
Fix crash in Colliders when PhysicsMaterial asset is reloaded in editor

### DIFF
--- a/Source/Engine/Physics/Colliders/Collider.cpp
+++ b/Source/Engine/Physics/Colliders/Collider.cpp
@@ -21,6 +21,8 @@ Collider::Collider(const SpawnParams& params)
     , _cachedScale(1.0f)
     , _contactOffset(2.0f)
 {
+    Material.Loaded.Bind<Collider, &Collider::OnMaterialChanged>(this);
+    Material.Unload.Bind<Collider, &Collider::OnMaterialChanged>(this);
     Material.Changed.Bind<Collider, &Collider::OnMaterialChanged>(this);
 }
 

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -4474,6 +4474,16 @@ void PhysicsBackend::DestroyController(void* controller)
     controllerPhysX->release();
 }
 
+void PhysicsBackend::DestroyMaterial(void* material)
+{
+    ASSERT_LOW_LAYER(material);
+    auto materialPhysX = (PxMaterial*)material;
+    materialPhysX->userData = nullptr;
+    FlushLocker.Lock();
+    DeleteObjects.Add(materialPhysX);
+    FlushLocker.Unlock();
+}
+
 void PhysicsBackend::DestroyObject(void* object)
 {
     ASSERT_LOW_LAYER(object);

--- a/Source/Engine/Physics/Physics.cpp
+++ b/Source/Engine/Physics/Physics.cpp
@@ -81,7 +81,7 @@ void PhysicsSettings::Deserialize(DeserializeStream& stream, ISerializeModifier*
 PhysicalMaterial::~PhysicalMaterial()
 {
     if (_material)
-        PhysicsBackend::DestroyObject(_material);
+        PhysicsBackend::DestroyMaterial(_material);
 }
 
 bool PhysicsService::Init()

--- a/Source/Engine/Physics/PhysicsBackend.h
+++ b/Source/Engine/Physics/PhysicsBackend.h
@@ -314,6 +314,7 @@ public:
     static void DestroyShape(void* shape);
     static void DestroyJoint(void* joint);
     static void DestroyController(void* controller);
+    static void DestroyMaterial(void* material);
     static void DestroyObject(void* object);
     static void RemoveCollider(PhysicsColliderActor* collider);
     static void RemoveJoint(Joint* joint);

--- a/Source/Engine/Physics/PhysicsBackendEmpty.cpp
+++ b/Source/Engine/Physics/PhysicsBackendEmpty.cpp
@@ -865,6 +865,10 @@ void PhysicsBackend::DestroyController(void* controller)
 {
 }
 
+void PhysicsBackend::DestroyMaterial(void* material)
+{
+}
+
 void PhysicsBackend::DestroyObject(void* object)
 {
 }


### PR DESCRIPTION
PhysicsMaterial reference stored in PhysX was never removed and refreshed when the asset is being reloaded in editor.