### PR TITLE
Clean up JsonAssetWindow options cm if it exists.

### DIFF
--- a/Source/Editor/Windows/Assets/JsonAssetWindow.cs
+++ b/Source/Editor/Windows/Assets/JsonAssetWindow.cs
@@ -242,8 +242,11 @@ namespace FlaxEditor.Windows.Assets
 
         private void OpenOptionsContextMenu()
         {
-            if (_optionsCM != null && _optionsCM.ContainsFocus)
-                return;
+            if (_optionsCM != null)
+            {
+                _optionsCM.Hide();
+                _optionsCM.Dispose();
+            }
             
             _optionsCM = new ContextMenu();
             _optionsCM.AddButton("Copy type name", () => Clipboard.Text = Asset.DataTypeName);


### PR DESCRIPTION
Fix issue of multiple json asset window options cms from appearing.