### PR TITLE
Add rotate position shape as particle module.

### DIFF
--- a/Source/Editor/Surface/Archetypes/ParticleModules.cs
+++ b/Source/Editor/Surface/Archetypes/ParticleModules.cs
@@ -924,6 +924,25 @@ namespace FlaxEditor.Surface.Archetypes
                     (int)ModuleType.Initialize,
                 },
             },
+            new NodeArchetype
+            {
+                TypeID = 216,
+                Create = CreateParticleModuleNode,
+                Title = "Rotate Position Shape",
+                Description = "Rotate the shape.",
+                Flags = DefaultModuleFlags,
+                Size = new Float2(200, 1 * Surface.Constants.LayoutOffsetY),
+                DefaultValues = new object[]
+                {
+                    true,
+                    (int)ModuleType.Initialize,
+                    Quaternion.Identity,
+                },
+                Elements = new []
+                {
+                    NodeElementArchetype.Factory.Input(-0.5f, "Rotation", true, typeof(Quaternion), 0, 2),
+                }
+            },
             GetParticleAttribute(ModuleType.Initialize, 250, "Set Position", "Sets the particle position", typeof(Float3), Float3.Zero),
             GetParticleAttribute(ModuleType.Initialize, 251, "Set Lifetime", "Sets the particle lifetime (in seconds)", typeof(float), 10.0f),
             GetParticleAttribute(ModuleType.Initialize, 252, "Set Age", "Sets the particle age (in seconds)", typeof(float), 0.0f),

--- a/Source/Engine/Particles/Graph/CPU/ParticleEmitterGraph.CPU.ParticleModules.cpp
+++ b/Source/Engine/Particles/Graph/CPU/ParticleEmitterGraph.CPU.ParticleModules.cpp
@@ -1163,7 +1163,12 @@ void ParticleEmitterGraphCPUExecutor::ProcessModule(ParticleEmitterGraphCPUNode*
 #define INPUTS_FETCH() \
 const Quaternion quat = (Quaternion)GetValue(quatBox, 2);
 #define LOGIC() \
-*(Float3*)positionPtr = quat * *((Float3*)positionPtr); \
+Quaternion nq = Quaternion::Invert(quat); \
+Float3 v3 = *((Float3*)positionPtr); \
+Float4 v4 = Float4(v3); \
+Quaternion q = Quaternion(v4); \
+Quaternion rq = quat * (q * nq); \
+*(Float3*)positionPtr = Float3(rq.X, rq.Y, rq.Z); \
 positionPtr += stride;
 
         if (node->UsePerParticleDataResolve())

--- a/Source/Engine/Particles/Graph/CPU/ParticleEmitterGraph.CPU.ParticleModules.cpp
+++ b/Source/Engine/Particles/Graph/CPU/ParticleEmitterGraph.CPU.ParticleModules.cpp
@@ -1150,6 +1150,43 @@ void ParticleEmitterGraphCPUExecutor::ProcessModule(ParticleEmitterGraphCPUNode*
         // Not supported
         break;
     }
+    // Rotate Position Shape
+    case 216:
+    {
+        PARTICLE_EMITTER_MODULE("Rotate Position Shape");
+        auto& positionAttr = context.Data->Buffer->Layout->Attributes[node->Attributes[0]];
+
+        byte* positionPtr = start + positionAttr.Offset;
+
+        auto quatBox = node->GetBox(0);
+
+#define INPUTS_FETCH() \
+const Quaternion quat = (Quaternion)GetValue(quatBox, 2);
+#define LOGIC() \
+*(Float3*)positionPtr = quat * *((Float3*)positionPtr); \
+positionPtr += stride;
+
+        if (node->UsePerParticleDataResolve())
+        {
+            for (int32 particleIndex = particlesStart; particleIndex < particlesEnd; particleIndex++)
+            {
+                context.ParticleIndex = particleIndex;
+                INPUTS_FETCH();
+                LOGIC();
+            }
+        }
+        else
+        {
+            INPUTS_FETCH();
+            for (int32 particleIndex = particlesStart; particleIndex < particlesEnd; particleIndex++)
+            {
+                LOGIC();
+            }
+        }
+#undef INPUTS_FETCH
+#undef LOGIC
+        break;
+    }
 
     // Helper macros for collision modules to share the code
 #define COLLISION_BEGIN() \

--- a/Source/Engine/Particles/Graph/GPU/ParticleEmitterGraph.GPU.ParticleModules.cpp
+++ b/Source/Engine/Particles/Graph/GPU/ParticleEmitterGraph.GPU.ParticleModules.cpp
@@ -632,6 +632,20 @@ void ParticleEmitterGPUGenerator::ProcessModule(Node* node)
             ), position.Value, param.ShaderName, wsPos);
         break;
     }
+    // Rotate position shape
+    case 216:
+    {
+        auto positionAttr = AccessParticleAttribute(node, nodeGpu->Attributes[0], AccessMode::Write);
+        const Value quaternion = tryGetValue(node->GetBox(0), Value::InitForZero(VariantType::Quaternion)).Cast(VariantType::Quaternion);
+        _writer.Write(
+            TEXT(
+                "   {{\n"
+                "       // Rotate position shape\n"
+                "       {0} = QuatRotateVector({1}, {0});\n"
+                "   }}\n"
+                ), positionAttr.Value, quaternion.Value);
+        break;
+    }
 
     // Helper macros for collision modules to share the code
 #define COLLISION_BEGIN() \


### PR DESCRIPTION
This allows to do something like this <https://docs.flaxengine.com/manual/particles/tutorials/rotate-particles.html> with only this code:
![image](https://github.com/user-attachments/assets/0060c0ea-1f0f-494e-8522-0c70f0608cd4)

It is nice to be able to rotate the initial shape that the particles are starting at.

Let me know if anyone thinks of a better name than "Rotate Position Shape".
