### PR TITLE
Select all assets and scripts that are dropped in the tree panel.

### DIFF
--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -160,16 +160,23 @@ namespace FlaxEditor.Windows.Assets
                 var result = base.OnDragDrop(ref location, data);
                 if (result == DragDropEffect.None)
                 {
+                    _window._isDragging = true;
                     // Drag assets
                     if (_dragAssets != null && _dragAssets.HasValidDrag)
                     {
+                        List<SceneGraphNode> graphNodes = new List<SceneGraphNode>();
                         for (int i = 0; i < _dragAssets.Objects.Count; i++)
                         {
                             var item = _dragAssets.Objects[i];
                             var actor = item.OnEditorDrop(this);
                             actor.Name = item.ShortName;
                             _window.Spawn(actor);
+                            var graphNode = _window.Graph.Root.Find(actor);;
+                            if (graphNode != null)
+                                graphNodes.Add(graphNode);
                         }
+                        if (graphNodes.Count > 0)
+                            _window.Select(graphNodes);
                         result = DragDropEffect.Move;
                     }
                     // Drag actor type
@@ -213,6 +220,7 @@ namespace FlaxEditor.Windows.Assets
                     // Drag script item
                     else if (_dragScriptItems != null && _dragScriptItems.HasValidDrag)
                     {
+                        List<SceneGraphNode> graphNodes = new List<SceneGraphNode>();
                         for (int i = 0; i < _dragScriptItems.Objects.Count; i++)
                         {
                             var item = _dragScriptItems.Objects[i];
@@ -227,8 +235,13 @@ namespace FlaxEditor.Windows.Assets
                                 }
                                 actor.Name = actorType.Name;
                                 _window.Spawn(actor);
+                                var graphNode = _window.Graph.Root.Find(actor);;
+                                if (graphNode != null)
+                                    graphNodes.Add(graphNode);
                             }
                         }
+                        if (graphNodes.Count > 0)
+                            _window.Select(graphNodes);
                         result = DragDropEffect.Move;
                     }
                     _dragHandlers.OnDragDrop(null);

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -160,7 +160,7 @@ namespace FlaxEditor.Windows.Assets
                 var result = base.OnDragDrop(ref location, data);
                 if (result == DragDropEffect.None)
                 {
-                    _window._isDragging = true;
+                    _window._isDropping = true;
                     // Drag assets
                     if (_dragAssets != null && _dragAssets.HasValidDrag)
                     {

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -42,7 +42,7 @@ namespace FlaxEditor.Windows.Assets
         private bool _liveReload = false;
         private bool _isUpdatingSelection, _isScriptsReloading;
         private DateTime _modifiedTime = DateTime.MinValue;
-        private bool _isDragging = false;
+        private bool _isDropping = false;
 
         /// <summary>
         /// Gets the prefab hierarchy tree control.
@@ -274,14 +274,14 @@ namespace FlaxEditor.Windows.Assets
                 return true;
             }
 
-            if (button == MouseButton.Left && _treePanel.ContainsPoint(ref location) && !_isDragging)
+            if (button == MouseButton.Left && _treePanel.ContainsPoint(ref location) && !_isDropping)
             {
                 _tree.Deselect();
                 return true;
             }
-            if (_isDragging)
+            if (_isDropping)
             {
-                _isDragging = false;
+                _isDropping = false;
                 return true;
             }
             return false;

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -42,6 +42,7 @@ namespace FlaxEditor.Windows.Assets
         private bool _liveReload = false;
         private bool _isUpdatingSelection, _isScriptsReloading;
         private DateTime _modifiedTime = DateTime.MinValue;
+        private bool _isDragging = false;
 
         /// <summary>
         /// Gets the prefab hierarchy tree control.
@@ -273,9 +274,14 @@ namespace FlaxEditor.Windows.Assets
                 return true;
             }
 
-            if (button == MouseButton.Left && _treePanel.ContainsPoint(ref location))
+            if (button == MouseButton.Left && _treePanel.ContainsPoint(ref location) && !_isDragging)
             {
                 _tree.Deselect();
+                return true;
+            }
+            if (_isDragging)
+            {
+                _isDragging = false;
                 return true;
             }
             return false;

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -33,6 +33,7 @@ namespace FlaxEditor.Windows
         private DragControlType _dragControlType;
         private DragScriptItems _dragScriptItems;
         private DragHandlers _dragHandlers;
+        private bool _isDropping = false;
 
         /// <summary>
         /// Scene tree panel.
@@ -356,10 +357,12 @@ namespace FlaxEditor.Windows
 
             if (buttons == MouseButton.Left)
             {
-                if (Editor.StateMachine.CurrentState.CanEditScene)
+                if (Editor.StateMachine.CurrentState.CanEditScene && !_isDropping)
                 {
                     Editor.SceneEditing.Deselect();
                 }
+                if (_isDropping)
+                    _isDropping = false;
                 return true;
             }
 
@@ -439,9 +442,11 @@ namespace FlaxEditor.Windows
             var result = base.OnDragDrop(ref location, data);
             if (result == DragDropEffect.None)
             {
+                _isDropping = true;
                 // Drag assets
                 if (_dragAssets != null && _dragAssets.HasValidDrag)
                 {
+                    List<SceneGraphNode> graphNodes = new List<SceneGraphNode>();
                     for (int i = 0; i < _dragAssets.Objects.Count; i++)
                     {
                         var item = _dragAssets.Objects[i];
@@ -453,8 +458,13 @@ namespace FlaxEditor.Windows
                         var actor = item.OnEditorDrop(this);
                         actor.Name = item.ShortName;
                         Level.SpawnActor(actor);
+                        var graphNode = Editor.Scene.GetActorNode(actor.ID);
+                        if (graphNode != null)
+                            graphNodes.Add(graphNode);
                         Editor.Scene.MarkSceneEdited(actor.Scene);
                     }
+                    if (graphNodes.Count > 0)
+                        Editor.SceneEditing.Select(graphNodes);
                     result = DragDropEffect.Move;
                 }
                 // Drag actor type
@@ -500,6 +510,7 @@ namespace FlaxEditor.Windows
                 // Drag script item
                 else if (_dragScriptItems != null && _dragScriptItems.HasValidDrag)
                 {
+                    List<SceneGraphNode> graphNodes = new List<SceneGraphNode>();
                     for (int i = 0; i < _dragScriptItems.Objects.Count; i++)
                     {
                         var item = _dragScriptItems.Objects[i];
@@ -514,9 +525,14 @@ namespace FlaxEditor.Windows
                             }
                             actor.Name = actorType.Name;
                             Level.SpawnActor(actor);
+                            var graphNode = Editor.Scene.GetActorNode(actor.ID);
+                            if (graphNode != null)
+                                graphNodes.Add(graphNode);
                             Editor.Scene.MarkSceneEdited(actor.Scene);
                         }
                     }
+                    if (graphNodes.Count > 0)
+                        Editor.SceneEditing.Select(graphNodes);
                     result = DragDropEffect.Move;
                 }
 


### PR DESCRIPTION
When dragging assets and scripts directly in the tree panel (scene and prefab) and not under an actor node, they are not automatically selected. This PR handles automatically selecting all of the dropped assets/scripts in those panels.