### PR TITLE
Fix statically linked binary modules not getting compiled

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -500,7 +500,7 @@ namespace Flax.Build
                     }
 
                     // Compile C++ file with binary module (only for first module in the binary module to prevent multiple implementations)
-                    if (buildData.BinaryModules.FirstOrDefault(x => x.Key == module.BinaryModuleName)?.First() == module)
+                    if (buildData.BinaryModules.FirstOrDefault(x => x.Key == module.BinaryModuleName)?.First(x => !(x is DepsModule || x is HeaderOnlyModule)) == module)
                     {
                         var project = GetModuleProject(module, buildData);
                         var binaryModuleSourcePath = Path.Combine(project.ProjectFolderPath, "Source", module.BinaryModuleName + ".Gen.cpp");


### PR DESCRIPTION
The first module in the list might not be the expected module, which leaves out the statically linked binary module definition file to not be compiled at all. Noticed this issue while developing SDL module, which happened to be a `DepsModule` and always the first one on these lists.