### PR TITLE
Visject: Comment rename improvements and regression fix

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1502,9 +1502,10 @@ namespace FlaxEditor.Surface.Archetypes
                     {
                         data = new object[]
                         {
-                            filterText.Substring(2),
-                            new Color(1.0f, 1.0f, 1.0f, 0.2f),
-                            new Float2(400.0f, 400.0f),
+                            filterText.Substring(2), // Title
+                            new Color(1.0f, 1.0f, 1.0f, 0.2f), // Color
+                            new Float2(400.0f, 400.0f), // Size
+                            -1, // Order
                         };
                         return true;
                     }

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -172,10 +172,21 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override void Update(float deltaTime)
         {
-            if (_isRenaming && (!_renameTextBox.IsFocused || !RootWindow.IsFocused))
+            if (_isRenaming)
             {
-                Rename(_renameTextBox.Text);
-                StopRenaming();
+                // Stop renaming when clicking anywhere else
+                if (!_renameTextBox.IsFocused || !RootWindow.IsFocused)
+                {
+                    Rename(_renameTextBox.Text);
+                    StopRenaming();
+                }
+            }
+            else
+            {
+                if (IsSelected && Input.GetKeyDown(KeyboardKeys.F2))
+                { 
+                    StartRenaming();
+                }
             }
 
             base.Update(deltaTime);
@@ -417,6 +428,12 @@ namespace FlaxEditor.Surface
             base.OnShowSecondaryContextMenu(menu, location);
 
             menu.AddSeparator();
+            menu.AddButton("Rename", () =>
+            {
+                if(!_isRenaming)
+                    StartRenaming();
+            });
+
             ContextMenuChildMenu cmOrder = menu.AddChildMenu("Order");
             {
                 cmOrder.ContextMenu.AddButton("Bring Forward", () =>


### PR DESCRIPTION
This commit adds the ability to rename surface comments in visject by pressing F2. This is more in line of what operating systems like windows or linux do. Resolves #3092 

A rename button also got added to the context menu of surface comments:
![image](https://github.com/user-attachments/assets/769b8cc8-fca6-48cc-8839-e3b8739eb940)

---

An oversight in my comment order PR #1759 also broke creating comments when typing "// custom comment title" into the node search box. This PR fixes the regression.

