### PR TITLE
Surface Comments: Aligned text when editing title

### DIFF
--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -74,6 +74,7 @@ namespace FlaxEditor.Surface
                 Visible = false,
                 Parent = this,
                 EndEditOnClick = false, // We have to handle this ourselves, otherwise the textbox instantly loses focus when double-clicking the header
+                HorizontalAlignment = TextAlignment.Center,
             };
         }
 


### PR DESCRIPTION
Quick one line change, now that #2653 got fixed, to align the text when editing a surface comment header. This makes the text jump around less and prevents the text to jump offscreen, if the comment is wider than the visject viewport.

Before:
![CommentHeadersOld](https://github.com/user-attachments/assets/5945bd04-db53-4761-a70b-1fe187bbeb41)

After:
![CommentHeadersNew-1726859309132](https://github.com/user-attachments/assets/154140e6-6ecd-46c5-8818-e61e9250f965)
(Gif glitched after trimming for some reason, the important part is still visible tho)