### PR TITLE
Remove redundant first tab on floating window.

### DIFF
--- a/Source/Editor/GUI/Docking/DockPanelProxy.cs
+++ b/Source/Editor/GUI/Docking/DockPanelProxy.cs
@@ -187,6 +187,10 @@ namespace FlaxEditor.GUI.Docking
             var headerRect = HeaderRectangle;
             var tabsCount = _panel.TabsCount;
 
+            // Return and don't draw tab if only 1 window and it is floating
+            if (_panel.IsFloating && tabsCount == 1 && _panel.ChildPanelsCount == 0)
+                return;
+ 
             // Check if has only one window docked
             if (tabsCount == 1)
             {
@@ -501,7 +505,10 @@ namespace FlaxEditor.GUI.Docking
         /// <inheritdoc />
         public override void GetDesireClientArea(out Rectangle rect)
         {
-            rect = new Rectangle(0, DockPanel.DefaultHeaderHeight, Width, Height - DockPanel.DefaultHeaderHeight);
+            if (_panel.TabsCount == 1 && _panel.IsFloating && _panel.ChildPanelsCount == 0)
+                rect = new Rectangle(0, 0, Width, Height);
+            else
+                rect = new Rectangle(0, DockPanel.DefaultHeaderHeight, Width, Height - DockPanel.DefaultHeaderHeight);
         }
 
         private DragDropEffect TrySelectTabUnderLocation(ref Float2 location)


### PR DESCRIPTION
Removes the redundant first tab on a floating editor window. Adding tabs will work the same as before.

Before:
![image](https://github.com/user-attachments/assets/953786b7-5233-4602-8c7e-e9df4ecc8c69)


After:
![image](https://github.com/user-attachments/assets/2ff31745-ac1c-463b-8efa-9916f41c7757)

