### PR TITLE
New allocations model

### DIFF
--- a/Source/Engine/ContentExporters/AssetsExportingManager.cpp
+++ b/Source/Engine/ContentExporters/AssetsExportingManager.cpp
@@ -128,8 +128,7 @@ bool AssetsExportingManagerService::Init()
 void AssetsExportingManagerService::Dispose()
 {
     // Cleanup
-    AssetsExportingManager::Exporters.Clear();
-    AssetsExportingManager::Exporters.SetCapacity(0);
+    AssetsExportingManager::Exporters.ClearToFree();
 }
 
 #endif

--- a/Source/Engine/Core/Collections/Array.h
+++ b/Source/Engine/Core/Collections/Array.h
@@ -398,10 +398,7 @@ public:
     /// <summary>
     /// Tries to reduce the capacity of the collection to fit its current size.
     /// </summary>
-    /// <remarks>
-    /// Equivalent of <c>std::vector::shrink_to_fit</c>.
-    /// </remarks>
-    FORCE_INLINE void Compact()
+    FORCE_INLINE void ShrinkToFit()
     {
         if (_count == 0)
         {
@@ -465,7 +462,7 @@ public:
 
         if (!preserveContents) 
         {
-            Clear();
+            Clear(); // Count is set to zero.
 
             _allocation.Free();
             _capacity = _allocation.Allocate(minCapacity);
@@ -473,6 +470,7 @@ public:
         else
         {
             _capacity = AllocationOperation::Relocate<T, AllocationType>(_allocation, minCapacity, _count);
+            ASSERT(_capacity >= minCapacity); // Count stays the same.
         }
     }
 
@@ -779,16 +777,7 @@ public:
     /// <param name="other">The other collection.</param>
     void Swap(Array& other)
     {
-        if IF_CONSTEXPR (AllocationType::HasSwap)
-        {
-            _allocation.Swap(other._allocation);
-            ::Swap(_count, other._count);
-            ::Swap(_capacity, other._capacity);
-        }
-        else
-        {
-            ::Swap(other, *this);
-        }
+        ::Swap(*this, other); //TODO Optimize this.
     }
 
     /// <summary>

--- a/Source/Engine/Core/Collections/BitArray.h
+++ b/Source/Engine/Core/Collections/BitArray.h
@@ -92,10 +92,15 @@ public:
     FORCE_INLINE BitArray(BitArray&& other) noexcept
     {
         _count = other._count;
-        _capacity = other._capacity;
+        _capacity = AllocationOperation::MoveAllocated<ItemType, AllocationType>(
+            other._allocation, 
+            _allocation, 
+            other._count, 
+            other._capacity
+        );
+
         other._count = 0;
         other._capacity = 0;
-        _allocation.Swap(other._allocation);
     }
 
     /// <summary>

--- a/Source/Engine/Core/Collections/Dictionary.h
+++ b/Source/Engine/Core/Collections/Dictionary.h
@@ -187,9 +187,9 @@ public:
         _deletedCount = other._deletedCount;
         _size = AllocationOperation::MoveAllocated<Bucket, AllocationType>(
             other._allocation, 
-            _allocation,
-            _size,
-            _size
+            this->_allocation,
+            other._size,
+            other._size
         );
 
         other._elementsCount = 0;
@@ -227,6 +227,7 @@ public:
     {
         if (this != &other)
         {
+            // ClearToFree without changing capacity
             Clear();
             _allocation.Free();
 
@@ -234,9 +235,9 @@ public:
             _deletedCount = other._deletedCount;
             _size = AllocationOperation::MoveAllocated<Bucket, AllocationType>(
                 other._allocation,
-                _allocation,
-                _size,
-                _size
+                this->_allocation,
+                other._size,
+                other._size
             );
 
             other._elementsCount = 0;

--- a/Source/Engine/Core/Collections/Dictionary.h
+++ b/Source/Engine/Core/Collections/Dictionary.h
@@ -101,7 +101,7 @@ public:
 private:
     int32 _elementsCount = 0;
     int32 _deletedCount = 0;
-    int32 _size = 0;
+    int32 _size = 0; //TODO Rename to _capacity?
     AllocationData _allocation;
 
     FORCE_INLINE static void MoveToEmpty(AllocationData& to, AllocationData& from, const int32 fromSize)

--- a/Source/Engine/Core/Collections/Dictionary.h
+++ b/Source/Engine/Core/Collections/Dictionary.h
@@ -183,6 +183,9 @@ public:
     /// <param name="other">The other collection to move.</param>
     Dictionary(Dictionary&& other) noexcept
     {
+        if (other._size == 0) // Empty collection
+            return;
+
         _elementsCount = other._elementsCount;
         _deletedCount = other._deletedCount;
         _size = AllocationOperation::MoveAllocated<Bucket, AllocationType>(
@@ -227,6 +230,9 @@ public:
     {
         if (this != &other)
         {
+            if (other._size == 0) // Empty collection
+                return *this;
+
             // ClearToFree without changing capacity
             Clear();
             _allocation.Free();
@@ -789,11 +795,13 @@ public:
     /// <param name="other">The other collection to clone.</param>
     void Clone(const Dictionary& other)
     {
-        // TODO: if both key and value are POD types then use raw memory copy for buckets
         Clear();
         EnsureCapacity(other.Capacity(), false);
+
         for (Iterator i = other.Begin(); i != other.End(); ++i)
             Add(i);
+
+        ASSERT(Count() == other.Count());
     }
 
     /// <summary>

--- a/Source/Engine/Core/Collections/HashSet.h
+++ b/Source/Engine/Core/Collections/HashSet.h
@@ -84,7 +84,7 @@ public:
 private:
     int32 _elementsCount = 0;
     int32 _deletedCount = 0;
-    int32 _size = 0;
+    int32 _size = 0; //TODO Rename to _capacity?
     AllocationData _allocation;
 
     FORCE_INLINE static void MoveToEmpty(AllocationData& to, AllocationData& from, const int32 fromSize)

--- a/Source/Engine/Core/Collections/HashSet.h
+++ b/Source/Engine/Core/Collections/HashSet.h
@@ -189,15 +189,22 @@ public:
     {
         if (this != &other)
         {
+            // ClearToFree without changing capacity
             Clear();
             _allocation.Free();
+
             _elementsCount = other._elementsCount;
             _deletedCount = other._deletedCount;
-            _size = other._size;
+            _size = AllocationOperation::MoveAllocated<Bucket, AllocationType>(
+                other._allocation, 
+                this->_allocation, 
+                other._size, 
+                other._size
+            );
+
             other._elementsCount = 0;
             other._deletedCount = 0;
             other._size = 0;
-            MoveToEmpty(_allocation, other._allocation, _size);
         }
         return *this;
     }

--- a/Source/Engine/Core/Memory/Allocation.h
+++ b/Source/Engine/Core/Memory/Allocation.h
@@ -57,16 +57,12 @@ public:
 
         FORCE_INLINE void Allocate(const int32 capacity)
         {
-#if ENABLE_ASSERTION_LOW_LAYERS
-            ASSERT(capacity <= Capacity);
-#endif
+            ASSERT_LOW_LAYER(capacity <= Capacity;
         }
 
         FORCE_INLINE void Relocate(const int32 capacity, int32 oldCount, int32 newCount)
         {
-#if ENABLE_ASSERTION_LOW_LAYERS
-            ASSERT(capacity <= Capacity);
-#endif
+            ASSERT_LOW_LAYER(capacity <= Capacity;
         }
 
         FORCE_INLINE void Free()
@@ -157,10 +153,9 @@ public:
 
         FORCE_INLINE void Allocate(const int32 capacity)
         {
-#if  ENABLE_ASSERTION_LOW_LAYERS
-            ASSERT(!_data);
-#endif
+            ASSERT_LOW_LAYER(!_data);
             _data = static_cast<T*>(Allocator::Allocate(capacity * sizeof(T)));
+
 #if !BUILD_RELEASE
             if (!_data)
                 OUT_OF_MEMORY;
@@ -170,6 +165,7 @@ public:
         FORCE_INLINE void Relocate(const int32 capacity, int32 oldCount, int32 newCount)
         {
             T* newData = capacity != 0 ? static_cast<T*>(Allocator::Allocate(capacity * sizeof(T))) : nullptr;
+
 #if !BUILD_RELEASE
             if (!newData && capacity != 0)
                 OUT_OF_MEMORY;

--- a/Source/Engine/Core/Memory/Allocation.h
+++ b/Source/Engine/Core/Memory/Allocation.h
@@ -20,9 +20,25 @@ public:
         byte _data[Capacity * sizeof(T)];
 
     public:
+        constexpr static int32 MinCapacity = Capacity, MaxCapacity = Capacity;
+
+
         FORCE_INLINE Data() = default;
 
         FORCE_INLINE ~Data() = default;
+
+
+        /// <summary> Checks if the allocation can be moved. </summary>
+        FORCE_INLINE bool CanMove() const
+        {
+            return false; // Fixed allocation cannot be moved at all.
+        }
+
+        /// <summary> No allocation can be copied. </summary>
+        auto operator=(const Data&) -> Data& = delete;
+
+        /// <summary> Fixed allocation must not be moved. *It's fixed, after all.* </summary>
+        auto operator=(Data&&) -> Data& = delete;
 
 
         /// <summary> No allocation can be copied. </summary>
@@ -30,14 +46,6 @@ public:
 
         /// <summary> Fixed allocation must not be moved. *It's fixed, after all.* </summary>
         Data(Data&&) = delete;
-
-
-        /// <summary> No allocation can be copied. </summary>
-        auto operator=(const Data&)->Data & = delete;
-
-        /// <summary> Fixed allocation must not be moved. *It's fixed, after all.* </summary>
-        auto operator=(Data&&)->Data & = delete;
-
 
 
         FORCE_INLINE T* Get()
@@ -74,6 +82,8 @@ public:
         T* _data = nullptr;
 
     public:
+        constexpr static int32 MinCapacity = 0, MaxCapacity = INT32_MAX;
+
         FORCE_INLINE Data() = default;
 
         FORCE_INLINE ~Data()
@@ -82,8 +92,12 @@ public:
               Allocator::Free(_data);
         }
 
-        /// <summary> No allocation can be copied. </summary>
-        Data(const Data&) = delete;
+
+        /// <summary> Checks if the allocation can be moved. </summary>
+        FORCE_INLINE bool CanMove() const
+        {
+            return true;
+        }
 
         /// <summary> Initializes allocation by moving data from another allocation. </summary>
         FORCE_INLINE Data(Data&& other) noexcept
@@ -91,9 +105,6 @@ public:
             ::Swap(this->_data, other._data);
             // Other allocation is now empty.
         }
-
-        /// <summary> No allocation can be copied. </summary>
-        auto operator=(const Data&)->Data & = delete;
 
         /// <summary> Reassigns allocation by moving data from another allocation. </summary>
         FORCE_INLINE auto operator=(Data&& other) noexcept -> Data&
@@ -105,6 +116,14 @@ public:
             }
             return *this;
         }
+
+
+        /// <summary> No allocation can be copied. </summary>
+        Data(const Data&) = delete;
+
+        /// <summary> No allocation can be copied. </summary>
+        auto operator=(const Data&) -> Data & = delete;
+
 
         FORCE_INLINE T* Get()
         {
@@ -143,7 +162,7 @@ public:
 /// <summary>
 /// The memory allocation policy that uses inlined memory of the fixed size and supports using additional allocation to increase its capacity (eg. via heap allocation).
 /// </summary>
-template<int Capacity, typename OtherAllocator = HeapAllocation>
+template<int Capacity, typename FallbackAllocator = HeapAllocation>
 class InlinedAllocation
 {
 public:
@@ -151,47 +170,87 @@ public:
     class alignas(sizeof(void*)) Data
     {
     private:
-        typedef typename OtherAllocator::template Data<T> OtherData;
-
-        bool _useOther = false; //TODO Fix alignment
-        byte _data[Capacity * sizeof(T)];
-        OtherData _other;
+        using FallbackData = typename FallbackAllocator::template Data<T>;
+        
+        byte _inlinedData[Capacity * sizeof(T)];
+        FallbackData _fallbackData;
+        bool _useFallback = false; 
 
     public:
+        constexpr static int32 MinCapacity = Capacity, MaxCapacity = INT32_MAX;
+
+
         FORCE_INLINE Data() = default;
 
         FORCE_INLINE ~Data() = default;
 
 
+        /// <summary> Checks if the allocation can be moved. </summary>
+        FORCE_INLINE bool CanMove() const
+        {
+            // If the inlined allocation is used, it can be moved.
+            return _useFallback ? _fallbackData.CanMove() : false;
+        }
+
+
         /// <summary> No allocation can be copied. </summary>
         Data(const Data&) = delete;
-
-        /// <summary> Inlined allocation must not be moved. It uses *fixed* allocation. </summary>
-        Data(Data&&) = delete;
 
         /// <summary> No allocation can be copied. </summary>
         auto operator=(const Data&)->Data & = delete;
 
-        /// <summary> Inlined allocation must not be moved. It uses *fixed* allocation. </summary>
-        auto operator=(Data&&)->Data & = delete;
+        /// <summary>
+        /// Inlined allocation move is conditional.
+        /// Attempts to move when not possible will result in crash.
+        /// </summary>
+        Data(Data&& other) noexcept
+        {
+            // Do not initialize the inlined data.
+
+            ASSERT_LOW_LAYER(other.CanMove());
+
+            _useFallback = true; // We know that only the backup the other allocation can be moved.
+            _fallbackData = ::MoveTemp<FallbackData>(other._fallbackData);
+        }
+
+        /// <summary>
+        /// Inlined allocation move is conditional
+        /// Attempts to move when not possible will result in crash.
+        /// </summary>
+        auto operator=(Data&& other) noexcept -> Data&
+        {
+            if (this == &other) 
+            {
+                return *this;
+            }
+
+            // Do not initialize the inlined data.
+
+            ASSERT_LOW_LAYER(other.CanMove());
+
+            _useFallback = true; // We know that only the backup the other allocation can be moved.
+            _fallbackData = ::MoveTemp<FallbackData>(other._fallbackData);
+
+            return *this;
+        }
 
 
         FORCE_INLINE T* Get()
         {
-            return _useOther ? _other.Get() : reinterpret_cast<T*>(_data);
+            return _useFallback ? _fallbackData.Get() : reinterpret_cast<T*>(_inlinedData);
         }
 
         FORCE_INLINE const T* Get() const
         {
-            return _useOther ? _other.Get() : reinterpret_cast<const T*>(_data);
+            return _useFallback ? _fallbackData.Get() : reinterpret_cast<const T*>(_inlinedData);
         }
 
         FORCE_INLINE int32 Allocate(int32 capacity)
         {
             if (capacity > Capacity)
             {
-                _useOther = true;
-                return _other.Allocate(capacity);
+                _useFallback = true;
+                return _fallbackData.Allocate(capacity);
             }
 
             return Capacity;
@@ -199,19 +258,26 @@ public:
 
         FORCE_INLINE void Free()
         {
-            if (_useOther)
+            if (_useFallback)
             {
-                _useOther = false;
-                _other.Free();
+                _useFallback = false;
+                _fallbackData.Free();
             }
         }
     };
 };
 
+/// <summary>
+/// Utility class used to manage memory allocations, with objects occupying the memory one by one.
+/// </summary>
+/// <param name="T"> The type of the elements stored in the allocation. </param>
 template<typename T>
 class AllocationOperations
 {
 public:
+    template<typename Allocation>
+    constexpr static bool IsMoveConstructible = TIsMoveConstructible<typename Allocation::Data>::Value;
+
     /// <summary>
     /// This function transfers the data from the source allocation to the destination allocation.
     /// If possible, it will use allocation move constructor to avoid moving the individual elements.
@@ -222,7 +288,7 @@ public:
     /// <param name="capacity"> The capacity of the destination allocation. If a new allocation is not required, this parameter will be ignored. </param>
     template<
         typename Allocation,
-        typename TEnableIf<TIsMoveConstructible<typename Allocation::Data>::Value, int>::Type = 0
+        typename TEnableIf<IsMoveConstructible<Allocation>, int>::Type = 0 // Move constructible
     >
     FORCE_INLINE static void MoveAllocated(
         typename Allocation::template Data<T>& source,
@@ -240,11 +306,11 @@ public:
     /// </summary>
     /// <param name="source"> The source allocation. </param>
     /// <param name="destination"> The destination allocation. It must be empty. </param>
-    /// <param name="count"> The number of elements to move. Algorithm assumes that elements from 0 to count-1 are valid, meaning that they are constructed and can be moved. </param>
+    /// <param name="count"> The number of elements to move. Algorithm assumes that elements [0, count) are valid, meaning that they are constructed and can be moved. </param>
     /// <param name="capacity"> The capacity of the destination allocation. If a new allocation is not required, this parameter will be ignored. </param>
     template<
         typename Allocation,
-        typename TEnableIf<!TIsMoveConstructible<typename Allocation::Data>::Value, int>::Type = 0
+        typename TEnableIf<!IsMoveConstructible<Allocation>, int>::Type = 0 // NOT move constructible
     >
     FORCE_INLINE static void MoveAllocated(
         typename Allocation::template Data<T>& source,
@@ -257,6 +323,59 @@ public:
         Memory::MoveItems(destination.Get(), source.Get(), count);
         Memory::DestructItems(source.Get(), count);
         source.Free();
+    }
+
+
+    template<
+        typename Allocation,
+        typename TEnableIf<IsMoveConstructible<Allocation>, int>::Type = 0 // Move constructible
+    >
+    FORCE_INLINE static int32 Relocate(
+        typename Allocation::template Data<T>& allocation,
+        const int32 desiredCapacity,
+        const int32 currentCount
+    )
+    {
+        ASSERT(Math::IsInRange(desiredCapacity, Allocation::MinCapacity, Allocation::MaxCapacity)); // Ensure that the desired capacity is within the bounds of the allocation policy.
+
+        // Invoking this method means that an allocation must happen!
+        // Collection should take responsibility of determining that a relocation is actually required.
+        // It must also ensure that the new capacity obeys the rules of the allocation policy.
+
+        typename Allocation::template Data<T> newAllocation;
+
+        const int32 newCapacity = newAllocation.Allocate(desiredCapacity); // Allocate new memory.
+        const int32 newCount = Math::Min(currentCount, newCapacity); // Determine how many elements can be moved, how many fit in the new allocation.
+
+        Memory::MoveItems(newAllocation.Get(), allocation.Get(), newCount); // Move fitting elements.
+        Memory::DestructItems(allocation.Get(), currentCount); // Destruct all elements in the old allocation. (Both moved and not fitting)
+
+        allocation.Free(); // Free the old allocation...
+        allocation = ::MoveTemp(newAllocation); // ...and replace it with the new one.
+
+        return newCapacity; // Return the new capacity, so the collection can update its internal state.
+    }
+
+    template<
+        typename Allocation,
+        typename TEnableIf<!IsMoveConstructible<Allocation>, int>::Type = 0 // NOT move constructible
+    >
+    FORCE_INLINE static int32 Relocate(
+        typename Allocation::template Data<T>& allocation,
+        const int32 desiredCapacity,
+        const int32 currentCount
+    )
+    {
+        ASSERT(Math::IsInRange(desiredCapacity, Allocation::MinCapacity, Allocation::MaxCapacity)); // Ensure that the desired capacity is within the bounds of the allocation policy.
+
+        // Relocating elements is not possible for non-move constructible types.
+        // Thus the only way to change the capacity is to destroy not fitting elements and cap the capacity.
+
+        const int32 newCount = Math::Min(currentCount, desiredCapacity); // Determine how many elements can stay, how many fit in the hypothetical allocation.
+
+        Memory::DestructItems(allocation.Get() + newCount, currentCount - newCount); // Destruct all elements that do not fit in the new allocation.
+
+        return desiredCapacity; // Return the new capacity, so the collection can update its internal state.
     }
 };
 

--- a/Source/Engine/Core/Memory/Allocation.h
+++ b/Source/Engine/Core/Memory/Allocation.h
@@ -9,12 +9,13 @@
 
 // --- Memory Allocation Policy Usage ---
 // 1. Allocation policy uses subclass of Data to store a handle to one (or zero) memory allocations.
-// 2. Tracking the capacity is the responsibility of the collection, not the allocation policy.
-// 3. Resultant capacity of the allocation can exceed the requested. Allocation shares information about the actual capacity.
-// 3. Allocation policy is not responsible for tracking valid elements in the allocation.
-// 4. Accessing the data can be only between Allocate and Free calls.
-// 5. Requesting to allocate numbers exceeding the limits of the policy is undefined behavior.
-// 5. Data can be move-able or not, determining it swap-ability.
+// 2. Allocation itself must never be zero-sized.
+// 3. Tracking the capacity is the responsibility of the collection, not the allocation policy.
+// 4. Resultant capacity of the allocation can exceed the requested. Allocation shares information about the actual capacity.
+// 5. Allocation policy is not responsible for tracking valid elements in the allocation.
+// 6. Accessing the data can be only between Allocate and Free calls.
+// 7. Requesting to allocate numbers exceeding the limits of the policy is undefined behavior.
+// 8. Data can be move-able or not, determining it swap-ability.
 
 
 /// <summary>

--- a/Source/Engine/Core/Memory/AllocationOperation.h
+++ b/Source/Engine/Core/Memory/AllocationOperation.h
@@ -1,0 +1,157 @@
+// Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#include "Memory.h"
+#include "Engine/Core/Core.h"
+#include "Engine/Core/Math/Math.h"
+
+
+/// <summary>
+/// Utility class used to manage memory allocations, with objects occupying the memory one by one.
+/// </summary>
+/// <param name="T"> The type of the elements stored in the allocation. </param>
+template<typename T>
+class AllocationOperation
+{
+public:
+    template<typename Allocation>
+    constexpr static bool IsMoveConstructible = TIsMoveConstructible<typename Allocation::Data>::Value;
+
+private:
+    template<typename Allocation>
+    FORCE_INLINE static int32 MoveAllocatedOneByOne(
+        typename Allocation::template Data<T>& source,
+        typename Allocation::template Data<T>& destination,
+        const int32 count,
+        const int32 capacity
+    )
+    {
+        const int32 newCapacity = destination.Allocate(capacity);
+
+        Memory::MoveItems(destination.Get(), source.Get(), count);
+        Memory::DestructItems(source.Get(), count);
+        source.Free();
+
+        return newCapacity;
+    }
+
+
+public:
+    /// <summary>
+    /// This function transfers the data from the source allocation to the destination allocation.
+    /// If possible, it will use allocation move constructor to avoid moving the individual elements.
+    /// </summary>
+    /// <param name="source"> The source allocation. After the call, it will be empty. </param>
+    /// <param name="destination"> The destination allocation. It must be empty. </param>
+    /// <param name="count"> The number of elements to move. Algorithm assumes that elements from 0 to count-1 are valid, meaning that they are constructed and can be moved. </param>
+    /// <param name="capacity"> The capacity of the destination allocation. If a new allocation is not required, this parameter will be ignored. </param>
+    /// <returns> The new capacity of the destination allocation. </returns>
+    /// <remarks> Empty allocation means it has 0 capacity (outside of Allocation and Free). </remarks>
+    template<
+        typename Allocation,
+        typename TEnableIf<IsMoveConstructible<Allocation>, int>::Type = 0 // Move constructible
+    >
+    FORCE_INLINE static int32 MoveAllocated(
+        typename Allocation::template Data<T>& source,
+        typename Allocation::template Data<T>& destination,
+        const int32 count,
+        const int32 capacity
+    )
+    {
+        if (source.CanMove())
+        {
+            destination = ::MoveTemp(source);
+            return capacity;
+        }
+
+        return MoveAllocatedOneByOne<Allocation>(source, destination, count, capacity);
+    }
+
+    /// <summary>
+    /// This function transfers the data from the source allocation to the destination allocation.
+    /// If possible, it will use allocation move constructor to avoid moving the individual elements.
+    /// </summary>
+    /// <param name="source"> The source allocation. After the call, it will be empty. </param>
+    /// <param name="destination"> The destination allocation. It must be empty. </param>
+    /// <param name="count"> The number of elements to move. Algorithm assumes that elements [0, count) are valid, meaning that they are constructed and can be moved. </param>
+    /// <param name="capacity"> The capacity of the destination allocation. If a new allocation is not required, this parameter will be ignored. </param>
+    /// <returns> The new capacity of the destination allocation. </returns>
+    /// <remarks> Empty allocation means it has 0 capacity (outside of Allocation and Free). </remarks>
+    template<
+        typename Allocation,
+        typename TEnableIf<!IsMoveConstructible<Allocation>, int>::Type = 0 // NOT move constructible
+    >
+    FORCE_INLINE static int32 MoveAllocated(
+        typename Allocation::template Data<T>& source,
+        typename Allocation::template Data<T>& destination,
+        const int32 count,
+        const int32 capacity
+    )
+    {
+        return MoveAllocatedOneByOne<Allocation>(source, destination, count, capacity);
+    }
+
+
+    /// <summary> This function attempts to relocate the elements from the current allocation to a new allocation, to alter the capacity. </summary>
+    /// <param name="allocation"> The current allocation. </param>
+    /// <param name="desiredCapacity"> The desired capacity of the allocation, be it higher or lower. </param>
+    /// <param name="count"> The number of elements to move. Algorithm assumes that elements [0, count) are valid, meaning that they are constructed and can be moved. </param>
+    /// <returns> The new capacity of the allocation. </returns>
+    template<
+        typename Allocation,
+        typename TEnableIf<IsMoveConstructible<Allocation>, int>::Type = 0 // Move constructible
+    >
+    FORCE_INLINE static int32 Relocate(
+        typename Allocation::template Data<T>& allocation,
+        const int32 desiredCapacity,
+        const int32 count
+    )
+    {
+        ASSERT(Math::IsInRange(desiredCapacity, Allocation::MinCapacity, Allocation::MaxCapacity)); // Ensure that the desired capacity is within the bounds of the allocation policy.
+
+        // Invoking this method means that an allocation must happen!
+        // Collection should take responsibility of determining that a relocation is actually required.
+        // It must also ensure that the new capacity obeys the rules of the allocation policy.
+
+        typename Allocation::template Data<T> newAllocation;
+
+        const int32 newCapacity = newAllocation.Allocate(desiredCapacity); // Allocate new memory.
+        const int32 newCount = Math::Min(count, newCapacity); // Determine how many elements can be moved, how many fit in the new allocation.
+
+        Memory::MoveItems(newAllocation.Get(), allocation.Get(), newCount); // Move fitting elements.
+        Memory::DestructItems(allocation.Get(), count); // Destruct all elements in the old allocation. (Both moved and not fitting)
+
+        allocation.Free(); // Free the old allocation...
+        allocation = ::MoveTemp(newAllocation); // ...and replace it with the new one.
+
+        return newCapacity; // Return the new capacity, so the collection can update its internal state.
+    }
+
+    /// <summary> This function attempts to relocate the elements from the current allocation to a new allocation, to alter the capacity. </summary>
+    /// <param name="allocation"> The current allocation. </param>
+    /// <param name="desiredCapacity"> The desired capacity of the allocation, be it higher or lower. </param>
+    /// <param name="count"> The number of elements to move. Algorithm assumes that elements [0, count) are valid, meaning that they are constructed and can be moved. </param>
+    /// <returns> The new capacity of the allocation. </returns>
+    template<
+        typename Allocation,
+        typename TEnableIf<!IsMoveConstructible<Allocation>, int>::Type = 0 // NOT move constructible
+    >
+    FORCE_INLINE static int32 Relocate(
+        typename Allocation::template Data<T>& allocation,
+        const int32 desiredCapacity,
+        const int32 count
+    )
+    {
+        ASSERT(Math::IsInRange(desiredCapacity, Allocation::MinCapacity, Allocation::MaxCapacity)); // Ensure that the desired capacity is within the bounds of the allocation policy.
+
+        // Relocating elements is not possible for non-move constructible types.
+        // Thus, the only way to change the capacity is to destroy not fitting elements and cap the capacity.
+
+        const int32 newCount = Math::Min(count, desiredCapacity); // Determine how many elements can stay, how many fit in the hypothetical allocation.
+
+        Memory::DestructItems(allocation.Get() + newCount, count - newCount); // Destruct all elements that do not fit in the new allocation. //TODO Should that even be a thing?
+
+        return desiredCapacity; // Return the new capacity, so the collection can update its internal state.
+    }
+};

--- a/Source/Engine/Core/Memory/Memory.h
+++ b/Source/Engine/Core/Memory/Memory.h
@@ -263,7 +263,7 @@ namespace Memory
     /// <param name="src">The address of the first memory location to pass to the move constructor.</param>
     /// <param name="count">The number of element to move. Can be equal 0.</param>
     template<typename T, typename U>
-    FORCE_INLINE typename TEnableIf<!TIsBitwiseConstructible<T, U>::Value>::Type MoveItems(T* dst, const U* src, int32 count)
+    FORCE_INLINE typename TEnableIf<!TIsBitwiseConstructible<T, U>::Value>::Type MoveItems(T* dst, const /* <- WTF */ U* src, int32 count)
     {
         while (count--)
         {

--- a/Source/Engine/Core/Templates.h
+++ b/Source/Engine/Core/Templates.h
@@ -234,6 +234,12 @@ struct TIsCopyConstructible
 	enum { Value = __is_constructible(T, typename TAddLValueReference<typename TAddConst<T>::Type>::Type) };
 };
 
+template<typename T>
+struct TIsMoveConstructible
+{
+    enum { Value = __is_constructible(T, typename TAddRValueReference<T>::Type) };
+};
+
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Checks if a type has a trivial copy constructor.

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/QueryHeapDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/QueryHeapDX12.cpp
@@ -79,7 +79,7 @@ void QueryHeapDX12::Destroy()
     SAFE_RELEASE(_resultBuffer);
     SAFE_RELEASE(_queryHeap);
     _currentBatch.Clear();
-    _resultData.SetCapacity(0);
+    _resultData.ClearToFree();
 }
 
 void QueryHeapDX12::EndQueryBatchAndResolveQueryData(GPUContextDX12* context)

--- a/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
@@ -1146,10 +1146,8 @@ bool Prefab::UpdateInternal(const Array<SceneObject*>& defaultInstanceObjects, r
         ObjectsCount = 0;
         ObjectsIds.Resize(0);
         NestedPrefabs.Resize(0);
-        ObjectsDataCache.Clear();
-        ObjectsDataCache.SetCapacity(0);
-        ObjectsCache.Clear();
-        ObjectsCache.SetCapacity(0);
+        ObjectsDataCache.ClearToFree();
+        ObjectsCache.ClearToFree();
         if (_defaultInstance)
         {
             _defaultInstance->DeleteObject();

--- a/Source/Engine/Level/Prefabs/Prefab.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.cpp
@@ -188,12 +188,9 @@ void Prefab::unload(bool isReloading)
     ObjectsCount = 0;
     ObjectsIds.Resize(0);
     NestedPrefabs.Resize(0);
-    ObjectsDataCache.Clear();
-    ObjectsDataCache.SetCapacity(0);
-    ObjectsHierarchyCache.Clear();
-    ObjectsHierarchyCache.SetCapacity(0);
-    ObjectsCache.Clear();
-    ObjectsCache.SetCapacity(0);
+    ObjectsDataCache.ClearToFree();
+    ObjectsHierarchyCache.ClearToFree();
+    ObjectsCache.ClearToFree();
     if (_defaultInstance)
     {
         _defaultInstance->DeleteObject();

--- a/Source/Engine/Level/Prefabs/PrefabManager.cpp
+++ b/Source/Engine/Level/Prefabs/PrefabManager.cpp
@@ -119,7 +119,7 @@ Actor* PrefabManager::SpawnPrefab(Prefab* prefab, const Transform& transform, Ac
     if (objectsCache)
     {
         objectsCache->Clear();
-        objectsCache->SetCapacity(prefab->ObjectsDataCache.Capacity());
+        objectsCache->EnsureCapacity(prefab->ObjectsDataCache.Capacity());
     }
     auto& data = *prefab->Data;
     SceneObjectsFactory::Context context(modifier.Value);

--- a/Source/Engine/Particles/ParticleSystem.cpp
+++ b/Source/Engine/Particles/ParticleSystem.cpp
@@ -460,7 +460,7 @@ void ParticleSystem::unload(bool isReloading)
     FramesPerSecond = 0.0f;
     DurationFrames = 0;
     Emitters.Resize(0);
-    EmittersParametersOverrides.SetCapacity(0);
+    EmittersParametersOverrides.ClearToFree();
     Tracks.Resize(0);
 #if !BUILD_RELEASE
     _debugName.Clear();

--- a/Source/Engine/Particles/Particles.cpp
+++ b/Source/Engine/Particles/Particles.cpp
@@ -1212,10 +1212,10 @@ void ParticleManagerService::Dispose()
     }
     CleanupGPUParticlesSorting();
 #endif
-    ParticlesDrawCPU::SortingKeys[0].SetCapacity(0);
-    ParticlesDrawCPU::SortingKeys[1].SetCapacity(0);
-    ParticlesDrawCPU::SortingIndices.SetCapacity(0);
-    ParticlesDrawCPU::SortedIndices.SetCapacity(0);
+    ParticlesDrawCPU::SortingKeys[0].ClearToFree();
+    ParticlesDrawCPU::SortingKeys[1].ClearToFree();
+    ParticlesDrawCPU::SortingIndices.ClearToFree();
+    ParticlesDrawCPU::SortedIndices.ClearToFree();
 
     PoolLocker.Lock();
     for (auto i = Pool.Begin(); i.IsNotEnd(); ++i)

--- a/Source/Engine/Physics/Actors/Cloth.cpp
+++ b/Source/Engine/Physics/Actors/Cloth.cpp
@@ -188,7 +188,7 @@ void Cloth::SetPaint(Span<const float> value)
     if (value.IsInvalid())
     {
         // Remove paint when set to empty
-        _paint.SetCapacity(0);
+        _paint.ClearToFree();
 #if WITH_CLOTH
         if (_cloth)
         {

--- a/Source/Engine/Profiler/ProfilingTools.cpp
+++ b/Source/Engine/Profiler/ProfilingTools.cpp
@@ -209,10 +209,9 @@ void ProfilingToolsService::Update()
 
 void ProfilingToolsService::Dispose()
 {
-    ProfilingTools::EventsCPU.Clear();
-    ProfilingTools::EventsCPU.SetCapacity(0);
-    ProfilingTools::EventsGPU.SetCapacity(0);
-    ProfilingTools::EventsNetwork.SetCapacity(0);
+    ProfilingTools::EventsCPU.ClearToFree();
+    ProfilingTools::EventsGPU.ClearToFree();
+    ProfilingTools::EventsNetwork.ClearToFree();
 }
 
 bool ProfilingTools::GetEnabled()

--- a/Source/Engine/Renderer/GBufferPass.cpp
+++ b/Source/Engine/Renderer/GBufferPass.cpp
@@ -97,7 +97,7 @@ void GBufferPass::Dispose()
     SAFE_DELETE(_vertexColors);
     SAFE_DELETE(_lodPreview);
     SAFE_DELETE(_materialComplexity);
-    IndexBufferToModelLOD.SetCapacity(0);
+    IndexBufferToModelLOD.ClearToFree();
 #endif
 }
 

--- a/Source/Engine/Threading/JobSystem.cpp
+++ b/Source/Engine/Threading/JobSystem.cpp
@@ -164,7 +164,7 @@ void JobSystemService::Dispose()
         }
     }
 
-    JobContexts.SetCapacity(0);
+    JobContexts.ClearToFree();
     Jobs.Release();
     for (auto& e : MemPool)
         Platform::Free(e.First);

--- a/Source/Engine/Visject/VisjectMeta.cpp
+++ b/Source/Engine/Visject/VisjectMeta.cpp
@@ -34,7 +34,7 @@ bool VisjectMeta::Load(ReadStream* stream, bool loadData)
         }
         else
         {
-            e.Data.SetCapacity(0);
+            e.Data.ClearToFree();
             stream->SetPosition(stream->GetPosition() + dataSize);
         }
     }


### PR DESCRIPTION
# Issues

This PR features experimental changes to Flax allocation policy model. Unfortunately, previous one suffered issues:

1. **Calculating capacity growth and allocating is not synchronized.** This means that current model can not work in multithreaded environment. If internal state of context injected to data changes between calls it could result in undefined state. Different solution could be assuming that `CalculateCapacityGrowth` is pure, but this means it could be moved completely outside of the Data class.
2. **Allocation policies should not govern lifecycle of the objects.** This problem is more subtle: The issue is that using allocators to govern lifecycles means that both collection and allocator must share information about validity of stored object. For trivial situations, where objects are valid at [0, n), the information can be passed with *count* of objects. For any more complicated scenario this method fails.

# Decisions

1. **Calculate capacity grow on allocation.** Now collection itself is responsible for tracking the capacity - the memory given by the allocation. Thanks to this solution, allocator itself can determine the state of the context and give a better result.
2. **Add constraints on allocators: `MinCapacity` and `MaxCapacity`.** This will help the collection automatically select the capacity of the collection.
3. **Remove ability to manually select capacity of a collection, and replace it with `ClearToFree` and `ShrinkToFit` (with old `EnsureCapacity`).** So collections themselves are given more control over the capacity of the collections.
4. **Implement set of shared operations on collections to execute typical operations.** For example, type-agnostic transferring objects between allocations. Not only, it allows to erase type from the allocation policy itself, but also allows to use `Platform::Copy` for trivially/bitwise copyable types. This method also allows to automatically select the method of transferring allocations data (e.g. pointer swap).

# Tasks

- [x] Remove problematic methods from allocation: `CalculateCapacityGrow`, `Relocate`.
- [x] Implement set of operations on linear allocations.
- [ ] Fix collections to use shared allocation operations.
- [ ] Complete Allocation type erasure.
- [ ] Implement new allocation policies.

# Final Note

Stabilizing this branch will take me weeks, I would be super glad if I was given feedback frequently.