### PR TITLE
Use `CHECK_DEBUG` over `ASSERT` in normalized direction checks

### DIFF
--- a/Source/Engine/Core/Math/Quaternion.cpp
+++ b/Source/Engine/Core/Math/Quaternion.cpp
@@ -289,7 +289,7 @@ void Quaternion::Billboard(const Float3& objectPosition, const Float3& cameraPos
 
 Quaternion Quaternion::FromDirection(const Float3& direction)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), Quaternion::Identity);
     Quaternion orientation;
     if (Float3::Dot(direction, Float3::Up) >= 0.999f)
     {

--- a/Source/Engine/Core/Math/Ray.cs
+++ b/Source/Engine/Core/Math/Ray.cs
@@ -57,6 +57,7 @@ using Real = System.Single;
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using FlaxEngine.Assertions;
 
 namespace FlaxEngine
 {
@@ -77,6 +78,7 @@ namespace FlaxEngine
         {
             Position = position;
             Direction = direction;
+            Assert.IsTrue(Direction.IsNormalized, "The Ray Direction was not normalized");
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/Ray.h
+++ b/Source/Engine/Core/Math/Ray.h
@@ -46,7 +46,7 @@ public:
         : Position(position)
         , Direction(direction)
     {
-        ASSERT(Direction.IsNormalized());
+        CHECK_DEBUG(Direction.IsNormalized());
     }
 
 public:

--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -952,7 +952,7 @@ void DebugDraw::DrawActorsTree(Actor* actor)
 
 void DebugDraw::DrawAxisFromDirection(const Vector3& origin, const Vector3& direction, float size, float duration, bool depthTest)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_DEBUG(direction.IsNormalized());
     const auto rot = Quaternion::FromDirection(direction);
     const Vector3 up = (rot * Vector3::Up);
     const Vector3 forward = (rot * Vector3::Forward);
@@ -978,7 +978,7 @@ void DebugDraw::DrawRay(const Vector3& origin, const Vector3& direction, const C
 
 void DebugDraw::DrawRay(const Vector3& origin, const Vector3& direction, const Color& color, float length, float duration, bool depthTest)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_DEBUG(direction.IsNormalized());
     if (isnan(length) || isinf(length))
         return;
     DrawLine(origin, origin + (direction * length), color, duration, depthTest);

--- a/Source/Engine/Physics/Colliders/Collider.cpp
+++ b/Source/Engine/Physics/Colliders/Collider.cpp
@@ -71,7 +71,7 @@ void Collider::SetContactOffset(float value)
 
 bool Collider::RayCast(const Vector3& origin, const Vector3& direction, float& resultHitDistance, float maxDistance) const
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     resultHitDistance = MAX_float;
     if (_shape == nullptr)
         return false;
@@ -80,7 +80,7 @@ bool Collider::RayCast(const Vector3& origin, const Vector3& direction, float& r
 
 bool Collider::RayCast(const Vector3& origin, const Vector3& direction, RayCastHit& hitInfo, float maxDistance) const
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     if (_shape == nullptr)
         return false;
     return PhysicsBackend::RayCastShape(_shape, _transform.Translation, _transform.Orientation, origin, direction, hitInfo, maxDistance);

--- a/Source/Engine/Physics/Physics.cpp
+++ b/Source/Engine/Physics/Physics.cpp
@@ -235,91 +235,91 @@ bool Physics::LineCastAll(const Vector3& start, const Vector3& end, Array<RayCas
 
 bool Physics::RayCast(const Vector3& origin, const Vector3& direction, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->RayCast(origin, direction, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::RayCast(const Vector3& origin, const Vector3& direction, RayCastHit& hitInfo, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->RayCast(origin, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->RayCastAll(origin, direction, results, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->BoxCast(center, halfExtents, direction, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->BoxCast(center, halfExtents, direction, hitInfo, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::BoxCastAll(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, Array<RayCastHit>& results, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->BoxCastAll(center, halfExtents, direction, results, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::SphereCast(const Vector3& center, const float radius, const Vector3& direction, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->SphereCast(center, radius, direction, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::SphereCast(const Vector3& center, const float radius, const Vector3& direction, RayCastHit& hitInfo, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->SphereCast(center, radius, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::SphereCastAll(const Vector3& center, const float radius, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->SphereCastAll(center, radius, direction, results, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::CapsuleCast(const Vector3& center, const float radius, const float height, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->CapsuleCast(center, radius, height, direction, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::CapsuleCast(const Vector3& center, const float radius, const float height, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->CapsuleCast(center, radius, height, direction, hitInfo, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::CapsuleCastAll(const Vector3& center, const float radius, const float height, const Vector3& direction, Array<RayCastHit>& results, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->CapsuleCastAll(center, radius, height, direction, results, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::ConvexCast(const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->ConvexCast(center, convexMesh, scale, direction, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::ConvexCast(const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->ConvexCast(center, convexMesh, scale, direction, hitInfo, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::ConvexCastAll(const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, Array<RayCastHit>& results, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return DefaultScene->ConvexCastAll(center, convexMesh, scale, direction, results, rotation, maxDistance, layerMask, hitTriggers);
 }
 
@@ -520,91 +520,91 @@ bool PhysicsScene::LineCastAll(const Vector3& start, const Vector3& end, Array<R
 
 bool PhysicsScene::RayCast(const Vector3& origin, const Vector3& direction, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::RayCast(_scene, origin, direction, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::RayCast(const Vector3& origin, const Vector3& direction, RayCastHit& hitInfo, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::RayCast(_scene, origin, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::RayCastAll(_scene, origin, direction, results, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::BoxCast(_scene, center, halfExtents, direction, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::BoxCast(_scene, center, halfExtents, direction, hitInfo, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::BoxCastAll(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, Array<RayCastHit>& results, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::BoxCastAll(_scene, center, halfExtents, direction, results, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::SphereCast(const Vector3& center, const float radius, const Vector3& direction, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::SphereCast(_scene, center, radius, direction, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::SphereCast(const Vector3& center, const float radius, const Vector3& direction, RayCastHit& hitInfo, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::SphereCast(_scene, center, radius, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::SphereCastAll(const Vector3& center, const float radius, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::SphereCastAll(_scene, center, radius, direction, results, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::CapsuleCast(const Vector3& center, const float radius, const float height, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::CapsuleCast(_scene, center, radius, height, direction, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::CapsuleCast(const Vector3& center, const float radius, const float height, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::CapsuleCast(_scene, center, radius, height, direction, hitInfo, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::CapsuleCastAll(const Vector3& center, const float radius, const float height, const Vector3& direction, Array<RayCastHit>& results, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::CapsuleCastAll(_scene, center, radius, height, direction, results, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::ConvexCast(const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::ConvexCast(_scene, center, convexMesh, scale, direction, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::ConvexCast(const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::ConvexCast(_scene, center, convexMesh, scale, direction, hitInfo, rotation, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::ConvexCastAll(const Vector3& center, const CollisionData* convexMesh, const Vector3& scale, const Vector3& direction, Array<RayCastHit>& results, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     return PhysicsBackend::ConvexCastAll(_scene, center, convexMesh, scale, direction, results, rotation, maxDistance, layerMask, hitTriggers);
 }
 

--- a/Source/Engine/Platform/Platform.h
+++ b/Source/Engine/Platform/Platform.h
@@ -35,7 +35,7 @@
 #endif
 
 #if ENABLE_ASSERTION
-// Performs hard assertion of the expression. Crashes the engine and inserts debugger break in case of expression fail.
+// Performs a hard assertion of the expression. Crashes the engine and triggers a debugger break if the expression fails.
 #define ASSERT(expression) \
     if (!(expression)) \
     { \
@@ -46,24 +46,40 @@
         Platform::Assert(#expression, __FILE__, __LINE__); \
     }
 #else
+// Performs a hard assertion of the expression. Crashes the engine and triggers a debugger break if the expression fails.
 #define ASSERT(expression) ((void)0)
 #endif
 #if ENABLE_ASSERTION_LOW_LAYERS
+// Performs a hard assertion of the expression. Crashes the engine and triggers a debugger break if the expression fails.
 #define ASSERT_LOW_LAYER(x) ASSERT(x)
 #else
+// Performs a hard assertion of the expression. Crashes the engine and triggers a debugger break if the expression fails.
 #define ASSERT_LOW_LAYER(x)
 #endif
 
-// Performs soft check of the expression. Logs the expression fail to log and returns the function call.
+// Performs a soft check of the expression. Logs the expression failure and returns from the function call.
 #define CHECK(expression) \
     if (!(expression)) \
     { \
         Platform::CheckFailed(#expression, __FILE__, __LINE__); \
         return; \
     }
+// Performs a soft check of the expression. Logs the expression failure and returns from the function call using the given return value.
 #define CHECK_RETURN(expression, returnValue) \
     if (!(expression)) \
     { \
         Platform::CheckFailed(#expression, __FILE__, __LINE__); \
         return returnValue; \
     }
+
+#if ENABLE_ASSERTION
+// Performs a soft check of the expression. Logs the expression failure and returns from the function call.
+#define CHECK_DEBUG(expression) CHECK(expression)
+// Performs a soft check of the expression. Logs the expression failure and returns from the function call using the given return value.
+#define CHECK_RETURN_DEBUG(expression, returnValue) CHECK_RETURN(expression, returnValue)
+#else
+// Performs a soft check of the expression. Logs the expression failure and returns from the function call.
+#define CHECK_DEBUG(expression) ((void)0)
+// Performs a soft check of the expression. Logs the expression failure and returns from the function call using the given return value.
+#define CHECK_RETURN_DEBUG(expression, returnValue) ((void)0)
+#endif

--- a/Source/Engine/Terrain/TerrainPatch.cpp
+++ b/Source/Engine/Terrain/TerrainPatch.cpp
@@ -1963,7 +1963,7 @@ bool TerrainPatch::UpdateCollision()
 
 bool TerrainPatch::RayCast(const Vector3& origin, const Vector3& direction, float& resultHitDistance, float maxDistance) const
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     if (_physicsShape == nullptr)
         return false;
     Vector3 shapePos;
@@ -1974,7 +1974,7 @@ bool TerrainPatch::RayCast(const Vector3& origin, const Vector3& direction, floa
 
 bool TerrainPatch::RayCast(const Vector3& origin, const Vector3& direction, float& resultHitDistance, Vector3& resultHitNormal, float maxDistance) const
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     if (_physicsShape == nullptr)
         return false;
     Vector3 shapePos;
@@ -1992,7 +1992,7 @@ bool TerrainPatch::RayCast(const Vector3& origin, const Vector3& direction, floa
 
 bool TerrainPatch::RayCast(const Vector3& origin, const Vector3& direction, float& resultHitDistance, TerrainChunk*& resultChunk, float maxDistance) const
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     if (_physicsShape == nullptr)
         return false;
     Vector3 shapePos;
@@ -2030,7 +2030,7 @@ bool TerrainPatch::RayCast(const Vector3& origin, const Vector3& direction, floa
 
 bool TerrainPatch::RayCast(const Vector3& origin, const Vector3& direction, RayCastHit& hitInfo, float maxDistance) const
 {
-    ASSERT(direction.IsNormalized());
+    CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
     if (_physicsShape == nullptr)
         return false;
     Vector3 shapePos;


### PR DESCRIPTION
Avoid crashing the engine with wrong input, only log the error when un-normalized vectors are passed. The added assert in C# `Ray` is not fatal and doesn't crash the engine.