### PR TITLE
Add Requesting engine exit event. Expose Fatal error and requesting exit it to c#

### DIFF
--- a/Source/Engine/Engine/Base/GameBase.cpp
+++ b/Source/Engine/Engine/Base/GameBase.cpp
@@ -199,6 +199,7 @@ void GameBaseImpl::OnMainWindowClosed()
 
     // Request engine exit
     Globals::IsRequestingExit = true;
+    Engine::RequestingExit();
 }
 
 void GameBaseImpl::OnPostRender(GPUContext* context, RenderContext& renderContext)

--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -70,6 +70,7 @@ Action Engine::LateFixedUpdate;
 Action Engine::Draw;
 Action Engine::Pause;
 Action Engine::Unpause;
+Action Engine::RequestingExit;
 Window* Engine::MainWindow = nullptr;
 
 int32 Engine::Main(const Char* cmdLine)
@@ -259,10 +260,12 @@ void Engine::RequestExit(int32 exitCode)
     {
         Globals::IsRequestingExit = true;
         Globals::ExitCode = exitCode;
+        RequestingExit();
     }
 #else
     Globals::IsRequestingExit = true;
     Globals::ExitCode = exitCode;
+    RequestingExit();
 #endif
 }
 

--- a/Source/Engine/Engine/Engine.h
+++ b/Source/Engine/Engine/Engine.h
@@ -79,6 +79,11 @@ public:
     /// </summary>
     static Action Unpause;
 
+    /// <summary>
+    /// Event called when the engine is requesting exit.
+    /// </summary>
+    API_EVENT() static Action RequestingExit;
+
 public:
 
     /// <summary>

--- a/Source/Engine/Engine/Globals.h
+++ b/Source/Engine/Engine/Globals.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Engine/Core/Delegate.h"
 #include "Engine/Scripting/ScriptingType.h"
 #include "Engine/Input/Enums.h"
 
@@ -59,8 +60,18 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(Globals);
     // True if fatal error occurred (engine is exiting)
     static bool FatalErrorOccurred;
 
-    // True if engine need to be closed
+    // True if engine needs to be closed
     static bool IsRequestingExit;
+
+    /// <summary>
+    /// True if engine needs to be closed
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE static bool GetIsRequestingExit() { return IsRequestingExit; }
+
+    /// <summary>
+    /// True if fatal error occurred (engine is exiting)
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE static bool GetFatalErrorOccurred() { return FatalErrorOccurred; }
 
     // Exit code
     static int32 ExitCode;

--- a/Source/Engine/Engine/Globals.h
+++ b/Source/Engine/Engine/Globals.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "Engine/Core/Delegate.h"
 #include "Engine/Scripting/ScriptingType.h"
 #include "Engine/Input/Enums.h"
 

--- a/Source/Engine/Platform/Base/PlatformBase.cpp
+++ b/Source/Engine/Platform/Base/PlatformBase.cpp
@@ -271,6 +271,7 @@ void PlatformBase::Fatal(const Char* msg, void* context)
     Globals::FatalErrorOccurred = true;
     Globals::IsRequestingExit = true;
     Globals::ExitCode = -1;
+    Engine::RequestingExit();
 
     // Collect crash info (platform-dependant implementation that might collect stack trace and/or create memory dump)
     {


### PR DESCRIPTION
Adds Engine.RequestingExit event

Exposes Globals.IsRequestingExit and Globals.FatalErrorOccured to c#