### PR TITLE
Add the option to ignore specific warnings during build.

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -256,6 +256,13 @@ namespace Flax.Build
 #endif
             if (buildOptions.ScriptingAPI.IgnoreMissingDocumentationWarnings)
                 args.Add("-nowarn:1591");
+            if (buildOptions.ScriptingAPI.IgnoreSpecificWarnings.Any())
+            {
+                foreach (var warningString in buildOptions.ScriptingAPI.IgnoreSpecificWarnings)
+                {
+                    args.Add($"-nowarn:{warningString}");
+                }
+            }
 
             // Optimizations prevent debugging, only enable in release builds by default
             var optimize = optimizeAssembly.HasValue ? optimizeAssembly.Value : buildData.Configuration == TargetConfiguration.Release;

--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -236,7 +236,7 @@ namespace Flax.Build.NativeCpp
             public HashSet<string> Analyzers;
 
             /// <summary>
-            /// The specific .NET warning to ignore.
+            /// The specific warnings to ignore.
             /// </summary>
             public HashSet<string> IgnoreSpecificWarnings;
 

--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -236,6 +236,11 @@ namespace Flax.Build.NativeCpp
             public HashSet<string> Analyzers;
 
             /// <summary>
+            /// The specific .NET warning to ignore.
+            /// </summary>
+            public HashSet<string> IgnoreSpecificWarnings;
+
+            /// <summary>
             /// True if ignore compilation warnings due to missing code documentation comments.
             /// </summary>
             public bool IgnoreMissingDocumentationWarnings;
@@ -265,6 +270,7 @@ namespace Flax.Build.NativeCpp
                 FileReferences.AddRange(other.FileReferences);
                 Analyzers.AddRange(other.Analyzers);
                 IgnoreMissingDocumentationWarnings |= other.IgnoreMissingDocumentationWarnings;
+                IgnoreSpecificWarnings.AddRange(other.IgnoreSpecificWarnings);
             }
         }
 
@@ -338,6 +344,7 @@ namespace Flax.Build.NativeCpp
             },
             FileReferences = new HashSet<string>(),
             Analyzers = new HashSet<string>(),
+            IgnoreSpecificWarnings = new HashSet<string>(),
         };
 
         /// <summary>

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
@@ -125,6 +125,13 @@ namespace Flax.Build.Projects.VisualStudio
                 csProjectFileContent.AppendLine("    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>");
                 if (configuration.TargetBuildOptions.ScriptingAPI.IgnoreMissingDocumentationWarnings)
                     csProjectFileContent.AppendLine("    <NoWarn>1591</NoWarn>");
+                if (configuration.TargetBuildOptions.ScriptingAPI.IgnoreSpecificWarnings.Any())
+                {
+                    foreach (var warningString in configuration.TargetBuildOptions.ScriptingAPI.IgnoreSpecificWarnings)
+                    {
+                        csProjectFileContent.AppendLine($"    <NoWarn>{warningString}</NoWarn>");
+                    }
+                }
                 csProjectFileContent.AppendLine(string.Format("    <DocumentationFile>{0}\\{1}.CSharp.xml</DocumentationFile>", outputPath, project.BaseName));
                 csProjectFileContent.AppendLine("    <UseVSHostingProcess>true</UseVSHostingProcess>");
                 csProjectFileContent.AppendLine("  </PropertyGroup>");
@@ -156,6 +163,13 @@ namespace Flax.Build.Projects.VisualStudio
                 csProjectFileContent.AppendLine("    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>");
                 if (configuration.TargetBuildOptions.ScriptingAPI.IgnoreMissingDocumentationWarnings)
                     csProjectFileContent.AppendLine("    <NoWarn>1591</NoWarn>");
+                if (configuration.TargetBuildOptions.ScriptingAPI.IgnoreSpecificWarnings.Any())
+                {
+                    foreach (var warningString in configuration.TargetBuildOptions.ScriptingAPI.IgnoreSpecificWarnings)
+                    {
+                        csProjectFileContent.AppendLine($"    <NoWarn>{warningString}</NoWarn>");
+                    }
+                }
                 csProjectFileContent.AppendLine(string.Format("    <DocumentationFile>{0}\\{1}.CSharp.xml</DocumentationFile>", outputPath, project.BaseName));
                 csProjectFileContent.AppendLine("    <UseVSHostingProcess>true</UseVSHostingProcess>");
                 csProjectFileContent.AppendLine("  </PropertyGroup>");

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -284,6 +284,13 @@ namespace Flax.Build.Projects.VisualStudio
             csProjectFileContent.AppendLine("    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>");
             if (configuration.TargetBuildOptions.ScriptingAPI.IgnoreMissingDocumentationWarnings)
                 csProjectFileContent.AppendLine("    <NoWarn>1591</NoWarn>");
+            if (configuration.TargetBuildOptions.ScriptingAPI.IgnoreSpecificWarnings.Any())
+            {
+                foreach (var warningString in configuration.TargetBuildOptions.ScriptingAPI.IgnoreSpecificWarnings)
+                {
+                    csProjectFileContent.AppendLine($"    <NoWarn>{warningString}</NoWarn>");
+                }
+            }
             csProjectFileContent.AppendLine(string.Format("    <DocumentationFile>{0}\\{1}.CSharp.xml</DocumentationFile>", outputPath, project.BaseName));
             csProjectFileContent.AppendLine("    <UseVSHostingProcess>true</UseVSHostingProcess>");
 


### PR DESCRIPTION
This adds the option to ignore specific user defined warnings in the build files.

```
public override void Setup(BuildOptions options)
{
       base.Setup(options);
       options.ScriptingAPI.IgnoreSpecificWarnings.Add("CS0168");
       options.ScriptingAPI.IgnoreSpecificWarnings.Add("CS0649");
       options.ScriptingAPI.IgnoreSpecificWarnings.Add("CS0414");
}
```