### PR TITLE
Fix android build on .net9 and use DotNet version that is found by build tool path.

### DIFF
--- a/Source/Editor/Cooker/Steps/DeployDataStep.cpp
+++ b/Source/Editor/Cooker/Steps/DeployDataStep.cpp
@@ -224,11 +224,14 @@ bool DeployDataStep::Perform(CookingData& data)
                     {
                         Array<String> versionParts;
                         pathParts[i - 1].Split('.', versionParts);
-                        const String majorVersion = versionParts[0].TrimTrailing();
-                        uint32 versionNum;
-                        StringUtils::Parse(*majorVersion, majorVersion.Length(), &versionNum);
-                        if (versionNum < GAME_BUILD_DOTNET_RUNTIME_MAX_VER || versionNum > GAME_BUILD_DOTNET_RUNTIME_MIN_VER) // Check for major part
-                            version = majorVersion;
+                        if (!versionParts.IsEmpty())
+                        {
+                            const String majorVersion = versionParts[0].TrimTrailing();
+                            int32 versionNum;
+                            StringUtils::Parse(*majorVersion, majorVersion.Length(), &versionNum);
+                            if (Math::IsInRange(versionNum, GAME_BUILD_DOTNET_RUNTIME_MIN_VER, GAME_BUILD_DOTNET_RUNTIME_MAX_VER)) // Check for major part
+                                version = majorVersion;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fix #3140 by adding `libSystem.Globalization.Native.so` to deploy list.

This also adds finding the .net version that is returned by the build tool to use the correct folders for getting build libs. Ex: with .net9 installed, the building wants to use it but the libs were being looked for in the .net8 folder which doesnt exist in the 9.0.0 runtime folder.