### PR TITLE
Gizmo improvements

### DIFF
--- a/Source/Editor/Gizmo/TransformGizmoBase.Draw.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.Draw.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using FlaxEditor.Options;
+using FlaxEditor.SceneGraph;
 using FlaxEngine;
+using System;
 
 namespace FlaxEditor.Gizmo
 {
@@ -18,7 +21,12 @@ namespace FlaxEditor.Gizmo
         private MaterialInstance _materialAxisY;
         private MaterialInstance _materialAxisZ;
         private MaterialInstance _materialAxisFocus;
+        private MaterialInstance _materialAxisLocked;
         private MaterialBase _materialSphere;
+
+        // Material Parameter Names
+        const String _brightnessParamName = "Brightness";
+        const String _opacityParamName = "Opacity";
 
         private void InitDrawing()
         {
@@ -34,6 +42,7 @@ namespace FlaxEditor.Gizmo
             _materialAxisY = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisY");
             _materialAxisZ = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisZ");
             _materialAxisFocus = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisFocus");
+            _materialAxisLocked = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisLocked");
             _materialSphere = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialSphere");
 
             // Ensure that every asset was loaded
@@ -50,6 +59,23 @@ namespace FlaxEditor.Gizmo
             {
                 Platform.Fatal("Failed to load transform gizmo resources.");
             }
+
+            ApplyGizmoOptionsToMaterials(Editor.Instance.Options.Options);
+
+            Editor.Instance.Options.OptionsChanged += ApplyGizmoOptionsToMaterials;
+        }
+
+        private void ApplyGizmoOptionsToMaterials(EditorOptions o)
+        {
+            _materialAxisX.SetParameterValue(_brightnessParamName, o.Visual.transformGizmoBrightness);
+            _materialAxisY.SetParameterValue(_brightnessParamName, o.Visual.transformGizmoBrightness);
+            _materialAxisZ.SetParameterValue(_brightnessParamName, o.Visual.transformGizmoBrightness);
+            _materialAxisLocked.SetParameterValue(_brightnessParamName, o.Visual.transformGizmoBrightness);
+
+            _materialAxisX.SetParameterValue(_opacityParamName, o.Visual.transformGizmoOpacity);
+            _materialAxisY.SetParameterValue(_opacityParamName, o.Visual.transformGizmoOpacity);
+            _materialAxisZ.SetParameterValue(_opacityParamName, o.Visual.transformGizmoOpacity);
+            _materialAxisLocked.SetParameterValue(_opacityParamName, o.Visual.transformGizmoOpacity);
         }
 
         /// <inheritdoc />
@@ -59,6 +85,21 @@ namespace FlaxEditor.Gizmo
                 return;
             if (!_modelCube || !_modelCube.IsLoaded)
                 return;
+
+            bool gizmoLocked = false;
+
+            // Find out if any of the selected objects can not be moved.
+            if (Editor.Instance.StateMachine.IsPlayMode)
+            {
+                foreach (SceneGraphNode obj in Editor.Instance.SceneEditing.Selection)
+                {
+                    if (obj.CanTransform == false)
+                    {
+                        gizmoLocked = true;
+                        break;
+                    }
+                }
+            }
 
             // As all axisMesh have the same pivot, add a little offset to the x axisMesh, this way SortDrawCalls is able to sort the draw order
             // https://github.com/FlaxEngine/FlaxEngine/issues/680
@@ -92,32 +133,38 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationY(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                transAxisMesh.Draw(ref renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, ref m3);
+                MaterialInstance xAxisMaterialTransform = gizmoLocked ? _materialAxisLocked : (isXAxis ? _materialAxisFocus : _materialAxisX);
+                transAxisMesh.Draw(ref renderContext, xAxisMaterialTransform, ref m3);
 
                 // Y axis
                 Matrix.RotationX(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                transAxisMesh.Draw(ref renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, ref m3);
+                MaterialInstance yAxisMaterialTransform = gizmoLocked ? _materialAxisLocked : (isYAxis ? _materialAxisFocus : _materialAxisY);
+                transAxisMesh.Draw(ref renderContext, yAxisMaterialTransform, ref m3);
 
                 // Z axis
                 Matrix.RotationX(Mathf.Pi, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                transAxisMesh.Draw(ref renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, ref m3);
+                MaterialInstance zAxisMaterialTransform = gizmoLocked ? _materialAxisLocked : (isZAxis ? _materialAxisFocus : _materialAxisZ);
+                transAxisMesh.Draw(ref renderContext, zAxisMaterialTransform, ref m3);
 
                 // XY plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationX(Mathf.PiOverTwo), new Vector3(boxSize * boxScale, boxSize * boxScale, 0.0f));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX, ref m3);
+                MaterialInstance xyPlaneMaterialTransform = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX);
+                cubeMesh.Draw(ref renderContext, xyPlaneMaterialTransform, ref m3);
 
                 // ZX plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.Identity, new Vector3(boxSize * boxScale, 0.0f, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ, ref m3);
+                MaterialInstance zxPlaneMaterialTransform = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisY);
+                cubeMesh.Draw(ref renderContext, zxPlaneMaterialTransform, ref m3);
 
                 // YZ plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationZ(Mathf.PiOverTwo), new Vector3(0.0f, boxSize * boxScale, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY, ref m3);
+                MaterialInstance yzPlaneMaterialTransform = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisZ);
+                cubeMesh.Draw(ref renderContext, yzPlaneMaterialTransform, ref m3);
 
                 // Center sphere
                 Matrix.Scaling(gizmoModelsScale2RealGizmoSize, out m2);
@@ -136,15 +183,18 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationZ(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                rotationAxisMesh.Draw(ref renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, ref m3);
+                MaterialInstance xAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isXAxis ? _materialAxisFocus : _materialAxisX);
+                rotationAxisMesh.Draw(ref renderContext, xAxisMaterialRotate, ref m3);
 
                 // Y axis
-                rotationAxisMesh.Draw(ref renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, ref m1);
+                MaterialInstance yAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isYAxis ? _materialAxisFocus : _materialAxisY);
+                rotationAxisMesh.Draw(ref renderContext, yAxisMaterialRotate, ref m1);
 
                 // Z axis
                 Matrix.RotationX(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                rotationAxisMesh.Draw(ref renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, ref m3);
+                MaterialInstance zAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isZAxis ? _materialAxisFocus : _materialAxisZ);
+                rotationAxisMesh.Draw(ref renderContext, zAxisMaterialRotate, ref m3);
 
                 // Center box
                 Matrix.Scaling(gizmoModelsScale2RealGizmoSize, out m2);
@@ -163,32 +213,38 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationY(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref mx1, out m3);
-                scaleAxisMesh.Draw(ref renderContext, isXAxis ? _materialAxisFocus : _materialAxisX, ref m3);
+                MaterialInstance xAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isXAxis ? _materialAxisFocus : _materialAxisX);
+                scaleAxisMesh.Draw(ref renderContext, xAxisMaterialRotate, ref m3);
 
                 // Y axis
                 Matrix.RotationX(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                scaleAxisMesh.Draw(ref renderContext, isYAxis ? _materialAxisFocus : _materialAxisY, ref m3);
+                MaterialInstance yAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isYAxis ? _materialAxisFocus : _materialAxisY);
+                scaleAxisMesh.Draw(ref renderContext, yAxisMaterialRotate, ref m3);
 
                 // Z axis
                 Matrix.RotationX(Mathf.Pi, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                scaleAxisMesh.Draw(ref renderContext, isZAxis ? _materialAxisFocus : _materialAxisZ, ref m3);
+                MaterialInstance zAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isZAxis ? _materialAxisFocus : _materialAxisZ);
+                scaleAxisMesh.Draw(ref renderContext, zAxisMaterialRotate, ref m3);
 
                 // XY plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationX(Mathf.PiOverTwo), new Vector3(boxSize * boxScale, boxSize * boxScale, 0.0f));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX, ref m3);
+                MaterialInstance xyPlaneMaterialScale = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX);
+                cubeMesh.Draw(ref renderContext, xyPlaneMaterialScale, ref m3);
 
                 // ZX plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.Identity, new Vector3(boxSize * boxScale, 0.0f, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ, ref m3);
+                MaterialInstance zxPlaneMaterialScale = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ);
+                cubeMesh.Draw(ref renderContext, zxPlaneMaterialScale, ref m3);
 
                 // YZ plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationZ(Mathf.PiOverTwo), new Vector3(0.0f, boxSize * boxScale, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                cubeMesh.Draw(ref renderContext, _activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY, ref m3);
+                MaterialInstance yzPlaneMaterialScale = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY);
+                cubeMesh.Draw(ref renderContext, yzPlaneMaterialScale, ref m3);
 
                 // Center box
                 Matrix.Scaling(gizmoModelsScale2RealGizmoSize, out m2);

--- a/Source/Editor/Options/VisualOptions.cs
+++ b/Source/Editor/Options/VisualOptions.cs
@@ -54,6 +54,20 @@ namespace FlaxEditor.Options
         public Color HighlightColor { get; set; } = new Color(0.0f, 0.533f, 1.0f, 1.0f);
 
         /// <summary>
+        /// Gets or set a value indicating how bright the transform gizmo is. Value over 1 will result in the gizmo emitting light.
+        /// </summary>
+        [DefaultValue(1f), Range(0f, 5f)]
+        [EditorDisplay("Transform Gizmo", "Gizmo Brightness"), EditorOrder(210)]
+        public float transformGizmoBrightness { get; set; } = 1f;
+
+        /// <summary>
+        /// Gets or set a value indicating the opactiy of the transform gizmo.
+        /// </summary>
+        [DefaultValue(1f), Range(0f, 1f)]
+        [EditorDisplay("Transform Gizmo", "Gizmo Opacity"), EditorOrder(211)]
+        public float transformGizmoOpacity { get; set; } = 1f;
+
+        /// <summary>
         /// Gets or sets a value indicating whether enable MSAA for DebugDraw primitives rendering. Helps with pixel aliasing but reduces performance.
         /// </summary>
         [DefaultValue(true)]

--- a/Source/Editor/Options/VisualOptions.cs
+++ b/Source/Editor/Options/VisualOptions.cs
@@ -22,35 +22,35 @@ namespace FlaxEditor.Options
         /// Gets or sets the first outline color.
         /// </summary>
         [DefaultValue(typeof(Color), "0.039,0.827,0.156")]
-        [EditorDisplay("Gizmo"), EditorOrder(100), Tooltip("The first color of the selection outline gradient.")]
+        [EditorDisplay("Transform Gizmo"), EditorOrder(100), Tooltip("The first color of the selection outline gradient.")]
         public Color SelectionOutlineColor0 { get; set; } = new Color(0.039f, 0.827f, 0.156f);
 
         /// <summary>
         /// Gets or sets the second outline color.
         /// </summary>
         [DefaultValue(typeof(Color), "0.019,0.615,0.101")]
-        [EditorDisplay("Gizmo"), EditorOrder(101), Tooltip("The second color of the selection outline gradient.")]
+        [EditorDisplay("Transform Gizmo"), EditorOrder(101), Tooltip("The second color of the selection outline gradient.")]
         public Color SelectionOutlineColor1 { get; set; } = new Color(0.019f, 0.615f, 0.101f);
 
         /// <summary>
         /// Gets or sets the selection outline size for UI controls.
         /// </summary>
         [DefaultValue(2.0f)]
-        [EditorDisplay("Gizmo", "UI Control Outline Size"), EditorOrder(100), Tooltip("The size of the selection outline for UI controls.")]
+        [EditorDisplay("UI Gizmo", "UI Control Outline Size"), EditorOrder(103), Tooltip("The size of the selection outline for UI controls.")]
         public float UISelectionOutlineSize { get; set; } = 2.0f;
 
         /// <summary>
         /// Gets or sets the transform gizmo size.
         /// </summary>
         [DefaultValue(1.0f), Limit(0.01f, 100.0f, 0.01f)]
-        [EditorDisplay("Gizmo"), EditorOrder(110), Tooltip("The transform gizmo size.")]
+        [EditorDisplay("Transform Gizmo"), EditorOrder(110), Tooltip("The transform gizmo size.")]
         public float GizmoSize { get; set; } = 1.0f;
 
         /// <summary>
         /// Gets or sets the color used to highlight selected meshes and CSG surfaces.
         /// </summary>
         [DefaultValue(typeof(Color), "0.0,0.533,1.0,1.0")]
-        [EditorDisplay("Gizmo"), EditorOrder(200), Tooltip("The color used to highlight selected meshes and CSG surfaces.")]
+        [EditorDisplay("Transform Gizmo"), EditorOrder(200), Tooltip("The color used to highlight selected meshes and CSG surfaces.")]
         public Color HighlightColor { get; set; } = new Color(0.0f, 0.533f, 1.0f, 1.0f);
 
         /// <summary>


### PR DESCRIPTION
This pr adds:
- Better categorization of the *Visual* tab in the editor options
- Greyed out gizmo when some of the selected objects can not be moved because of their static flags during game mode
- Options to change opacity and brightness of the transform gizmos

*Gizmo transparency and brightness:*
The center dot not being affected by the new options is on purpose, I think it makes the gizmo easier to see against a background with similar color of the locked gizmo.

The brightness slider has a min and max value because if you push it too far, the colors start to change. And for the opacity slider it just makes sense for it to be 0 to 1.

https://github.com/user-attachments/assets/4695aa65-1561-46fb-afcf-6dc8e42882df

*I've fixed the missing space in the naming of the options*

*Gizmo disabled:*

https://github.com/user-attachments/assets/2798a100-fd2e-46b5-ba14-fa362771d37b

I added two new parameters to *"Flax/Content/Editor/Gizmo/Material"*, one for brightness and one for opacity control.
I also created a new material called *MaterialAxisLocked*, which is used when the gizmo is locked:
[GizmoNewMaterials.zip](https://github.com/user-attachments/files/18029237/GizmoNewMaterials.zip)


Currently the gizmo will still display as locked even when only one of multiple selected objects can not move. I think it's more important to communicate that some of the actors wont receive the transformation than having the axis colors display.

Closes #2373.
I've not added the suggested text because I think the greyed out gizmo communicates that the actor is static well enough. Although I'm not against adding it if people think that's a good idea.

