### PR TITLE
Remove zero clamping from HingeJointDrive in Editor

### DIFF
--- a/Source/Engine/Physics/Joints/HingeJoint.h
+++ b/Source/Engine/Physics/Joints/HingeJoint.h
@@ -38,7 +38,7 @@ API_STRUCT() struct HingeJointDrive
     /// <summary>
     /// Target velocity of the joint.
     /// </summary>
-    API_FIELD(Attributes="Limit(0)") float Velocity = 0.0f;
+    API_FIELD() float Velocity = 0.0f;
 
     /// <summary>
     /// Maximum torque the drive is allowed to apply.


### PR DESCRIPTION
Additional fix to #79 to remove the minimum limit from Editor-side.
