### PR TITLE
Add named terrain layers

### DIFF
--- a/Source/Editor/CustomEditors/Editors/TerrainLayerEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/TerrainLayerEditor.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
+
+using FlaxEditor.Content.Settings;
+using FlaxEditor.CustomEditors.Elements;
+using FlaxEditor.GUI;
+
+namespace FlaxEditor.CustomEditors.Editors
+{
+    /// <summary>
+    /// Custom editor for picking terrain layers. Instead of choosing bit mask or layer index it shows a combo box with simple layer picking by name.
+    /// </summary>
+    public sealed class TerrainLayerEditor : CustomEditor
+    {
+        private ComboBoxElement element;
+
+        /// <inheritdoc />
+        public override DisplayStyle Style => DisplayStyle.Inline;
+
+        /// <inheritdoc />
+        public override void Initialize(LayoutElementsContainer layout)
+        {
+            element = layout.ComboBox();
+            element.ComboBox.SetItems(LayersAndTagsSettings.GetCurrentTerrainLayers());
+            element.ComboBox.SelectedIndex = (int)Values[0];
+            element.ComboBox.SelectedIndexChanged += OnSelectedIndexChanged;
+        }
+
+        private void OnSelectedIndexChanged(ComboBox comboBox)
+        {
+            int value = comboBox.SelectedIndex;
+            if (value == -1)
+                value = 0;
+
+            SetValue(value);
+        }
+
+        /// <inheritdoc />
+        public override void Refresh()
+        {
+            base.Refresh();
+
+            element.ComboBox.SelectedIndex = (int)Values[0];
+        }
+    }
+}

--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
 using System;
+using FlaxEditor.Content.Settings;
 using FlaxEditor.Scripting;
 using FlaxEditor.Surface.Elements;
 using FlaxEditor.Windows.Assets;
@@ -590,7 +591,7 @@ namespace FlaxEditor.Surface.Archetypes
                 },
                 Elements = new[]
                 {
-                    NodeElementArchetype.Factory.ComboBox(0, 0, 70.0f, 0, FlaxEditor.Tools.Terrain.PaintTerrainGizmoMode.TerrainLayerNames),
+                    NodeElementArchetype.Factory.ComboBox(0, 0, 70.0f, 0, LayersAndTagsSettings.GetCurrentTerrainLayers()),
                     NodeElementArchetype.Factory.Output(0, "", typeof(float), 0),
                 }
             },

--- a/Source/Editor/Tools/Terrain/Paint/SingleLayerMode.cs
+++ b/Source/Editor/Tools/Terrain/Paint/SingleLayerMode.cs
@@ -60,7 +60,7 @@ namespace FlaxEditor.Tools.Terrain.Paint
         /// <summary>
         /// The layer to paint with it.
         /// </summary>
-        [EditorOrder(10), Tooltip("The layer to paint with it. Terrain material can access per-layer blend weight to perform materials or textures blending.")]
+        [EditorOrder(10), Tooltip("The layer to paint on. Terrain material can access a per-layer blend weight to perform material or texture blending."), CustomEditorAlias("FlaxEditor.CustomEditors.Editors.TerrainLayerEditor")]
         public Layers Layer = Layers.Layer0;
 
         /// <inheritdoc />

--- a/Source/Editor/Tools/Terrain/PaintTerrainGizmoMode.cs
+++ b/Source/Editor/Tools/Terrain/PaintTerrainGizmoMode.cs
@@ -21,21 +21,6 @@ namespace FlaxEditor.Tools.Terrain
     [HideInEditor]
     public class PaintTerrainGizmoMode : EditorGizmoMode
     {
-        /// <summary>
-        /// The terrain layer names.
-        /// </summary>
-        public static readonly string[] TerrainLayerNames =
-        {
-            "Layer 0",
-            "Layer 1",
-            "Layer 2",
-            "Layer 3",
-            "Layer 4",
-            "Layer 5",
-            "Layer 6",
-            "Layer 7",
-        };
-
         private struct SplatmapData
         {
             public IntPtr DataPtr;

--- a/Source/Engine/Core/Config/LayersAndTagsSettings.cs
+++ b/Source/Engine/Core/Config/LayersAndTagsSettings.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using FlaxEngine;
@@ -28,6 +29,29 @@ namespace FlaxEditor.Content.Settings
         public static string[] GetCurrentLayers()
         {
             return GetCurrentLayers(out int _);
+        }
+
+        /// <summary>
+        /// The layers names.
+        /// </summary>
+        [EditorOrder(10), EditorDisplay("Terrain Layers", EditorDisplayAttribute.InlineStyle), Collection(CanResize = false, Display = CollectionAttribute.DisplayType.Inline)]
+        public string[] TerrainLayers = new string[8];
+
+        /// <summary>
+        /// Gets the current terrain layer names. Returns "Layer" + index for layers without a name.
+        /// </summary>
+        /// <returns>The layer names.</returns>
+        public static string[] GetCurrentTerrainLayers()
+        {
+            string[] layerNames = GameSettings.Load<LayersAndTagsSettings>().TerrainLayers.ToArray();
+
+            for (int i = 0; i < layerNames.Length; i++)
+            {
+                if (string.IsNullOrEmpty(layerNames[i]))
+                    layerNames[i] = $"Terrain Layer {i}";
+            }
+
+            return layerNames;
         }
 
         [LibraryImport("FlaxEngine", EntryPoint = "LayersAndTagsSettingsInternal_GetCurrentLayers", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(FlaxEngine.Interop.StringMarshaller))]

--- a/Source/Engine/Core/Config/LayersAndTagsSettings.cs
+++ b/Source/Engine/Core/Config/LayersAndTagsSettings.cs
@@ -42,6 +42,9 @@ namespace FlaxEditor.Content.Settings
         /// <returns>The layer names.</returns>
         public static string[] GetCurrentTerrainLayers()
         {
+    #if FLAX_TESTS
+            return Array.Empty<string>();
+    #else
             string[] layerNames = GameSettings.Load<LayersAndTagsSettings>().TerrainLayers;
 
             for (int i = 0; i < layerNames.Length; i++)
@@ -51,6 +54,7 @@ namespace FlaxEditor.Content.Settings
             }
 
             return layerNames;
+    #endif
         }
 
         [LibraryImport("FlaxEngine", EntryPoint = "LayersAndTagsSettingsInternal_GetCurrentLayers", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(FlaxEngine.Interop.StringMarshaller))]

--- a/Source/Engine/Core/Config/LayersAndTagsSettings.cs
+++ b/Source/Engine/Core/Config/LayersAndTagsSettings.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using FlaxEngine;
@@ -35,7 +34,7 @@ namespace FlaxEditor.Content.Settings
         /// The layers names.
         /// </summary>
         [EditorOrder(10), EditorDisplay("Terrain Layers", EditorDisplayAttribute.InlineStyle), Collection(CanResize = false, Display = CollectionAttribute.DisplayType.Inline)]
-        public string[] TerrainLayers = Enumerable.Repeat(string.Empty, 8).ToArray();
+        public string[] TerrainLayers = new string[8];
 
         /// <summary>
         /// Gets the current terrain layer names. Returns "Layer" + index for layers without a name.
@@ -43,7 +42,7 @@ namespace FlaxEditor.Content.Settings
         /// <returns>The layer names.</returns>
         public static string[] GetCurrentTerrainLayers()
         {
-            string[] layerNames = GameSettings.Load<LayersAndTagsSettings>().TerrainLayers.ToArray();
+            string[] layerNames = GameSettings.Load<LayersAndTagsSettings>().TerrainLayers;
 
             for (int i = 0; i < layerNames.Length; i++)
             {

--- a/Source/Engine/Core/Config/LayersAndTagsSettings.cs
+++ b/Source/Engine/Core/Config/LayersAndTagsSettings.cs
@@ -35,7 +35,7 @@ namespace FlaxEditor.Content.Settings
         /// The layers names.
         /// </summary>
         [EditorOrder(10), EditorDisplay("Terrain Layers", EditorDisplayAttribute.InlineStyle), Collection(CanResize = false, Display = CollectionAttribute.DisplayType.Inline)]
-        public string[] TerrainLayers = new string[8];
+        public string[] TerrainLayers = Enumerable.Repeat(string.Empty, 8).ToArray();
 
         /// <summary>
         /// Gets the current terrain layer names. Returns "Layer" + index for layers without a name.

--- a/Source/Engine/Core/Config/LayersAndTagsSettings.cs
+++ b/Source/Engine/Core/Config/LayersAndTagsSettings.cs
@@ -43,7 +43,7 @@ namespace FlaxEditor.Content.Settings
         public static string[] GetCurrentTerrainLayers()
         {
     #if FLAX_TESTS
-            return Array.Empty<string>();
+            return System.Array.Empty<string>();
     #else
             string[] layerNames = GameSettings.Load<LayersAndTagsSettings>().TerrainLayers;
 

--- a/Source/Engine/Core/Config/LayersAndTagsSettings.cs
+++ b/Source/Engine/Core/Config/LayersAndTagsSettings.cs
@@ -48,7 +48,7 @@ namespace FlaxEditor.Content.Settings
             for (int i = 0; i < layerNames.Length; i++)
             {
                 if (string.IsNullOrEmpty(layerNames[i]))
-                    layerNames[i] = $"Terrain Layer {i}";
+                    layerNames[i] = $"Layer {i}";
             }
 
             return layerNames;


### PR DESCRIPTION
Adds the ability to assign names to terrain layers via a new section *Terrain Layers* in *Layers And Tags Settings*.
Uses a custom editor (`TerrainLayerEditor`) to display the names.
If there is no name assigned in the settings, the layer is displayed as *"Layer" + layer index* (f.e. "Layer 1").

It'd be cool if someone could test this a bit. I did some testing, but it was so much more easy to implement than I expected, I'm worried I missed something.

I'd like to receive feedback on `LayersAndTagsSettings.GetCurrentTerrainLayers()`, especially about the part where I load the settings.

![image](https://github.com/user-attachments/assets/a7c2f02c-3410-459a-af64-086838e544da)
![image](https://github.com/user-attachments/assets/92ca40bd-903a-419c-9781-794706fe638f)
![image](https://github.com/user-attachments/assets/2cae15a8-302d-467a-b36c-c712e244ea04)