### PR TITLE
Make it possible to pan editor when rmb down on node

### DIFF
--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -146,6 +146,8 @@ namespace FlaxEditor.Surface
         /// </summary>
         protected virtual Color FooterColor => GroupArchetype.Color;
 
+        private Float2 mouseDownMousePosition;
+
         /// <summary>
         /// Calculates the size of the node including header, footer, and margins.
         /// </summary>
@@ -1093,7 +1095,7 @@ namespace FlaxEditor.Surface
             if (button == MouseButton.Left && (Archetype.Flags & NodeFlags.NoCloseButton) == 0 && _closeButtonRect.Contains(ref location))
                 return true;
             if (button == MouseButton.Right)
-                return true;
+                mouseDownMousePosition = Input.Mouse.Position;
 
             return false;
         }
@@ -1114,6 +1116,9 @@ namespace FlaxEditor.Surface
             // Secondary Context Menu
             if (button == MouseButton.Right)
             {
+                if (mouseDownMousePosition != Input.Mouse.Position)
+                    return true;
+
                 if (!IsSelected)
                     Surface.Select(this);
                 var tmp = PointToParent(ref location);


### PR DESCRIPTION
Currently you have to start the right click in an empty space in the node editor.

This pr makes it possible to also start right click on a node by checking if the mouse moved.