### PR TITLE
Add generic CSharpProxy. Add Empty C# template.

### DIFF
--- a/Content/Editor/Scripting/CSharpEmptyTemplate.cs
+++ b/Content/Editor/Scripting/CSharpEmptyTemplate.cs
@@ -1,0 +1,6 @@
+%copyright%using System;
+using System.Collections.Generic;
+using FlaxEngine;
+
+namespace %namespace%;
+

--- a/Source/Editor/Content/Items/CSharpScriptItem.cs
+++ b/Source/Editor/Content/Items/CSharpScriptItem.cs
@@ -5,7 +5,7 @@ using FlaxEngine;
 namespace FlaxEditor.Content
 {
     /// <summary>
-    /// Content item that contains C# script file with source code.
+    /// Content item that contains C# file with source code.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.ScriptItem" />
     public class CSharpScriptItem : ScriptItem

--- a/Source/Editor/Content/Proxy/CSharpProxy.cs
+++ b/Source/Editor/Content/Proxy/CSharpProxy.cs
@@ -30,7 +30,7 @@ namespace FlaxEditor.Content
         /// </summary>
         /// <param name="path">The path to the template</param>
         protected abstract void GetTemplatePath(out string path);
-        
+
         /// <inheritdoc />
         public override void Create(string outputPath, object arg)
         {
@@ -61,7 +61,7 @@ namespace FlaxEditor.Content
 
         /// <inheritdoc />
         public override string FileExtension => "cs";
-        
+
         /// <inheritdoc />
         public override Color AccentColor => Color.FromRGB(0x1c9c2b);
     }

--- a/Source/Editor/Content/Proxy/CSharpProxy.cs
+++ b/Source/Editor/Content/Proxy/CSharpProxy.cs
@@ -9,19 +9,15 @@ using FlaxEngine;
 namespace FlaxEditor.Content
 {
     /// <summary>
-    /// Context proxy object for C# script files.
+    /// Proxy object for C# files
     /// </summary>
-    /// <seealso cref="FlaxEditor.Content.CSharpScriptProxy" />
-    [ContentContextMenu("New/C# Script")]
-    public class CSharpScriptProxy : ScriptProxy
+    /// /// <seealso cref="FlaxEditor.Content.ScriptProxy" />
+    public abstract class CSharpProxy : ScriptProxy
     {
         /// <summary>
         /// The script files extension filter.
         /// </summary>
-        public static readonly string ExtensionFiler = "*.cs";
-
-        /// <inheritdoc />
-        public override string Name => "C# Script";
+        public static readonly string ExtensionFilter = "*.cs";
 
         /// <inheritdoc />
         public override bool IsProxyFor(ContentItem item)
@@ -29,11 +25,17 @@ namespace FlaxEditor.Content
             return item is CSharpScriptItem;
         }
 
+        /// <summary>
+        /// Gets the path for the C# template.
+        /// </summary>
+        /// <param name="path">The path to the template</param>
+        protected abstract void GetTemplatePath(out string path);
+        
         /// <inheritdoc />
         public override void Create(string outputPath, object arg)
         {
             // Load template
-            var templatePath = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/ScriptTemplate.cs");
+            GetTemplatePath(out var templatePath);
             var scriptTemplate = File.ReadAllText(templatePath);
 
             // Find the module that this script is being added (based on the path)
@@ -59,8 +61,42 @@ namespace FlaxEditor.Content
 
         /// <inheritdoc />
         public override string FileExtension => "cs";
-
+        
         /// <inheritdoc />
         public override Color AccentColor => Color.FromRGB(0x1c9c2b);
+    }
+    
+    /// <summary>
+    /// Context proxy object for C# script files.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
+    [ContentContextMenu("New/C#/C# Script")]
+    public class CSharpScriptProxy : CSharpProxy
+    {
+        /// <inheritdoc />
+        public override string Name => "C# Script";
+
+        /// <inheritdoc />
+        protected override void GetTemplatePath(out string path)
+        {
+            path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/ScriptTemplate.cs");
+        }
+    }
+    
+    /// <summary>
+    /// Context proxy object for empty C# files.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
+    [ContentContextMenu("New/C#/C# Empty File")]
+    public class CSharpEmptyProxy : CSharpProxy
+    {
+        /// <inheritdoc />
+        public override string Name => "C# Empty File";
+
+        /// <inheritdoc />
+        protected override void GetTemplatePath(out string path)
+        {
+            path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/CSharpEmptyTemplate.cs");
+        }
     }
 }

--- a/Source/Editor/Content/Proxy/CppProxy.cs
+++ b/Source/Editor/Content/Proxy/CppProxy.cs
@@ -11,7 +11,7 @@ namespace FlaxEditor.Content
     /// <summary>
     /// Context proxy object for C++ files.
     /// </summary>
-    /// <seealso cref="FlaxEditor.Content.CSharpScriptProxy" />
+    /// <seealso cref="FlaxEditor.Content.ScriptProxy" />
     public abstract class CppProxy : ScriptProxy
     {
         /// <summary>
@@ -74,7 +74,7 @@ namespace FlaxEditor.Content
     /// <summary>
     /// Context proxy object for C++ script files.
     /// </summary>
-    /// <seealso cref="FlaxEditor.Content.CSharpScriptProxy" />
+    /// <seealso cref="FlaxEditor.Content.CppProxy" />
     [ContentContextMenu("New/C++/C++ Script")]
     public class CppScriptProxy : CppProxy
     {
@@ -98,7 +98,7 @@ namespace FlaxEditor.Content
     /// <summary>
     /// Context proxy object for C++ Json Asset files.
     /// </summary>
-    /// <seealso cref="FlaxEditor.Content.CSharpScriptProxy" />
+    /// <seealso cref="FlaxEditor.Content.CppProxy" />
     [ContentContextMenu("New/C++/C++ Function Library")]
     public class CppStaticClassProxy : CppProxy
     {
@@ -116,7 +116,7 @@ namespace FlaxEditor.Content
     /// <summary>
     /// Context proxy object for C++ Json Asset files.
     /// </summary>
-    /// <seealso cref="FlaxEditor.Content.CSharpScriptProxy" />
+    /// <seealso cref="FlaxEditor.Content.CppProxy" />
     [ContentContextMenu("New/C++/C++ Json Asset")]
     public class CppAssetProxy : CppProxy
     {

--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -1093,6 +1093,7 @@ namespace FlaxEditor.Modules
             Proxy.Add(new ParticleSystemProxy());
             Proxy.Add(new SceneAnimationProxy());
             Proxy.Add(new CSharpScriptProxy());
+            Proxy.Add(new CSharpEmptyProxy());
             Proxy.Add(new CppAssetProxy());
             Proxy.Add(new CppStaticClassProxy());
             Proxy.Add(new CppScriptProxy());


### PR DESCRIPTION
This makes it easier to create C# proxies with templates.