### PR TITLE
Re-enable scale center gizmo.

### DIFF
--- a/Source/Editor/Gizmo/TransformGizmoBase.Selection.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.Selection.cs
@@ -169,12 +169,12 @@ namespace FlaxEditor.Gizmo
                     closestIntersection = intersection;
                 }
 
-                /*// Center
-                if (CenterBoxRaw.Intersects(ref localRay, out intersection) && intersection < closestIntersection)
+                // Center
+                if (CenterBoxRaw.Intersects(ref localRay, out intersection) && intersection > closestIntersection)
                 {
                     _activeAxis = Axis.Center;
                     closestIntersection = intersection;
-                }*/
+                }
 
                 break;
             }

--- a/Source/Editor/Gizmo/TransformGizmoBase.Settings.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.Settings.cs
@@ -20,7 +20,7 @@ namespace FlaxEditor.Gizmo
         /// <summary>
         /// Offset to move axis away from center
         /// </summary>
-        private const float AxisOffset = 0.8f;
+        private const float AxisOffset = 1.2f;
 
         /// <summary>
         /// How thick the axis should be

--- a/Source/Editor/Gizmo/TransformGizmoBase.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.cs
@@ -501,7 +501,7 @@ namespace FlaxEditor.Gizmo
                         _scaleDelta = Vector3.Zero;
 
                         if (ActiveAxis == Axis.Center)
-                            scaleDelta = new Vector3(scaleDelta.AvgValue);
+                            scaleDelta = new Vector3(scaleDelta.ValuesSum);
                     }
 
                     // Apply transformation (but to the parents, not whole selection pool)


### PR DESCRIPTION
This moves the axis out a little further from the center (1.2 instead of 0.8). fixes a bug where the snap did not work correctly with the center scale gizmo. It still isnt perfect, must be some math off somewhere.

Also, since the axis materials are set for 1 opacity anyways, can we enable depth testing in the material and make them opaque instead of transparent? This will get rid of the issue of certain transform axis gizmos showing on top of others when they shouldn't be.