### PR TITLE
Lightmap UV Material Node

### DIFF
--- a/Source/Editor/Surface/Archetypes/Textures.cs
+++ b/Source/Editor/Surface/Archetypes/Textures.cs
@@ -434,6 +434,19 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.ComboBox(50, Surface.Constants.LayoutOffsetY * 4, 100, 0, typeof(CommonSamplerType))
                 }
             },
+            new NodeArchetype
+            {
+                TypeID = 18,
+                Title = "Lightmap UV",
+                AlternativeTitles = new string[] { "Lightmap TexCoord" }, 
+                Description = "Lightmap UVs",
+                Flags = NodeFlags.MaterialGraph,
+                Size = new Float2(110, 30),
+                Elements = new []
+                {
+                    NodeElementArchetype.Factory.Output(0, "UVs", typeof(Float2), 0)
+                }
+            }
         };
     }
 }

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Textures.cpp
@@ -733,6 +733,25 @@ void MaterialGenerator::ProcessGroupTextures(Box* box, Node* node, Value& value)
         _writer.Write(*triplanarTexture);
         value = result;
     }
+    // Get Lightmap UV
+    case 18: 
+    {
+        auto output = writeLocal(Value::InitForZero(ValueType::Float2), node);
+        auto lightmapUV = String::Format(TEXT(
+            "{{\n"
+            "#if USE_LIGHTMAP\n"
+            "\t {0} = input.LightmapUV;\n"
+            "#else\n"
+            "\t {0} = float2(0,0);\n"
+            "#endif\n"
+            "}}\n"
+        ), output.Value);
+
+        _writer.Write(*lightmapUV);
+
+        value = output;
+        break;
+    }
     default:
         break;
     }


### PR DESCRIPTION
Simply adds a new node to the material graph that returns the Lightmap UV or (0, 0) if it is not available.

Happy to make this return the UV instead if a lightmap UV is not available but this could also make things confusing?