### PR TITLE
Make "Edit Prefab" no longer change content panel file path

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -86,10 +86,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
 
                             // Edit selected prefab asset
                             var editPrefab = panel.Button("Edit Prefab");
-                            editPrefab.Button.Clicked += () =>
-                            {
-                                Editor.Instance.Windows.ContentWin.Open(Editor.Instance.ContentDatabase.FindAsset(prefab.ID));
-                            };
+                            editPrefab.Button.Clicked += () => Editor.Instance.Windows.ContentWin.Open(Editor.Instance.ContentDatabase.FindAsset(prefab.ID));
 
                             // Viewing changes applied to this actor
                             var viewChanges = panel.Button("View Changes");

--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -9,6 +9,7 @@ using FlaxEditor.CustomEditors.Elements;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Tree;
+using FlaxEditor.Modules;
 using FlaxEditor.Scripting;
 using FlaxEditor.Windows;
 using FlaxEditor.Windows.Assets;
@@ -87,9 +88,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                             var editPrefab = panel.Button("Edit Prefab");
                             editPrefab.Button.Clicked += () =>
                             {
-                                Editor.Instance.Windows.ContentWin.ClearItemsSearch();
-                                Editor.Instance.Windows.ContentWin.Select(prefab);
-                                Editor.Instance.Windows.ContentWin.Open(Editor.Instance.Windows.ContentWin.View.Selection[0]);
+                                Editor.Instance.Windows.ContentWin.Open(Editor.Instance.ContentDatabase.FindAsset(prefab.ID));
                             };
 
                             // Viewing changes applied to this actor


### PR DESCRIPTION
It's always bothered me that the "Edit Prefab" button changes the directory the Content Panel has open.
My primary use case for that button is to quickly open a prefab, when I have an asset selected in the Content Panel that I want to drag into the prefab.

If someone still wants to change the Content panel to the file path of the prefab, they can use the "Select Prefab" button (or I'll make an editor setting for that if there is demand).