### PR TITLE
Ignore Translate/Rotate/Scale/TransformSpace hotkeys while holding RMB.

### DIFF
--- a/Source/Editor/Viewport/EditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/EditorGizmoViewport.cs
@@ -360,11 +360,36 @@ namespace FlaxEditor.Viewport
             };
             
             // Setup input actions
-            viewport.InputActions.Add(options => options.TranslateMode, () => transformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate);
-            viewport.InputActions.Add(options => options.RotateMode, () => transformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate);
-            viewport.InputActions.Add(options => options.ScaleMode, () => transformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale);
+            viewport.InputActions.Add(options => options.TranslateMode, () => 
+            {
+                viewport.GetInput(out var input);
+                if (input.IsMouseRightDown)
+                    return;
+                
+                transformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate;
+            });
+            viewport.InputActions.Add(options => options.RotateMode, () => 
+            {
+                viewport.GetInput(out var input);
+                if (input.IsMouseRightDown)
+                    return;
+
+                transformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate;
+            });
+            viewport.InputActions.Add(options => options.ScaleMode, () =>
+            {
+                viewport.GetInput(out var input);
+                if (input.IsMouseRightDown)
+                    return;
+
+                transformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale;
+            });
             viewport.InputActions.Add(options => options.ToggleTransformSpace, () =>
             {
+                viewport.GetInput(out var input);
+                if (input.IsMouseRightDown)
+                    return;
+
                 transformGizmo.ToggleTransformSpace();
                 if (useProjectCache)
                     editor.ProjectCache.SetCustomData("TransformSpaceState", transformGizmo.ActiveTransformSpace.ToString());


### PR DESCRIPTION
Allows to use industry standard WER hotkeys for transformations and not change modes while navigating through level.

It doesn't change the default mapping, so it only partially solves this:
https://github.com/FlaxEngine/FlaxEngine/issues/2641