### PR TITLE
Expose additional Actor virtual methods to c#

### DIFF
--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -996,37 +996,37 @@ public:
     /// <summary>
     /// Called when actor parent gets changed.
     /// </summary>
-    virtual void OnParentChanged();
+    API_FUNCTION() virtual void OnParentChanged();
 
     /// <summary>
     /// Called when actor transform gets changed.
     /// </summary>
-    virtual void OnTransformChanged();
+    API_FUNCTION() virtual void OnTransformChanged();
 
     /// <summary>
     /// Called when actor active state gets changed.
     /// </summary>
-    virtual void OnActiveChanged();
+    API_FUNCTION() virtual void OnActiveChanged();
 
     /// <summary>
     /// Called when actor active in tree state gets changed.
     /// </summary>
-    virtual void OnActiveInTreeChanged();
+    API_FUNCTION() virtual void OnActiveInTreeChanged();
 
     /// <summary>
     /// Called when order in parent children array gets changed.
     /// </summary>
-    virtual void OnOrderInParentChanged();
+    API_FUNCTION() virtual void OnOrderInParentChanged();
 
     /// <summary>
     /// Called when actor static flag gets changed.
     /// </summary>
-    virtual void OnStaticFlagsChanged();
+    API_FUNCTION() virtual void OnStaticFlagsChanged();
 
     /// <summary>
     /// Called when layer gets changed.
     /// </summary>
-    virtual void OnLayerChanged();
+    API_FUNCTION() virtual void OnLayerChanged();
 
     /// <summary>
     /// Called when adding object to the game.

--- a/Source/Engine/UI/UICanvas.cpp
+++ b/Source/Engine/UI/UICanvas.cpp
@@ -17,7 +17,7 @@ MMethod* UICanvas_PostDeserialize = nullptr;
 MMethod* UICanvas_Enable = nullptr;
 MMethod* UICanvas_Disable = nullptr;
 #if USE_EDITOR
-MMethod* UICanvas_OnActiveInTreeChanged = nullptr;
+MMethod* UICanvas_ActiveInTreeChanged = nullptr;
 #endif
 MMethod* UICanvas_EndPlay = nullptr;
 MMethod* UICanvas_ParentChanged = nullptr;
@@ -49,7 +49,7 @@ UICanvas::UICanvas(const SpawnParams& params)
         UICanvas_Enable = mclass->GetMethod("Enable");
         UICanvas_Disable = mclass->GetMethod("Disable");
 #if USE_EDITOR
-        UICanvas_OnActiveInTreeChanged = mclass->GetMethod("OnActiveInTreeChanged");
+        UICanvas_ActiveInTreeChanged = mclass->GetMethod("ActiveInTreeChanged");
 #endif
         UICanvas_EndPlay = mclass->GetMethod("EndPlay");
         UICanvas_ParentChanged = mclass->GetMethod("ParentChanged");
@@ -182,7 +182,7 @@ void UICanvas::OnTransformChanged()
 
 void UICanvas::OnActiveInTreeChanged()
 {
-    UICANVAS_INVOKE(OnActiveInTreeChanged);
+    UICANVAS_INVOKE(ActiveInTreeChanged);
 
     // Base
     Actor::OnActiveInTreeChanged();

--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -773,7 +773,7 @@ namespace FlaxEngine
         }
 
 #if FLAX_EDITOR
-        internal void OnActiveInTreeChanged()
+        internal void ActiveInTreeChanged()
         {
             if (RenderMode == CanvasRenderMode.ScreenSpace && _editorRoot != null && _guiRoot != null)
             {


### PR DESCRIPTION
This exposes several virtual actor methods to c#. Fixes conflict with UICanvas `OnActiveInTreeChanged` method naming after exposing to c#.