### PR TITLE
Add more scripting templates.

### DIFF
--- a/Content/Editor/Scripting/ActorTemplate.cpp
+++ b/Content/Editor/Scripting/ActorTemplate.cpp
@@ -1,0 +1,19 @@
+%copyright%#include "%filename%.h"
+
+%class%::%class%(const SpawnParams& params)
+    : Actor(params)
+{
+
+}
+
+void %class%::OnEnable()
+{
+    Actor::OnEnable();
+    // Here you can add code that needs to be called when script is enabled (eg. register for events)
+}
+
+void %class%::OnDisable()
+{
+    Actor::OnDisable();
+    // Here you can add code that needs to be called when script is disabled (eg. unregister from events)
+}

--- a/Content/Editor/Scripting/ActorTemplate.cs
+++ b/Content/Editor/Scripting/ActorTemplate.cs
@@ -1,0 +1,39 @@
+%copyright%using System;
+using System.Collections.Generic;
+using FlaxEngine;
+
+namespace %namespace%;
+
+/// <summary>
+/// %class% Actor.
+/// </summary>
+public class %class% : Actor
+{
+    /// <inheritdoc/>
+    public override void OnBeginPlay()
+    {
+        base.OnBeginPlay();
+        // Here you can add code that needs to be called when Actor added to the game. This is called during edit time as well.
+    }
+
+    /// <inheritdoc/>
+    public override void OnEndPlay()
+    {
+        base.OnEndPlay();
+        // Here you can add code that needs to be called when Actor removed to the game. This is called during edit time as well.
+    }
+    
+    /// <inheritdoc/>
+    public override void OnEnable()
+    {
+        base.OnEnable();
+        // Here you can add code that needs to be called when Actor is enabled (eg. register for events). This is called during edit time as well.
+    }
+
+    /// <inheritdoc/>
+    public override void OnDisable()
+    {
+        base.OnDisable();
+        // Here you can add code that needs to be called when Actor is disabled (eg. unregister from events). This is called during edit time as well.
+    }
+}

--- a/Content/Editor/Scripting/ActorTemplate.h
+++ b/Content/Editor/Scripting/ActorTemplate.h
@@ -1,0 +1,13 @@
+%copyright%#pragma once
+
+#include "Engine/Level/Actor.h"
+
+API_CLASS() class %module%%class% : public Actor
+{
+API_AUTO_SERIALIZATION();
+DECLARE_SCENE_OBJECT(%class%);
+
+    // [Actor]
+    void OnEnable() override;
+    void OnDisable() override;
+};

--- a/Content/Editor/Scripting/EmptyClassTemplate.cs
+++ b/Content/Editor/Scripting/EmptyClassTemplate.cs
@@ -1,0 +1,13 @@
+%copyright%using System;
+using System.Collections.Generic;
+using FlaxEngine;
+
+namespace %namespace%;
+
+/// <summary>
+/// %class% class.
+/// </summary>
+public class %class%
+{
+
+}

--- a/Content/Editor/Scripting/EmptyInterfaceTemplate.cs
+++ b/Content/Editor/Scripting/EmptyInterfaceTemplate.cs
@@ -1,0 +1,13 @@
+%copyright%using System;
+using System.Collections.Generic;
+using FlaxEngine;
+
+namespace %namespace%;
+
+/// <summary>
+/// %class% interface.
+/// </summary>
+public interface %class%
+{
+
+}

--- a/Content/Editor/Scripting/EmptyStructTemplate.cs
+++ b/Content/Editor/Scripting/EmptyStructTemplate.cs
@@ -1,0 +1,13 @@
+%copyright%using System;
+using System.Collections.Generic;
+using FlaxEngine;
+
+namespace %namespace%;
+
+/// <summary>
+/// %class% struct.
+/// </summary>
+public struct %class%
+{
+
+}

--- a/Source/Editor/Content/Proxy/CSharpProxy.cs
+++ b/Source/Editor/Content/Proxy/CSharpProxy.cs
@@ -73,10 +73,10 @@ namespace FlaxEditor.Content
     }
     
     /// <summary>
-    /// Context proxy object for C# script files.
+    /// Context proxy object for C# Script files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/C# Script")]
+    [ContentContextMenu("New/C#/Scripting/C# Script")]
     public class CSharpScriptProxy : CSharpProxy
     {
         /// <inheritdoc />
@@ -90,10 +90,27 @@ namespace FlaxEditor.Content
     }
     
     /// <summary>
+    /// Context proxy object for C# Actor files.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
+    [ContentContextMenu("New/C#/Scripting/C# Actor")]
+    public class CSharpActorProxy : CSharpProxy
+    {
+        /// <inheritdoc />
+        public override string Name => "C# Actor";
+
+        /// <inheritdoc />
+        protected override void GetTemplatePath(out string path)
+        {
+            path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/ActorTemplate.cs");
+        }
+    }
+    
+    /// <summary>
     /// Context proxy object for empty C# files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/C# Empty File")]
+    [ContentContextMenu("New/C#/Generic/C# Empty File")]
     public class CSharpEmptyProxy : CSharpProxy
     {
         /// <inheritdoc />
@@ -103,6 +120,57 @@ namespace FlaxEditor.Content
         protected override void GetTemplatePath(out string path)
         {
             path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/CSharpEmptyTemplate.cs");
+        }
+    }
+    
+    /// <summary>
+    /// Context proxy object for empty C# class files.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
+    [ContentContextMenu("New/C#/Generic/C# Class")]
+    public class CSharpEmptyClassProxy : CSharpProxy
+    {
+        /// <inheritdoc />
+        public override string Name => "C# Class";
+
+        /// <inheritdoc />
+        protected override void GetTemplatePath(out string path)
+        {
+            path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/EmptyClassTemplate.cs");
+        }
+    }
+    
+    /// <summary>
+    /// Context proxy object for empty C# struct files.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
+    [ContentContextMenu("New/C#/Generic/C# Struct")]
+    public class CSharpEmptyStructProxy : CSharpProxy
+    {
+        /// <inheritdoc />
+        public override string Name => "C# Struct";
+
+        /// <inheritdoc />
+        protected override void GetTemplatePath(out string path)
+        {
+            path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/EmptyStructTemplate.cs");
+        }
+    }
+    
+    /// <summary>
+    /// Context proxy object for empty C# interface files.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
+    [ContentContextMenu("New/C#/Generic/C# Interface")]
+    public class CSharpEmptyInterfaceProxy : CSharpProxy
+    {
+        /// <inheritdoc />
+        public override string Name => "C# Interface";
+
+        /// <inheritdoc />
+        protected override void GetTemplatePath(out string path)
+        {
+            path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/EmptyInterfaceTemplate.cs");
         }
     }
 }

--- a/Source/Editor/Content/Proxy/CSharpProxy.cs
+++ b/Source/Editor/Content/Proxy/CSharpProxy.cs
@@ -76,7 +76,7 @@ namespace FlaxEditor.Content
     /// Context proxy object for C# Script files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/Scripting/C# Script")]
+    [ContentContextMenu("New/C#/C# Script")]
     public class CSharpScriptProxy : CSharpProxy
     {
         /// <inheritdoc />
@@ -93,7 +93,7 @@ namespace FlaxEditor.Content
     /// Context proxy object for C# Actor files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/Scripting/C# Actor")]
+    [ContentContextMenu("New/C#/C# Actor")]
     public class CSharpActorProxy : CSharpProxy
     {
         /// <inheritdoc />
@@ -110,7 +110,7 @@ namespace FlaxEditor.Content
     /// Context proxy object for empty C# files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/Generic/C# Empty File")]
+    [ContentContextMenu("New/C#/C# Empty File")]
     public class CSharpEmptyProxy : CSharpProxy
     {
         /// <inheritdoc />
@@ -127,7 +127,7 @@ namespace FlaxEditor.Content
     /// Context proxy object for empty C# class files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/Generic/C# Class")]
+    [ContentContextMenu("New/C#/C# Class")]
     public class CSharpEmptyClassProxy : CSharpProxy
     {
         /// <inheritdoc />
@@ -144,7 +144,7 @@ namespace FlaxEditor.Content
     /// Context proxy object for empty C# struct files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/Generic/C# Struct")]
+    [ContentContextMenu("New/C#/C# Struct")]
     public class CSharpEmptyStructProxy : CSharpProxy
     {
         /// <inheritdoc />
@@ -161,7 +161,7 @@ namespace FlaxEditor.Content
     /// Context proxy object for empty C# interface files.
     /// </summary>
     /// <seealso cref="FlaxEditor.Content.CSharpProxy" />
-    [ContentContextMenu("New/C#/Generic/C# Interface")]
+    [ContentContextMenu("New/C#/C# Interface")]
     public class CSharpEmptyInterfaceProxy : CSharpProxy
     {
         /// <inheritdoc />

--- a/Source/Editor/Content/Proxy/CppProxy.cs
+++ b/Source/Editor/Content/Proxy/CppProxy.cs
@@ -100,6 +100,24 @@ namespace FlaxEditor.Content
             sourceTemplate = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/ScriptTemplate.cpp");
         }
     }
+    
+    /// <summary>
+    /// Context proxy object for C++ Actor files.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Content.CppProxy" />
+    [ContentContextMenu("New/C++/C++ Actor")]
+    public class CppActorProxy : CppProxy
+    {
+        /// <inheritdoc />
+        public override string Name => "C++ Actor";
+
+        /// <inheritdoc />
+        protected override void GetTemplatePaths(out string headerTemplate, out string sourceTemplate)
+        {
+            headerTemplate = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/ActorTemplate.h");
+            sourceTemplate = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor/Scripting/ActorTemplate.cpp");
+        }
+    }
 
     /// <summary>
     /// Context proxy object for C++ Json Asset files.

--- a/Source/Editor/Modules/ContentDatabaseModule.cs
+++ b/Source/Editor/Modules/ContentDatabaseModule.cs
@@ -1136,9 +1136,14 @@ namespace FlaxEditor.Modules
             Proxy.Add(new SceneAnimationProxy());
             Proxy.Add(new CSharpScriptProxy());
             Proxy.Add(new CSharpEmptyProxy());
+            Proxy.Add(new CSharpEmptyClassProxy());
+            Proxy.Add(new CSharpEmptyStructProxy());
+            Proxy.Add(new CSharpEmptyInterfaceProxy());
+            Proxy.Add(new CSharpActorProxy());
             Proxy.Add(new CppAssetProxy());
             Proxy.Add(new CppStaticClassProxy());
             Proxy.Add(new CppScriptProxy());
+            Proxy.Add(new CppActorProxy());
             Proxy.Add(new SceneProxy());
             Proxy.Add(new PrefabProxy());
             Proxy.Add(new IESProfileProxy());


### PR DESCRIPTION
Templates that are added in this commit:
- C# Actor
- C# Class
- C# Struct
- C# Interface
- C++ Actor

This also splits some of the C# templates into different sub menus. Generic (Class, Struct, Empty File, Interface) and Scripting (Actor, Script).

Related issue: <https://github.com/FlaxEngine/FlaxEngine/issues/3061>