### PR TITLE
Fix Quaternion.FromDirection giving bogus output when fed a perfect down vector

### DIFF
--- a/Source/Engine/Core/Math/Quaternion.cpp
+++ b/Source/Engine/Core/Math/Quaternion.cpp
@@ -294,6 +294,10 @@ Quaternion Quaternion::FromDirection(const Float3& direction)
     {
         RotationAxis(Float3::Left, PI_OVER_2, orientation);
     }
+    else if (Float3::Dot(direction, Float3::Down) >= 0.999f)
+    {
+        RotationAxis(Float3::Right, PI_OVER_2, orientation);
+    }
     else
     {
         Float3 right, up;

--- a/Source/Engine/Core/Math/Quaternion.cs
+++ b/Source/Engine/Core/Math/Quaternion.cs
@@ -654,6 +654,10 @@ namespace FlaxEngine
             {
                 orientation = RotationAxis(Float3.Left, Mathf.PiOverTwo);
             }
+            else if (Float3.Dot(direction, Float3.Down) >= 0.999f)
+            {
+                orientation = RotationAxis(Float3.Right, Mathf.PiOverTwo);
+            }
             else
             {
                 var right = Float3.Cross(direction, Float3.Up);


### PR DESCRIPTION
Fixes Quaternion.FromDirection on both c# and c++ side where it would have an issue when fed a perfect down vector (if both X and Z components were zero, it would go at an odd angle)

see video of bug that this PR fixes:
Red line is constructed by
```
DebugDraw.DrawLine(cursorPosition, cursorPosition + cursorPlane.Normal * 100.0f, Color.Red, 0.0f, false);
```
Blue line is constructed by
```
Quaternion quat = Quaternion.FromDirection(cursorPlane.Normal);
DebugDraw.DrawLine(cursorPosition, cursorPosition + (Vector3.Forward * quat) * 200.0f, Color.Blue, 0.0f, false);
```

https://github.com/user-attachments/assets/5301931d-80b5-4839-9bb7-2bc6a21d231f

After fix:

https://github.com/user-attachments/assets/958ba08b-977d-45f7-90c7-2a6642ba6005

