### PR TITLE
Fix Visual Studio solution nested project names on Unix systems

### DIFF
--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
@@ -356,13 +356,13 @@ namespace Flax.Build.Projects.VisualStudio
 
                     if (project.SourceDirectories != null && project.SourceDirectories.Count == 1)
                     {
-                        var subFolder = Utilities.MakePathRelativeTo(Path.GetDirectoryName(project.SourceDirectories[0]), project.WorkspaceRootPath);
-                        if (subFolder.StartsWith("Source\\"))
-                            subFolder = subFolder.Substring(7);
+                        var subFolder = Utilities.NormalizePath(Utilities.MakePathRelativeTo(Path.GetDirectoryName(project.SourceDirectories[0]), project.WorkspaceRootPath));
+                        if (subFolder.StartsWith("Source/"))
+                            subFolder = subFolder.Substring("Source/".Length);
                         if (subFolder.Length != 0)
                         {
                             if (folder.Length != 0)
-                                folder += '\\';
+                                folder += '/';
                             folder += subFolder;
                         }
                     }
@@ -370,12 +370,12 @@ namespace Flax.Build.Projects.VisualStudio
                     if (string.IsNullOrEmpty(folder))
                         continue;
 
-                    var folderParents = folder.Split('\\');
+                    var folderParents = folder.Split('/');
                     for (int i = 0; i < folderParents.Length; i++)
                     {
                         var folderPath = folderParents[0];
                         for (int j = 1; j <= i; j++)
-                            folderPath += '\\' + folderParents[j];
+                            folderPath += '/' + folderParents[j];
 
                         if (folderNames.Contains(folderPath))
                         {
@@ -397,7 +397,7 @@ namespace Flax.Build.Projects.VisualStudio
                 {
                     var folderGuid = folderIds[folder].ToString("B").ToUpperInvariant();
                     var typeGuid = ProjectTypeGuids.ToOption(ProjectTypeGuids.SolutionFolder);
-                    var lastSplit = folder.LastIndexOf('\\');
+                    var lastSplit = folder.LastIndexOf('/');
                     var name = lastSplit != -1 ? folder.Substring(lastSplit + 1) : folder;
 
                     vcSolutionFileContent.AppendLine(string.Format("Project(\"{0}\") = \"{1}\", \"{2}\", \"{3}\"", typeGuid, name, folder, folderGuid));
@@ -573,7 +573,7 @@ namespace Flax.Build.Projects.VisualStudio
                     // Write nested folders hierarchy
                     foreach (var folder in folderNames)
                     {
-                        var lastSplit = folder.LastIndexOf('\\');
+                        var lastSplit = folder.LastIndexOf('/');
                         if (lastSplit != -1)
                         {
                             var folderGuid = folderIds[folder].ToString("B").ToUpperInvariant();
@@ -615,8 +615,9 @@ namespace Flax.Build.Projects.VisualStudio
             {
                 var profiles = new Dictionary<string, string>();
                 var profile = new StringBuilder();
-                var editorPath = Utilities.NormalizePath(Path.Combine(Globals.EngineRoot, Platform.GetEditorBinaryDirectory(), $"Development/FlaxEditor{Utilities.GetPlatformExecutableExt()}")).Replace('\\', '/');
-                var workspacePath = Utilities.NormalizePath(solutionDirectory).Replace('\\', '/');
+                var configuration = "Development";
+                var editorPath = Utilities.NormalizePath(Path.Combine(Globals.EngineRoot, Platform.GetEditorBinaryDirectory(), configuration, $"FlaxEditor{Utilities.GetPlatformExecutableExt()}"));
+                var workspacePath = Utilities.NormalizePath(solutionDirectory);
                 foreach (var project in projects)
                 {
                     if (project.Type == TargetType.DotNetCore)


### PR DESCRIPTION
The C# Dev Kit extension in VSCode after one of the latest updates fails to load the solution due to backslashes present in project names, which were left there by the solution generator not parsing the folders properly in file paths.