### PR TITLE
Software reflections for forward pass

### DIFF
--- a/Content/Editor/MaterialTemplates/Features/ForwardShading.hlsl
+++ b/Content/Editor/MaterialTemplates/Features/ForwardShading.hlsl
@@ -33,8 +33,6 @@ DECLARE_LIGHTSHADOWDATA_ACCESS(DirectionalLightShadow);
 
 // Pixel Shader function for Forward Pass
 META_PS(USE_FORWARD, FEATURE_LEVEL_ES2)
-META_PERMUTATION_1(USE_GLOBAL_SURFACE_ATLAS=0)
-META_PERMUTATION_1(USE_GLOBAL_SURFACE_ATLAS=1)
 void PS_Forward(
 		in PixelInput input
 		,out float4 output : SV_Target0
@@ -69,6 +67,7 @@ void PS_Forward(
 	gBuffer.Color = material.Color;
 	gBuffer.Specular = material.Specular;
 	gBuffer.AO = material.AO;
+	// gBuffer.ViewPos is the view position in WORLD SPACE
 	gBuffer.ViewPos = ViewPos;
 #if MATERIAL_SHADING_MODEL == SHADING_MODEL_SUBSURFACE
 	gBuffer.CustomData = float4(material.SubsurfaceColor, material.Opacity);
@@ -152,7 +151,6 @@ void PS_Forward(
 
 	// Add lighting (apply ambient occlusion)
 	output.rgb += light.rgb * gBuffer.AO;
-	output = 
 
 #endif
 

--- a/Content/Editor/MaterialTemplates/Features/SDFReflections.hlsl
+++ b/Content/Editor/MaterialTemplates/Features/SDFReflections.hlsl
@@ -1,0 +1,39 @@
+// Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
+
+@0// SDF Reflections: Defines
+#define USE_GLOBAL_SURFACE_ATLAS 1
+@1// SDF Reflections: Includes
+#include "./Flax/GlobalSignDistanceField.hlsl"
+#include "./Flax/GI/GlobalSurfaceAtlas.hlsl"
+@2// SDF Reflections: Constants
+GlobalSDFData GlobalSDF;
+GlobalSurfaceAtlasData GlobalSurfaceAtlas;
+@3// SDF Reflections: Resources
+Texture3D<float> GlobalSDFTex : register(t__SRV__);
+Texture3D<float> GlobalSDFMip : register(t__SRV__);
+ByteAddressBuffer GlobalSurfaceAtlasChunks : register(t__SRV__);
+ByteAddressBuffer RWGlobalSurfaceAtlasCulledObjects : register(t__SRV__);
+Buffer<float4> GlobalSurfaceAtlasObjects : register(t__SRV__);
+Texture2D GlobalSurfaceAtlasDepth : register(t__SRV__);
+Texture2D GlobalSurfaceAtlasTex : register(t__SRV__);
+@4// SDF Reflections: Utilities
+bool TraceSDFSoftwareReflections(GBufferSample gBuffer, float3 reflectWS, out float4 surfaceAtlas)
+{
+	GlobalSDFTrace sdfTrace;
+    float maxDistance = 100000;
+    float selfOcclusionBias = GlobalSDF.CascadeVoxelSize[0];
+    sdfTrace.Init(gBuffer.WorldPos + gBuffer.Normal * selfOcclusionBias, reflectWS, 0.0f, maxDistance);
+    GlobalSDFHit sdfHit = RayTraceGlobalSDF(GlobalSDF, GlobalSDFTex, GlobalSDFMip, sdfTrace);
+    if (sdfHit.IsHit())
+    {
+        float3 hitPosition = sdfHit.GetHitPosition(sdfTrace);
+        float surfaceThreshold = GetGlobalSurfaceAtlasThreshold(GlobalSDF, sdfHit);
+        surfaceAtlas = SampleGlobalSurfaceAtlas(GlobalSurfaceAtlas, GlobalSurfaceAtlasChunks, RWGlobalSurfaceAtlasCulledObjects, GlobalSurfaceAtlasObjects, GlobalSurfaceAtlasDepth, GlobalSurfaceAtlasTex, hitPosition, -reflectWS, surfaceThreshold);
+        
+        return true;
+    }
+
+    return false;
+}
+
+@5// SDF Reflections: Shaders

--- a/Source/Engine/Graphics/Materials/ForwardMaterialShader.cpp
+++ b/Source/Engine/Graphics/Materials/ForwardMaterialShader.cpp
@@ -178,6 +178,7 @@ bool ForwardMaterialShader::Load()
     psDesc.VS = _shader->GetVS("VS");
     if (psDesc.VS == nullptr)
         return true;
+
     psDesc.PS = _shader->GetPS("PS_Forward");
     psDesc.DepthWriteEnable = false;
     psDesc.BlendMode = BlendingMode::AlphaBlend;

--- a/Source/Engine/Graphics/Materials/ForwardMaterialShader.cpp
+++ b/Source/Engine/Graphics/Materials/ForwardMaterialShader.cpp
@@ -53,6 +53,8 @@ void ForwardMaterialShader::Bind(BindParameters& params)
     // Setup features
     if ((_info.FeaturesFlags & MaterialFeaturesFlags::GlobalIllumination) != MaterialFeaturesFlags::None)
         GlobalIlluminationFeature::Bind(params, cb, srv);
+    if ((_info.FeaturesFlags & MaterialFeaturesFlags::ScreenSpaceReflections) != MaterialFeaturesFlags::None)
+        SDFReflectionsFeature::Bind(params, cb, srv);
     ForwardShadingFeature::Bind(params, cb, srv);
 
     // Setup parameters

--- a/Source/Engine/Graphics/Materials/MaterialShaderFeatures.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialShaderFeatures.cpp
@@ -23,8 +23,6 @@ void ForwardShadingFeature::Bind(MaterialShader::BindParameters& params, Span<by
     const int32 envProbeShaderRegisterIndex = srv + 0;
     const int32 skyLightShaderRegisterIndex = srv + 1;
     const int32 dirLightShaderRegisterIndex = srv + 2;
-    const int32 surfaceAtlasDepthShaderRegisterIndex = srv + 3;
-    const int32 surfaceAtlasTexShaderRegisterIndex = srv + 4;
     const bool canUseShadow = view.Pass != DrawPass::Depth;
 
     // Set fog input

--- a/Source/Engine/Graphics/Materials/MaterialShaderFeatures.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialShaderFeatures.cpp
@@ -100,15 +100,6 @@ void ForwardShadingFeature::Bind(MaterialShader::BindParameters& params, Span<by
         params.GPUContext->UnBindSR(envProbeShaderRegisterIndex);
     }
 
-    // Bind sdf resources if using software reflections
-    if (!GlobalSignDistanceFieldPass::Instance()->Render(params.RenderContext, params.GPUContext, bindingDataSDF) &&
-        !GlobalSurfaceAtlasPass::Instance()->Render(params.RenderContext, params.GPUContext, bindingDataSurfaceAtlas))
-    {
-        useGlobalSurfaceAtlas = true;
-        data.GlobalSDF = bindingDataSDF.Constants;
-        data.GlobalSurfaceAtlas = bindingDataSurfaceAtlas.Constants;
-    }
-
     // Set local lights
     data.LocalLightsCount = 0;
     const BoundingSphere objectBounds(drawCall.ObjectPosition, drawCall.ObjectRadius);
@@ -143,13 +134,13 @@ bool LightmapFeature::Bind(MaterialShader::BindParameters& params, Span<byte>& c
 
     const bool useLightmap = EnumHasAnyFlags(params.RenderContext.View.Flags, ViewFlags::GI)
 #if USE_EDITOR
-            && EnableLightmapsUsage
+        && EnableLightmapsUsage
 #endif
-            && drawCall.Surface.Lightmap != nullptr;
+        && drawCall.Surface.Lightmap != nullptr;
     if (useLightmap)
     {
         // Bind lightmap textures
-        GPUTexture *lightmap0, *lightmap1, *lightmap2;
+        GPUTexture* lightmap0, * lightmap1, * lightmap2;
         drawCall.Features.Lightmap->GetTextures(&lightmap0, &lightmap1, &lightmap2);
         params.GPUContext->BindSR(srv + 0, lightmap0);
         params.GPUContext->BindSR(srv + 1, lightmap1);
@@ -207,6 +198,61 @@ bool GlobalIlluminationFeature::Bind(MaterialShader::BindParameters& params, Spa
     return useGI;
 }
 
+bool SDFReflectionsFeature::Bind(MaterialShader::BindParameters& params, Span<byte>& cb, int32& srv)
+{
+    auto& data = *(Data*)cb.Get();
+    ASSERT_LOW_LAYER(cb.Length() >= sizeof(Data));
+
+    bool useSDFReflections = false;
+    if (EnumHasAnyFlags(params.RenderContext.View.Flags, ViewFlags::Reflections))
+    {
+        switch (params.RenderContext.List->Settings.ScreenSpaceReflections.TraceMode)
+        {
+        case ReflectionsTraceMode::SoftwareTracing:
+        {
+            GlobalSignDistanceFieldPass::BindingData bindingDataSDF;
+            GlobalSurfaceAtlasPass::BindingData bindingDataSurfaceAtlas;
+
+            if (!GlobalSignDistanceFieldPass::Instance()->Get(params.RenderContext.Buffers, bindingDataSDF) &&
+                !GlobalSurfaceAtlasPass::Instance()->Get(params.RenderContext.Buffers, bindingDataSurfaceAtlas))
+            {
+                useSDFReflections = true;
+
+                // Bind DDGI data
+                data.GlobalSDF = bindingDataSDF.Constants;
+                data.GlobalSurfaceAtlas = bindingDataSurfaceAtlas.Constants;
+
+                params.GPUContext->BindSR(srv + 0, bindingDataSDF.Texture ? bindingDataSDF.Texture->ViewVolume() : nullptr);
+                params.GPUContext->BindSR(srv + 1, bindingDataSDF.TextureMip ? bindingDataSDF.TextureMip->ViewVolume() : nullptr);
+                params.GPUContext->BindSR(srv + 2, bindingDataSurfaceAtlas.Chunks ? bindingDataSurfaceAtlas.Chunks->View() : nullptr);
+                params.GPUContext->BindSR(srv + 3, bindingDataSurfaceAtlas.CulledObjects ? bindingDataSurfaceAtlas.CulledObjects->View() : nullptr);
+                params.GPUContext->BindSR(srv + 4, bindingDataSurfaceAtlas.Objects ? bindingDataSurfaceAtlas.Objects->View() : nullptr);
+                params.GPUContext->BindSR(srv + 5, bindingDataSurfaceAtlas.AtlasDepth->View());
+                params.GPUContext->BindSR(srv + 6, bindingDataSurfaceAtlas.AtlasLighting->View());
+            }
+            break;
+        }
+        }
+    }
+
+    if (!useSDFReflections)
+    {
+        data.GlobalSDF.CascadesCount = 0;
+        // Unbind SRVs to prevent issues
+        params.GPUContext->UnBindSR(srv + 0);
+        params.GPUContext->UnBindSR(srv + 1);
+        params.GPUContext->UnBindSR(srv + 2);
+        params.GPUContext->UnBindSR(srv + 3);
+        params.GPUContext->UnBindSR(srv + 4);
+        params.GPUContext->UnBindSR(srv + 5);
+        params.GPUContext->UnBindSR(srv + 6);
+    }
+
+    cb = Span<byte>(cb.Get() + sizeof(Data), cb.Length() - sizeof(Data));
+    srv += SRVs;
+    return useSDFReflections;
+}
+
 #if USE_EDITOR
 
 void ForwardShadingFeature::Generate(GeneratorData& data)
@@ -232,6 +278,11 @@ void LightmapFeature::Generate(GeneratorData& data)
 void GlobalIlluminationFeature::Generate(GeneratorData& data)
 {
     data.Template = TEXT("Features/GlobalIllumination.hlsl");
+}
+
+void SDFReflectionsFeature::Generate(GeneratorData& data)
+{
+    data.Template = TEXT("Features/SDFReflections.hlsl");
 }
 
 void DistortionFeature::Generate(GeneratorData& data)

--- a/Source/Engine/Graphics/Materials/MaterialShaderFeatures.h
+++ b/Source/Engine/Graphics/Materials/MaterialShaderFeatures.h
@@ -6,6 +6,8 @@
 #include "Engine/Core/Math/Rectangle.h"
 #include "Engine/Core/Types/Span.h"
 #include "Engine/Renderer/GI/DynamicDiffuseGlobalIllumination.h"
+#include "Engine/Renderer/GlobalSignDistanceFieldPass.h"
+#include "Engine/Renderer/GI/GlobalSurfaceAtlasPass.h"
 
 // Material shader features are plugin-based functionalities that are reusable between different material domains.
 struct MaterialShaderFeature
@@ -84,6 +86,25 @@ struct GlobalIlluminationFeature : MaterialShaderFeature
         {
         DynamicDiffuseGlobalIlluminationPass::ConstantsData DDGI;
         });
+
+    static bool Bind(MaterialShader::BindParameters& params, Span<byte>& cb, int32& srv);
+#if USE_EDITOR
+    static void Generate(GeneratorData& data);
+#endif
+};
+
+// Material shader feature that adds SDF Reflections feature (software reflections). 
+struct SDFReflectionsFeature : MaterialShaderFeature
+{
+    enum { SRVs = 7 };
+
+    PACK_STRUCT(struct Data
+    {
+        GlobalSignDistanceFieldPass::ConstantsData GlobalSDF;
+        GlobalSurfaceAtlasPass::ConstantsData GlobalSurfaceAtlas;
+    });
+
+    
 
     static bool Bind(MaterialShader::BindParameters& params, Span<byte>& cb, int32& srv);
 #if USE_EDITOR

--- a/Source/Engine/Renderer/GI/GlobalSurfaceAtlasPass.cpp
+++ b/Source/Engine/Renderer/GI/GlobalSurfaceAtlasPass.cpp
@@ -360,6 +360,17 @@ void GlobalSurfaceAtlasPass::Dispose()
     _shader = nullptr;
 }
 
+bool GlobalSurfaceAtlasPass::Get(const RenderBuffers* buffers, BindingData& result)
+{
+    auto* surfaceAtlasData = buffers ? buffers->FindCustomBuffer<GlobalSurfaceAtlasCustomBuffer>(TEXT("GlobalSurfaceAtlas")) : nullptr;
+    if (surfaceAtlasData && surfaceAtlasData->LastFrameUsed + 1 >= Engine::FrameCount) // Allow to use Surface Atlas from the previous frame (not used currently)
+    {
+        result = surfaceAtlasData->Result;
+        return false;
+    }
+    return true;
+}
+
 bool GlobalSurfaceAtlasPass::Render(RenderContext& renderContext, GPUContext* context, BindingData& result)
 {
     // Skip if not supported

--- a/Source/Engine/Renderer/GI/GlobalSurfaceAtlasPass.h
+++ b/Source/Engine/Renderer/GI/GlobalSurfaceAtlasPass.h
@@ -66,6 +66,14 @@ private:
 
 public:
     /// <summary>
+    /// Gets the Global Surface Atlas (only if enabled in Graphics Settings).
+    /// </summary>
+    /// <param name="buffers">The rendering context buffers.</param>
+    /// <param name="result">The result Global Surface Atlas data for binding to the shaders.</param>
+    /// <returns>True if there is no valid Global Surface Atlas rendered during this frame, otherwise false.</returns>
+    bool Get(const RenderBuffers* buffers, BindingData& result);
+
+    /// <summary>
     /// Renders the Global Surface Atlas.
     /// </summary>
     /// <param name="renderContext">The rendering context.</param>

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
@@ -199,6 +199,8 @@ bool MaterialGenerator::Generate(WriteStream& source, MaterialInfo& materialInfo
         ADD_FEATURE(DistortionFeature);
         if (materialInfo.BlendMode != MaterialBlendMode::Opaque && EnumHasAnyFlags(materialInfo.FeaturesFlags, MaterialFeaturesFlags::GlobalIllumination))
         ADD_FEATURE(GlobalIlluminationFeature);
+        if (materialInfo.BlendMode != MaterialBlendMode::Opaque && EnumHasAnyFlags(materialInfo.FeaturesFlags, MaterialFeaturesFlags::ScreenSpaceReflections))
+        ADD_FEATURE(SDFReflectionsFeature);
         if (materialInfo.BlendMode != MaterialBlendMode::Opaque)
         ADD_FEATURE(ForwardShadingFeature);
         break;

--- a/Source/Shaders/SSR.shader
+++ b/Source/Shaders/SSR.shader
@@ -150,8 +150,8 @@ float4 PS_RayTracePass(Quad_VS2PS input) : SV_Target0
         float surfaceThreshold = GetGlobalSurfaceAtlasThreshold(GlobalSDF, sdfHit);
         float4 surfaceAtlas = SampleGlobalSurfaceAtlas(GlobalSurfaceAtlas, GlobalSurfaceAtlasChunks, RWGlobalSurfaceAtlasCulledObjects, GlobalSurfaceAtlasObjects, GlobalSurfaceAtlasDepth, GlobalSurfaceAtlasTex, hitPosition, -reflectWS, surfaceThreshold);
         // Now the sdf reflection part is significantly darker than the screen space part
-		// TODO: Maybe multiply surfaceAtlas by a constant to make it brighter
-		result = lerp(surfaceAtlas, float4(result.rgb, 1), result.a);
+		// TODO: Maybe multiply surfaceAtlas by a constant to make it brighter, adding 2* looks fine
+		result = lerp(2 * surfaceAtlas, float4(result.rgb, 1), result.a);
     }
 #endif
 


### PR DESCRIPTION
Add software reflections support for forward pass materials, fixes #2703.  
Note: SDF reflections takes 7 texture slots and it's costly, so maybe add a material option to enable or disable it.  

Showcase: 
![SoftRefl](https://github.com/FlaxEngine/FlaxEngine/assets/33123710/106867e1-ab69-408a-a876-c0b61fb85c22)

The third picture may not look as good as the first one since there's no SSR blurring in forward pass, but it quite resembles the first overall. The strange patterns (also seen in the opaque version) are due to the inaccuracy of the SDF itself, not caused by rendering artifacts. 