### PR TITLE
Added eDETECT_CCD_CONTACT to PairFlags, hopefully properly enabling CCD for PhysX

### DIFF
--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -666,6 +666,8 @@ PxFilterFlags FilterShader(
 {
     const bool maskTest = (filterData0.word0 & filterData1.word1) && (filterData1.word0 & filterData0.word1);
 
+    auto& settings = *PhysicsSettings::Get();
+
     // Let triggers through
     if (PxFilterObjectIsTrigger(attributes0) || PxFilterObjectIsTrigger(attributes1))
     {
@@ -697,6 +699,8 @@ PxFilterFlags FilterShader(
         pairFlags |= PxPairFlag::eNOTIFY_TOUCH_LOST;
         pairFlags |= PxPairFlag::ePOST_SOLVER_VELOCITY;
         pairFlags |= PxPairFlag::eNOTIFY_CONTACT_POINTS;
+        if (!settings.DisableCCD) 
+            pairFlags |= PxPairFlag::eDETECT_CCD_CONTACT;
         return PxFilterFlag::eDEFAULT;
     }
 


### PR DESCRIPTION
This PR simply does what the title says. After many posts about CCD seemingly not working I took it upon myself to maybe see why and noticed there was no `eDETECT_CCD_CONTACT` flag anywhere, which is seemingly required for CCD to work.

https://github.com/user-attachments/assets/c6b5e366-5d2e-4209-a707-1230783be09b

https://github.com/user-attachments/assets/c83696b3-09ca-463a-bcc6-8d707394f3e5

Attached is a demonstration of the before and after with the Third Person Sample, which is typically used to show that CCD is not working.

Not 100% sure if my implementation is correct but it seems to work for me. Both Rigidbodies need CCD enabled and disabling CCD in the PhysicsSettings returns the broken functionality.