### PR TITLE
Add .aab bundling for Android.

### DIFF
--- a/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
@@ -379,7 +379,7 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
             }
         }
         // Copy result package
-        const String aab = data.OriginalOutputPath / (distributionPackage ? TEXT("app/build/outputs/apk/release/app-release.aab") : TEXT("app/build/outputs/bundle/debug/app-debug.aab"));
+        const String aab = data.OriginalOutputPath / (distributionPackage ? TEXT("app/build/outputs/bundle/release/app-release.aab") : TEXT("app/build/outputs/bundle/debug/app-debug.aab"));
         const String outputAab = data.OriginalOutputPath / EditorUtilities::GetOutputName() + TEXT(".aab");
         if (FileSystem::CopyFile(outputAab, aab))
         {

--- a/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
@@ -375,16 +375,19 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
             const int32 result = Platform::CreateProcess(procSettings);
             if (result != 0)
             {
-                data.Error(String::Format(TEXT("Failed to build Gradle project into package (result code: {0}). See log for more info."), result));
+                data.Error(String::Format(TEXT("Failed to build Gradle project into .aab package (result code: {0}). See log for more info."), result));
+                return true;
             }
         }
         // Copy result package
         const String aab = data.OriginalOutputPath / (distributionPackage ? TEXT("app/build/outputs/bundle/release/app-release.aab") : TEXT("app/build/outputs/bundle/debug/app-debug.aab"));
         const String outputAab = data.OriginalOutputPath / EditorUtilities::GetOutputName() + TEXT(".aab");
         if (FileSystem::CopyFile(outputAab, aab))
-            LOG(Error, "Failed to copy package from {0} to {1}", aab, outputAab);
-        else
-            LOG(Info, "Output AAB Android application package: {0} (size: {1} MB)", outputAab, FileSystem::GetFileSize(outputAab) / 1024 / 1024);
+        {
+            LOG(Error, "Failed to copy .aab package from {0} to {1}", aab, outputAab);
+            return true;
+        }
+        LOG(Info, "Output Android AAB application package: {0} (size: {1} MB)", outputAab, FileSystem::GetFileSize(outputAab) / 1024 / 1024);
     }
 
     // .apk
@@ -395,7 +398,7 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
         const int32 result = Platform::CreateProcess(procSettings);
         if (result != 0)
         {
-            data.Error(String::Format(TEXT("Failed to build Gradle project into package (result code: {0}). See log for more info."), result));
+            data.Error(String::Format(TEXT("Failed to build Gradle project into .apk package (result code: {0}). See log for more info."), result));
             return true;
         }
     }
@@ -404,7 +407,7 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
     const String outputApk = data.OriginalOutputPath / EditorUtilities::GetOutputName() + TEXT(".apk");
     if (FileSystem::CopyFile(outputApk, apk))
     {
-        LOG(Error, "Failed to copy package from {0} to {1}", apk, outputApk);
+        LOG(Error, "Failed to copy .apk package from {0} to {1}", apk, outputApk);
         return true;
     }
     LOG(Info, "Output Android APK application package: {0} (size: {1} MB)", outputApk, FileSystem::GetFileSize(outputApk) / 1024 / 1024);

--- a/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Android/AndroidPlatformTools.cpp
@@ -364,7 +364,8 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
     }
 #endif
     const bool distributionPackage = buildSettings->ForDistribution || data.Configuration == BuildConfiguration::Release;
-    if (data.CustomDefines.Contains(String(TEXT("BuildAAB"))))
+    
+    if (platformSettings->BuildAAB)
     {
         // .aab
         {
@@ -375,43 +376,39 @@ bool AndroidPlatformTools::OnPostProcess(CookingData& data)
             if (result != 0)
             {
                 data.Error(String::Format(TEXT("Failed to build Gradle project into package (result code: {0}). See log for more info."), result));
-                return true;
             }
         }
         // Copy result package
         const String aab = data.OriginalOutputPath / (distributionPackage ? TEXT("app/build/outputs/bundle/release/app-release.aab") : TEXT("app/build/outputs/bundle/debug/app-debug.aab"));
         const String outputAab = data.OriginalOutputPath / EditorUtilities::GetOutputName() + TEXT(".aab");
         if (FileSystem::CopyFile(outputAab, aab))
-        {
             LOG(Error, "Failed to copy package from {0} to {1}", aab, outputAab);
-            return true;
-        }
-        LOG(Info, "Output Android application package: {0} (size: {1} MB)", outputAab, FileSystem::GetFileSize(outputAab) / 1024 / 1024);
+        else
+            LOG(Info, "Output AAB Android application package: {0} (size: {1} MB)", outputAab, FileSystem::GetFileSize(outputAab) / 1024 / 1024);
     }
-    else
+
+    // .apk
     {
-        // .apk
+        CreateProcessSettings procSettings;
+        procSettings.FileName = String::Format(TEXT("\"{0}\" {1}"), data.OriginalOutputPath / gradlew, distributionPackage ? TEXT("assemble") : TEXT("assembleDebug"));
+        procSettings.WorkingDirectory = data.OriginalOutputPath;
+        const int32 result = Platform::CreateProcess(procSettings);
+        if (result != 0)
         {
-            CreateProcessSettings procSettings;
-            procSettings.FileName = String::Format(TEXT("\"{0}\" {1}"), data.OriginalOutputPath / gradlew, distributionPackage ? TEXT("assemble") : TEXT("assembleDebug"));
-            procSettings.WorkingDirectory = data.OriginalOutputPath;
-            const int32 result = Platform::CreateProcess(procSettings);
-            if (result != 0)
-            {
-                data.Error(String::Format(TEXT("Failed to build Gradle project into package (result code: {0}). See log for more info."), result));
-                return true;
-            }
-        }
-        // Copy result package
-        const String apk = data.OriginalOutputPath / (distributionPackage ? TEXT("app/build/outputs/apk/release/app-release-unsigned.apk") : TEXT("app/build/outputs/apk/debug/app-debug.apk"));
-        const String outputApk = data.OriginalOutputPath / EditorUtilities::GetOutputName() + TEXT(".apk");
-        if (FileSystem::CopyFile(outputApk, apk))
-        {
-            LOG(Error, "Failed to copy package from {0} to {1}", apk, outputApk);
+            data.Error(String::Format(TEXT("Failed to build Gradle project into package (result code: {0}). See log for more info."), result));
             return true;
         }
-        LOG(Info, "Output Android application package: {0} (size: {1} MB)", outputApk, FileSystem::GetFileSize(outputApk) / 1024 / 1024);
     }
+    // Copy result package
+    const String apk = data.OriginalOutputPath / (distributionPackage ? TEXT("app/build/outputs/apk/release/app-release-unsigned.apk") : TEXT("app/build/outputs/apk/debug/app-debug.apk"));
+    const String outputApk = data.OriginalOutputPath / EditorUtilities::GetOutputName() + TEXT(".apk");
+    if (FileSystem::CopyFile(outputApk, apk))
+    {
+        LOG(Error, "Failed to copy package from {0} to {1}", apk, outputApk);
+        return true;
+    }
+    LOG(Info, "Output Android APK application package: {0} (size: {1} MB)", outputApk, FileSystem::GetFileSize(outputApk) / 1024 / 1024);
+    
 
     return false;
 }

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -233,6 +233,44 @@ namespace FlaxEditor.Windows
             class Android : Platform
             {
                 protected override BuildPlatform BuildPlatform => BuildPlatform.AndroidARM64;
+                private bool _buildAAB = false;
+
+                [EditorOrder(21), Tooltip("Build an android app bundle instead of an APK"), EditorDisplay(null, "Build .aab")]
+                public bool BuildAAB 
+                {
+                    get => _buildAAB;
+                    set
+                    {
+                        _buildAAB = value;
+                        if (value)
+                        {
+                            
+                            var newDefines = new List<string>();
+                            if (CustomDefines != null)
+                                newDefines.AddRange(CustomDefines);
+                            newDefines.Add("BuildAAB");
+                            CustomDefines = newDefines.ToArray();
+                        }
+                        else
+                        {
+                            if (CustomDefines != null)
+                            {
+                                if (CustomDefines.Contains("BuildAAB"))
+                                {
+                                    var newDefines = new List<string>();
+                                    foreach (var define in CustomDefines)
+                                    {
+                                        if (!define.Equals("BuildAAB", StringComparison.Ordinal))
+                                        {
+                                            newDefines.Add(define);
+                                        }
+                                    }
+                                    CustomDefines = newDefines.ToArray();
+                                }
+                            }
+                        }
+                    } 
+                }
             }
 
             class Switch : Platform

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -244,7 +244,8 @@ namespace FlaxEditor.Windows
                         _buildAAB = value;
                         if (value)
                         {
-                            
+                            if (CustomDefines != null && CustomDefines.Contains("BuildAAB"))
+                                return;
                             var newDefines = new List<string>();
                             if (CustomDefines != null)
                                 newDefines.AddRange(CustomDefines);

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -233,45 +233,6 @@ namespace FlaxEditor.Windows
             class Android : Platform
             {
                 protected override BuildPlatform BuildPlatform => BuildPlatform.AndroidARM64;
-                private bool _buildAAB = false;
-
-                [EditorOrder(21), Tooltip("Build an android app bundle instead of an APK"), EditorDisplay(null, "Build .aab")]
-                public bool BuildAAB 
-                {
-                    get => _buildAAB;
-                    set
-                    {
-                        _buildAAB = value;
-                        if (value)
-                        {
-                            if (CustomDefines != null && CustomDefines.Contains("BuildAAB"))
-                                return;
-                            var newDefines = new List<string>();
-                            if (CustomDefines != null)
-                                newDefines.AddRange(CustomDefines);
-                            newDefines.Add("BuildAAB");
-                            CustomDefines = newDefines.ToArray();
-                        }
-                        else
-                        {
-                            if (CustomDefines != null)
-                            {
-                                if (CustomDefines.Contains("BuildAAB"))
-                                {
-                                    var newDefines = new List<string>();
-                                    foreach (var define in CustomDefines)
-                                    {
-                                        if (!define.Equals("BuildAAB", StringComparison.Ordinal))
-                                        {
-                                            newDefines.Add(define);
-                                        }
-                                    }
-                                    CustomDefines = newDefines.ToArray();
-                                }
-                            }
-                        }
-                    } 
-                }
             }
 
             class Switch : Platform

--- a/Source/Engine/Platform/Android/AndroidPlatformSettings.h
+++ b/Source/Engine/Platform/Android/AndroidPlatformSettings.h
@@ -109,6 +109,12 @@ API_CLASS(sealed, Namespace="FlaxEditor.Content.Settings") class FLAXENGINE_API 
     TextureQuality TexturesQuality = TextureQuality::ASTC_Medium;
 
     /// <summary>
+    /// Whether to build android app bundle (aab) side by side with apk.
+    /// </summary>
+    API_FIELD(Attributes="EditorOrder(500), EditorDisplay(\"General\", \"Build .aab\")")
+    bool BuildAAB;
+
+    /// <summary>
     /// Custom icon texture to use for the application (overrides the default one).
     /// </summary>
     API_FIELD(Attributes="EditorOrder(1030), EditorDisplay(\"Other\")")


### PR DESCRIPTION
Adds the option to bundle the android app as an .aab instead of .apk. This can be done via the `Build .aab` checkbox or add a custom define of `BuildAAB` which the checkbox does automatically.

![image](https://github.com/user-attachments/assets/8a60db89-bd1c-4307-919d-1a95608e2c88)
