### PR TITLE
Allow user to add splash image to splash screen.

### DIFF
--- a/Source/Editor/Windows/SplashScreen.h
+++ b/Source/Editor/Windows/SplashScreen.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Engine/Content/Assets/Texture.h"
 #include "Engine/Core/Types/DateTime.h"
 #include "Engine/Platform/Window.h"
 
@@ -18,6 +19,7 @@ private:
     Window* _window = nullptr;
     Font* _titleFont = nullptr;
     Font* _subtitleFont = nullptr;
+    Texture* _splashTexture = nullptr;
     String _title;
     DateTime _startTime;
     String _infoText;
@@ -78,4 +80,5 @@ private:
     void OnDraw();
     bool HasLoadedFonts() const;
     void OnFontLoaded(Asset* asset);
+    void OnTextureLoaded(Asset* asset);
 };


### PR DESCRIPTION
This allows users to put a texture named "SplashImage.flax" inside of the "Content/SplashImage" folder and it will use it as the project splash screen image at start up. Recommended texture size is 600x200. I am open to suggestions on the text layout positioning.


Image of a custom splash screen:
![image](https://github.com/user-attachments/assets/d816b623-d5e4-400f-bc91-2ee7a7e7d8dd)
