### PR TITLE
Fix graphical glitches in Vulkan backend with AMD GPUs

### DIFF
--- a/Source/Engine/GraphicsDevice/Vulkan/DescriptorSetVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/DescriptorSetVulkan.cpp
@@ -292,7 +292,7 @@ DescriptorPoolSetContainerVulkan* DescriptorPoolsManagerVulkan::AcquirePoolSetCo
     ScopeLock lock(_locker);
     for (auto* poolSet : _poolSets)
     {
-        if (poolSet->Refs == 0)
+        if (poolSet->Refs == 0 && Engine::FrameCount - poolSet->LastFrameUsed > VULKAN_RESOURCE_DELETE_SAFE_FRAMES_COUNT)
         {
             poolSet->LastFrameUsed = Engine::FrameCount;
             poolSet->Reset();


### PR DESCRIPTION
Fixes the following validation error when rendering at high framerates or when multiple windows are open:

> Validation Error:-1611285309(VUID-vkResetDescriptorPool-descriptorPool-00313) Validation Error: [ VUID-vkResetDescriptorPool-descriptorPool-00313 ] Object 0: handle = 0x10f8002600000003803ad0 type = VK_OBJECT_TYPE_DESCRIPTOR_POOL; | MessageID = 0x9f0f5b0cc3 | vkResetDescriptorPool(): descriptorPool descriptor sets in use by VkCommandBuffer 0x5df0e2202d90a90[]0 The Vulkan spec states: All uses of descriptorPool (via any allocated descriptor sets) must have completed execution (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkResetDescriptorPool-descriptorPool-00313)