### PR TITLE
Fixed NetworkLagDriver having wrong ChannelType and Length

### DIFF
--- a/Source/Engine/Networking/Drivers/NetworkLagDriver.cpp
+++ b/Source/Engine/Networking/Drivers/NetworkLagDriver.cpp
@@ -132,9 +132,10 @@ void NetworkLagDriver::SendMessage(const NetworkChannelType channelType, const N
 
     auto& msg = _messages.AddOne();
     msg.Lag = (double)Lag;
+    msg.ChannelType = channelType;
     msg.Type = 0;
-    msg.Message = message;
     msg.MessageData.Set(message.Buffer, message.Length);
+    msg.MessageLength = message.Length;
 }
 
 void NetworkLagDriver::SendMessage(NetworkChannelType channelType, const NetworkMessage& message, NetworkConnection target)
@@ -147,10 +148,11 @@ void NetworkLagDriver::SendMessage(NetworkChannelType channelType, const Network
 
     auto& msg = _messages.AddOne();
     msg.Lag = (double)Lag;
+    msg.ChannelType = channelType;
     msg.Type = 1;
-    msg.Message = message;
     msg.Target = target;
     msg.MessageData.Set(message.Buffer, message.Length);
+    msg.MessageLength = message.Length;
 }
 
 void NetworkLagDriver::SendMessage(const NetworkChannelType channelType, const NetworkMessage& message, const Array<NetworkConnection, HeapAllocation>& targets)
@@ -163,10 +165,11 @@ void NetworkLagDriver::SendMessage(const NetworkChannelType channelType, const N
 
     auto& msg = _messages.AddOne();
     msg.Lag = (double)Lag;
+    msg.ChannelType = channelType;
     msg.Type = 2;
-    msg.Message = message;
     msg.Targets = targets;
     msg.MessageData.Set(message.Buffer, message.Length);
+    msg.MessageLength = message.Length;
 }
 
 NetworkDriverStats NetworkLagDriver::GetStats()
@@ -197,19 +200,21 @@ void NetworkLagDriver::OnUpdate()
         if (msg.Lag > 0.0)
             continue;
 
-        // Fix message to point to the current buffer
-        msg.Message.Buffer = msg.MessageData.Get();
+        // Use this helper message as a container to send the stored data and length to the ENet driver
+        NetworkMessage message;
+        message.Buffer = msg.MessageData.Get();
+        message.Length = msg.MessageLength;
 
         switch (msg.Type)
         {
         case 0:
-            _driver->SendMessage(msg.ChannelType, msg.Message);
+            _driver->SendMessage(msg.ChannelType, message);
             break;
         case 1:
-            _driver->SendMessage(msg.ChannelType, msg.Message, msg.Target);
+            _driver->SendMessage(msg.ChannelType, message, msg.Target);
             break;
         case 2:
-            _driver->SendMessage(msg.ChannelType, msg.Message, msg.Targets);
+            _driver->SendMessage(msg.ChannelType, message, msg.Targets);
             break;
         }
         _messages.RemoveAt(i);

--- a/Source/Engine/Networking/Drivers/NetworkLagDriver.h
+++ b/Source/Engine/Networking/Drivers/NetworkLagDriver.h
@@ -22,10 +22,10 @@ private:
         double Lag;
         int32 Type;
         NetworkChannelType ChannelType;
-        NetworkMessage Message;
         NetworkConnection Target;
         Array<NetworkConnection> Targets;
         Array<byte> MessageData; // TODO: use message buffers cache (of size config.MessageSize) to reduce dynamic memory allocations
+        uint32 MessageLength;
     };
 
     struct LagEvent


### PR DESCRIPTION
There were some bugs with NetworkLagDriver.
First, the delayed messages did not store the ChannelType.
Second, it potentially can send the wrong message length to internal ENet driver. It stores a reference to the old message to be sent after the delay, but that message is recycled and could have different data and a different length by the time it's sent. 

While the old implementation does save out the data and apply it, I have it save out the length too now. Additionally, I removed the reference to the old message, and just use a placeholder one when sending, since all that's needed is the data and length. Before, changing the data in the old reference could potentially overwrite another message currently being used.

This was causing some occasional invalid packets being sent for my project, but with these changes it seems to have fixed it.