### PR TITLE
Remove bindings for InputEvent and InputAxis events on dispose.

### DIFF
--- a/Source/Engine/Engine/InputAxis.cs
+++ b/Source/Engine/Engine/InputAxis.cs
@@ -60,6 +60,7 @@ namespace FlaxEngine
         ~InputAxis()
         {
             Input.AxisValueChanged -= Handler;
+            ValueChanged = null;
         }
 
         /// <summary>
@@ -68,6 +69,7 @@ namespace FlaxEngine
         public void Dispose()
         {
             Input.AxisValueChanged -= Handler;
+            ValueChanged = null;
             GC.SuppressFinalize(this);
         }
 

--- a/Source/Engine/Engine/InputEvent.cs
+++ b/Source/Engine/Engine/InputEvent.cs
@@ -70,6 +70,10 @@ namespace FlaxEngine
         ~InputEvent()
         {
             Input.ActionTriggered -= Handler;
+            Triggered = null;
+            Pressed = null;
+            Pressing = null;
+            Released = null;
         }
 
         private void Handler(string name, InputActionState state)
@@ -100,6 +104,10 @@ namespace FlaxEngine
         public void Dispose()
         {
             Input.ActionTriggered -= Handler;
+            Triggered = null;
+            Pressed = null;
+            Pressing = null;
+            Released = null;
             GC.SuppressFinalize(this);
         }
 


### PR DESCRIPTION
This will remove the methods bound to the events in `InputEvent` and `InputAxis` when Dispose is called. Between editor play sessions right now it will keep bad references and data if using lambdas between editor play sessions. This fixes that issue.