### PR TITLE
Add context to object reference control to narrow finding actors and scripts

### DIFF
--- a/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
@@ -39,6 +39,11 @@ namespace FlaxEditor.CustomEditors.Editors
         private DragHandlers _dragHandlers;
 
         /// <summary>
+        /// The presenter using this control.
+        /// </summary>
+        public IPresenterOwner PresenterContext;
+
+        /// <summary>
         /// Gets or sets the allowed objects type (given type and all sub classes). Must be <see cref="Object"/> type of any subclass.
         /// </summary>
         public ScriptType Type
@@ -152,7 +157,7 @@ namespace FlaxEditor.CustomEditors.Editors
                     Value = actor;
                     RootWindow.Focus();
                     Focus();
-                });
+                }, PresenterContext);
             }
             else
             {
@@ -161,7 +166,7 @@ namespace FlaxEditor.CustomEditors.Editors
                     Value = script;
                     RootWindow.Focus();
                     Focus();
-                });
+                }, PresenterContext);
             }
         }
 
@@ -491,6 +496,7 @@ namespace FlaxEditor.CustomEditors.Editors
             if (!HasDifferentTypes)
             {
                 _element = layout.Custom<FlaxObjectRefPickerControl>();
+                _element.CustomControl.PresenterContext = Presenter.Owner;
                 _element.CustomControl.Type = Values.Type.Type != typeof(object) || Values[0] == null ? Values.Type : TypeUtils.GetObjectType(Values[0]);
                 _element.CustomControl.ValueChanged += () => SetValue(_element.CustomControl.Value);
             }

--- a/Source/Editor/GUI/Popups/ActorSearchPopup.cs
+++ b/Source/Editor/GUI/Popups/ActorSearchPopup.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
 using System;
+using FlaxEditor.Windows;
+using FlaxEditor.Windows.Assets;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -55,18 +57,26 @@ namespace FlaxEditor.GUI
         private IsValidDelegate _isValid;
         private Action<Actor> _selected;
 
-        private ActorSearchPopup(IsValidDelegate isValid, Action<Actor> selected)
+        private ActorSearchPopup(IsValidDelegate isValid, Action<Actor> selected, CustomEditors.IPresenterOwner context)
         {
             _isValid = isValid;
             _selected = selected;
 
             ItemClicked += OnItemClicked;
 
-            // TODO: use async thread to search scenes
-            for (int i = 0; i < Level.ScenesCount; i++)
+            if (context is PropertiesWindow propertiesWindow || context == null)
             {
-                Find(Level.GetScene(i));
+                // TODO: use async thread to search scenes
+                for (int i = 0; i < Level.ScenesCount; i++)
+                {
+                    Find(Level.GetScene(i));
+                }
             }
+            else if (context is PrefabWindow prefabWindow)
+            {
+                Find(prefabWindow.Graph.MainActor);
+            }
+            
             SortItems();
         }
 
@@ -98,10 +108,11 @@ namespace FlaxEditor.GUI
         /// <param name="showTargetLocation">The show target location.</param>
         /// <param name="isValid">Event called to check if a given actor item is valid to be used.</param>
         /// <param name="selected">Event called on actor item pick.</param>
+        /// <param name="context">The presenter owner context (i.e. PrefabWindow, PropertiesWindow).</param>
         /// <returns>The dialog.</returns>
-        public static ActorSearchPopup Show(Control showTarget, Float2 showTargetLocation, IsValidDelegate isValid, Action<Actor> selected)
+        public static ActorSearchPopup Show(Control showTarget, Float2 showTargetLocation, IsValidDelegate isValid, Action<Actor> selected, CustomEditors.IPresenterOwner context)
         {
-            var popup = new ActorSearchPopup(isValid, selected);
+            var popup = new ActorSearchPopup(isValid, selected, context);
             popup.Show(showTarget, showTargetLocation);
             return popup;
         }

--- a/Source/Editor/GUI/Popups/ScriptSearchPopup.cs
+++ b/Source/Editor/GUI/Popups/ScriptSearchPopup.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
 using System;
+using FlaxEditor.Windows;
+using FlaxEditor.Windows.Assets;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Utilities;
@@ -66,18 +68,26 @@ namespace FlaxEditor.GUI
         private IsValidDelegate _isValid;
         private Action<Script> _selected;
 
-        private ScriptSearchPopup(IsValidDelegate isValid, Action<Script> selected)
+        private ScriptSearchPopup(IsValidDelegate isValid, Action<Script> selected, CustomEditors.IPresenterOwner context)
         {
             _isValid = isValid;
             _selected = selected;
 
             ItemClicked += OnItemClicked;
 
-            // TODO: use async thread to search scenes
-            for (int i = 0; i < Level.ScenesCount; i++)
+            if (context is PropertiesWindow propertiesWindow || context == null)
             {
-                Find(Level.GetScene(i));
+                // TODO: use async thread to search scenes
+                for (int i = 0; i < Level.ScenesCount; i++)
+                {
+                    Find(Level.GetScene(i));
+                }
             }
+            else if (context is PrefabWindow prefabWindow)
+            {
+                Find(prefabWindow.Graph.MainActor);
+            }
+
             SortItems();
         }
 
@@ -113,10 +123,11 @@ namespace FlaxEditor.GUI
         /// <param name="showTargetLocation">The show target location.</param>
         /// <param name="isValid">Event called to check if a given script item is valid to be used.</param>
         /// <param name="selected">Event called on script item pick.</param>
+        /// <param name="context">The presenter owner context (i.e. PrefabWindow, PropertiesWindow).</param>
         /// <returns>The dialog.</returns>
-        public static ScriptSearchPopup Show(Control showTarget, Float2 showTargetLocation, IsValidDelegate isValid, Action<Script> selected)
+        public static ScriptSearchPopup Show(Control showTarget, Float2 showTargetLocation, IsValidDelegate isValid, Action<Script> selected, CustomEditors.IPresenterOwner context)
         {
-            var popup = new ScriptSearchPopup(isValid, selected);
+            var popup = new ScriptSearchPopup(isValid, selected, context);
             popup.Show(showTarget, showTargetLocation);
             return popup;
         }

--- a/Source/Editor/GUI/Timeline/Tracks/ActorTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/ActorTrack.cs
@@ -264,7 +264,7 @@ namespace FlaxEditor.GUI.Timeline.Tracks
 
         private void OnClickedSelect()
         {
-            ActorSearchPopup.Show(this, PointFromScreen(FlaxEngine.Input.MouseScreenPosition), IsActorValid, SetActor);
+            ActorSearchPopup.Show(this, PointFromScreen(FlaxEngine.Input.MouseScreenPosition), IsActorValid, SetActor, null);
         }
 
         private void OnClickedSelectActor(Image image, MouseButton button)


### PR DESCRIPTION
This makes a actor or script reference inside of a prefab only show actors or scripts related to that specific prefab when it finds possible references using the dropdown. This also adds drag drop changes to look at the context as well.

There is more work to do in this area such as removing scene specific references when creating a prefab.