### PR TITLE
Use nameof for adding new Modules to build targets.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -261,7 +261,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 if (!file.Contains("GameProjectTarget"))
                     continue; // Skip 
 
-                if (file.Contains("Modules.Add(\"Game\")"))
+                if (file.Contains("Modules.Add(\"Game\")") || file.Contains("Modules.Add(nameof(Game))"))
                 {
                     // Assume Game represents the main game module
                     moduleName = "Game";

--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -226,7 +226,7 @@ bool Editor::CheckProjectUpgrade()
                                "        base.Init();\n"
                                "\n"
                                "        // Reference the modules for game\n"
-                               "        Modules.Add(\"{0}\");\n"
+                               "        Modules.Add(nameof({0}));\n"
                                "    }}\n"
                                "}}\n"
                            ), codeName), Encoding::UTF8);
@@ -242,7 +242,7 @@ bool Editor::CheckProjectUpgrade()
                                "        base.Init();\n"
                                "\n"
                                "        // Reference the modules for editor\n"
-                               "        Modules.Add(\"{0}\");\n"
+                               "        Modules.Add(nameof({0}));\n"
                                "{1}"
                                "    }}\n"
                                "}}\n"

--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -476,7 +476,7 @@ int32 Editor::LoadProduct()
                                              "        base.Init();\n"
                                              "\n"
                                              "        // Reference the modules for game\n"
-                                             "        Modules.Add(\"Game\");\n"
+                                             "        Modules.Add(nameof(Game));\n"
                                              "    }\n"
                                              "}\n"), Encoding::UTF8);
         failed |= File::WriteAllText(projectPath / TEXT("Source/GameEditorTarget.Build.cs"),TEXT(
@@ -490,7 +490,7 @@ int32 Editor::LoadProduct()
                                          "        base.Init();\n"
                                          "\n"
                                          "        // Reference the modules for editor\n"
-                                         "        Modules.Add(\"Game\");\n"
+                                         "        Modules.Add(nameof(Game));\n"
                                          "    }\n"
                                          "}\n"), Encoding::UTF8);
         failed |= File::WriteAllText(projectPath / TEXT("Source/Game/Game.Build.cs"),TEXT(

--- a/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
@@ -382,7 +382,7 @@ namespace FlaxEditor.Modules.SourceCodeEditing
 
             // Get editor target and target files and add module
             var files = Directory.GetFiles(path);
-            var targetModuleText = $"Modules.Add(\"{moduleName}\");\n        ";
+            var targetModuleText = $"Modules.Add(nameof({moduleName}));\n        ";
             foreach (var file in files)
             {
                 if (!file.Contains(".Build.cs", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Close #2880 
I agree with the suggestion of using nameof. it makes it easier to find if a module is removed as it will produce an error.