### PR TITLE
fix crash with prefab window open on script reload

### DIFF
--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -627,7 +627,7 @@ namespace FlaxEditor.Viewport
             // Debug draw all actors in prefab
             foreach (var child in SceneGraphRoot.ChildNodes)
             {
-                if (child is not ActorNode actorNode)
+                if (child is not ActorNode actorNode || !actorNode.Actor)
                     continue;
                 DebugDraw.DrawActorsTree(actorNode.Actor);
             }


### PR DESCRIPTION
On 1.9, if I have a prefab window open, edit a script, and return back to the editor, it crashes upon script reload completion.  This, however, doesn't occur on master.  Thus, I'm not sure if this is the best way to resolve the crash as the underlying cause itself should probably be found and fixed.

That said, I have no idea what other code may be related to nor may be causing the issue, so at the very least I wanted to open this PR to raise awareness of the situation.