### PR TITLE
Fix mesh collider not inverting correctly due to negative scale.

### DIFF
--- a/Source/Engine/Physics/Colliders/MeshCollider.cpp
+++ b/Source/Engine/Physics/Colliders/MeshCollider.cpp
@@ -133,7 +133,13 @@ void MeshCollider::GetGeometry(CollisionShape& collision)
     // Prepare scale
     Float3 scale = _cachedScale;
     const float minSize = 0.001f;
-    scale = Float3::Max(scale.GetAbsolute(), minSize);
+    Float3 scaleAbs = scale.GetAbsolute();
+    if (scaleAbs.X < minSize)
+        scale.X = Math::Sign(scale.X) * minSize;
+    if (scaleAbs.Y < minSize)
+        scale.Y = Math::Sign(scale.Y) * minSize;
+    if (scaleAbs.Z < minSize)
+        scale.Z = Math::Sign(scale.Z) * minSize;
 
     // Setup shape (based on type)
     CollisionDataType type = CollisionDataType::None;


### PR DESCRIPTION
Fix #2737 

I am sure there is a probably a better fix for this somewhere, but this seems to work.