### PR TITLE
Fix last list element label positioning.

### DIFF
--- a/Source/Editor/CustomEditors/GUI/PropertiesList.cs
+++ b/Source/Editor/CustomEditors/GUI/PropertiesList.cs
@@ -256,7 +256,7 @@ namespace FlaxEditor.CustomEditors.GUI
                     var firstChild = label.FirstChildControlContainer.Children[label.FirstChildControlIndex];
                     yStarts[i] = firstChild.PointToParent(this, Float2.Zero).Y;
                     if (i == count - 1)
-                        yStarts[i + 1] = firstChild.PointToParent(this, firstChild.Size).Y;
+                        yStarts[i + 1] = firstChild.Parent.Bottom;
                 }
                 else
                 {


### PR DESCRIPTION
The recent change to this seems to broke the last element's label position in a property list if it have more than 1 value.

Right now:
![image](https://github.com/user-attachments/assets/4141f204-10aa-4489-a00d-421e0fafcc0e)

After this change:
![image](https://github.com/user-attachments/assets/04bbf5eb-a85c-42dd-961e-1454c08cc58a)
