### PR TITLE
Standardize spacing for import path ui in assets. add import path ui to model prefab.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ModelPrefabEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ModelPrefabEditor.cs
@@ -53,6 +53,9 @@ public class ModelPrefabEditor : GenericEditor
             }
         }
 
+        // Creates the import path UI
+        Utilities.Utils.CreateImportPathUI(layout, modelPrefab.ImportPath, false);
+
         var button = layout.Button("Reimport", "Reimports the source asset as prefab.");
         _reimportButton = button.Button;
         _reimportButton.Clicked += OnReimport;

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -391,10 +391,22 @@ namespace FlaxEditor.Utilities
         public static void CreateImportPathUI(CustomEditors.LayoutElementsContainer parentLayout, Content.BinaryAssetItem assetItem)
         {
             assetItem.GetImportPath(out var path);
+            CreateImportPathUI(parentLayout, path);
+        }
+
+        /// <summary>
+        /// Creates an Import path ui that show the import path and adds a button to show the folder in the file system.
+        /// </summary>
+        /// <param name="parentLayout">The parent layout container.</param>
+        /// <param name="path">The import path.</param>
+        /// <param name="useInitialSpacing">Whether to use an initial layout space of 5 for separation.</param>
+        public static void CreateImportPathUI(CustomEditors.LayoutElementsContainer parentLayout, string path, bool useInitialSpacing = true)
+        {
             if (!string.IsNullOrEmpty(path))
             {
-                parentLayout.Space(5);
-                parentLayout.Label("Import Path:");
+                if (useInitialSpacing)
+                    parentLayout.Space(5);
+                parentLayout.Label("Import Path:").Label.TooltipText = "Source asset path (can be relative or absolute to the project)";
                 var textBox = parentLayout.TextBox().TextBox;
                 textBox.TooltipText = "Path is not editable here.";
                 textBox.IsReadOnly = true;

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -104,7 +104,7 @@ namespace FlaxEditor.Windows.Assets
                     // Creates the import path UI
                     Utilities.Utils.CreateImportPathUI(layout, window.Item as BinaryAssetItem);
 
-                    layout.Space(10);
+                    layout.Space(5);
                     var reimportButton = layout.Button("Reimport");
                     reimportButton.Button.Clicked += () => ((PropertiesProxy)Values[0]).Reimport();
                 }

--- a/Source/Editor/Windows/Assets/CubeTextureWindow.cs
+++ b/Source/Editor/Windows/Assets/CubeTextureWindow.cs
@@ -57,7 +57,7 @@ namespace FlaxEditor.Windows.Assets
                     // Creates the import path UI
                     Utilities.Utils.CreateImportPathUI(layout, window.Item as BinaryAssetItem);
 
-                    layout.Space(10);
+                    layout.Space(5);
                     var reimportButton = layout.Button("Reimport");
                     reimportButton.Button.Clicked += () => ((PropertiesProxy)Values[0]).Reimport();
                 }

--- a/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
+++ b/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
@@ -123,7 +123,7 @@ namespace FlaxEditor.Windows.Assets
                     // Creates the import path UI
                     Utilities.Utils.CreateImportPathUI(layout, proxy._window.Item as BinaryAssetItem);
 
-                    layout.Space(10);
+                    layout.Space(5);
                     var reimportButton = layout.Button("Reimport");
                     reimportButton.Button.Clicked += () => ((PropertiesProxy)Values[0]).Reimport();
                 }

--- a/Source/Editor/Windows/Assets/TextureWindow.cs
+++ b/Source/Editor/Windows/Assets/TextureWindow.cs
@@ -149,7 +149,7 @@ namespace FlaxEditor.Windows.Assets
                     Utilities.Utils.CreateImportPathUI(layout, proxy._window.Item as BinaryAssetItem);
 
                     // Reimport
-                    layout.Space(10);
+                    layout.Space(5);
                     var reimportButton = layout.Button("Reimport");
                     reimportButton.Button.Clicked += () => ((ImportPropertiesProxy)Values[0]).Reimport();
                 }

--- a/Source/Engine/Level/Scripts/ModelPrefab.h
+++ b/Source/Engine/Level/Scripts/ModelPrefab.h
@@ -19,7 +19,7 @@ API_CLASS(Attributes="HideInEditor") class FLAXENGINE_API ModelPrefab : public S
     /// <summary>
     /// Source model file path (absolute or relative to the project).
     /// </summary>
-    API_FIELD(Attributes="ReadOnly") String ImportPath;
+    API_FIELD(Attributes="ReadOnly, HideInEditor") String ImportPath;
 
     /// <summary>
     /// Model file import settings.


### PR DESCRIPTION
This standardizes a spacing between the Button UI for the new import path UI and the reimport button. This also adds the import path UI to the model prefab so it has access to the show in explorer button.

![image](https://github.com/user-attachments/assets/7ae88b84-8006-4c7a-af9e-0b13fd4937eb)
