### PR TITLE
Force rebuild on proxy changes if rebuild is true

### DIFF
--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -1275,6 +1275,12 @@ namespace FlaxEditor.Modules
                 }
                 _dirtyNodes.Clear();
             }
+
+            // Lazy-rebuilds
+            if (_rebuildFlag)
+            {
+                RebuildInternal();
+            }
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -737,7 +737,7 @@ namespace FlaxEditor.Modules
         {
             Proxy.Insert(0, proxy);
             if (rebuild)
-                Rebuild();
+                Rebuild(true);
         }
 
         /// <summary>
@@ -749,7 +749,7 @@ namespace FlaxEditor.Modules
         {
             Proxy.Remove(proxy);
             if (rebuild)
-                Rebuild();
+                Rebuild(true);
         }
 
         /// <summary>
@@ -1275,10 +1275,6 @@ namespace FlaxEditor.Modules
                 }
                 _dirtyNodes.Clear();
             }
-
-            // Lazy-rebuilds
-            if (_rebuildFlag)
-                RebuildInternal();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This saves an extra step when adding proxies.

I have to use this code right now, other wise when I change back the editor and have an actor selected property references will be cleared.
 ```
Editor.ContentDatabase.AddProxy(new SpawnableJsonAssetProxy<TestingJsonStuff>(Editor.Icons.SwitchSettings128), true);
Editor.ContentDatabase.Rebuild(true);
```

This just simplifies the code to only have to be
`Editor.ContentDatabase.AddProxy(new SpawnableJsonAssetProxy<TestingJsonStuff>(Editor.Icons.SwitchSettings128), true);`