### PR TITLE
Force Child Expand for Horizontal and Vertical panel

### DIFF
--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -345,9 +345,6 @@ namespace FlaxEngine.GUI
             }
         }
 
-        
-        public Float2 MinSize;
-
         /// <summary>
         /// The custom tag object value linked to the control.
         /// </summary>

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -345,6 +345,9 @@ namespace FlaxEngine.GUI
             }
         }
 
+        
+        public Float2 MinSize;
+
         /// <summary>
         /// The custom tag object value linked to the control.
         /// </summary>

--- a/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
@@ -1,7 +1,5 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
-using FlaxEngine.Utilities;
-
 namespace FlaxEngine.GUI
 {
     /// <summary>
@@ -11,19 +9,11 @@ namespace FlaxEngine.GUI
     [ActorToolbox("GUI")]
     public class HorizontalPanel : PanelWithMargins
     {
-
-        
-        
-        private int direction;
-        private float prevWidthss;
-        private bool minSizeInitialized = false;
         /// <summary>
         /// Initializes a new instance of the <see cref="HorizontalPanel"/> class.
         /// </summary>
         public HorizontalPanel()
         {
-
-            
         }
 
         /// <inheritdoc />
@@ -44,6 +34,7 @@ namespace FlaxEngine.GUI
                 }
             }
         }
+
 
         /// <inheritdoc />
         protected override void PerformLayoutAfterChildren()
@@ -111,55 +102,65 @@ namespace FlaxEngine.GUI
                         }
                     }
                 }
+          
             }
 
-           
-            PerformExpansion();
+            if(!_autoSize)
+                PerformExpansion();
 
         }
 
         /// <inheritdoc />
-        protected override void OnSizeChanged()
-        {
-            var prevBounds = Bounds.Width ;
-            base.OnSizeChanged();
-            direction = prevWidthss < Bounds.Width ? 1 : -1;
-            prevWidthss = prevBounds;
-            
-
-
-        }
-
-        private void PerformExpansion()
+        protected override void PerformExpansion()
         {
 
-            if (ChildForceExpandWidth && _children.Count > 0)
+            if (ForceChildExpand && _children.Count > 0)
             {
                 // Calculate the available width for children (taking margins into account)
-                float availableWidth = Width - _margin.Left - _margin.Right;
+                float availableWidth = Width - _margin.Left - _margin.Right - (_children.Count - 1) * _spacing;
+
                 // Calculate the width each child should take up
                 float childWidth = availableWidth / _children.Count;
 
-                // Loop through each visible child and set their width
-                foreach (var child in _children)
+                // Adjust for the first and last child to prevent being cut off
+                float firstChildX = _margin.Left;
+                float lastChildX = Width - _margin.Right - childWidth;
+
+                // Loop through each child and set their width and position
+                float left = _margin.Left;
+                for (int i = 0; i < _children.Count; i++)
                 {
+                    Control child = _children[i];
                     if (child.Visible)
                     {
-                        // Set each child's width to be equal (no shrinking or growing logic needed)
-                        child.Width = childWidth;
+                        // Adjust the width and position of the first and last children
+                        if (i == 0)
+                        {
+                            // First child, position it at the start and set its width                           
+                            child.Width = childWidth;
+                            child.X = firstChildX;
+                        }
+                        else if (i == _children.Count - 1)
+                        {
+                            // Last child, position it near the right edge and set its width                           
+                            child.Width = childWidth;
+                            child.X = lastChildX;
+                        }
+                        else
+                        {
+                            // For all other children, distribute the width evenly                       
+                            child.Width = childWidth;
+                            child.X = left;
+                        }
 
-                        //// Ensure no child becomes smaller than its MinSize.X if set
-                        //if (child.MinSize.X > 0 && child.Width < child.MinSize.X)
-                        //{
-                        //    child.Width = child.MinSize.X;
-                        //}
+                        // Move the `left` pointer to the right for the next child
+                        left = child.Right + _spacing;
                     }
+                    child.PerformLayout(true);
                 }
-
             }
 
         }
 
-      
     }
 }

--- a/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
@@ -1,5 +1,7 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using FlaxEngine.Utilities;
+
 namespace FlaxEngine.GUI
 {
     /// <summary>
@@ -9,11 +11,19 @@ namespace FlaxEngine.GUI
     [ActorToolbox("GUI")]
     public class HorizontalPanel : PanelWithMargins
     {
+
+        
+        
+        private int direction;
+        private float prevWidthss;
+        private bool minSizeInitialized = false;
         /// <summary>
         /// Initializes a new instance of the <see cref="HorizontalPanel"/> class.
         /// </summary>
         public HorizontalPanel()
         {
+
+            
         }
 
         /// <inheritdoc />
@@ -49,6 +59,7 @@ namespace FlaxEngine.GUI
                 Control c = _children[i];
                 if (c.Visible)
                 {
+
                     var w = c.Width;
                     var ch = ControlChildSize ? h : c.Height;
                     if (Mathf.IsZero(c.AnchorMin.X) && Mathf.IsZero(c.AnchorMax.X))
@@ -56,12 +67,14 @@ namespace FlaxEngine.GUI
                         c.Bounds = new Rectangle(left + _offset.X, _margin.Top + _offset.Y, w, ch);
                         left = c.Right + _spacing;
                         hasAnyLeft = true;
+
                     }
                     else if (Mathf.IsOne(c.AnchorMin.X) && Mathf.IsOne(c.AnchorMax.X))
                     {
                         right += w + _spacing;
                         c.Bounds = new Rectangle(Width - right + _offset.X, _margin.Top + _offset.Y, w, ch);
-                        hasAnyRight = true;
+
+
                     }
                     maxHeight = Mathf.Max(maxHeight, ch);
                 }
@@ -84,6 +97,7 @@ namespace FlaxEngine.GUI
             {
                 // Apply layout alignment
                 var offset = Width - left - _margin.Right;
+
                 if (_alignment == TextAlignment.Center)
                     offset *= 0.5f;
                 for (int i = 0; i < _children.Count; i++)
@@ -98,6 +112,54 @@ namespace FlaxEngine.GUI
                     }
                 }
             }
+
+           
+            PerformExpansion();
+
         }
+
+        /// <inheritdoc />
+        protected override void OnSizeChanged()
+        {
+            var prevBounds = Bounds.Width ;
+            base.OnSizeChanged();
+            direction = prevWidthss < Bounds.Width ? 1 : -1;
+            prevWidthss = prevBounds;
+            
+
+
+        }
+
+        private void PerformExpansion()
+        {
+
+            if (ChildForceExpandWidth && _children.Count > 0)
+            {
+                // Calculate the available width for children (taking margins into account)
+                float availableWidth = Width - _margin.Left - _margin.Right;
+                // Calculate the width each child should take up
+                float childWidth = availableWidth / _children.Count;
+
+                // Loop through each visible child and set their width
+                foreach (var child in _children)
+                {
+                    if (child.Visible)
+                    {
+                        // Set each child's width to be equal (no shrinking or growing logic needed)
+                        child.Width = childWidth;
+
+                        //// Ensure no child becomes smaller than its MinSize.X if set
+                        //if (child.MinSize.X > 0 && child.Width < child.MinSize.X)
+                        //{
+                        //    child.Width = child.MinSize.X;
+                        //}
+                    }
+                }
+
+            }
+
+        }
+
+      
     }
 }

--- a/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
+++ b/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
@@ -36,6 +36,11 @@ namespace FlaxEngine.GUI
         protected TextAlignment _alignment = TextAlignment.Near;
 
         /// <summary>
+        /// The force child expand flag.
+        /// </summary>
+        protected bool _forceChildExpand;  
+
+        /// <summary>
         /// Gets or sets the left margin.
         /// </summary>
         [HideInEditor, NoSerialize]
@@ -160,10 +165,20 @@ namespace FlaxEngine.GUI
         [EditorOrder(35), DefaultValue(true), Tooltip("If checked, the panel can resize children controls (eg. auto-fit width/height).")]
         public bool ControlChildSize { get; set; } = true;
 
-        [EditorOrder(36), DefaultValue(false), Tooltip("If checked, the panel will force expand children width.")]
-        public bool ChildForceShrinkWidth { get; set; } = false;
-        [EditorOrder(37), DefaultValue(false), Tooltip("If checked, the panel will force expand children height.")]
-        public bool ChildForceExpandWidth { get; set; } = false;
+        /// <summary>
+        /// Gets or sets the value indicating whenever the panel will force expand children width.
+        /// <para>Logic is disabled when <see cref="AutoSize"/> is true</para>
+        /// </summary>
+        [EditorOrder(36), DefaultValue(false), Tooltip("If checked, the panel will force expand/shrink children."), VisibleIf(nameof(AutoSize), true)]
+        public bool ForceChildExpand
+        {
+            get { return ControlChildSize &&  _forceChildExpand; }  // False when ControlChildSize is false. 
+            set
+            {
+                _forceChildExpand = value;  // Set the value to the backing field
+                PerformLayoutAfterChildren();    // Trigger the layout function whenever set
+            }
+        }
 
         /// <summary>
         /// Gets or sets the panel area margin.
@@ -206,6 +221,21 @@ namespace FlaxEngine.GUI
         : base(0, 0, 64, 64)
         {
             AutoFocus = false;
+        }
+
+        internal override void RemoveChildInternal(Control child)
+        {
+            base.RemoveChildInternal(child);
+            if (ForceChildExpand)
+                PerformLayoutAfterChildren();
+        }
+
+        /// <summary>
+        /// Logic for performing expansion/contraction of the children.
+        /// </summary>
+        protected virtual void PerformExpansion()
+        {
+
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
+++ b/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
@@ -160,6 +160,11 @@ namespace FlaxEngine.GUI
         [EditorOrder(35), DefaultValue(true), Tooltip("If checked, the panel can resize children controls (eg. auto-fit width/height).")]
         public bool ControlChildSize { get; set; } = true;
 
+        [EditorOrder(36), DefaultValue(false), Tooltip("If checked, the panel will force expand children width.")]
+        public bool ChildForceShrinkWidth { get; set; } = false;
+        [EditorOrder(37), DefaultValue(false), Tooltip("If checked, the panel will force expand children height.")]
+        public bool ChildForceExpandWidth { get; set; } = false;
+
         /// <summary>
         /// Gets or sets the panel area margin.
         /// </summary>

--- a/Source/Engine/UI/GUI/Panels/VerticalPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/VerticalPanel.cs
@@ -98,6 +98,61 @@ namespace FlaxEngine.GUI
                     }
                 }
             }
+
+            if (!_autoSize)
+                PerformExpansion();
         }
+
+        /// <inheritdoc />
+        protected override void PerformExpansion()
+        {
+
+            if (ForceChildExpand && _children.Count > 0)
+            {
+                // Calculate the available height for children (taking margins into account)
+                float availableHeight = Height - _margin.Top - _margin.Bottom - (_children.Count - 1) * _spacing;
+
+                // Calculate the height each child should take up
+                float childHeight = availableHeight / _children.Count;
+
+                // Adjust for the first and last child to prevent being cut off
+                float firstChildY = _margin.Top;
+                float lastChildY = Height - _margin.Bottom - childHeight;
+
+                // Loop through each child and set their height and position
+                float top = _margin.Top;
+                for (int i = 0; i < _children.Count; i++)
+                {
+                    Control child = _children[i];
+                    if (child.Visible)
+                    {
+                        // Adjust the height and position of the first and last children
+                        if (i == 0)
+                        {
+                            // First child, position it at the start and set its height                            
+                            child.Height = childHeight;
+                            child.Y = firstChildY;
+                        }
+                        else if (i == _children.Count - 1)
+                        {
+                            // Last child, position it near the bottom edge and set its height                            
+                            child.Height = childHeight;
+                            child.Y = lastChildY;
+                        }
+                        else
+                        {
+                            // For all other children, distribute the height evenly                            
+                            child.Height = childHeight;
+                            child.Y = top;
+                        }
+
+                        // Move the `top` pointer to the bottom for the next child
+                        top = child.Bottom + _spacing;
+                    }
+                    child.PerformLayout(true);
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
### Overview
The main purpose of this PR is to add a `Force Child Expand` similar to Unity's.
- Flax already has child alignment but didn't have `Force Child Expand`
- `Force Child Expand` - lets the Developer have an option to **constrain** the children of H/V panels
  - Therefore, when adding new children to the panel it would automatically adjust the children's Width/Height.

https://github.com/user-attachments/assets/062e42ca-8954-4293-b43d-0abba8514e36

#### Reference
- #2599 - might be related

### Implementation
##### Main Changes
- [PanelWithMargins.cs](Source/Engine/UI/GUI/Panels/PanelWithMargins.cs)
  - `RemoveChildInternal` - Overridden, to ensure that the children upon deletion would update the Layout
  - `PerformExpansion` - Function to be called by Horizontal/Vertical panel. Main purpose is to perform the children's auto expansion/shrinkage
- [Horizontal.cs](Source/Engine/UI/GUI/Panels/HorizontalPanel.cs)/[Vertical.cs](Source/Engine/UI/GUI/Panels/VerticalPanel.cs)
  - `PerformExpansion` 
    1. Available Space Calculation: Determines the total space for child controls, accounting for margins and spacing.
    2. Uniform Size Allocation: Assigns each child an equal width or height, depending on the panel type.
    3. Position Adjustment for Edges: Positions the first and last child near the panel’s edges to prevent cutoff.
    4. Spacing for Remaining Children: Distributes remaining children with equal spacing between them.
 - `ForceChildExpand` - is only Visible when `AutoSize` is disabled. When `AutoSize` is enable, `PerformExpansion` is not called

##### Video


https://github.com/user-attachments/assets/10427c37-fe8c-497f-9046-a78f3b70aca3

https://github.com/user-attachments/assets/4a3e0d44-ef20-46c6-b06d-8b1eb778310f




##### Use-case
###### Problem
Say you wanted a set of buttons to be constrained by a container. With the current implementation of H/V panels. You can either use:
- `AutoSize` - Automatically adjust the parent panel (H/V panel) to their children's Size.
- `ControlChildSize` - Be able to control the Height/Width, respectively (H/V panel), But the more children that has been added it will overflow the panel.

https://github.com/user-attachments/assets/398e1b2a-74b0-459f-94bc-aa79f1995b3c

###### Solution
With this PR, you can now constrain H/V panels based on the parent's Width/Height, respectively for (Horizontal/Vertical panel).
- Below is what I am using for my building upgrade ui. The idea is that I want the Vertical panel to be the constrained for each upgrade available. Within the V panel, the children is a H panel that has the name, multiple Resources (another H panel), and a button.


https://github.com/user-attachments/assets/4ed17f3e-b679-4c80-99ed-46f93f89394d

- 0:00 - 0:27 - Using AutoSize/ControlChildSize only
  - you can see that it overflowed
- 0:28 - End - Using ControlChildSize/ForceChildExpand
  - you can see that it it constrained by the parent panel
