### PR TITLE
Fix models imported with negative scale using optional import option to reverse winding order

### DIFF
--- a/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
@@ -766,8 +766,6 @@ bool ModelTool::ImportDataAssimp(const String& path, ModelData& data, Options& o
         if (options.CalculateTangents)
             flags |= aiProcess_CalcTangentSpace;
         if (options.ReverseWindingOrder)
-            // actually we need to remove this flag
-            // flags |= aiProcess_FlipWindingOrder;
             flags &= ~aiProcess_FlipWindingOrder;
         if (options.OptimizeMeshes)
             flags |= aiProcess_OptimizeMeshes | aiProcess_SplitLargeMeshes | aiProcess_ImproveCacheLocality;

--- a/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.Assimp.cpp
@@ -765,6 +765,10 @@ bool ModelTool::ImportDataAssimp(const String& path, ModelData& data, Options& o
             flags |= aiProcess_FixInfacingNormals | aiProcess_GenSmoothNormals;
         if (options.CalculateTangents)
             flags |= aiProcess_CalcTangentSpace;
+        if (options.ReverseWindingOrder)
+            // actually we need to remove this flag
+            // flags |= aiProcess_FlipWindingOrder;
+            flags &= ~aiProcess_FlipWindingOrder;
         if (options.OptimizeMeshes)
             flags |= aiProcess_OptimizeMeshes | aiProcess_SplitLargeMeshes | aiProcess_ImproveCacheLocality;
         if (options.MergeMeshes)

--- a/Source/Engine/Tools/ModelTool/ModelTool.AutodeskFbxSdk.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.AutodeskFbxSdk.cpp
@@ -385,6 +385,19 @@ bool ProcessMesh(ImporterData& data, FbxMesh* fbxMesh, MeshData& mesh, String& e
         mesh.Indices[i] = fbxIndices[i];
     }
 
+    if (data.Options.ReverseWindingOrder)
+    {
+        for (int32 i = 0; i < vertexCount; i += 3)
+        {
+            Swap(meshIndices[i + 1], meshIndices[i + 2]);
+            Swap(meshPositions[i + 1], meshPositions[i + 2]);
+            if (meshNormals)
+                Swap(meshNormals[i + 1], meshNormals[i + 2]);
+            if (meshTangents)
+                Swap(meshTangents[i + 1], meshTangents[i + 2]);
+        }
+    }
+
     // Texture coordinates
     FbxGeometryElementUV* texcoords = fbxMesh->GetElementUV(0);
     if (texcoords)

--- a/Source/Engine/Tools/ModelTool/ModelTool.OpenFBX.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.OpenFBX.cpp
@@ -775,6 +775,24 @@ bool ProcessMesh(ModelData& result, OpenFbxImporterData& data, const ofbx::Mesh*
         }
     }
 
+    // Reverse winding order
+    if (data.Options.ReverseWindingOrder)
+    {
+        uint32* meshIndices = mesh.Indices.Get();
+        Float3* meshPositions = mesh.Positions.Get();
+        Float3* meshNormals = mesh.Normals.HasItems() ? mesh.Normals.Get() : nullptr;
+        Float3* meshTangents = mesh.Tangents.HasItems() ? mesh.Tangents.Get() : nullptr;
+
+        for (int i = 0; i < vertexCount; i += 3) {
+            Swap(meshIndices[i + 1], meshIndices[i + 2]);
+            Swap(meshPositions[i + 1], meshPositions[i + 2]);
+            if (meshNormals)
+                Swap(meshNormals[i + 1], meshNormals[i + 2]);
+            if (meshTangents)
+                Swap(meshTangents[i + 1], meshTangents[i + 2]);
+        }
+    }
+
     // Lightmap UVs
     if (data.Options.LightmapUVsSource == ModelLightmapUVsSource::Disable)
     {

--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -667,6 +667,7 @@ void ModelTool::Options::Serialize(SerializeStream& stream, const void* otherObj
     SERIALIZE(FlipNormals);
     SERIALIZE(CalculateTangents);
     SERIALIZE(SmoothingTangentsAngle);
+    SERIALIZE(ReverseWindingOrder);
     SERIALIZE(OptimizeMeshes);
     SERIALIZE(MergeMeshes);
     SERIALIZE(ImportLODs);
@@ -717,6 +718,7 @@ void ModelTool::Options::Deserialize(DeserializeStream& stream, ISerializeModifi
     DESERIALIZE(FlipNormals);
     DESERIALIZE(CalculateTangents);
     DESERIALIZE(SmoothingTangentsAngle);
+    DESERIALIZE(ReverseWindingOrder);
     DESERIALIZE(OptimizeMeshes);
     DESERIALIZE(MergeMeshes);
     DESERIALIZE(ImportLODs);

--- a/Source/Engine/Tools/ModelTool/ModelTool.h
+++ b/Source/Engine/Tools/ModelTool/ModelTool.h
@@ -170,6 +170,9 @@ public:
         // Specifies the maximum angle (in degrees) that may be between two vertex tangents before their tangents and bi-tangents are smoothed. The default value is 45.
         API_FIELD(Attributes="EditorOrder(45), EditorDisplay(\"Geometry\"), VisibleIf(nameof(ShowSmoothingTangentsAngle)), Limit(0, 45, 0.1f)")
         float SmoothingTangentsAngle = 45.0f;
+        // If checked, the winding order of the vertices will be reversed.
+        API_FIELD(Attributes="EditorOrder(47), EditorDisplay(\"Geometry\"), VisibleIf(nameof(ShowGeometry))")
+        bool ReverseWindingOrder = false;
         // Enable/disable meshes geometry optimization.
         API_FIELD(Attributes="EditorOrder(50), EditorDisplay(\"Geometry\"), VisibleIf(nameof(ShowGeometry))")
         bool OptimizeMeshes = true;


### PR DESCRIPTION
Models imported with a negative scale can import with an incorrect winding order via certain formats like .dae and .fbx

The proposed fix adds an option in the model importer to reverse the winding order. With assimp this is accomplished by removing the aiProcess_FlipWindingOrder from the flags. With OpenFBX and Autodesk FBX SDK it is implemented with a simple manual swap per triangle. It should also correctly swap normals and tangents.

I was unable to test with the Autodesk SDK, but the other importers are working as intended.

Fixes #2253

Default import behavior:
![image](https://github.com/user-attachments/assets/fdf8ce3c-ca07-4e11-8c04-840a55cb7f00)

Reversed winding order:
![image](https://github.com/user-attachments/assets/3c36cd18-fb8e-4126-9c7b-fb25a3356c01)

