### PR TITLE
Add being able to add a thumbnail to a `SpawnableJsonProxy`

### DIFF
--- a/Source/Editor/Content/Proxy/JsonAssetProxy.cs
+++ b/Source/Editor/Content/Proxy/JsonAssetProxy.cs
@@ -166,6 +166,18 @@ namespace FlaxEditor.Content
         /// <inheritdoc />
         public override string Name { get; } = Utilities.Utils.GetPropertyNameUI(typeof(T).Name);
 
+        private SpriteHandle _thumbnail;
+
+        public SpawnableJsonAssetProxy()
+        {
+            _thumbnail = SpriteHandle.Invalid;
+        }
+        
+        public SpawnableJsonAssetProxy(SpriteHandle thumbnail)
+        {
+            _thumbnail = thumbnail;
+        }
+
         /// <inheritdoc />
         public override bool CanCreate(ContentFolder targetLocation)
         {
@@ -176,6 +188,12 @@ namespace FlaxEditor.Content
         public override void Create(string outputPath, object arg)
         {
             Editor.SaveJsonAsset(outputPath, new T());
+        }
+        
+        /// <inheritdoc />
+        public override AssetItem ConstructItem(string path, string typeName, ref Guid id)
+        {
+            return _thumbnail.IsValid ? new JsonAssetItem(path, id, typeName, _thumbnail) : base.ConstructItem(path, typeName, ref id);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This makes it easy to add custom assets thumbnails without having to create a proxy.

Example code:
```
[ContentContextMenu("New/Testing/Testing Json Asset")]
public class TestingJsonStuff
{
    public string TestString;
}

#if FLAX_EDITOR
public class TestingEditorPlugin : EditorPlugin
{
    public override void InitializeEditor()
    {
        base.InitializeEditor();
        Editor.ContentDatabase.AddProxy(new SpawnableJsonAssetProxy<TestingJsonStuff>(Editor.Icons.SwitchSettings128));
        Editor.ContentDatabase.Rebuild(true);
    }
}
#endif
```

Result:
![image](https://github.com/user-attachments/assets/46d4e8e0-ddac-4f1a-b44a-505eeeeebb24)
