### PR TITLE
Nameless c++ function argument support for C# generation

### DIFF
--- a/Source/Engine/Tests/TestScripting.h
+++ b/Source/Engine/Tests/TestScripting.h
@@ -178,6 +178,9 @@ public:
         return static_cast<float>(number);
     }
 
+    // Test nameless arguments
+    API_FUNCTION() void TestNamelessArguments(int32, float, bool){}
+
     int32 TestInterfaceMethod(const String& str) override
     {
         return str.Length();

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Parsing.cs
@@ -390,7 +390,22 @@ namespace Flax.Build.Bindings
 
                 // Read parameter type and name
                 currentParam.Type = ParseType(ref context);
-                currentParam.Name = context.Tokenizer.ExpectToken(TokenType.Identifier).Value;
+                token = context.Tokenizer.NextToken();
+                if (token.Type == TokenType.Identifier)
+                {
+                    currentParam.Name = token.Value;
+                }
+                // Support nameless arguments. assume optional usage
+                else
+                {
+                    context.Tokenizer.PreviousToken();
+                    if (string.IsNullOrEmpty(currentParam.Attributes))
+                        currentParam.Attributes = "Optional";
+                    else
+                        currentParam.Attributes += ", Optional";
+                    currentParam.Name = $"namelessArg{parameters.Count}";
+                }
+                
                 if (currentParam.IsOut && (currentParam.Type.IsPtr || currentParam.Type.IsRef) && currentParam.Type.Type.EndsWith("*"))
                 {
                     // Pointer to value passed as output pointer


### PR DESCRIPTION
Closes #2237

This assumes if the C++ argument does not have a name that it is optional and marks it in C# as such as that seems to be the standard usage in C++ for nameless arguments.