### PR TITLE
Fix `HasBorder` and `BorderThickness` for RichTextBox

### DIFF
--- a/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
@@ -233,7 +233,8 @@ namespace FlaxEngine.GUI
             if (IsMouseOver || IsNavFocused)
                 backColor = BackgroundSelectedColor;
             Render2D.FillRectangle(rect, backColor);
-            Render2D.DrawRectangle(rect, IsFocused ? BorderSelectedColor : BorderColor);
+            if (HasBorder)
+                Render2D.DrawRectangle(rect, IsFocused ? BorderSelectedColor : BorderColor, BorderThickness);
 
             // Apply view offset and clip mask
             if (ClipText)


### PR DESCRIPTION
`HasBorder` and `BorderThickness` were not implemented for `RichTextBox`.