### PR TITLE
Dont show Select prefab, Edit prefab, and view changes buttons when editing actor in the prefab.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -67,32 +67,35 @@ namespace FlaxEditor.CustomEditors.Dedicated
                         // Use default prefab instance as a reference for the editor
                         Values.SetReferenceValue(prefabInstance);
 
-                        // Add some UI
-                        var panel = layout.CustomContainer<UniformGridPanel>();
-                        panel.CustomControl.Height = 20.0f;
-                        panel.CustomControl.SlotsVertically = 1;
-                        panel.CustomControl.SlotsHorizontally = 3;
-
-                        // Selecting actor prefab asset
-                        var selectPrefab = panel.Button("Select Prefab");
-                        selectPrefab.Button.Clicked += () =>
+                        if (Presenter == Editor.Instance.Windows.PropertiesWin.Presenter)
                         {
-                            Editor.Instance.Windows.ContentWin.ClearItemsSearch();
-                            Editor.Instance.Windows.ContentWin.Select(prefab);
-                        };
+                            // Add some UI
+                            var panel = layout.CustomContainer<UniformGridPanel>();
+                            panel.CustomControl.Height = 20.0f;
+                            panel.CustomControl.SlotsVertically = 1;
+                            panel.CustomControl.SlotsHorizontally = 3;
+                            
+                            // Selecting actor prefab asset
+                            var selectPrefab = panel.Button("Select Prefab");
+                            selectPrefab.Button.Clicked += () =>
+                            {
+                                Editor.Instance.Windows.ContentWin.ClearItemsSearch();
+                                Editor.Instance.Windows.ContentWin.Select(prefab);
+                            };
 
-                        // Edit selected prefab asset
-                        var editPrefab = panel.Button("Edit Prefab");
-                        editPrefab.Button.Clicked += () =>
-                        {
-                            Editor.Instance.Windows.ContentWin.ClearItemsSearch();
-                            Editor.Instance.Windows.ContentWin.Select(prefab);
-                            Editor.Instance.Windows.ContentWin.Open(Editor.Instance.Windows.ContentWin.View.Selection[0]);
-                        };
+                            // Edit selected prefab asset
+                            var editPrefab = panel.Button("Edit Prefab");
+                            editPrefab.Button.Clicked += () =>
+                            {
+                                Editor.Instance.Windows.ContentWin.ClearItemsSearch();
+                                Editor.Instance.Windows.ContentWin.Select(prefab);
+                                Editor.Instance.Windows.ContentWin.Open(Editor.Instance.Windows.ContentWin.View.Selection[0]);
+                            };
 
-                        // Viewing changes applied to this actor
-                        var viewChanges = panel.Button("View Changes");
-                        viewChanges.Button.Clicked += () => ViewChanges(viewChanges.Button, new Float2(0.0f, 20.0f));
+                            // Viewing changes applied to this actor
+                            var viewChanges = panel.Button("View Changes");
+                            viewChanges.Button.Clicked += () => ViewChanges(viewChanges.Button, new Float2(0.0f, 20.0f));
+                        }
 
                         // Link event to update editor on prefab apply
                         _linkedPrefabId = prefab.ID;


### PR DESCRIPTION
This will only show these buttons in the properties panel and will not show them while editing an actor in the prefab asset itself as they are not needed there.
![image](https://github.com/FlaxEngine/FlaxEngine/assets/71274967/4cf039fc-5d75-4ecc-b253-ca97f4e18123)
