### PR TITLE
Fix .exe being deleted when using the "Run cooked build" option.

### DIFF
--- a/Source/Editor/Cooker/GameCooker.cpp
+++ b/Source/Editor/Cooker/GameCooker.cpp
@@ -671,11 +671,14 @@ bool GameCookerImpl::Build()
     MCore::Thread::Attach();
 
     // Build Started
-    CallEvent(GameCooker::EventType::BuildStarted);
-    data.Tools->OnBuildStarted(data);
-    for (int32 stepIndex = 0; stepIndex < Steps.Count(); stepIndex++)
-        Steps[stepIndex]->OnBuildStarted(data);
-    data.InitProgress(Steps.Count());
+    if (!EnumHasAnyFlags(data.Options, BuildOptions::NoCook))
+    {
+        CallEvent(GameCooker::EventType::BuildStarted);
+        data.Tools->OnBuildStarted(data);
+        for (int32 stepIndex = 0; stepIndex < Steps.Count(); stepIndex++)
+            Steps[stepIndex]->OnBuildStarted(data);
+        data.InitProgress(Steps.Count());
+    }
 
     // Execute all steps in a sequence
     bool failed = false;
@@ -741,10 +744,13 @@ bool GameCookerImpl::Build()
     }
     IsRunning = false;
     CancelFlag = 0;
-    for (int32 stepIndex = 0; stepIndex < Steps.Count(); stepIndex++)
-        Steps[stepIndex]->OnBuildEnded(data, failed);
-    data.Tools->OnBuildEnded(data, failed);
-    CallEvent(failed ? GameCooker::EventType::BuildFailed : GameCooker::EventType::BuildDone);
+    if (!EnumHasAnyFlags(data.Options, BuildOptions::NoCook))
+    {
+        for (int32 stepIndex = 0; stepIndex < Steps.Count(); stepIndex++)
+            Steps[stepIndex]->OnBuildEnded(data, failed);
+        data.Tools->OnBuildEnded(data, failed);
+        CallEvent(failed ? GameCooker::EventType::BuildFailed : GameCooker::EventType::BuildDone);
+    }
     Delete(Data);
     Data = nullptr;
 


### PR DESCRIPTION
Skips calling build events if `NoCook` option is passed into the game cooker. It doesnt make sense to run these if we dont want it to cook. This also fixes an issue with the .exe being deleted when the no cook option is used because the .exe is being deleted in the `WindowsPlatformTools::OnBuildStarted` method.