### PR TITLE
Add "File" menu option to open game project folder

### DIFF
--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -538,6 +538,7 @@ namespace FlaxEditor.Modules
             cm.AddSeparator();
             cm.AddButton("Open project...", OpenProject);
             cm.AddButton("Reload project", ReloadProject);
+            cm.AddButton("Open project folder", () => FileSystem.ShowFileExplorer(Editor.Instance.GameProject.ProjectFolderPath));
             cm.AddSeparator();
             cm.AddButton("Exit", "Alt+F4", () => Editor.Windows.MainWindow.Close(ClosingReason.User));
 


### PR DESCRIPTION
It happened quite often that I needed a reliable method to open the project folder in file explorer.

I know this can be achieved via the Content panel, but you need to right click on the right folder, and when the output or log panel is docked at the bottom and it's focused, you first have to switch to the Content one.

![image](https://github.com/user-attachments/assets/4c871715-aa10-4710-b65e-f8d02784b190)
