### PR TITLE
Fix calling null actor in prefab debug draw.

### DIFF
--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -635,6 +635,8 @@ namespace FlaxEditor.Viewport
                 if (child is not ActorNode actorNode)
                     continue;
                 var actor = actorNode.Actor;
+                if (!actor)
+                    continue;
                 if (collectActors)
                     Utils.GetActorsTree(_debugDrawActors, actor);
                 DebugDraw.DrawActorsTree(actor);


### PR DESCRIPTION
Fix #2898 