### PR TITLE
Visject: Tooltip/Description Panel

### DIFF
--- a/Source/Editor/Surface/Archetypes/Particles.cs
+++ b/Source/Editor/Surface/Archetypes/Particles.cs
@@ -122,7 +122,7 @@ namespace FlaxEditor.Surface.Archetypes
                         {
                             Name = module.Title,
                             Tag = module.TypeID,
-                            TooltipText = module.Description,
+                            TooltipText = $"{module.Signature}\n{module.Description}",
                         });
                     }
                     cm.ItemClicked += item => AddModule((ushort)item.Tag);

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -51,6 +51,10 @@ namespace FlaxEditor.Surface.ContextMenu
         private Elements.Box _selectedBox;
         private NodeArchetype _parameterGetNodeArchetype;
         private NodeArchetype _parameterSetNodeArchetype;
+        private bool _useDescriptionPanel;
+        private string _currentDescriptionText;
+        private Panel _descriptionPanel;
+        private Label _descriptionLabel;
 
         /// <summary>
         /// The selected item
@@ -81,6 +85,11 @@ namespace FlaxEditor.Surface.ContextMenu
             /// True if surface parameters are not read-only and can be modified via setter node.
             /// </summary>
             public bool CanSetParameters;
+
+            /// <summary>
+            /// True if the surface should make use of a description panel drawn at the bottom of the context menu
+            /// </summary>
+            public bool UseDescriptionPanel;
 
             /// <summary>
             /// The groups archetypes. Cannot be null.
@@ -127,9 +136,11 @@ namespace FlaxEditor.Surface.ContextMenu
             _parameterGetNodeArchetype = info.ParameterGetNodeArchetype ?? Archetypes.Parameters.Nodes[0];
             if (info.CanSetParameters)
                 _parameterSetNodeArchetype = info.ParameterSetNodeArchetype ?? Archetypes.Parameters.Nodes[3];
+            _useDescriptionPanel = info.UseDescriptionPanel;
 
+            float descriptionHeight = 75;
             // Context menu dimensions
-            Size = new Float2(300, 400);
+            Size = new Float2(300, 400 + (_useDescriptionPanel ? descriptionHeight : 0));
 
             var headerPanel = new Panel(ScrollBars.None)
             {
@@ -187,7 +198,7 @@ namespace FlaxEditor.Surface.ContextMenu
             // Create first panel (for scrollbar)
             var panel1 = new Panel(ScrollBars.Vertical)
             {
-                Bounds = new Rectangle(0, _searchBox.Bottom + 1, Width, Height - _searchBox.Bottom - 2),
+                Bounds = new Rectangle(0, _searchBox.Bottom + 1, Width, Height - _searchBox.Bottom - (_useDescriptionPanel ? descriptionHeight : 0) - 2),
                 Parent = this
             };
 
@@ -201,6 +212,27 @@ namespace FlaxEditor.Surface.ContextMenu
                 IsScrollable = true,
             };
             _groupsPanel = panel2;
+
+            // Create description panel if enabled
+            if (_useDescriptionPanel)
+            {
+                var descriptionPanel = new Panel(ScrollBars.None)
+                {
+                    Parent = this,
+                    Bounds = new Rectangle(0, Height - descriptionHeight, Width, descriptionHeight),
+                    BackgroundColor = Style.Current.BackgroundNormal,
+                };
+                _descriptionPanel = descriptionPanel;
+
+                var descriptionLabel = new Label(8,8,Width-16,Height-16)
+                {
+                    Parent = _descriptionPanel,
+                    HorizontalAlignment = TextAlignment.Near,
+                    VerticalAlignment = TextAlignment.Near,
+                    Wrapping = TextWrapping.WrapWords,
+                };
+                _descriptionLabel = descriptionLabel;
+            }
 
             // Init groups
             var nodes = new List<NodeArchetype>();
@@ -547,6 +579,14 @@ namespace FlaxEditor.Surface.ContextMenu
         {
             for (int i = 0; i < _groups.Count; i++)
                 _groups[i].Open(animate);
+        }
+
+        public void SetDescriptionText(string text)
+        {
+            if(!_useDescriptionPanel)
+                return;
+            _currentDescriptionText = text;
+            _descriptionLabel.Text = _currentDescriptionText;
         }
 
         /// <summary>

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -138,9 +138,8 @@ namespace FlaxEditor.Surface.ContextMenu
                 _parameterSetNodeArchetype = info.ParameterSetNodeArchetype ?? Archetypes.Parameters.Nodes[3];
             _useDescriptionPanel = info.UseDescriptionPanel;
 
-            float descriptionHeight = 75;
             // Context menu dimensions
-            Size = new Float2(300, 400 + (_useDescriptionPanel ? descriptionHeight : 0));
+            Size = new Float2(300, 400);
 
             var headerPanel = new Panel(ScrollBars.None)
             {
@@ -152,7 +151,7 @@ namespace FlaxEditor.Surface.ContextMenu
             };
 
             // Title bar
-            var titleFontReference = new FontReference(Style.Current.FontLarge.Asset, 10);
+            var titleFontReference = new FontReference(Style.Current.FontMedium.Asset, 11);
             var titleLabel = new Label
             {
                 Width = Width * 0.5f - 8f,
@@ -198,7 +197,7 @@ namespace FlaxEditor.Surface.ContextMenu
             // Create first panel (for scrollbar)
             var panel1 = new Panel(ScrollBars.Vertical)
             {
-                Bounds = new Rectangle(0, _searchBox.Bottom + 1, Width, Height - _searchBox.Bottom - (_useDescriptionPanel ? descriptionHeight : 0) - 2),
+                Bounds = new Rectangle(0, _searchBox.Bottom + 1, Width, Height - _searchBox.Bottom - 2),
                 Parent = this
             };
 
@@ -219,13 +218,13 @@ namespace FlaxEditor.Surface.ContextMenu
                 var descriptionPanel = new Panel(ScrollBars.None)
                 {
                     Parent = this,
-                    Bounds = new Rectangle(0, Height - descriptionHeight, Width, descriptionHeight),
+                    Bounds = new Rectangle(0, Height, Width, 0),
                     BackgroundColor = Style.Current.BackgroundNormal,
                 };
                 _descriptionPanel = descriptionPanel;
 
-                var signatureFontReference = new FontReference(Style.Current.FontLarge.Asset, 11);
-                var signatureLabel = new Label(8, 12, Width - 16, Height - 16)
+                var signatureFontReference = new FontReference(Style.Current.FontMedium.Asset, 10);
+                var signatureLabel = new Label(8, 12, Width - 16, 0)
                 {
                     Parent = _descriptionPanel,
                     HorizontalAlignment = TextAlignment.Near,
@@ -234,16 +233,20 @@ namespace FlaxEditor.Surface.ContextMenu
                     Font = signatureFontReference,
                     Bold = true,
                     Italic = true,
+                    AutoHeight = true,
                 };
+                signatureLabel.SetAnchorPreset(AnchorPresets.TopLeft, true);
                 _descriptionSignatureLabel = signatureLabel;
                 
-                var descriptionLabel = new Label(8, 40, Width - 16, Height - 16)
+                var descriptionLabel = new Label(8, 0, Width - 16, 0)
                 {
                     Parent = _descriptionPanel,
                     HorizontalAlignment = TextAlignment.Near,
                     VerticalAlignment = TextAlignment.Near,
                     Wrapping = TextWrapping.WrapWords,
+                    AutoHeight = true,
                 };
+                descriptionLabel.SetAnchorPreset(AnchorPresets.TopLeft, true);
                 _descriptionLabel = descriptionLabel;
             }
 
@@ -598,8 +601,17 @@ namespace FlaxEditor.Surface.ContextMenu
         {
             if(!_useDescriptionPanel)
                 return;
+            
             _descriptionSignatureLabel.Text = header;
+            var panelHeight = _descriptionSignatureLabel.Height;
+
+            _descriptionLabel.Y = _descriptionSignatureLabel.Bounds.Bottom + 8f;
             _descriptionLabel.Text = text;
+
+            panelHeight += _descriptionLabel.Height + 8f + 24f;
+            _descriptionPanel.Height = panelHeight;
+            Size = new Float2(300, 400 + _descriptionPanel.Height);
+            UpdateWindowSize();
         }
 
         /// <summary>

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -225,7 +225,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 _descriptionPanel = descriptionPanel;
 
                 var signatureFontReference = new FontReference(Style.Current.FontLarge.Asset, 11);
-                var signatureLabel = new Label(8, 8, Width - 16, Height - 16)
+                var signatureLabel = new Label(8, 12, Width - 16, Height - 16)
                 {
                     Parent = _descriptionPanel,
                     HorizontalAlignment = TextAlignment.Near,

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -52,8 +52,8 @@ namespace FlaxEditor.Surface.ContextMenu
         private NodeArchetype _parameterGetNodeArchetype;
         private NodeArchetype _parameterSetNodeArchetype;
         private bool _useDescriptionPanel;
-        private string _currentDescriptionText;
         private Panel _descriptionPanel;
+        private Label _descriptionSignatureLabel;
         private Label _descriptionLabel;
 
         /// <summary>
@@ -224,7 +224,20 @@ namespace FlaxEditor.Surface.ContextMenu
                 };
                 _descriptionPanel = descriptionPanel;
 
-                var descriptionLabel = new Label(8,8,Width-16,Height-16)
+                var signatureFontReference = new FontReference(Style.Current.FontLarge.Asset, 11);
+                var signatureLabel = new Label(8, 8, Width - 16, Height - 16)
+                {
+                    Parent = _descriptionPanel,
+                    HorizontalAlignment = TextAlignment.Near,
+                    VerticalAlignment = TextAlignment.Near,
+                    Wrapping = TextWrapping.WrapWords,
+                    Font = signatureFontReference,
+                    Bold = true,
+                    Italic = true,
+                };
+                _descriptionSignatureLabel = signatureLabel;
+                
+                var descriptionLabel = new Label(8, 40, Width - 16, Height - 16)
                 {
                     Parent = _descriptionPanel,
                     HorizontalAlignment = TextAlignment.Near,
@@ -581,12 +594,12 @@ namespace FlaxEditor.Surface.ContextMenu
                 _groups[i].Open(animate);
         }
 
-        public void SetDescriptionText(string text)
+        public void SetDescriptionText(string header, string text)
         {
             if(!_useDescriptionPanel)
                 return;
-            _currentDescriptionText = text;
-            _descriptionLabel.Text = _currentDescriptionText;
+            _descriptionSignatureLabel.Text = header;
+            _descriptionLabel.Text = text;
         }
 
         /// <summary>

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -62,7 +62,7 @@ namespace FlaxEditor.Surface.ContextMenu
             Group = group;
             _groupArchetype = groupArchetype;
             _archetype = archetype;
-            TooltipText = _archetype.Description;
+            TooltipText = $"{_archetype.Signature}\n{_archetype.Description}";
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace FlaxEditor.Surface.ContextMenu
         public override void OnMouseEnter(Float2 location)
         {
             base.OnMouseEnter(location);
-            Group.ContextMenu.SetDescriptionText(_archetype.Description);
+            Group.ContextMenu.SetDescriptionText(_archetype.Signature, _archetype.Description);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMItem.cs
@@ -339,6 +339,13 @@ namespace FlaxEditor.Surface.ContextMenu
         }
 
         /// <inheritdoc />
+        public override void OnMouseEnter(Float2 location)
+        {
+            base.OnMouseEnter(location);
+            Group.ContextMenu.SetDescriptionText(_archetype.Description);
+        }
+
+        /// <inheritdoc />
         public override void OnMouseLeave()
         {
             _isMouseDown = false;

--- a/Source/Editor/Surface/NodeArchetype.cs
+++ b/Source/Editor/Surface/NodeArchetype.cs
@@ -135,6 +135,11 @@ namespace FlaxEditor.Surface
         public string SubTitle;
 
         /// <summary>
+        /// Node signature for tooltip and description purposes
+        /// </summary>
+        public string Signature;
+
+        /// <summary>
         /// Short node description.
         /// </summary>
         public string Description;
@@ -210,6 +215,7 @@ namespace FlaxEditor.Surface
                 Flags = Flags,
                 Title = Title,
                 SubTitle = SubTitle,
+                Signature = Signature,
                 Description = Description,
                 AlternativeTitles = (string[])AlternativeTitles?.Clone(),
                 Tag = Tag,

--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -124,7 +124,7 @@ namespace FlaxEditor.Surface
             Archetype = nodeArch;
             GroupArchetype = groupArch;
             AutoFocus = false;
-            TooltipText = nodeArch.Description;
+            TooltipText = TooltipText = $"{nodeArch.Signature}\n{nodeArch.Description}";
             CullChildren = false;
             BackgroundColor = Style.Current.BackgroundNormal;
 

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -237,6 +237,7 @@ namespace FlaxEditor.Surface
             return new VisjectCM(new VisjectCM.InitInfo
             {
                 CanSetParameters = CanSetParameters,
+                UseDescriptionPanel = UseContextMenuDescriptionPanel,
                 Groups = NodeArchetypes,
                 CanSpawnNode = CanUseNodeType,
                 ParametersGetter = () => Parameters,

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -536,6 +536,11 @@ namespace FlaxEditor.Surface
         public virtual bool CanSetParameters => false;
 
         /// <summary>
+        /// True of the context menu should make use of a description panel drawn at the bottom of the menu
+        /// </summary>
+        public virtual bool UseContextMenuDescriptionPanel => false;
+
+        /// <summary>
         /// Gets a value indicating whether surface supports/allows live previewing graph modifications due to value sliders and color pickers. True by default but disabled for shader surfaces that generate and compile shader source at flight.
         /// </summary>
         public virtual bool CanLivePreviewValueChanges => true;

--- a/Source/Editor/Surface/VisualScriptSurface.cs
+++ b/Source/Editor/Surface/VisualScriptSurface.cs
@@ -370,7 +370,8 @@ namespace FlaxEditor.Surface
                         node.DefaultValues[2] = parameters.Length;
                         node.Flags &= ~NodeFlags.NoSpawnViaGUI;
                         node.Title = SurfaceUtils.GetMethodDisplayName((string)node.DefaultValues[1]);
-                        node.Description = SurfaceUtils.GetVisualScriptMemberInfoDescription(member);
+                        node.Signature = SurfaceUtils.GetVisualScriptMemberInfoSignature(member);
+                        node.Description = SurfaceUtils.GetVisualScriptMemberShortDescription(member);
                         node.SubTitle = string.Format(" (in {0})", scriptTypeName);
                         node.Tag = member;
 
@@ -418,7 +419,8 @@ namespace FlaxEditor.Surface
                             node.DefaultValues[3] = member.IsStatic;
                             node.Flags &= ~NodeFlags.NoSpawnViaGUI;
                             node.Title = "Get " + name;
-                            node.Description = SurfaceUtils.GetVisualScriptMemberInfoDescription(member);
+                            node.Signature = SurfaceUtils.GetVisualScriptMemberInfoSignature(member);
+                            node.Description = SurfaceUtils.GetVisualScriptMemberShortDescription(member);
                             node.SubTitle = string.Format(" (in {0})", scriptTypeName);
 
                             // Create group archetype
@@ -452,7 +454,8 @@ namespace FlaxEditor.Surface
                             node.DefaultValues[3] = member.IsStatic;
                             node.Flags &= ~NodeFlags.NoSpawnViaGUI;
                             node.Title = "Set " + name;
-                            node.Description = SurfaceUtils.GetVisualScriptMemberInfoDescription(member);
+                            node.Signature = SurfaceUtils.GetVisualScriptMemberInfoSignature(member);
+                            node.Description = SurfaceUtils.GetVisualScriptMemberShortDescription(member);
                             node.SubTitle = string.Format(" (in {0})", scriptTypeName);
 
                             // Create group archetype
@@ -510,7 +513,8 @@ namespace FlaxEditor.Surface
                         bindNode.DefaultValues[1] = name;
                         bindNode.Flags &= ~NodeFlags.NoSpawnViaGUI;
                         bindNode.Title = "Bind " + name;
-                        bindNode.Description = SurfaceUtils.GetVisualScriptMemberInfoDescription(member);
+                        bindNode.Signature = SurfaceUtils.GetVisualScriptMemberInfoSignature(member);
+                        bindNode.Description = SurfaceUtils.GetVisualScriptMemberShortDescription(member);
                         bindNode.SubTitle = string.Format(" (in {0})", scriptTypeName);
                         ((IList<NodeArchetype>)group.Archetypes).Add(bindNode);
 
@@ -520,6 +524,7 @@ namespace FlaxEditor.Surface
                         unbindNode.DefaultValues[1] = name;
                         unbindNode.Flags &= ~NodeFlags.NoSpawnViaGUI;
                         unbindNode.Title = "Unbind " + name;
+                        unbindNode.Signature = bindNode.Signature;
                         unbindNode.Description = bindNode.Description;
                         unbindNode.SubTitle = bindNode.SubTitle;
                         ((IList<NodeArchetype>)group.Archetypes).Add(unbindNode);

--- a/Source/Editor/Surface/VisualScriptSurface.cs
+++ b/Source/Editor/Surface/VisualScriptSurface.cs
@@ -175,6 +175,9 @@ namespace FlaxEditor.Surface
         public override bool CanSetParameters => true;
 
         /// <inheritdoc />
+        public override bool UseContextMenuDescriptionPanel => true;
+
+        /// <inheritdoc />
         public override bool CanUseNodeType(GroupArchetype groupArchetype, NodeArchetype nodeArchetype)
         {
             return (nodeArchetype.Flags & NodeFlags.VisualScriptGraph) != 0 && base.CanUseNodeType(groupArchetype, nodeArchetype);


### PR DESCRIPTION
This PR aims to add a panel to the visject context menu which allows users to quickly distinguish nodes in the context menu list. This is especially useful for visual scripting and mimics the behaviour of other known visual scripting tools like Bolt/Unity Visual Scripting.

The goal of the panel is not to replace the tooltip, but to make it way easier to understand what a node does and what the inputs and outputs are. Especially people who are new to scripting or prefer visual scripting will find this helpful.

### Concept
This is what the panel should look like once it's finished (concept by ElevenArt on discord)
![Untitled](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/002a8238-d6ce-48b8-8b95-ca3d3da2ac19)

### Current State
This is the current state of the panel. The MVP basically. (based on the very first concept by ElevenArt on discord)
![DescriptionPanelState1](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/f2ba8f62-20ca-45fb-9641-d3ee4324bb01)

### ToDo
- [x] Fetch signature of methods and co
- [x] Fetch description/tooltip of nodes
- [x] Show description panel when hovering over an item
- [ ] Show description panel when highlighting an item (via keyboard)
- [x] Resize description panel automatically to fit text and other elements
- [ ] Show icon of class where the method and co are defined
- [ ] Show parameters of methods with types and icons
- [ ] Show return/outputs of methods with types and icons
- [ ] Still evaluating: Add toggle in editor options to disable the panel 
- [ ] Testing
- [ ] Styling
- [ ] Cleanup
- [ ] Done 🥳

**Optional**
- [ ] Find a way to replace XML tags like "see cref" (e.g. by just rendering the referenced class in bold text) (see pic 1)
- [ ] Fix wrong XML/Description fetching. In some cases the whole archetype description gets fetched as the signature (see pic 2)
- [ ] Add descriptions to nodes that currently don't have any descriptions. E.g. Boolean XOR, NOR, NAND

![image](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/3dbfbb5e-2781-43e4-abb0-818834e7c058)
_Pic 1_

![image](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/eafd19a0-9c29-4fb2-bacd-5c25c7247225)
_Pic 2_


Note 1) Since this is an addition to the general visject context menu it can be enabled for all graph tools. As of now this feature is only enabled in the visual scripting graph and doesn't show up in other graph tools.