### PR TITLE
Change terrain modes to not be visible if no terrain panel is showing

### DIFF
--- a/Source/Editor/Tools/Terrain/CarveTab.cs
+++ b/Source/Editor/Tools/Terrain/CarveTab.cs
@@ -113,6 +113,7 @@ namespace FlaxEditor.Tools.Terrain
             }
 
             _createTerrainButton.Clicked += OnCreateNewTerrainClicked;
+            OnSelectionChanged();
         }
 
         private void OnSceneLoaded(Scene arg1, Guid arg2)
@@ -159,6 +160,7 @@ namespace FlaxEditor.Tools.Terrain
             }
 
             _noTerrainPanel.Visible = terrain == null;
+            _modes.Visible = !_noTerrainPanel.Visible;
         }
 
         private void InitSculptMode()


### PR DESCRIPTION
Fixes issue of toolstrips and drop downs from being clicked on the terrain modes when the no terrain panel is showing