### PR TITLE
Handle C++ curly brace field default values for code gen to C#

### DIFF
--- a/Source/Engine/Tests/TestScripting.h
+++ b/Source/Engine/Tests/TestScripting.h
@@ -8,6 +8,35 @@
 #include "Engine/Scripting/ScriptingObject.h"
 #include "Engine/Scripting/SerializableScriptingObject.h"
 
+// Test default values init on fields.
+API_STRUCT(NoDefault) struct TestDefaultValues
+{
+    DECLARE_SCRIPTING_TYPE_MINIMAL(TestDefaultValues);
+
+    // Default value case 1
+    API_FIELD() float TestFloat1 = {};
+    // Default value case 2
+    API_FIELD() float TestFloat2 = { };
+    // Default value case 3
+    API_FIELD() float TestFloat3 = {1.0f};
+    // Default value case 4
+    API_FIELD() float TestFloat4 = float{};
+    // Default value case 5
+    API_FIELD() float TestFloat5 = float{ };
+    // Default value case 6
+    API_FIELD() float TestFloat6 = float{1.0f};
+    // Default value case 7
+    API_FIELD() float TestFloat7 {};
+    // Default value case 8
+    API_FIELD() float TestFloat8 {1.0f};
+    // Default value case 9
+    API_FIELD() float TestFloat9 = 1.0f;
+    // Default value case 10
+    API_FIELD() float TestFloat10 = 1.f;
+    // Default value case 11
+    API_FIELD() float TestFloat11 = 1;
+};
+
 // Test interface (name conflict with namespace)
 API_INTERFACE(Namespace="Foo") class FLAXENGINE_API IFoo
 {

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -153,6 +153,17 @@ namespace Flax.Build.Bindings
             case "false": return value;
             }
 
+            // Handle C++ bracket default values that are not arrays
+            if (value.StartsWith("{") && value.EndsWith("}") && valueType != null && !valueType.IsArray && valueType.Type != "Array")
+            {
+                value = value.Replace("{", "").Replace("}", "").Trim();
+                if (string.IsNullOrEmpty(value))
+                {
+                    value = $"default({valueType.Type})";
+                    return value;
+                }
+            }
+
             // Numbers
             if (float.TryParse(value, out _) || (value[value.Length - 1] == 'f' && float.TryParse(value.Substring(0, value.Length - 1), out _)))
             {

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -153,6 +153,17 @@ namespace Flax.Build.Bindings
             case "false": return value;
             }
 
+            // Handle float{_} style type of default values
+            if (valueType != null && value.StartsWith($"{valueType.Type}") && value.EndsWith("}"))
+            {
+                value = value.Replace($"{valueType.Type}", "").Replace("{", "").Replace("}", "").Trim();
+                if (string.IsNullOrEmpty(value))
+                {
+                    value = $"default({valueType.Type})";
+                    return value;
+                }
+            }
+
             // Handle C++ bracket default values that are not arrays
             if (value.StartsWith("{") && value.EndsWith("}") && valueType != null && !valueType.IsArray && valueType.Type != "Array")
             {

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
@@ -1352,10 +1352,16 @@ namespace Flax.Build.Bindings
             desc.Name = ParseName(ref context);
 
             // Read ';' or default value or array size or bit-field size
-            token = context.Tokenizer.ExpectAnyTokens(new[] { TokenType.SemiColon, TokenType.Equal, TokenType.LeftBracket, TokenType.Colon });
+            token = context.Tokenizer.ExpectAnyTokens(new[] { TokenType.SemiColon, TokenType.Equal, TokenType.LeftBracket, TokenType.LeftCurlyBrace, TokenType.Colon });
             if (token.Type == TokenType.Equal)
             {
                 context.Tokenizer.SkipUntil(TokenType.SemiColon, out desc.DefaultValue, false);
+            }
+            // Handle ex: API_FIELD() Type FieldName {DefaultValue};
+            else if (token.Type == TokenType.LeftCurlyBrace)
+            {
+                context.Tokenizer.SkipUntil(TokenType.SemiColon, out desc.DefaultValue, false);
+                desc.DefaultValue = '{' + desc.DefaultValue;
             }
             else if (token.Type == TokenType.LeftBracket)
             {


### PR DESCRIPTION
Handles the code gen for field default values if they are not an array and have curly braces.

```
API_FIELD() float TestFloat = {};
API_FIELD() float TestFloat = { };
API_FIELD() float TestFloat = {1.0f};

API_FIELD() float TestFloat = float{};
API_FIELD() float TestFloat = float{ };
API_FIELD() float TestFloat = float{1.0f};

API_FIELD() float TestFloat {};
API_FIELD() float TestFloat {1.0f};
```

Part of #2237 