### PR TITLE
Rename VisualScriptingDescriptionPanel to NodeDescriptionPanel

### DIFF
--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -376,11 +376,11 @@ namespace FlaxEditor.Options
         public float ConnectionCurvature { get; set; } = 1.0f;
 
         /// <summary>
-        /// Gets or sets the visject connection curvature.
+        /// Gets or sets a value that indicates wether the context menu description panel is shown or not.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Visject"), EditorOrder(550), Tooltip("Shows/hides the description panel in the visual scripting context menu.")]
-        public bool VisualScriptingDescriptionPanel { get; set; } = true;
+        [EditorDisplay("Visject"), EditorOrder(550), Tooltip("Shows/hides the description panel in visual scripting context menu.")]
+        public bool NodeDescriptionPanel { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the surface grid snapping option.

--- a/Source/Editor/Surface/ContextMenu/VisjectCM.cs
+++ b/Source/Editor/Surface/ContextMenu/VisjectCM.cs
@@ -809,7 +809,7 @@ namespace FlaxEditor.Surface.ContextMenu
             if (!_useDescriptionPanel)
                 return;
 
-            if (archetype == null || !Editor.Instance.Options.Options.Interface.VisualScriptingDescriptionPanel)
+            if (archetype == null || !Editor.Instance.Options.Options.Interface.NodeDescriptionPanel)
             {
                 HideDescriptionPanel();
                 return;


### PR DESCRIPTION
The description panel no longer only shows in the visual scripting editor but also in the material editor. There is one editor setting that shows/ hides both so I changed the name to something more general.