### PR TITLE
Add code gen for FixedAllocation arrays to generate Collection attribute with allocation count

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -911,9 +911,10 @@ namespace Flax.Build.Bindings
                 {
                     if (defaultValueType.GenericArgs.Count > 1)
                     {
-                        if (defaultValueType.GenericArgs[1].Type.Contains("FixedAllocation", StringComparison.Ordinal))
+                        var allocationArg = defaultValueType.GenericArgs[1];
+                        if (allocationArg.Type.Contains("FixedAllocation", StringComparison.Ordinal) && allocationArg.GenericArgs.Count > 0)
                         {
-                            if (int.TryParse(defaultValueType.GenericArgs[1].GenericArgs[0].ToString(), out int allocation))
+                            if (int.TryParse(allocationArg.GenericArgs[0].ToString(), out int allocation))
                             {
                                 contents.Append(indent).Append($"[Collection(MaxCount={allocation.ToString()})]").AppendLine();
                             }


### PR DESCRIPTION
Closes #2879 

This will not generate a Collection attribute with a MaxCount if the array uses a define as the count for `FixedAllocation`