### PR TITLE
Perform layout of splitter panel once splitter is done being dragged.

### DIFF
--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -130,6 +130,7 @@ namespace FlaxEngine.GUI
             {
                 // Clear flag
                 _splitterClicked = false;
+                PerformLayout();
 
                 // End capturing mouse
                 EndMouseCapture();


### PR DESCRIPTION
This fixes the issue of the horizonal scrollbars staying visible after one of the panel has been shrunk due to a splitter being moved.