### PR TITLE
Add saving collection element groups.

### DIFF
--- a/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
@@ -1,5 +1,7 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using System;
+using FlaxEditor.GUI.ContextMenu;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -23,6 +25,11 @@ namespace FlaxEditor.CustomEditors.Elements
             HeaderHeight = 18.0f,
             EnableContainmentLines = true,
         };
+
+        /// <summary>
+        /// Event is fired if the group can setup a context menu and the context menu is being setup.
+        /// </summary>
+        public Action<ContextMenu, DropPanel> SetupContextMenu;
 
         /// <inheritdoc />
         public override ContainerControl ContainerControl => Panel;

--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -74,11 +74,11 @@ namespace FlaxEditor.CustomEditors
         {
             var element = Group(title, useTransparentHeader);
             element.Panel.Tag = linkedEditor;
-            element.Panel.MouseButtonRightClicked += OnGroupPanelMouseButtonRightClicked;
+            element.Panel.MouseButtonRightClicked += (panel, location) => OnGroupPanelMouseButtonRightClicked(element, panel, location);
             return element;
         }
 
-        private void OnGroupPanelMouseButtonRightClicked(DropPanel groupPanel, Float2 location)
+        private void OnGroupPanelMouseButtonRightClicked(GroupElement element, DropPanel groupPanel, Float2 location)
         {
             var linkedEditor = (CustomEditor)groupPanel.Tag;
             var menu = new ContextMenu();
@@ -91,6 +91,7 @@ namespace FlaxEditor.CustomEditors
             menu.AddButton("Copy", linkedEditor.Copy);
             var paste = menu.AddButton("Paste", linkedEditor.Paste);
             paste.Enabled = linkedEditor.CanPaste;
+            element.SetupContextMenu?.Invoke(menu, groupPanel);
 
             menu.Show(groupPanel, location);
         }


### PR DESCRIPTION
This PR adds saving individual collection element drop panel states and adds open all and close all menu buttons for collections.

If there are any additional "identifiers" that should be used in the save name to save the state, let me know. I feel like I need to add something for custom editor windows to add a unique identifier, but I have not found a good way to get the asset with the information available in the custom editor to get it's ID.

There are still some cases where the save identifier may not be unique and may affect other collections closed/not closed state.

Close #2515