### PR TITLE
Call `Actor::OnBeginPlay` by collecting all actors instead of hierarchical by children

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -875,14 +875,6 @@ void Actor::BeginPlay(SceneBeginData* data)
             e->BeginPlay(data);
     }
 
-    // Update children
-    for (int32 i = 0; i < Children.Count(); i++)
-    {
-        auto e = Children.Get()[i];
-        if (!e->IsDuringPlay())
-            e->BeginPlay(data);
-    }
-
     // Fire events for scripting
     if (IsActiveInHierarchy() && GetScene() && !_isEnabled)
     {

--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -1076,6 +1076,13 @@ bool Level::loadScene(rapidjson_flax::Value& data, int32 engineBuild, Scene** ou
         Scenes.Add(scene);
         SceneBeginData beginData;
         scene->BeginPlay(&beginData);
+        Array<Actor*> sceneActors = scene->GetActors(Actor::GetStaticClass());
+        for (int i = 0; i < sceneActors.Count(); i++)
+        {
+            auto a = sceneActors[i];
+            if (!a->IsDuringPlay())
+                a->BeginPlay(&beginData);
+        }
         beginData.OnDone();
     }
 

--- a/Source/Engine/Level/Scene/Scene.cpp
+++ b/Source/Engine/Level/Scene/Scene.cpp
@@ -13,6 +13,7 @@
 #include "Engine/Navigation/NavMeshBoundsVolume.h"
 #include "Engine/Navigation/NavMesh.h"
 #include "Engine/Profiler/ProfilerCPU.h"
+#include "Engine/Scripting/ManagedCLR/MClass.h"
 #include "Engine/Serialization/Serialization.h"
 #if USE_EDITOR
 #include "Engine/Engine/Globals.h"
@@ -102,6 +103,26 @@ void Scene::ClearLightmaps()
 void Scene::BuildCSG(float timeoutMs)
 {
     CSGData.BuildCSG(timeoutMs);
+}
+
+Array<Actor*> Scene::GetActors(const MClass* type, bool activeOnly)
+{
+    Array<Actor*> result;
+    CHECK_RETURN(type, result);
+    for (int32 i = 0; i < Children.Count(); i++)
+        GetActors(type, Children.Get()[i], activeOnly, result);
+    return result;
+}
+
+
+void Scene::GetActors(const MClass* type, Actor* actor, bool activeOnly, Array<Actor*>& result)
+{
+    if (activeOnly && !actor->GetIsActive())
+        return;
+    if (actor->GetClass()->IsSubClassOf(type))
+        result.Add(actor);
+    for (auto child : actor->Children)
+        GetActors(type, child, activeOnly, result);
 }
 
 #if USE_EDITOR

--- a/Source/Engine/Level/Scene/Scene.h
+++ b/Source/Engine/Level/Scene/Scene.h
@@ -81,6 +81,14 @@ public:
     /// <param name="timeoutMs">The timeout to wait before building CSG (in milliseconds).</param>
     API_FUNCTION() void BuildCSG(float timeoutMs = 50);
 
+    /// <summary>
+    /// Finds all the actors of the given type in the scene.
+    /// </summary>
+    /// <param name="type">Type of the actor to search for. Includes any actors derived from the type.</param>
+    /// <param name="activeOnly">Finds only active actors in the scene.</param>
+    /// <returns>Found actors list.</returns>
+    API_FUNCTION() Array<Actor*> GetActors(API_PARAM(Attributes="TypeReference(typeof(Actor))") const MClass* type, bool activeOnly = false);
+
 #if USE_EDITOR
 
     /// <summary>
@@ -113,6 +121,7 @@ private:
     void CreateCsgCollider();
     void CreateCsgModel();
     void OnCsgCollisionDataChanged();
+    void GetActors(const MClass* type, Actor* actor, bool activeOnly, Array<Actor*>& result);
     void OnCsgModelChanged();
 #if COMPILE_WITH_CSG_BUILDER
     void OnCSGBuildEnd();


### PR DESCRIPTION
This allows for parents to be changed on start in a Script.

This does run slower than the previous solution, but it doesn't rely on the parent/child actor relationship to initialize the actor.

Fix #2751
Fix #2623