### PR TITLE
Hide animated model parameters on end play.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/AnimatedModelEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/AnimatedModelEditor.cs
@@ -1,5 +1,7 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using System;
+using FlaxEditor.CustomEditors.Elements;
 using FlaxEditor.Surface;
 using FlaxEngine;
 
@@ -31,6 +33,22 @@ namespace FlaxEditor.CustomEditors.Dedicated
                                                     (instance, parameter, tag) => ((AnimatedModel)instance).GetParameterValue(parameter.Identifier),
                                                     (instance, value, parameter, tag) => ((AnimatedModel)instance).SetParameterValue(parameter.Identifier, value),
                                                     Values);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Refresh()
+        {
+            base.Refresh();
+
+            // Check if parameters group is still showing if not in play mode and hide it.
+            if (!Editor.Instance.StateMachine.IsPlayMode)
+            {
+                var group = Layout.Children.Find(x => x is GroupElement g && g.Panel.HeaderText.Equals("Parameters", StringComparison.Ordinal));
+                if (group != null)
+                {
+                    RebuildLayout();
+                }
             }
         }
     }

--- a/Source/Editor/CustomEditors/Dedicated/AnimatedModelEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/AnimatedModelEditor.cs
@@ -14,6 +14,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
     [CustomEditor(typeof(AnimatedModel)), DefaultEditor]
     public class AnimatedModelEditor : ActorEditor
     {
+        private bool _parametersAdded = false;
+
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
         {
@@ -33,6 +35,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                                                     (instance, parameter, tag) => ((AnimatedModel)instance).GetParameterValue(parameter.Identifier),
                                                     (instance, value, parameter, tag) => ((AnimatedModel)instance).SetParameterValue(parameter.Identifier, value),
                                                     Values);
+                _parametersAdded = true;
             }
         }
 
@@ -42,12 +45,13 @@ namespace FlaxEditor.CustomEditors.Dedicated
             base.Refresh();
 
             // Check if parameters group is still showing if not in play mode and hide it.
-            if (!Editor.Instance.StateMachine.IsPlayMode)
+            if (!Editor.Instance.StateMachine.IsPlayMode && _parametersAdded)
             {
                 var group = Layout.Children.Find(x => x is GroupElement g && g.Panel.HeaderText.Equals("Parameters", StringComparison.Ordinal));
                 if (group != null)
                 {
                     RebuildLayout();
+                    _parametersAdded = false;
                 }
             }
         }


### PR DESCRIPTION
Ran into an issue where parameters for animated models will continue to show if the animated model is selected when ending play. This will hide the parameters on end play if the group exists.