### PR TITLE
Fix heightmap invert

### DIFF
--- a/Source/Editor/Tools/Terrain/TerrainTools.cpp
+++ b/Source/Editor/Tools/Terrain/TerrainTools.cpp
@@ -203,7 +203,7 @@ bool TerrainTools::GenerateTerrain(Terrain* terrain, const Int2& numberOfPatches
             {
                 for (int32 x = 0; x < heightmapSize; x++)
                 {
-                    const Vector2 uv = uvStart + Vector2(x * heightmapSizeInv, z * heightmapSizeInv) * uvPerPatch;
+                    const Vector2 uv = uvStart + Vector2(x * heightmapSizeInv, ((float)heightmapSize - 1.0f - z) * heightmapSizeInv) * uvPerPatch;
                     const Color color = TextureTool::SampleLinear(sampler, uv, dataHeightmap.Mip0DataPtr->Get(), dataHeightmap.Mip0Size, dataHeightmap.RowPitch);
                     heightmapData[z * heightmapSize + x] = color.R * heightmapScale;
                 }

--- a/Source/Editor/Tools/Terrain/TerrainTools.cpp
+++ b/Source/Editor/Tools/Terrain/TerrainTools.cpp
@@ -203,7 +203,7 @@ bool TerrainTools::GenerateTerrain(Terrain* terrain, const Int2& numberOfPatches
             {
                 for (int32 x = 0; x < heightmapSize; x++)
                 {
-                    const Vector2 uv = uvStart + Vector2(x * heightmapSizeInv, ((float)heightmapSize - 1.0f - z) * heightmapSizeInv) * uvPerPatch;
+                    const Vector2 uv = uvStart + Vector2(x * heightmapSizeInv, (heightmapSize - 1 - z) * heightmapSizeInv) * uvPerPatch;
                     const Color color = TextureTool::SampleLinear(sampler, uv, dataHeightmap.Mip0DataPtr->Get(), dataHeightmap.Mip0Size, dataHeightmap.RowPitch);
                     heightmapData[z * heightmapSize + x] = color.R * heightmapScale;
                 }


### PR DESCRIPTION
Texture:
![image](https://github.com/user-attachments/assets/f956a6d2-5e55-43d7-af56-b661c0716a71)

Existing generation (top = +z, bottom = -z):
![image](https://github.com/user-attachments/assets/f604b51b-9997-437f-bef3-025b31ba54a1)

Correct y (top = +z, bottom = -z):
![image](https://github.com/user-attachments/assets/3bc057a4-d4bf-4438-8e4a-d1a31cd6c031)
