### PR TITLE
Warn if value is the wrong type for the animation graph parameter trying to be set.

### DIFF
--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -292,7 +292,11 @@ void AnimatedModel::SetParameterValue(const StringView& name, const Variant& val
     {
         if (param.Name == name)
         {
-            param.Value = value;
+            if (Variant::CanCast(value, param.Value.Type))
+                param.Value = value;
+            else
+                LOG(Warning, "Animation Graph parameter '{0}' in AnimatedModel {1} is type '{2}' and not type '{3}'.", String(name), ToString(), param.Value.Type, value.Type);
+
             return;
         }
     }


### PR DESCRIPTION
Similar to #3117 but for setting parameters on animated models.