### PR TITLE
Fix null reference in Visject CM if there are no elements associated with a node

### DIFF
--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -875,7 +875,7 @@ namespace FlaxEditor.Surface.ContextMenu
                         AddInputOutputElement(archetype, output.Type, true, $"{output.Name} ({output.Type.Name})");
                     }
                 }
-                else
+                else if (archetype.Elements != null) // Skip if no Elements (ex: Comment node)
                 {
                     foreach (var element in archetype.Elements)
                     {


### PR DESCRIPTION
Fix #2888 