### PR TITLE
Don't zoom in edit game window if shift is clicked and window is not focused

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1612,7 +1612,7 @@ namespace FlaxEditor.Viewport
                     _input.IsPanning = !isAltDown && mbDown && !rbDown;
                     _input.IsRotating = !isAltDown && !mbDown && rbDown;
                     _input.IsMoving = !isAltDown && mbDown && rbDown;
-                    _input.IsZooming = wheelInUse && !_input.IsShiftDown;
+                    _input.IsZooming = wheelInUse && !(_input.IsShiftDown || (!ContainsFocus && FlaxEngine.Input.GetKey(KeyboardKeys.Shift)));
                     _input.IsOrbiting = isAltDown && lbDown && !mbDown && !rbDown;
 
                     // Control move speed with RMB+Wheel


### PR DESCRIPTION
I went to paint the terrain, so I selected it in the toolbox. I then went to resize the gizmo with shift mouse wheel, but it started zooming because I did not have the edit game window focused. This fixes that issue and wont zoom if the edit game window is not focused and the user is pressing shift.