### PR TITLE
Fix NetworkManager not resetting LastUpdateTime

### DIFF
--- a/Source/Engine/Networking/NetworkManager.cpp
+++ b/Source/Engine/Networking/NetworkManager.cpp
@@ -364,6 +364,8 @@ void NetworkManager::Stop()
 
     State = NetworkConnectionState::Disconnected;
     Mode = NetworkManagerMode::Offline;
+    LastUpdateTime = 0;
+
     StateChanged();
 }
 


### PR DESCRIPTION
NetworkManager did not reset the LastUpdateTime variable to 0 when stopping. This lead to wrong behaviour in Update when Stopped and Started multiple times. This was especially visible when running in the editor, since LastUpdateTime was initialized once on editor start. When trying to connect to a server, the NetworkManager update would not poll events and therefore not connect, until the `currentTime - LastUpdateTime < minDeltaTime` requirement was met.

Fixes #2792 