### PR TITLE
Fix caret position in text box when no text but text alignment is applied

### DIFF
--- a/Source/Engine/Render2D/Font.cpp
+++ b/Source/Engine/Render2D/Font.cpp
@@ -402,7 +402,19 @@ Float2 Font::GetCharPosition(const StringView& text, int32 index, const TextLayo
 {
     // Check if there is no need to do anything
     if (text.IsEmpty())
-        return layout.Bounds.Location;
+    {
+        Float2 location = layout.Bounds.Location;
+        if (layout.VerticalAlignment == TextAlignment::Center)
+            location.Y += layout.Bounds.Size.Y * 0.5f - static_cast<float>(_height) * 0.5f;
+        else if (layout.VerticalAlignment == TextAlignment::Far)
+            location.Y += layout.Bounds.Size.Y - static_cast<float>(_height) * 0.5f;
+
+        if (layout.HorizontalAlignment == TextAlignment::Center)
+            location.X += layout.Bounds.Size.X * 0.5f;
+        else if (layout.HorizontalAlignment == TextAlignment::Far)
+            location.X += layout.Bounds.Size.X;
+        return location;
+    }
 
     // Process text
     Array<FontLineCache> lines;

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -292,7 +292,6 @@ namespace FlaxEngine.GUI
                 float alpha = Mathf.Saturate(Mathf.Cos(_animateTime * CaretFlashSpeed) * 0.5f + 0.7f);
                 alpha = alpha * alpha * alpha * alpha * alpha * alpha;
                 Render2D.FillRectangle(CaretBounds, CaretColor * alpha);
-                
             }
 
             // Restore rendering state


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/60fb3561-92ed-47b8-97c6-c205478c2b5d)

After:
![image](https://github.com/user-attachments/assets/894be541-da9f-4487-ab7a-70e3e2c47586)
