### PR TITLE
Visject: Fix broken float node spawning when typing decimal numbers into searchfield

### DIFF
--- a/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -96,15 +96,20 @@ namespace FlaxEditor.Surface.ContextMenu
                 int dotIndex = filterText.IndexOf('.');
                 if (dotIndex != -1)
                 {
-                    // Early out and make the group invisible if it doesn't start with the specified string
                     string filterGroupName = filterText.Substring(0, dotIndex);
-                    if (!Name.StartsWith(filterGroupName, StringComparison.InvariantCultureIgnoreCase))
+
+                    // If the string in front of the dot has the length of 0 or doesn't start with a letter we skip the filtering to make spawning floats work
+                    if (filterGroupName.Length > 0 && char.IsLetter(filterGroupName[0]))
                     {
-                        Visible = false;
-                        Profiler.EndEvent();
-                        return;
+                        // Early out and make the group invisible if it doesn't start with the specified string
+                        if (!Name.StartsWith(filterGroupName, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            Visible = false;
+                            Profiler.EndEvent();
+                            return;
+                        }
+                        filterText = filterText.Substring(dotIndex + 1);
                     }
-                    filterText = filterText.Substring(dotIndex + 1);
                 }
             }
 


### PR DESCRIPTION
Fixes a regression caused by #2662 

This PR adds a small check when filtering for groups with a dot. If the string is empty or doesn't start with a letter it will skip the group filtering logic to make spawning float nodes work again.

**Expected behaviour:**
![image](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/40ddc869-b373-478c-98f4-e0638085da34)

**Current behaviour:**
![image](https://github.com/FlaxEngine/FlaxEngine/assets/6757167/22d7df07-9e1c-42b0-9821-6e7274eb2da7)
