### PR TITLE
Allow for injecting scene children on scene loading

### DIFF
--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -1042,7 +1042,6 @@ bool Level::loadScene(rapidjson_flax::Value& data, int32 engineBuild, Scene** ou
         {
             child->RegisterObject();
         }
-        LOG(Warning, "{}", child->GetName());
     }
     sceneObjects->Resize(dataCount + injectedSceneChildren.Count());
 

--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -1037,10 +1037,14 @@ bool Level::loadScene(rapidjson_flax::Value& data, int32 engineBuild, Scene** ou
     // Add injected children of scene (via OnSceneLoading) into sceneObjects to be initialized
     for (auto child : injectedSceneChildren)
     {
-        sceneObjects->Add(child);
-        if (!child->IsRegistered())
+        Array<SceneObject*> injectedSceneObjects;
+        injectedSceneObjects.Add(child);
+        SceneQuery::GetAllSceneObjects(child, injectedSceneObjects);
+        for (auto o : injectedSceneObjects)
         {
-            child->RegisterObject();
+            if (!o->IsRegistered())
+                o->RegisterObject();
+            sceneObjects->Add(o);
         }
     }
 

--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -1043,7 +1043,6 @@ bool Level::loadScene(rapidjson_flax::Value& data, int32 engineBuild, Scene** ou
             child->RegisterObject();
         }
     }
-    sceneObjects->Resize(dataCount + injectedSceneChildren.Count());
 
     // Synchronize prefab instances (prefab may have objects removed or reordered so deserialized instances need to synchronize with it)
     // TODO: resave and force sync scenes during game cooking so this step could be skipped in game
@@ -1061,7 +1060,7 @@ bool Level::loadScene(rapidjson_flax::Value& data, int32 engineBuild, Scene** ou
         PROFILE_CPU_NAMED("Initialize");
 
         SceneObject** objects = sceneObjects->Get();
-        for (int32 i = 0; i < dataCount + injectedSceneChildren.Count(); i++)
+        for (int32 i = 0; i < sceneObjects->Count(); i++)
         {
             SceneObject* obj = objects[i];
             if (obj)


### PR DESCRIPTION
This allows for code to inject actors during the `SceneLoading` event and for them to be initialized correctly.

Allows for code like this in a game plugin:
```
public override void Initialize()
{
     base.Initialize();
     Level.SceneLoading += OnSceneLoading;
}

private void OnSceneLoading(Scene scene, Guid sceneId)
{
     var testActor = scene.AddChild<TestActor1>();
     testActor.AddScript<PrintOnStart>();
}
```