### PR TITLE
Keep property declared order if similar meta data token.

### DIFF
--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -178,6 +178,8 @@ namespace FlaxEditor.CustomEditors.Editors
                             return 1;
                         if (Info.MetadataToken < other.Info.MetadataToken)
                             return -1;
+                        // Keep declaration order if same metadata token.
+                        return 0;
                     }
 
                     // By name


### PR DESCRIPTION
Fixes visual scripting parameter order from always doing alphabetical sorting if not declared as alphabetical scripting order. because visual scripts always have metadata token of 0.