### PR TITLE
Change to invariant culture for unknown LCID.

### DIFF
--- a/Source/Engine/Localization/CultureInfo.cpp
+++ b/Source/Engine/Localization/CultureInfo.cpp
@@ -74,6 +74,8 @@ CultureInfo::CultureInfo(int32 lcid)
     }
     if (!_data)
     {
+        _lcid = 127;
+        _lcidParent = 0;
         _englishName = TEXT("Invariant Culture");
         LOG(Error, "Unknown LCID {0} for CultureInfo", lcid);
     }


### PR DESCRIPTION
This change successfully changes the culture to invariant culture if LCID is unknown.
Fix #2240 