### PR TITLE
Fix warnings about upcoming C# reserved keywords

### DIFF
--- a/Source/Editor/Content/Import/TextureImportEntry.cs
+++ b/Source/Editor/Content/Import/TextureImportEntry.cs
@@ -58,10 +58,10 @@ namespace FlaxEngine.Tools
                     FieldInfo[] fields = typeof(CustomMaxSizes).GetFields();
                     for (int i = 0; i < fields.Length; i++)
                     {
-                        var field = fields[i];
-                        if (field.Name.Equals("value__"))
+                        var @field = fields[i];
+                        if (@field.Name.Equals("value__"))
                             continue;
-                        if (value == (int)field.GetRawConstantValue())
+                        if (value == (int)@field.GetRawConstantValue())
                             return (CustomMaxSizes)value;
                     }
                     return CustomMaxSizes._8192;

--- a/Source/Editor/Scripting/ScriptType.cs
+++ b/Source/Editor/Scripting/ScriptType.cs
@@ -51,12 +51,12 @@ namespace FlaxEditor.Scripting
                 int standardToken = _managed?.MetadataToken ?? _custom?.MetadataToken ?? 0;
                 if (_managed is PropertyInfo && _managed.DeclaringType != null)
                 {
-                    var field = _managed.DeclaringType.GetField(string.Format("<{0}>k__BackingField", Name), BindingFlags.Instance | BindingFlags.NonPublic);
-                    if (field == null || field.MetadataToken == 0)
+                    var backingField = _managed.DeclaringType.GetField(string.Format("<{0}>k__BackingField", Name), BindingFlags.Instance | BindingFlags.NonPublic);
+                    if (backingField == null || backingField.MetadataToken == 0)
                     {
                         return standardToken;
                     }
-                    return field.MetadataToken;
+                    return backingField.MetadataToken;
                 }
                 return standardToken;
             }

--- a/Source/Engine/Core/Math/FloatR10G10B10A2.cs
+++ b/Source/Engine/Core/Math/FloatR10G10B10A2.cs
@@ -12,7 +12,7 @@ namespace FlaxEngine
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     public struct FloatR10G10B10A2
     {
-        private uint value;
+        private uint rawValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref = "T:FlaxEngine.FloatR10G10B10A2" /> structure.
@@ -23,7 +23,7 @@ namespace FlaxEngine
         /// <param name="w">The floating point value that should be stored in A component (2 bit format).</param>
         public FloatR10G10B10A2(float x, float y, float z, float w)
         {
-            value = Pack(x, y, z, w);
+            rawValue = Pack(x, y, z, w);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace FlaxEngine
         /// <param name="w">The floating point value that should be stored in alpha component (2 bit format).</param>
         public FloatR10G10B10A2(Float3 value, float w = 0)
         {
-            this.value = Pack(value.X, value.Y, value.Z, w);
+            rawValue = Pack(value.X, value.Y, value.Z, w);
         }
 
         /// <summary>
@@ -42,37 +42,33 @@ namespace FlaxEngine
         /// <param name = "value">The floating point value that should be stored in 10 bit format.</param>
         public FloatR10G10B10A2(Float4 value)
         {
-            this.value = Pack(value.X, value.Y, value.Z, value.W);
+            rawValue = Pack(value.X, value.Y, value.Z, value.W);
         }
 
         /// <summary>
         /// Gets or sets the raw 32 bit value used to back this vector.
         /// </summary>
-        public uint RawValue
-        {
-            get => value;
-            set => this.value = value;
-        }
+        public uint RawValue => rawValue;
 
         /// <summary>
         /// Gets the R component.
         /// </summary>
-        public float R => (value & 0x3FF) / 1023.0f;
+        public float R => (rawValue & 0x3FF) / 1023.0f;
 
         /// <summary>
         /// Gets the G component.
         /// </summary>
-        public float G => ((value >> 10) & 0x3FF) / 1023.0f;
+        public float G => ((rawValue >> 10) & 0x3FF) / 1023.0f;
 
         /// <summary>
         /// Gets the B component.
         /// </summary>
-        public float B => ((value >> 20) & 0x3FF) / 1023.0f;
+        public float B => ((rawValue >> 20) & 0x3FF) / 1023.0f;
 
         /// <summary>
         /// Gets the A component.
         /// </summary>
-        public float A => (value >> 30) / 3.0f;
+        public float A => (rawValue >> 30) / 3.0f;
 
         /// <summary>
         /// Performs an explicit conversion from <see cref = "T:FlaxEngine.Float4" /> to <see cref = "T:FlaxEngine.FloatR10G10B10A2" />.
@@ -102,7 +98,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name="left" /> has the same value as <paramref name="right" />; otherwise, <c>false</c>.</returns>
         public static bool operator ==(FloatR10G10B10A2 left, FloatR10G10B10A2 right)
         {
-            return left.value == right.value;
+            return left.rawValue == right.rawValue;
         }
 
         /// <summary>
@@ -113,7 +109,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name="left" /> has a different value than <paramref name="right" />; otherwise, <c>false</c>.</returns>
         public static bool operator !=(FloatR10G10B10A2 left, FloatR10G10B10A2 right)
         {
-            return left.value != right.value;
+            return left.rawValue != right.rawValue;
         }
 
         /// <summary>
@@ -131,7 +127,7 @@ namespace FlaxEngine
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return value.GetHashCode();
+            return rawValue.GetHashCode();
         }
 
         /// <summary>
@@ -142,7 +138,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name = "value1" /> is the same instance as <paramref name = "value2" /> or if both are <c>null</c> references or if <c>value1.Equals(value2)</c> returns <c>true</c>; otherwise, <c>false</c>.</returns>
         public static bool Equals(ref FloatR10G10B10A2 value1, ref FloatR10G10B10A2 value2)
         {
-            return value1.value == value2.value;
+            return value1.rawValue == value2.rawValue;
         }
 
         /// <summary>
@@ -152,7 +148,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the current instance is equal to the specified object; <c>false</c> otherwise.</returns>
         public bool Equals(FloatR10G10B10A2 other)
         {
-            return other.value == value;
+            return other.rawValue == rawValue;
         }
 
         /// <summary>
@@ -162,7 +158,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the current instance is equal to the specified object; <c>false</c> otherwise.</returns>
         public override bool Equals(object obj)
         {
-            return obj is FloatR10G10B10A2 other && value == other.value;
+            return obj is FloatR10G10B10A2 other && rawValue == other.rawValue;
         }
 
         private static uint Pack(float x, float y, float z, float w)
@@ -191,11 +187,11 @@ namespace FlaxEngine
         {
             Float3 vectorOut;
 
-            uint tmp = value & 0x3FF;
+            uint tmp = rawValue & 0x3FF;
             vectorOut.X = tmp / 1023.0f;
-            tmp = (value >> 10) & 0x3FF;
+            tmp = (rawValue >> 10) & 0x3FF;
             vectorOut.Y = tmp / 1023.0f;
-            tmp = (value >> 20) & 0x3FF;
+            tmp = (rawValue >> 20) & 0x3FF;
             vectorOut.Z = tmp / 1023.0f;
 
             return vectorOut;
@@ -209,13 +205,13 @@ namespace FlaxEngine
         {
             Float4 vectorOut;
 
-            uint tmp = value & 0x3FF;
+            uint tmp = rawValue & 0x3FF;
             vectorOut.X = tmp / 1023.0f;
-            tmp = (value >> 10) & 0x3FF;
+            tmp = (rawValue >> 10) & 0x3FF;
             vectorOut.Y = tmp / 1023.0f;
-            tmp = (value >> 20) & 0x3FF;
+            tmp = (rawValue >> 20) & 0x3FF;
             vectorOut.Z = tmp / 1023.0f;
-            vectorOut.W = (value >> 30) / 3.0f;
+            vectorOut.W = (rawValue >> 30) / 3.0f;
 
             return vectorOut;
         }

--- a/Source/Engine/Core/Math/FloatR11G11B10.cs
+++ b/Source/Engine/Core/Math/FloatR11G11B10.cs
@@ -21,7 +21,7 @@ namespace FlaxEngine
     {
         // Reference: [https://github.com/Microsoft/DirectXMath/blob/master/Inc/DirectXPackedVector.h]
 
-        private uint value;
+        private uint rawValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref = "T:FlaxEngine.FloatR11G11B10" /> structure.
@@ -31,7 +31,7 @@ namespace FlaxEngine
         /// <param name="z">The floating point value that should be stored in B component (10 bits format).</param>
         public FloatR11G11B10(float x, float y, float z)
         {
-            value = Pack(x, y, z);
+            rawValue = Pack(x, y, z);
         }
 
         /// <summary>
@@ -40,17 +40,13 @@ namespace FlaxEngine
         /// <param name="value">The floating point value that should be stored in compressed format.</param>
         public FloatR11G11B10(Float3 value)
         {
-            this.value = Pack(value.X, value.Y, value.Z);
+            rawValue = Pack(value.X, value.Y, value.Z);
         }
 
         /// <summary>
         /// Gets or sets the raw 32 bit value used to back this vector.
         /// </summary>
-        public uint RawValue
-        {
-            get => value;
-            set => this.value = value;
-        }
+        public uint RawValue => rawValue;
 
         /// <summary>
         /// Performs an explicit conversion from <see cref = "T:FlaxEngine.Float3" /> to <see cref = "T:FlaxEngine.FloatR11G11B10" />.
@@ -80,7 +76,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name="left" /> has the same value as <paramref name="right" />; otherwise, <c>false</c>.</returns>
         public static bool operator ==(FloatR11G11B10 left, FloatR11G11B10 right)
         {
-            return left.value == right.value;
+            return left.rawValue == right.rawValue;
         }
 
         /// <summary>
@@ -91,7 +87,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name="left" /> has a different value than <paramref name="right" />; otherwise, <c>false</c>.</returns>
         public static bool operator !=(FloatR11G11B10 left, FloatR11G11B10 right)
         {
-            return left.value != right.value;
+            return left.rawValue != right.rawValue;
         }
 
         /// <summary>
@@ -109,7 +105,7 @@ namespace FlaxEngine
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return value.GetHashCode();
+            return rawValue.GetHashCode();
         }
 
         /// <summary>
@@ -120,7 +116,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name="value1" /> is the same instance as <paramref name="value2" /> or if both are <c>null</c> references or if <c>value1.Equals(value2)</c> returns <c>true</c>; otherwise, <c>false</c>.</returns>
         public static bool Equals(ref FloatR11G11B10 value1, ref FloatR11G11B10 value2)
         {
-            return value1.value == value2.value;
+            return value1.rawValue == value2.rawValue;
         }
 
         /// <summary>
@@ -130,7 +126,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the current instance is equal to the specified object; <c>false</c> otherwise.</returns>
         public bool Equals(FloatR11G11B10 other)
         {
-            return other.value == value;
+            return other.rawValue == rawValue;
         }
 
         /// <summary>
@@ -140,7 +136,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the current instance is equal to the specified object; <c>false</c> otherwise.</returns>
         public override bool Equals(object obj)
         {
-            return obj is FloatR11G11B10 other && value == other.value;
+            return obj is FloatR11G11B10 other && rawValue == other.rawValue;
         }
 
         private static unsafe uint Pack(float x, float y, float z)
@@ -288,7 +284,7 @@ namespace FlaxEngine
         {
             int zeroExponent = -112;
 
-            Packed packed = new Packed(value);
+            Packed packed = new Packed(rawValue);
             uint* result = stackalloc uint[4];
             uint exponent;
 

--- a/Source/Engine/Core/Math/Half.cs
+++ b/Source/Engine/Core/Math/Half.cs
@@ -38,7 +38,7 @@ namespace FlaxEngine
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
     public struct Half
     {
-        private ushort value;
+        private ushort rawValue;
 
         /// <summary>
         /// Number of decimal digits of precision.
@@ -111,17 +111,13 @@ namespace FlaxEngine
         /// <param name = "value">The floating point value that should be stored in 16 bit format.</param>
         public Half(float value)
         {
-            this.value = HalfUtils.Pack(value);
+            rawValue = HalfUtils.Pack(value);
         }
 
         /// <summary>
         /// Gets or sets the raw 16 bit value used to back this half-float.
         /// </summary>
-        public ushort RawValue
-        {
-            get => value;
-            set => this.value = value;
-        }
+        public ushort RawValue => rawValue;
 
         /// <summary>
         /// Converts an array of half precision values into full precision values.
@@ -166,7 +162,7 @@ namespace FlaxEngine
         /// <returns>The converted value.</returns>
         public static implicit operator float(Half value)
         {
-            return HalfUtils.Unpack(value.value);
+            return HalfUtils.Unpack(value.rawValue);
         }
 
         /// <summary>
@@ -177,7 +173,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name = "left" /> has the same value as <paramref name = "right" />; otherwise, <c>false</c>.</returns>
         public static bool operator ==(Half left, Half right)
         {
-            return left.value == right.value;
+            return left.rawValue == right.rawValue;
         }
 
         /// <summary>
@@ -188,7 +184,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name = "left" /> has a different value than <paramref name = "right" />; otherwise, <c>false</c>.</returns>
         public static bool operator !=(Half left, Half right)
         {
-            return left.value != right.value;
+            return left.rawValue != right.rawValue;
         }
 
         /// <summary>
@@ -207,7 +203,7 @@ namespace FlaxEngine
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            ushort num = value;
+            ushort num = rawValue;
             return (((num * 3) / 2) ^ num);
         }
 
@@ -219,7 +215,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if <paramref name = "value1" /> is the same instance as <paramref name = "value2" /> or  if both are <c>null</c> references or if <c>value1.Equals(value2)</c> returns <c>true</c>; otherwise, <c>false</c>.</returns>
         public static bool Equals(ref Half value1, ref Half value2)
         {
-            return value1.value == value2.value;
+            return value1.rawValue == value2.rawValue;
         }
 
         /// <summary>
@@ -229,7 +225,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the current instance is equal to the specified object; <c>false</c> otherwise.</returns>
         public bool Equals(Half other)
         {
-            return other.value == value;
+            return other.rawValue == rawValue;
         }
 
         /// <summary>
@@ -248,7 +244,7 @@ namespace FlaxEngine
                 return false;
             }
             Half half = (Half)obj;
-            return half.value == value;
+            return half.rawValue == rawValue;
         }
 
         static Half()


### PR DESCRIPTION
`field` and possibly `value` are currently issuing following warnings when used in .NET SDK preview version:
```
info CS9258: 'field' is a contextual keyword in property accessors starting in language version preview. Use '@field' instead.
```