### PR TITLE
Add invert options for texture imports for Red, Blue, and Alpha channels.

### DIFF
--- a/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
+++ b/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
@@ -872,7 +872,7 @@ bool TextureTool::ImportTextureDirectXTex(ImageType type, const StringView& path
         SET_CURRENT_IMG(timage);
     }
 
-    // Check if invert red channel
+    // Check if invert blue channel
     if (!keepAsIs && options.InvertBlueChannel)
     {
         auto& timage = GET_TMP_IMG();

--- a/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
+++ b/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
@@ -730,6 +730,9 @@ bool TextureTool::ImportTextureDirectXTex(ImageType type, const StringView& path
     if (!options.FlipY &&
         !options.FlipX &&
         !options.InvertGreenChannel &&
+        !options.InvertRedChannel &&
+        !options.InvertAlphaChannel &&
+        !options.InvertBlueChannel &&
         !options.ReconstructZChannel &&
         options.Compress && 
         type == ImageType::DDS && 
@@ -831,15 +834,91 @@ bool TextureTool::ImportTextureDirectXTex(ImageType type, const StringView& path
                 for (size_t j = 0; j < w; ++j)
                 {
                     const DirectX::XMVECTOR value = inPixels[j];
-
                     const DirectX::XMVECTOR inverty = DirectX::XMVectorSubtract(DirectX::g_XMOne, value);
-
                     outPixels[j] = DirectX::XMVectorSelect(value, inverty, s_selecty);
                 }
             }, timage);
         if (FAILED(result))
         {
             errorMsg = String::Format(TEXT("Cannot invert green channel in texture, error: {0:x}"), static_cast<uint32>(result));
+            return true;
+        }
+        SET_CURRENT_IMG(timage);
+    }
+    
+    // Check if invert red channel
+    if (!keepAsIs && options.InvertRedChannel)
+    {
+        auto& timage = GET_TMP_IMG();
+        result = TransformImage(currentImage->GetImages(), currentImage->GetImageCount(), currentImage->GetMetadata(),
+            [&](DirectX::XMVECTOR* outPixels, const DirectX::XMVECTOR* inPixels, size_t w, size_t y)
+            {
+                static const DirectX::XMVECTORU32 s_selectx = { { { DirectX::XM_SELECT_1, DirectX::XM_SELECT_0, DirectX::XM_SELECT_0, DirectX::XM_SELECT_0 } } };
+
+                UNREFERENCED_PARAMETER(y);
+
+                for (size_t j = 0; j < w; ++j)
+                {
+                    const DirectX::XMVECTOR value = inPixels[j];
+                    const DirectX::XMVECTOR inverty = DirectX::XMVectorSubtract(DirectX::g_XMOne, value);
+                    outPixels[j] = DirectX::XMVectorSelect(value, inverty, s_selectx);
+                }
+            }, timage);
+        if (FAILED(result))
+        {
+            errorMsg = String::Format(TEXT("Cannot invert red channel in texture, error: {0:x}"), static_cast<uint32>(result));
+            return true;
+        }
+        SET_CURRENT_IMG(timage);
+    }
+
+    // Check if invert red channel
+    if (!keepAsIs && options.InvertBlueChannel)
+    {
+        auto& timage = GET_TMP_IMG();
+        result = TransformImage(currentImage->GetImages(), currentImage->GetImageCount(), currentImage->GetMetadata(),
+            [&](DirectX::XMVECTOR* outPixels, const DirectX::XMVECTOR* inPixels, size_t w, size_t y)
+            {
+                static const DirectX::XMVECTORU32 s_selectz = { { { DirectX::XM_SELECT_0, DirectX::XM_SELECT_0, DirectX::XM_SELECT_1, DirectX::XM_SELECT_0 } } };
+
+                UNREFERENCED_PARAMETER(y);
+
+                for (size_t j = 0; j < w; ++j)
+                {
+                    const DirectX::XMVECTOR value = inPixels[j];
+                    const DirectX::XMVECTOR inverty = DirectX::XMVectorSubtract(DirectX::g_XMOne, value);
+                    outPixels[j] = DirectX::XMVectorSelect(value, inverty, s_selectz);
+                }
+            }, timage);
+        if (FAILED(result))
+        {
+            errorMsg = String::Format(TEXT("Cannot invert blue channel in texture, error: {0:x}"), static_cast<uint32>(result));
+            return true;
+        }
+        SET_CURRENT_IMG(timage);
+    }
+
+    // Check if invert alpha channel
+    if (!keepAsIs && options.InvertAlphaChannel)
+    {
+        auto& timage = GET_TMP_IMG();
+        result = TransformImage(currentImage->GetImages(), currentImage->GetImageCount(), currentImage->GetMetadata(),
+            [&](DirectX::XMVECTOR* outPixels, const DirectX::XMVECTOR* inPixels, size_t w, size_t y)
+            {
+                static const DirectX::XMVECTORU32 s_selectw = { { { DirectX::XM_SELECT_0, DirectX::XM_SELECT_0, DirectX::XM_SELECT_0, DirectX::XM_SELECT_1 } } };
+
+                UNREFERENCED_PARAMETER(y);
+
+                for (size_t j = 0; j < w; ++j)
+                {
+                    const DirectX::XMVECTOR value = inPixels[j];
+                    const DirectX::XMVECTOR inverty = DirectX::XMVectorSubtract(DirectX::g_XMOne, value);
+                    outPixels[j] = DirectX::XMVectorSelect(value, inverty, s_selectw);
+                }
+            }, timage);
+        if (FAILED(result))
+        {
+            errorMsg = String::Format(TEXT("Cannot invert alpha channel in texture, error: {0:x}"), static_cast<uint32>(result));
             return true;
         }
         SET_CURRENT_IMG(timage);

--- a/Source/Engine/Tools/TextureTool/TextureTool.cpp
+++ b/Source/Engine/Tools/TextureTool/TextureTool.cpp
@@ -27,7 +27,7 @@ namespace
 
 String TextureTool::Options::ToString() const
 {
-    return String::Format(TEXT("Type: {}, IsAtlas: {}, NeverStream: {}, IndependentChannels: {}, sRGB: {}, GenerateMipMaps: {}, FlipY: {}, InvertGreen: {} Scale: {}, MaxSize: {}, Resize: {}, PreserveAlphaCoverage: {}, PreserveAlphaCoverageReference: {}, SizeX: {}, SizeY: {}"),
+    return String::Format(TEXT("Type: {}, IsAtlas: {}, NeverStream: {}, IndependentChannels: {}, sRGB: {}, GenerateMipMaps: {}, FlipY: {}, InvertRed: {}, InvertGreen: {}, InvertBlue {}, Invert Alpha {}, Scale: {}, MaxSize: {}, Resize: {}, PreserveAlphaCoverage: {}, PreserveAlphaCoverageReference: {}, SizeX: {}, SizeY: {}"),
                           ScriptingEnum::ToString(Type),
                           IsAtlas,
                           NeverStream,
@@ -35,7 +35,10 @@ String TextureTool::Options::ToString() const
                           sRGB,
                           GenerateMipMaps,
                           FlipY,
+                          InvertRedChannel,
                           InvertGreenChannel,
+                          InvertBlueChannel,
+                          InvertAlphaChannel,
                           Scale,
                           MaxSize,
                           MaxSize,
@@ -76,8 +79,17 @@ void TextureTool::Options::Serialize(SerializeStream& stream, const void* otherO
     stream.JKEY("FlipX");
     stream.Bool(FlipX);
 
+    stream.JKEY("InvertRedChannel");
+    stream.Bool(InvertRedChannel);
+
     stream.JKEY("InvertGreenChannel");
     stream.Bool(InvertGreenChannel);
+
+    stream.JKEY("InvertBlueChannel");
+    stream.Bool(InvertBlueChannel);
+
+    stream.JKEY("InvertAlphaChannel");
+    stream.Bool(InvertAlphaChannel);
 
     stream.JKEY("ReconstructZChannel");
     stream.Bool(ReconstructZChannel);
@@ -143,7 +155,10 @@ void TextureTool::Options::Deserialize(DeserializeStream& stream, ISerializeModi
     GenerateMipMaps = JsonTools::GetBool(stream, "GenerateMipMaps", GenerateMipMaps);
     FlipY = JsonTools::GetBool(stream, "FlipY", FlipY);
     FlipX = JsonTools::GetBool(stream, "FlipX", FlipX);
+    InvertRedChannel = JsonTools::GetBool(stream, "InvertRedChannel", InvertRedChannel);
     InvertGreenChannel = JsonTools::GetBool(stream, "InvertGreenChannel", InvertGreenChannel);
+    InvertBlueChannel = JsonTools::GetBool(stream, "InvertBlueChannel", InvertBlueChannel);
+    InvertAlphaChannel = JsonTools::GetBool(stream, "InvertAlphaChannel", InvertAlphaChannel);
     ReconstructZChannel = JsonTools::GetBool(stream, "ReconstructZChannel", ReconstructZChannel);
     Resize = JsonTools::GetBool(stream, "Resize", Resize);
     KeepAspectRatio = JsonTools::GetBool(stream, "KeepAspectRatio", KeepAspectRatio);

--- a/Source/Engine/Tools/TextureTool/TextureTool.h
+++ b/Source/Engine/Tools/TextureTool/TextureTool.h
@@ -61,12 +61,24 @@ API_CLASS(Namespace="FlaxEngine.Tools", Static) class FLAXENGINE_API TextureTool
         API_FIELD(Attributes="EditorOrder(71)")
         bool FlipX = false;
 
-        // True if to invert the green channel on a normal map. Good for OpenGL to DirectX conversion.
-        API_FIELD(Attributes = "EditorOrder(72)")
+        // Invert the red channel.
+        API_FIELD(Attributes = "EditorOrder(72), EditorDisplay(\"Invert Channels\"), ExpandGroups")
+        bool InvertRedChannel = false;
+
+        // Invert the green channel. Good for OpenGL to DirectX conversion.
+        API_FIELD(Attributes = "EditorOrder(73), EditorDisplay(\"Invert Channels\")")
         bool InvertGreenChannel = false;
 
+        // Invert the blue channel.
+        API_FIELD(Attributes = "EditorOrder(74), EditorDisplay(\"Invert Channels\")")
+        bool InvertBlueChannel = false;
+
+        // Invert the alpha channel.
+        API_FIELD(Attributes = "EditorOrder(75), EditorDisplay(\"Invert Channels\")")
+        bool InvertAlphaChannel = false;
+
         // Rebuild Z (blue) channel assuming X/Y are normals.
-        API_FIELD(Attributes = "EditorOrder(73)")
+        API_FIELD(Attributes = "EditorOrder(76)")
         bool ReconstructZChannel = false;
 
         // Texture size scale. Allows increasing or decreasing the imported texture resolution. Default is 1.


### PR DESCRIPTION
Closes #2215 