### PR TITLE
Only sort surface parameters alphabetically if script member order is set to Alphabetical.

### DIFF
--- a/Source/Editor/Surface/SurfaceUtils.cs
+++ b/Source/Editor/Surface/SurfaceUtils.cs
@@ -72,7 +72,12 @@ namespace FlaxEditor.Surface
                 }
 
                 // By name
-                return string.Compare(x.DisplayName, y.DisplayName, StringComparison.InvariantCulture);
+                if (Editor.Instance.Options.Options.General.ScriptMembersOrder == GeneralOptions.MembersOrder.Alphabetical)
+                {
+                    return string.Compare(x.DisplayName, y.DisplayName, StringComparison.InvariantCulture);
+                }
+                // Keep same order
+                return 0;
             }
         }
 
@@ -248,9 +253,7 @@ namespace FlaxEditor.Surface
                 data[i] = new GraphParameterData(null, parameter.Name, parameter.IsPublic, ToType(parameter.ParameterType), attributes, parameter);
                 i++;
             }
-            if (Editor.Instance.Options.Options.General.ScriptMembersOrder == GeneralOptions.MembersOrder.Alphabetical)
-                Array.Sort(data, GraphParameterData.Compare);
-
+            Array.Sort(data, GraphParameterData.Compare);
             return data;
         }
 

--- a/Source/Editor/Surface/SurfaceUtils.cs
+++ b/Source/Editor/Surface/SurfaceUtils.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Elements;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEditor.Utilities;
 using FlaxEngine.Utilities;
@@ -247,7 +248,9 @@ namespace FlaxEditor.Surface
                 data[i] = new GraphParameterData(null, parameter.Name, parameter.IsPublic, ToType(parameter.ParameterType), attributes, parameter);
                 i++;
             }
-            Array.Sort(data, GraphParameterData.Compare);
+            if (Editor.Instance.Options.Options.General.ScriptMembersOrder == GeneralOptions.MembersOrder.Alphabetical)
+                Array.Sort(data, GraphParameterData.Compare);
+
             return data;
         }
 


### PR DESCRIPTION
Fix #2825 