### PR TITLE
Add focus Output or Debug Log panel on Begin Play editor option

### DIFF
--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -138,7 +138,7 @@ namespace FlaxEditor.Options
         }
 
         /// <summary>
-        /// Avaliable options for focusing a log panel on Begin Play.
+        /// Avaliable options for showing a log panel on Begin Play.
         /// </summary>
         public enum LogWindowType
         {

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -2,7 +2,6 @@
 
 using System.ComponentModel;
 using FlaxEditor.GUI.Docking;
-using FlaxEditor.Utilities;
 using FlaxEngine;
 
 namespace FlaxEditor.Options
@@ -136,6 +135,25 @@ namespace FlaxEditor.Options
             /// Format using a unit that matches the value best.
             /// </summary>
             AutoUnit,
+        }
+
+        /// <summary>
+        /// Avaliable options for focusing a log panel on Begin Play.
+        /// </summary>
+        public enum LogWindowType
+        {
+            /// <summary>
+            /// Don't show any log panel.
+            /// </summary>
+            None,
+            /// <summary>
+            /// Show the Debug Log panel.
+            /// </summary>
+            DebugLog,
+            /// <summary>
+            /// Show the Output Log panel.
+            /// </summary>
+            OutputLog,
         }
 
         /// <summary>
@@ -341,18 +359,18 @@ namespace FlaxEditor.Options
         public bool OutputLogScrollToBottom { get; set; } = true;
 
         /// <summary>
-        /// Gets or set a value indicating wether the outpug log panel should be focussed on begin play.
-        /// </summary>
-        [DefaultValue(false)]
-        [EditorDisplay("Output Log", "Show Output Log Panel on Begin Play"), EditorOrder(471), Tooltip("Show the Output Log panel on Begin Play. Shows the previously selected panel on End Play.")]
-        public bool ShowOutputLogOnBeginPlay { get; set; } = false;
-
-        /// <summary>
         /// Gets or sets a value indicating whether auto-focus game window on play mode start.
         /// </summary>
         [DefaultValue(true)]
         [EditorDisplay("Play In-Editor", "Focus Game Window On Play"), EditorOrder(500), Tooltip("Determines whether auto-focus game window on play mode start.")]
         public bool FocusGameWinOnPlay { get; set; } = true;
+
+        /// <summary>
+        /// Gets or set a value indicating wether the outpug log panel should be focussed on begin play.
+        /// </summary>
+        [DefaultValue(LogWindowType.None)]
+        [EditorDisplay("Play In-Editor", "Show Log Panel On Begin Play"), EditorOrder(501), Tooltip("Show the set log panel on Begin Play. Shows the previously selected panel on End Play.")]
+        public LogWindowType ShowLogPanelOnBeginPlay { get; set; } = LogWindowType.None;
 
         /// <summary>
         /// Gets or sets a value indicating what action should be taken upon pressing the play button.

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -344,8 +344,8 @@ namespace FlaxEditor.Options
         /// Gets or set a value indicating wether the outpug log panel should be focussed on begin play.
         /// </summary>
         [DefaultValue(false)]
-        [EditorDisplay("Output Log", "Focus Output Log Panel on Begin Play"), EditorOrder(471), Tooltip("Focus the Output Log panel on Begin Play. Focuses the previously selected panel on End Play.")]
-        public bool FocusOutputLogOnBeginPlay { get; set; } = false;
+        [EditorDisplay("Output Log", "Show Output Log Panel on Begin Play"), EditorOrder(471), Tooltip("Show the Output Log panel on Begin Play. Shows the previously selected panel on End Play.")]
+        public bool ShowOutputLogOnBeginPlay { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether auto-focus game window on play mode start.

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -341,6 +341,13 @@ namespace FlaxEditor.Options
         public bool OutputLogScrollToBottom { get; set; } = true;
 
         /// <summary>
+        /// Gets or set a value indicating wether the outpug log panel should be focussed on begin play.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Output Log", "Focus Output Log Panel on Begin Play"), EditorOrder(471), Tooltip("Focus the Output Log panel on Begin Play. Focuses the previously selected panel on End Play.")]
+        public bool FocusOutputLogOnBeginPlay { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether auto-focus game window on play mode start.
         /// </summary>
         [DefaultValue(true)]

--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -440,7 +440,7 @@ namespace FlaxEditor.Windows
 
         private void OnPlayModeEnd()
         {
-            if (!focusOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow) || !_previousWindow.IsDisposing)
+            if (!focusOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow))
                 return;
 
             _previousWindow.Focus();

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -223,7 +223,7 @@ namespace FlaxEditor.Windows
 
         private void OnPlayModeBeginning()
         {
-            if (!Editor.Instance.Options.Options.Interface.FocusOutputLogOnBeginPlay)
+            if (!Editor.Instance.Options.Options.Interface.ShowOutputLogOnBeginPlay)
                 return;
 
             _previousWindow = this.ParentDockPanel.SelectedTab;
@@ -233,7 +233,7 @@ namespace FlaxEditor.Windows
 
         private void OnPlayModeEnd()
         {
-            if (!Editor.Instance.Options.Options.Interface.FocusOutputLogOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow))
+            if (!Editor.Instance.Options.Options.Interface.ShowOutputLogOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow) || !_previousWindow.IsDisposing)
                 return;
 
             _previousWindow.Focus();

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -126,6 +126,14 @@ namespace FlaxEditor.Windows
             }
         }
 
+        private bool focusOnBeginPlay
+        {
+            get 
+            {
+                return Editor.Instance.Options.Options.Interface.ShowLogPanelOnBeginPlay == InterfaceOptions.LogWindowType.OutputLog;
+            }
+        }
+
         private InterfaceOptions.TimestampsFormats _timestampsFormats;
         private bool _showLogType;
 
@@ -223,7 +231,7 @@ namespace FlaxEditor.Windows
 
         private void OnPlayModeBeginning()
         {
-            if (!Editor.Instance.Options.Options.Interface.ShowOutputLogOnBeginPlay)
+            if (!focusOnBeginPlay)
                 return;
 
             _previousWindow = this.ParentDockPanel.SelectedTab;
@@ -233,7 +241,7 @@ namespace FlaxEditor.Windows
 
         private void OnPlayModeEnd()
         {
-            if (!Editor.Instance.Options.Options.Interface.ShowOutputLogOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow) || !_previousWindow.IsDisposing)
+            if (!focusOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow) || !_previousWindow.IsDisposing)
                 return;
 
             _previousWindow.Focus();

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -241,7 +241,7 @@ namespace FlaxEditor.Windows
 
         private void OnPlayModeEnd()
         {
-            if (!focusOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow) || !_previousWindow.IsDisposing)
+            if (!focusOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow))
                 return;
 
             _previousWindow.Focus();

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -668,6 +668,8 @@ namespace FlaxEditor.Windows
             Editor.Options.OptionsChanged -= OnEditorOptionsChanged;
             GameCooker.Event -= OnGameCookerEvent;
             ScriptsBuilder.CompilationFailed -= OnScriptsCompilationFailed;
+            Editor.Instance.PlayModeBeginning -= OnPlayModeBeginning;
+            Editor.Instance.PlayModeEnd -= OnPlayModeEnd;
 
             // Cleanup
             _textBuffer.Clear();

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Docking;
 using FlaxEditor.GUI.Input;
 using FlaxEditor.Options;
 using FlaxEngine;
@@ -148,6 +149,7 @@ namespace FlaxEditor.Windows
         private VScrollBar _vScroll;
         private OutputTextBox _output;
         private ContextMenu _contextMenu;
+        private DockWindow _previousWindow;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugLogWindow"/> class.
@@ -210,10 +212,31 @@ namespace FlaxEditor.Windows
             Editor.Options.OptionsChanged += OnEditorOptionsChanged;
             OnEditorOptionsChanged(Editor.Options.Options);
 
+            Editor.Instance.PlayModeBeginning += OnPlayModeBeginning;
+            Editor.Instance.PlayModeEnd += OnPlayModeEnd;
+
             InputActions.Add(options => options.Search, _searchBox.Focus);
 
             GameCooker.Event += OnGameCookerEvent;
             ScriptsBuilder.CompilationFailed += OnScriptsCompilationFailed;
+        }
+
+        private void OnPlayModeBeginning()
+        {
+            if (!Editor.Instance.Options.Options.Interface.FocusOutputLogOnBeginPlay)
+                return;
+
+            _previousWindow = this.ParentDockPanel.SelectedTab;
+
+            this.ParentDockPanel.SelectTab(this);
+        }
+
+        private void OnPlayModeEnd()
+        {
+            if (!Editor.Instance.Options.Options.Interface.FocusOutputLogOnBeginPlay || !this.ParentDockPanel.ContainsTab(_previousWindow))
+                return;
+
+            _previousWindow.Focus();
         }
 
         private void OnViewButtonClicked()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9369ce93-1bca-4b27-b251-32550f5c4d6b)


Does what the title says.
Will focus the previously focused panel on end play if it's still in the same container than the selected log panel.
