### PR TITLE
Fix the profiler charts in place and only scroll profiler info.

### DIFF
--- a/Source/Editor/Windows/Profiler/Assets.cs
+++ b/Source/Editor/Windows/Profiler/Assets.cs
@@ -38,11 +38,28 @@ namespace FlaxEditor.Windows.Profiler
         : base("Assets")
         {
             // Layout
-            var panel = new Panel(ScrollBars.Vertical)
+            var mainPanel = new Panel(ScrollBars.None)
             {
                 AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = Margin.Zero,
                 Parent = this,
+            };
+            
+            // Chart
+            _memoryUsageChart = new SingleChart
+            {
+                Title = "Assets Memory Usage (CPU)",
+                AnchorPreset = AnchorPresets.HorizontalStretchTop,
+                FormatSample = v => Utilities.Utils.FormatBytesCount((int)v),
+                Parent = mainPanel,
+            };
+            _memoryUsageChart.SelectedSampleChanged += OnSelectedSampleChanged;
+
+            var panel = new Panel(ScrollBars.Vertical)
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(0, 0, _memoryUsageChart.Height + 2, 0),
+                Parent = mainPanel,
             };
             var layout = new VerticalPanel
             {
@@ -51,15 +68,6 @@ namespace FlaxEditor.Windows.Profiler
                 IsScrollable = true,
                 Parent = panel,
             };
-
-            // Chart
-            _memoryUsageChart = new SingleChart
-            {
-                Title = "Assets Memory Usage (CPU)",
-                FormatSample = v => Utilities.Utils.FormatBytesCount((int)v),
-                Parent = layout,
-            };
-            _memoryUsageChart.SelectedSampleChanged += OnSelectedSampleChanged;
 
             // Table
             var style = Style.Current;

--- a/Source/Editor/Windows/Profiler/CPU.cs
+++ b/Source/Editor/Windows/Profiler/CPU.cs
@@ -57,12 +57,30 @@ namespace FlaxEditor.Windows.Profiler
         : base("CPU")
         {
             // Layout
-            var panel = new Panel(ScrollBars.Vertical)
+            var mainPanel = new Panel(ScrollBars.None)
             {
                 AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = Margin.Zero,
                 Parent = this,
             };
+            
+            // Chart
+            _mainChart = new SingleChart
+            {
+                Title = "Update",
+                AnchorPreset = AnchorPresets.HorizontalStretchTop,
+                FormatSample = v => (Mathf.RoundToInt(v * 10.0f) / 10.0f) + " ms",
+                Parent = mainPanel,
+            };
+            _mainChart.SelectedSampleChanged += OnSelectedSampleChanged;
+            
+            var panel = new Panel(ScrollBars.Vertical)
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(0, 0, _mainChart.Height + 2, 0),
+                Parent = mainPanel,
+            };
+            //panel.Y = _mainChart.Height + 2;
             var layout = new VerticalPanel
             {
                 AnchorPreset = AnchorPresets.HorizontalStretchTop,
@@ -70,16 +88,7 @@ namespace FlaxEditor.Windows.Profiler
                 IsScrollable = true,
                 Parent = panel,
             };
-
-            // Chart
-            _mainChart = new SingleChart
-            {
-                Title = "Update",
-                FormatSample = v => (Mathf.RoundToInt(v * 10.0f) / 10.0f) + " ms",
-                Parent = layout,
-            };
-            _mainChart.SelectedSampleChanged += OnSelectedSampleChanged;
-
+            
             // Timeline
             _timeline = new Timeline
             {

--- a/Source/Editor/Windows/Profiler/GPU.cs
+++ b/Source/Editor/Windows/Profiler/GPU.cs
@@ -25,11 +25,38 @@ namespace FlaxEditor.Windows.Profiler
         : base("GPU")
         {
             // Layout
-            var panel = new Panel(ScrollBars.Vertical)
+            var mainPanel = new Panel(ScrollBars.None)
             {
                 AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = Margin.Zero,
                 Parent = this,
+            };
+            
+            // Chart
+            _drawTimeCPU = new SingleChart
+            {
+                Title = "Draw (CPU)",
+                AnchorPreset = AnchorPresets.HorizontalStretchTop,
+                FormatSample = v => (Mathf.RoundToInt(v * 10.0f) / 10.0f) + " ms",
+                Parent = mainPanel,
+            };
+            _drawTimeCPU.SelectedSampleChanged += OnSelectedSampleChanged;
+            
+            _drawTimeGPU = new SingleChart
+            {
+                Title = "Draw (GPU)",
+                AnchorPreset = AnchorPresets.HorizontalStretchTop,
+                Offsets = new Margin(0, 0, _drawTimeCPU.Height + 2, 0),
+                FormatSample = v => (Mathf.RoundToInt(v * 10.0f) / 10.0f) + " ms",
+                Parent = mainPanel,
+            };
+            _drawTimeGPU.SelectedSampleChanged += OnSelectedSampleChanged;
+            
+            var panel = new Panel(ScrollBars.Vertical)
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(0, 0, _drawTimeCPU.Height + _drawTimeGPU.Height + 4, 0),
+                Parent = mainPanel,
             };
             var layout = new VerticalPanel
             {
@@ -38,22 +65,6 @@ namespace FlaxEditor.Windows.Profiler
                 IsScrollable = true,
                 Parent = panel,
             };
-
-            // Chart
-            _drawTimeCPU = new SingleChart
-            {
-                Title = "Draw (CPU)",
-                FormatSample = v => (Mathf.RoundToInt(v * 10.0f) / 10.0f) + " ms",
-                Parent = layout,
-            };
-            _drawTimeCPU.SelectedSampleChanged += OnSelectedSampleChanged;
-            _drawTimeGPU = new SingleChart
-            {
-                Title = "Draw (GPU)",
-                FormatSample = v => (Mathf.RoundToInt(v * 10.0f) / 10.0f) + " ms",
-                Parent = layout,
-            };
-            _drawTimeGPU.SelectedSampleChanged += OnSelectedSampleChanged;
 
             // Timeline
             _timeline = new Timeline

--- a/Source/Editor/Windows/Profiler/MemoryGPU.cs
+++ b/Source/Editor/Windows/Profiler/MemoryGPU.cs
@@ -39,11 +39,28 @@ namespace FlaxEditor.Windows.Profiler
         : base("GPU Memory")
         {
             // Layout
-            var panel = new Panel(ScrollBars.Vertical)
+            var mainPanel = new Panel(ScrollBars.None)
             {
                 AnchorPreset = AnchorPresets.StretchAll,
                 Offsets = Margin.Zero,
                 Parent = this,
+            };
+            
+            // Chart
+            _memoryUsageChart = new SingleChart
+            {
+                Title = "GPU Memory Usage",
+                AnchorPreset = AnchorPresets.HorizontalStretchTop,
+                FormatSample = v => Utilities.Utils.FormatBytesCount((int)v),
+                Parent = mainPanel,
+            };
+            _memoryUsageChart.SelectedSampleChanged += OnSelectedSampleChanged;
+
+            var panel = new Panel(ScrollBars.Vertical)
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(0, 0, _memoryUsageChart.Height + 2, 0),
+                Parent = mainPanel,
             };
             var layout = new VerticalPanel
             {
@@ -52,15 +69,6 @@ namespace FlaxEditor.Windows.Profiler
                 IsScrollable = true,
                 Parent = panel,
             };
-
-            // Chart
-            _memoryUsageChart = new SingleChart
-            {
-                Title = "GPU Memory Usage",
-                FormatSample = v => Utilities.Utils.FormatBytesCount((int)v),
-                Parent = layout,
-            };
-            _memoryUsageChart.SelectedSampleChanged += OnSelectedSampleChanged;
 
             // Table
             var style = Style.Current;


### PR DESCRIPTION
Fix #1874 

This fixes the issue by only scrolling the info and not the chart as seen below.
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/e5d6f14b-7f96-46dd-a9b5-ab4eec92213f)
