### PR TITLE
Improve delete assets confirm dialog

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -638,12 +638,14 @@ namespace FlaxEditor.Windows
             var toDelete = new List<ContentItem>(items);
             toDelete.Sort((a, b) => a.IsFolder ? 1 : b.IsFolder ? -1 : a.Compare(b));
 
+            string singularPlural = toDelete.Count > 1 ? "s" : "";
+
             string msg = toDelete.Count == 1
-                         ? string.Format("Are you sure to delete \'{0}\'?\nThis action cannot be undone. Files will be deleted permanently.", items[0].Path)
-                         : string.Format("Are you sure to delete {0} selected items?\nThis action cannot be undone. Files will be deleted permanently.", items.Count);
+                         ? string.Format("Delete \'{0}\'?\n\nThis action cannot be undone.\nFiles will be deleted permanently.", items[0].Path)
+                         : string.Format("Delete {0} selected items?\n\nThis action cannot be undone.\nFiles will be deleted permanently.", items.Count);
 
             // Ask user
-            if (MessageBox.Show(msg, "Delete asset(s)", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) != DialogResult.OK)
+            if (MessageBox.Show(msg, "Delete asset" + singularPlural, MessageBoxButtons.OKCancel, MessageBoxIcon.Question) != DialogResult.OK)
                 return;
 
             // Clear navigation

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -641,7 +641,7 @@ namespace FlaxEditor.Windows
             string singularPlural = toDelete.Count > 1 ? "s" : "";
 
             string msg = toDelete.Count == 1
-                         ? string.Format("Delete \'{0}\'?\n\nThis action cannot be undone.\nFiles will be deleted permanently.", items[0].Path)
+                         ? string.Format("Delete \'{0}\'?\n\nThis action cannot be undone.\nFile will be deleted permanently.", items[0].Path)
                          : string.Format("Delete {0} selected items?\n\nThis action cannot be undone.\nFiles will be deleted permanently.", items.Count);
 
             // Ask user


### PR DESCRIPTION
- Improve visual spacing
- Improve grammar and reduce word count (reduced mental load imo)
- Make dialog prompt respect asset count

### Before
![image](https://github.com/user-attachments/assets/96e6e103-c894-43f7-a86a-808a6a55809f)
![image](https://github.com/user-attachments/assets/8f134298-76aa-4b9e-8eed-13f4d069d676)

### After
![image](https://github.com/user-attachments/assets/0cfbe2db-dac7-42d1-9090-2b69778bddf2)
<!-- ![image](https://github.com/user-attachments/assets/9b9b3dbe-b2c1-49cf-b407-2e5f176d16ff) -->
![image](https://github.com/user-attachments/assets/5d1e77a1-c046-4429-9207-ef11cb5df9eb)

