### PR TITLE
Add debug draw clear to game and editor panel

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -973,6 +973,15 @@ namespace FlaxEditor.Viewport
 
                 ViewWidgetButtonMenu.AddSeparator();
 
+                // Clear Debug Draw
+                {
+                    var button = ViewWidgetButtonMenu.AddButton("Clear Debug Draw");
+                    button.CloseMenuOnClick = false;
+                    button.Clicked += () => DebugDraw.Clear();
+                }
+
+                ViewWidgetButtonMenu.AddSeparator();
+
                 // Brightness
                 {
                     var brightness = ViewWidgetButtonMenu.AddButton("Brightness");

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -596,6 +596,13 @@ namespace FlaxEditor.Windows
                 checkbox.StateChanged += x => ShowDebugDraw = x.Checked;
             }
 
+            // Debug Draw Clear
+            {
+                var button = menu.AddButton("Clear Debug Draw");
+                button.CloseMenuOnClick = false;
+                button.Clicked += () => DebugDraw.Clear();
+            }
+
             menu.MinimumWidth = 200;
             menu.AddSeparator();
         }


### PR DESCRIPTION
This pr adds a button to clear all debug draw to the _Game Panel_ rmb menu as well as to the _View_ menu.

Has happened a lot of times that I wanted to get rid of some old debug draw with the click of a button.
Requires #2988 to be merged (which it is).

![image](https://github.com/user-attachments/assets/01e1fd0c-2aa3-450e-8f5b-63f5833ac456)
![image](https://github.com/user-attachments/assets/60850b92-c005-442c-a0f5-9602ac91a2e3)