### PR TITLE
Fix scene tree menu options being enabled when not supposed to be

### DIFF
--- a/Source/Editor/SceneGraph/Actors/SceneNode.cs
+++ b/Source/Editor/SceneGraph/Actors/SceneNode.cs
@@ -81,6 +81,7 @@ namespace FlaxEditor.SceneGraph.Actors
             if (Level.ScenesCount > 1)
                 contextMenu.AddButton("Unload all but this scene", OnUnloadAllButSelectedScene).LinkTooltip("Unloads all of the active scenes except for the selected scene.").Enabled = Editor.Instance.StateMachine.CurrentState.CanChangeScene;
 
+            contextMenu.MaximumItemsInViewCount += 3;
             base.OnContextMenu(contextMenu, window);
         }
 

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -55,9 +55,9 @@ namespace FlaxEditor.Windows
 
             b = contextMenu.AddButton("Rename", inputOptions.Rename, Rename);
             b = contextMenu.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
-            b.Enabled = hasSthSelected;
+            b.Enabled = hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).CanDuplicate;
 
-            if (isSingleActorSelected)
+            if (isSingleActorSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).Actor is not Scene)
             {
                 var convertMenu = contextMenu.AddChildMenu("Convert");
                 convertMenu.ContextMenu.AutoSort = true;
@@ -117,24 +117,24 @@ namespace FlaxEditor.Windows
                 }
             }
             b = contextMenu.AddButton("Delete", inputOptions.Delete, Editor.SceneEditing.Delete);
-            b.Enabled = hasSthSelected;
+            b.Enabled = hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).CanDelete;
 
             contextMenu.AddSeparator();
 
             b = contextMenu.AddButton("Copy", inputOptions.Copy, Editor.SceneEditing.Copy);
+            b.Enabled = hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).CanCopyPaste;
 
-            b.Enabled = hasSthSelected;
             contextMenu.AddButton("Paste", inputOptions.Paste, Editor.SceneEditing.Paste);
 
             b = contextMenu.AddButton("Cut", inputOptions.Cut, Editor.SceneEditing.Cut);
-            b.Enabled = canEditScene;
+            b.Enabled = canEditScene && ((ActorNode)Editor.SceneEditing.Selection[0]).CanCopyPaste;
 
             // Create option
 
             contextMenu.AddSeparator();
 
             b = contextMenu.AddButton("Parent to new Actor", inputOptions.GroupSelectedActors, Editor.SceneEditing.CreateParentForSelectedActors);
-            b.Enabled = canEditScene && hasSthSelected;
+            b.Enabled = canEditScene && hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).Actor is not Scene;
 
             b = contextMenu.AddButton("Create Prefab", Editor.Prefabs.CreatePrefab);
             b.Enabled = isSingleActorSelected &&

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -52,12 +52,13 @@ namespace FlaxEditor.Windows
             contextMenu.AddSeparator();
 
             // Basic editing options
-            var firstSelection = (ActorNode)Editor.SceneEditing.Selection[0];
+            var firstSelection = hasSthSelected ? Editor.SceneEditing.Selection[0] as ActorNode : null;
             b = contextMenu.AddButton("Rename", inputOptions.Rename, Rename);
+            b.Enabled = hasSthSelected;
             b = contextMenu.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
-            b.Enabled = hasSthSelected && firstSelection.CanDuplicate;
+            b.Enabled = hasSthSelected && (firstSelection != null ? firstSelection.CanDuplicate : true);
 
-            if (isSingleActorSelected && firstSelection.Actor is not Scene)
+            if (isSingleActorSelected && firstSelection?.Actor is not Scene)
             {
                 var convertMenu = contextMenu.AddChildMenu("Convert");
                 convertMenu.ContextMenu.AutoSort = true;
@@ -117,31 +118,31 @@ namespace FlaxEditor.Windows
                 }
             }
             b = contextMenu.AddButton("Delete", inputOptions.Delete, Editor.SceneEditing.Delete);
-            b.Enabled = hasSthSelected && firstSelection.CanDelete;
+            b.Enabled = hasSthSelected && (firstSelection != null ? firstSelection.CanDelete : true);
 
             contextMenu.AddSeparator();
 
             b = contextMenu.AddButton("Copy", inputOptions.Copy, Editor.SceneEditing.Copy);
-            b.Enabled = hasSthSelected && firstSelection.CanCopyPaste;
+            b.Enabled = hasSthSelected && (firstSelection != null ? firstSelection.CanCopyPaste : true);
 
             contextMenu.AddButton("Paste", inputOptions.Paste, Editor.SceneEditing.Paste);
 
             b = contextMenu.AddButton("Cut", inputOptions.Cut, Editor.SceneEditing.Cut);
-            b.Enabled = canEditScene && firstSelection.CanCopyPaste;
+            b.Enabled = canEditScene && hasSthSelected && (firstSelection != null ? firstSelection.CanCopyPaste : true);
 
             // Create option
 
             contextMenu.AddSeparator();
 
             b = contextMenu.AddButton("Parent to new Actor", inputOptions.GroupSelectedActors, Editor.SceneEditing.CreateParentForSelectedActors);
-            b.Enabled = canEditScene && hasSthSelected && firstSelection.Actor is not Scene;
+            b.Enabled = canEditScene && hasSthSelected && firstSelection?.Actor is not Scene;
 
             b = contextMenu.AddButton("Create Prefab", Editor.Prefabs.CreatePrefab);
             b.Enabled = isSingleActorSelected &&
-                        firstSelection.CanCreatePrefab &&
+                        (firstSelection != null ? firstSelection.CanCreatePrefab : false) &&
                         Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets;
 
-            bool hasPrefabLink = canEditScene && isSingleActorSelected && firstSelection.HasPrefabLink;
+            bool hasPrefabLink = canEditScene && isSingleActorSelected && (firstSelection != null ? firstSelection.HasPrefabLink : false);
             if (hasPrefabLink)
             {
                 contextMenu.AddButton("Select Prefab", Editor.Prefabs.SelectPrefab);

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -52,12 +52,12 @@ namespace FlaxEditor.Windows
             contextMenu.AddSeparator();
 
             // Basic editing options
-
+            var firstSelection = (ActorNode)Editor.SceneEditing.Selection[0];
             b = contextMenu.AddButton("Rename", inputOptions.Rename, Rename);
             b = contextMenu.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
-            b.Enabled = hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).CanDuplicate;
+            b.Enabled = hasSthSelected && firstSelection.CanDuplicate;
 
-            if (isSingleActorSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).Actor is not Scene)
+            if (isSingleActorSelected && firstSelection.Actor is not Scene)
             {
                 var convertMenu = contextMenu.AddChildMenu("Convert");
                 convertMenu.ContextMenu.AutoSort = true;
@@ -117,31 +117,31 @@ namespace FlaxEditor.Windows
                 }
             }
             b = contextMenu.AddButton("Delete", inputOptions.Delete, Editor.SceneEditing.Delete);
-            b.Enabled = hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).CanDelete;
+            b.Enabled = hasSthSelected && firstSelection.CanDelete;
 
             contextMenu.AddSeparator();
 
             b = contextMenu.AddButton("Copy", inputOptions.Copy, Editor.SceneEditing.Copy);
-            b.Enabled = hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).CanCopyPaste;
+            b.Enabled = hasSthSelected && firstSelection.CanCopyPaste;
 
             contextMenu.AddButton("Paste", inputOptions.Paste, Editor.SceneEditing.Paste);
 
             b = contextMenu.AddButton("Cut", inputOptions.Cut, Editor.SceneEditing.Cut);
-            b.Enabled = canEditScene && ((ActorNode)Editor.SceneEditing.Selection[0]).CanCopyPaste;
+            b.Enabled = canEditScene && firstSelection.CanCopyPaste;
 
             // Create option
 
             contextMenu.AddSeparator();
 
             b = contextMenu.AddButton("Parent to new Actor", inputOptions.GroupSelectedActors, Editor.SceneEditing.CreateParentForSelectedActors);
-            b.Enabled = canEditScene && hasSthSelected && ((ActorNode)Editor.SceneEditing.Selection[0]).Actor is not Scene;
+            b.Enabled = canEditScene && hasSthSelected && firstSelection.Actor is not Scene;
 
             b = contextMenu.AddButton("Create Prefab", Editor.Prefabs.CreatePrefab);
             b.Enabled = isSingleActorSelected &&
-                        ((ActorNode)Editor.SceneEditing.Selection[0]).CanCreatePrefab &&
+                        firstSelection.CanCreatePrefab &&
                         Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets;
 
-            bool hasPrefabLink = canEditScene && isSingleActorSelected && (Editor.SceneEditing.Selection[0] as ActorNode).HasPrefabLink;
+            bool hasPrefabLink = canEditScene && isSingleActorSelected && firstSelection.HasPrefabLink;
             if (hasPrefabLink)
             {
                 contextMenu.AddButton("Select Prefab", Editor.Prefabs.SelectPrefab);


### PR DESCRIPTION
Disables options in scene tree context menu that should not be enabled for scenes and other Actor nodes.