### PR TITLE
Add import path UI and button to open folder in asset import settings.

### DIFF
--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -384,6 +384,28 @@ namespace FlaxEditor.Utilities
         }
 
         /// <summary>
+        /// Creates an Import path ui that show the asset import path and adds a button to show the folder in the file system.
+        /// </summary>
+        /// <param name="parentLayout">The parent layout container.</param>
+        /// <param name="assetItem">The asset item to get the import path of.</param>
+        public static void CreateImportPathUI(CustomEditors.LayoutElementsContainer parentLayout, Content.BinaryAssetItem assetItem)
+        {
+            assetItem.GetImportPath(out var path);
+            if (!string.IsNullOrEmpty(path))
+            {
+                parentLayout.Space(5);
+                parentLayout.Label("Import Path:");
+                var textBox = parentLayout.TextBox().TextBox;
+                textBox.TooltipText = "Path is not editable here.";
+                textBox.IsReadOnly = true;
+                textBox.Text = path;
+                parentLayout.Space(2);
+                var button = parentLayout.Button(Constants.ShowInExplorer).Button;
+                button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+            }
+        }
+
+        /// <summary>
         /// Copies the directory. Supports subdirectories copy with files override option.
         /// </summary>
         /// <param name="srcDirectoryPath">The source directory path.</param>

--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Reflection;
 using System.Xml;
 using FlaxEditor.Content;
@@ -209,9 +210,22 @@ namespace FlaxEditor.Windows.Assets
                         var importSettingsField = typeof(PropertiesProxy).GetField("ImportSettings", BindingFlags.NonPublic | BindingFlags.Instance);
                         var importSettingsValues = new ValueContainer(new ScriptMemberInfo(importSettingsField)) { proxy.ImportSettings };
                         group.Object(importSettingsValues);
+                        
+                        (proxy.Window.Item as BinaryAssetItem).GetImportPath(out var path);
+                        if (!string.IsNullOrEmpty(path))
+                        {
+                            layout.Space(5);
+                            layout.Label("Import Path:");
+                            var textBox = layout.TextBox().TextBox;
+                            textBox.IsReadOnly = true;
+                            textBox.Text = path;
+                            layout.Space(2);
+                            var button = layout.Button("Open Import Path in Explorer").Button;
+                            button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+                        }
 
                         layout.Space(5);
-                        var reimportButton = group.Button("Reimport");
+                        var reimportButton = layout.Button("Reimport");
                         reimportButton.Button.Clicked += () => ((PropertiesProxy)Values[0]).Reimport();
                     }
                 }

--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -217,6 +217,7 @@ namespace FlaxEditor.Windows.Assets
                             layout.Space(5);
                             layout.Label("Import Path:");
                             var textBox = layout.TextBox().TextBox;
+                            textBox.TooltipText = "Path is not editable here.";
                             textBox.IsReadOnly = true;
                             textBox.Text = path;
                             layout.Space(2);

--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -210,20 +210,9 @@ namespace FlaxEditor.Windows.Assets
                         var importSettingsField = typeof(PropertiesProxy).GetField("ImportSettings", BindingFlags.NonPublic | BindingFlags.Instance);
                         var importSettingsValues = new ValueContainer(new ScriptMemberInfo(importSettingsField)) { proxy.ImportSettings };
                         group.Object(importSettingsValues);
-                        
-                        (proxy.Window.Item as BinaryAssetItem).GetImportPath(out var path);
-                        if (!string.IsNullOrEmpty(path))
-                        {
-                            layout.Space(5);
-                            layout.Label("Import Path:");
-                            var textBox = layout.TextBox().TextBox;
-                            textBox.TooltipText = "Path is not editable here.";
-                            textBox.IsReadOnly = true;
-                            textBox.Text = path;
-                            layout.Space(2);
-                            var button = layout.Button("Open Import Path in Explorer").Button;
-                            button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
-                        }
+
+                        // Creates the import path UI
+                        Utilities.Utils.CreateImportPathUI(layout, proxy.Window.Item as BinaryAssetItem);
 
                         layout.Space(5);
                         var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -100,20 +100,9 @@ namespace FlaxEditor.Windows.Assets
                     }
 
                     base.Initialize(layout);
-                    
-                    (window.Item as BinaryAssetItem).GetImportPath(out var path);
-                    if (!string.IsNullOrEmpty(path))
-                    {
-                        layout.Space(5);
-                        layout.Label("Import Path:");
-                        var textBox = layout.TextBox().TextBox;
-                        textBox.TooltipText = "Path is not editable here.";
-                        textBox.IsReadOnly = true;
-                        textBox.Text = path;
-                        layout.Space(2);
-                        var button = layout.Button("Open Import Path in Explorer").Button;
-                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
-                    }
+
+                    // Creates the import path UI
+                    Utilities.Utils.CreateImportPathUI(layout, window.Item as BinaryAssetItem);
 
                     layout.Space(10);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -107,6 +107,7 @@ namespace FlaxEditor.Windows.Assets
                         layout.Space(5);
                         layout.Label("Import Path:");
                         var textBox = layout.TextBox().TextBox;
+                        textBox.TooltipText = "Path is not editable here.";
                         textBox.IsReadOnly = true;
                         textBox.Text = path;
                         layout.Space(2);

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using System.IO;
 using System.Xml;
 using FlaxEditor.Content;
 using FlaxEditor.Content.Import;
@@ -99,6 +100,19 @@ namespace FlaxEditor.Windows.Assets
                     }
 
                     base.Initialize(layout);
+                    
+                    (window.Item as BinaryAssetItem).GetImportPath(out var path);
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        layout.Space(5);
+                        layout.Label("Import Path:");
+                        var textBox = layout.TextBox().TextBox;
+                        textBox.IsReadOnly = true;
+                        textBox.Text = path;
+                        layout.Space(2);
+                        var button = layout.Button("Open Import Path in Explorer").Button;
+                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+                    }
 
                     layout.Space(10);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/CubeTextureWindow.cs
+++ b/Source/Editor/Windows/Assets/CubeTextureWindow.cs
@@ -60,6 +60,7 @@ namespace FlaxEditor.Windows.Assets
                         layout.Space(5);
                         layout.Label("Import Path:");
                         var textBox = layout.TextBox().TextBox;
+                        textBox.TooltipText = "Path is not editable here.";
                         textBox.IsReadOnly = true;
                         textBox.Text = path;
                         layout.Space(2);

--- a/Source/Editor/Windows/Assets/CubeTextureWindow.cs
+++ b/Source/Editor/Windows/Assets/CubeTextureWindow.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using System.IO;
 using System.Xml;
 using FlaxEditor.Content;
 using FlaxEditor.Content.Import;
@@ -52,6 +53,19 @@ namespace FlaxEditor.Windows.Assets
                     }
 
                     base.Initialize(layout);
+                    
+                    (window.Item as BinaryAssetItem).GetImportPath(out var path);
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        layout.Space(5);
+                        layout.Label("Import Path:");
+                        var textBox = layout.TextBox().TextBox;
+                        textBox.IsReadOnly = true;
+                        textBox.Text = path;
+                        layout.Space(2);
+                        var button = layout.Button("Open Import Path in Explorer").Button;
+                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+                    }
 
                     layout.Space(10);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/CubeTextureWindow.cs
+++ b/Source/Editor/Windows/Assets/CubeTextureWindow.cs
@@ -53,20 +53,9 @@ namespace FlaxEditor.Windows.Assets
                     }
 
                     base.Initialize(layout);
-                    
-                    (window.Item as BinaryAssetItem).GetImportPath(out var path);
-                    if (!string.IsNullOrEmpty(path))
-                    {
-                        layout.Space(5);
-                        layout.Label("Import Path:");
-                        var textBox = layout.TextBox().TextBox;
-                        textBox.TooltipText = "Path is not editable here.";
-                        textBox.IsReadOnly = true;
-                        textBox.Text = path;
-                        layout.Space(2);
-                        var button = layout.Button("Open Import Path in Explorer").Button;
-                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
-                    }
+
+                    // Creates the import path UI
+                    Utilities.Utils.CreateImportPathUI(layout, window.Item as BinaryAssetItem);
 
                     layout.Space(10);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/ModelWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelWindow.cs
@@ -765,6 +765,7 @@ namespace FlaxEditor.Windows.Assets
                             layout.Space(5);
                             layout.Label("Import Path:");
                             var textBox = layout.TextBox().TextBox;
+                            textBox.TooltipText = "Path is not editable here.";
                             textBox.IsReadOnly = true;
                             textBox.Text = path;
                             layout.Space(2);

--- a/Source/Editor/Windows/Assets/ModelWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelWindow.cs
@@ -759,19 +759,8 @@ namespace FlaxEditor.Windows.Assets
                         var importSettingsValues = new ValueContainer(new ScriptMemberInfo(importSettingsField)) { proxy.ImportSettings };
                         group.Object(importSettingsValues);
 
-                        (proxy.Window.Item as BinaryAssetItem).GetImportPath(out var path);
-                        if (!string.IsNullOrEmpty(path))
-                        {
-                            layout.Space(5);
-                            layout.Label("Import Path:");
-                            var textBox = layout.TextBox().TextBox;
-                            textBox.TooltipText = "Path is not editable here.";
-                            textBox.IsReadOnly = true;
-                            textBox.Text = path;
-                            layout.Space(2);
-                            var button = layout.Button("Open Import Path in Explorer").Button;
-                            button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
-                        }
+                        // Creates the import path UI
+                        Utilities.Utils.CreateImportPathUI(layout, proxy.Window.Item as BinaryAssetItem);
 
                         layout.Space(5);
                         var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/ModelWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelWindow.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -758,8 +759,21 @@ namespace FlaxEditor.Windows.Assets
                         var importSettingsValues = new ValueContainer(new ScriptMemberInfo(importSettingsField)) { proxy.ImportSettings };
                         group.Object(importSettingsValues);
 
+                        (proxy.Window.Item as BinaryAssetItem).GetImportPath(out var path);
+                        if (!string.IsNullOrEmpty(path))
+                        {
+                            layout.Space(5);
+                            layout.Label("Import Path:");
+                            var textBox = layout.TextBox().TextBox;
+                            textBox.IsReadOnly = true;
+                            textBox.Text = path;
+                            layout.Space(2);
+                            var button = layout.Button("Open Import Path in Explorer").Button;
+                            button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+                        }
+
                         layout.Space(5);
-                        var reimportButton = group.Button("Reimport");
+                        var reimportButton = layout.Button("Reimport");
                         reimportButton.Button.Clicked += () => ((ImportPropertiesProxy)Values[0]).Reimport();
                     }
                 }

--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -1029,6 +1029,7 @@ namespace FlaxEditor.Windows.Assets
                             layout.Space(5);
                             layout.Label("Import Path:");
                             var textBox = layout.TextBox().TextBox;
+                            textBox.TooltipText = "Path is not editable here.";
                             textBox.IsReadOnly = true;
                             textBox.Text = path;
                             layout.Space(2);

--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -1022,20 +1022,9 @@ namespace FlaxEditor.Windows.Assets
                         var importSettingsField = typeof(ImportPropertiesProxy).GetField("ImportSettings", BindingFlags.NonPublic | BindingFlags.Instance);
                         var importSettingsValues = new ValueContainer(new ScriptMemberInfo(importSettingsField)) { proxy.ImportSettings };
                         group.Object(importSettingsValues);
-                        
-                        (proxy.Window.Item as BinaryAssetItem).GetImportPath(out var path);
-                        if (!string.IsNullOrEmpty(path))
-                        {
-                            layout.Space(5);
-                            layout.Label("Import Path:");
-                            var textBox = layout.TextBox().TextBox;
-                            textBox.TooltipText = "Path is not editable here.";
-                            textBox.IsReadOnly = true;
-                            textBox.Text = path;
-                            layout.Space(2);
-                            var button = layout.Button("Open Import Path in Explorer").Button;
-                            button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
-                        }
+
+                        // Creates the import path UI
+                        Utilities.Utils.CreateImportPathUI(layout, proxy.Window.Item as BinaryAssetItem);
 
                         layout.Space(5);
                         var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
+++ b/Source/Editor/Windows/Assets/SkinnedModelWindow.cs
@@ -1022,9 +1022,22 @@ namespace FlaxEditor.Windows.Assets
                         var importSettingsField = typeof(ImportPropertiesProxy).GetField("ImportSettings", BindingFlags.NonPublic | BindingFlags.Instance);
                         var importSettingsValues = new ValueContainer(new ScriptMemberInfo(importSettingsField)) { proxy.ImportSettings };
                         group.Object(importSettingsValues);
+                        
+                        (proxy.Window.Item as BinaryAssetItem).GetImportPath(out var path);
+                        if (!string.IsNullOrEmpty(path))
+                        {
+                            layout.Space(5);
+                            layout.Label("Import Path:");
+                            var textBox = layout.TextBox().TextBox;
+                            textBox.IsReadOnly = true;
+                            textBox.Text = path;
+                            layout.Space(2);
+                            var button = layout.Button("Open Import Path in Explorer").Button;
+                            button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+                        }
 
                         layout.Space(5);
-                        var reimportButton = group.Button("Reimport");
+                        var reimportButton = layout.Button("Reimport");
                         reimportButton.Button.Clicked += () => ((ImportPropertiesProxy)Values[0]).Reimport();
                     }
                 }

--- a/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
+++ b/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
@@ -119,20 +119,9 @@ namespace FlaxEditor.Windows.Assets
                     }
                     
                     base.Initialize(layout);
-
-                    (proxy._window.Item as BinaryAssetItem).GetImportPath(out var path);
-                    if (!string.IsNullOrEmpty(path))
-                    {
-                        layout.Space(5);
-                        layout.Label("Import Path:");
-                        var textBox = layout.TextBox().TextBox;
-                        textBox.TooltipText = "Path is not editable here.";
-                        textBox.IsReadOnly = true;
-                        textBox.Text = path;
-                        layout.Space(2);
-                        var button = layout.Button("Open Import Path in Explorer").Button;
-                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
-                    }
+                    
+                    // Creates the import path UI
+                    Utilities.Utils.CreateImportPathUI(layout, proxy._window.Item as BinaryAssetItem);
 
                     layout.Space(10);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
+++ b/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using System.IO;
 using System.Linq;
 using System.Xml;
 using FlaxEditor.Content;
@@ -110,7 +111,27 @@ namespace FlaxEditor.Windows.Assets
             {
                 public override void Initialize(LayoutElementsContainer layout)
                 {
+                    var proxy = (PropertiesProxy)Values[0];
+                    if (proxy._window == null)
+                    {
+                        layout.Label("Loading...", TextAlignment.Center);
+                        return;
+                    }
+                    
                     base.Initialize(layout);
+
+                    (proxy._window.Item as BinaryAssetItem).GetImportPath(out var path);
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        layout.Space(5);
+                        layout.Label("Import Path:");
+                        var textBox = layout.TextBox().TextBox;
+                        textBox.IsReadOnly = true;
+                        textBox.Text = path;
+                        layout.Space(2);
+                        var button = layout.Button("Open Import Path in Explorer").Button;
+                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+                    }
 
                     layout.Space(10);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
+++ b/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
@@ -126,6 +126,7 @@ namespace FlaxEditor.Windows.Assets
                         layout.Space(5);
                         layout.Label("Import Path:");
                         var textBox = layout.TextBox().TextBox;
+                        textBox.TooltipText = "Path is not editable here.";
                         textBox.IsReadOnly = true;
                         textBox.Text = path;
                         layout.Space(2);

--- a/Source/Editor/Windows/Assets/TextureWindow.cs
+++ b/Source/Editor/Windows/Assets/TextureWindow.cs
@@ -144,20 +144,9 @@ namespace FlaxEditor.Windows.Assets
 
                     // Import settings
                     base.Initialize(layout);
-                    
-                    (proxy._window.Item as BinaryAssetItem).GetImportPath(out var path);
-                    if (!string.IsNullOrEmpty(path))
-                    {
-                        layout.Space(5);
-                        layout.Label("Import Path:");
-                        var textBox = layout.TextBox().TextBox;
-                        textBox.TooltipText = "Path is not editable here.";
-                        textBox.IsReadOnly = true;
-                        textBox.Text = path;
-                        layout.Space(2);
-                        var button = layout.Button("Open Import Path in Explorer").Button;
-                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
-                    }
+
+                    // Creates the import path UI
+                    Utilities.Utils.CreateImportPathUI(layout, proxy._window.Item as BinaryAssetItem);
 
                     // Reimport
                     layout.Space(10);

--- a/Source/Editor/Windows/Assets/TextureWindow.cs
+++ b/Source/Editor/Windows/Assets/TextureWindow.cs
@@ -151,6 +151,7 @@ namespace FlaxEditor.Windows.Assets
                         layout.Space(5);
                         layout.Label("Import Path:");
                         var textBox = layout.TextBox().TextBox;
+                        textBox.TooltipText = "Path is not editable here.";
                         textBox.IsReadOnly = true;
                         textBox.Text = path;
                         layout.Space(2);

--- a/Source/Editor/Windows/Assets/TextureWindow.cs
+++ b/Source/Editor/Windows/Assets/TextureWindow.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
+using System.IO;
 using System.Xml;
 using FlaxEditor.Content;
 using FlaxEditor.Content.Import;
@@ -134,8 +135,28 @@ namespace FlaxEditor.Windows.Assets
             {
                 public override void Initialize(LayoutElementsContainer layout)
                 {
+                    var proxy = (ImportPropertiesProxy)Values[0];
+                    if (proxy._window == null)
+                    {
+                        layout.Label("Loading...", TextAlignment.Center);
+                        return;
+                    }
+
                     // Import settings
                     base.Initialize(layout);
+                    
+                    (proxy._window.Item as BinaryAssetItem).GetImportPath(out var path);
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        layout.Space(5);
+                        layout.Label("Import Path:");
+                        var textBox = layout.TextBox().TextBox;
+                        textBox.IsReadOnly = true;
+                        textBox.Text = path;
+                        layout.Space(2);
+                        var button = layout.Button("Open Import Path in Explorer").Button;
+                        button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
+                    }
 
                     // Reimport
                     layout.Space(10);


### PR DESCRIPTION
Adds import path (non-editable) and button to open the import folder for each asset type

![image](https://github.com/user-attachments/assets/b7fa9c92-e7f8-40e2-9c67-7cb92e426eef)
