### PR TITLE
Add option to invert the y-axis mouse rotation in the editor viewport camera.

### DIFF
--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -24,6 +24,13 @@ namespace FlaxEditor.Options
         [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
         [EditorDisplay("General"), EditorOrder(101), Tooltip("The mouse wheel sensitivity applied to zoom in orthographic mode.")]
         public float MouseWheelSensitivity { get; set; } = 1.0f;
+        
+        /// <summary>
+        /// Gets or sets whether to invert the Y rotation of the mouse in the editor viewport.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("General"), EditorOrder(102), Tooltip("Whether to invert the Y rotation of the mouse in the editor viewport.")]
+        public bool InvertMouseYAxisRotation { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the total amount of steps the camera needs to go from minimum to maximum speed.

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1704,6 +1704,8 @@ namespace FlaxEditor.Viewport
                 // Update
                 moveDelta *= dt * (60.0f * 4.0f);
                 mouseDelta *= 0.1833f * MouseSpeed * _mouseSensitivity;
+                if (options.Viewport.InvertMouseYAxisRotation)
+                    mouseDelta *= new Float2(1, -1);
                 UpdateView(dt, ref moveDelta, ref mouseDelta, out var centerMouse);
 
                 // Move mouse back to the root position


### PR DESCRIPTION
Closes #1918 