### PR TITLE
Add type display to empty object ref in editor

### DIFF
--- a/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
@@ -208,7 +208,7 @@ namespace FlaxEditor.CustomEditors.Editors
             else
             {
                 // Draw info
-                Render2D.DrawText(style.FontMedium, "-", nameRect, isEnabled ? Color.OrangeRed : Color.DarkOrange, TextAlignment.Near, TextAlignment.Center);
+                Render2D.DrawText(style.FontMedium, Type != null ? $"None ({Utilities.Utils.GetPropertyNameUI(Type.ToString())})" : "-", nameRect, isEnabled ? Color.OrangeRed : Color.DarkOrange, TextAlignment.Near, TextAlignment.Center);
             }
 
             // Draw picker button


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ea5a2187-fc1f-41b4-89a5-f9a876afb491)
