### PR TITLE
Fix CPU profiler crash on conversion to ulong.

### DIFF
--- a/Source/Editor/Windows/Profiler/CPU.cs
+++ b/Source/Editor/Windows/Profiler/CPU.cs
@@ -175,7 +175,7 @@ namespace FlaxEditor.Windows.Profiler
 
         private string FormatCellBytes(object x)
         {
-            return Utilities.Utils.FormatBytesCount((ulong)x);
+            return Utilities.Utils.FormatBytesCount(Convert.ToUInt64(x));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fix #3142 

I dont think this change is causing it, but the CPU profiler is choppy when running sometimes.