### PR TITLE
Add options to reconstruct z channel for textures.

### DIFF
--- a/Source/Engine/Tools/TextureTool/TextureTool.cpp
+++ b/Source/Engine/Tools/TextureTool/TextureTool.cpp
@@ -76,6 +76,9 @@ void TextureTool::Options::Serialize(SerializeStream& stream, const void* otherO
     stream.JKEY("InvertGreenChannel");
     stream.Bool(InvertGreenChannel);
 
+    stream.JKEY("ReconstructZChannel");
+    stream.Bool(ReconstructZChannel);
+
     stream.JKEY("Resize");
     stream.Bool(Resize);
 
@@ -134,6 +137,7 @@ void TextureTool::Options::Deserialize(DeserializeStream& stream, ISerializeModi
     GenerateMipMaps = JsonTools::GetBool(stream, "GenerateMipMaps", GenerateMipMaps);
     FlipY = JsonTools::GetBool(stream, "FlipY", FlipY);
     InvertGreenChannel = JsonTools::GetBool(stream, "InvertGreenChannel", InvertGreenChannel);
+    ReconstructZChannel = JsonTools::GetBool(stream, "ReconstructZChannel", ReconstructZChannel);
     Resize = JsonTools::GetBool(stream, "Resize", Resize);
     PreserveAlphaCoverage = JsonTools::GetBool(stream, "PreserveAlphaCoverage", PreserveAlphaCoverage);
     PreserveAlphaCoverageReference = JsonTools::GetFloat(stream, "PreserveAlphaCoverageReference", PreserveAlphaCoverageReference);

--- a/Source/Engine/Tools/TextureTool/TextureTool.h
+++ b/Source/Engine/Tools/TextureTool/TextureTool.h
@@ -61,7 +61,7 @@ API_CLASS(Namespace="FlaxEngine.Tools", Static) class FLAXENGINE_API TextureTool
         API_FIELD(Attributes = "EditorOrder(71)")
         bool InvertGreenChannel = false;
 
-        // True if to invert the green channel on a normal map. Good for OpenGL to DirectX conversion.
+        // Rebuild Z (blue) channel assuming X/Y are normals.
         API_FIELD(Attributes = "EditorOrder(72)")
         bool ReconstructZChannel = false;
 

--- a/Source/Engine/Tools/TextureTool/TextureTool.h
+++ b/Source/Engine/Tools/TextureTool/TextureTool.h
@@ -61,6 +61,10 @@ API_CLASS(Namespace="FlaxEngine.Tools", Static) class FLAXENGINE_API TextureTool
         API_FIELD(Attributes = "EditorOrder(71)")
         bool InvertGreenChannel = false;
 
+        // True if to invert the green channel on a normal map. Good for OpenGL to DirectX conversion.
+        API_FIELD(Attributes = "EditorOrder(72)")
+        bool ReconstructZChannel = false;
+
         // Texture size scale. Allows increasing or decreasing the imported texture resolution. Default is 1.
         API_FIELD(Attributes="EditorOrder(80), Limit(0.0001f, 1000.0f, 0.01f)")
         float Scale = 1.0f;


### PR DESCRIPTION
Useful for importing normal maps that only have x and y channels.


Code like similar methods are taken from <https://github.com/microsoft/DirectXTex/blob/main/Texconv/texconv.cpp> as an example.


image before:
![image](https://github.com/user-attachments/assets/a2e47019-c6cb-4cf5-a7c5-a5fe4f44ee21)

image after import with option selected:
![image](https://github.com/user-attachments/assets/aa681e1c-bce1-4fa6-b256-a9721ae51a20)
