### PR TITLE
UI Editor Gizmo selection improvement

### DIFF
--- a/Source/Editor/Gizmo/UIEditorGizmo.cs
+++ b/Source/Editor/Gizmo/UIEditorGizmo.cs
@@ -714,16 +714,15 @@ namespace FlaxEditor
 
         private bool RayCastControl(ref Float2 location, out Control hit)
         {
-#if false
-            // Raycast only controls with content (eg. skips transparent panels)
-            return RayCastChildren(ref location, out hit);
-#else
-            // Find any control under mouse (hierarchical)
-            hit = GetChildAtRecursive(location);
+            // First, raycast only controls with content (eg. skips transparent panels)
+            RayCastChildren(ref location, out hit);
+
+            // If raycast failed, then find any control under mouse (hierarchical)
+            hit = hit ?? GetChildAtRecursive(location);
             if (hit is View || hit is CanvasContainer)
                 hit = null;
+        
             return hit != null;
-#endif
         }
 
         private UIControlNode FindUIControlNode(Control control)

--- a/Source/Engine/UI/GUI/ContainerControl.cs
+++ b/Source/Engine/UI/GUI/ContainerControl.cs
@@ -859,6 +859,14 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override bool ContainsPoint(ref Float2 location, bool precise = false)
+        {
+            if (precise && this.GetType() == typeof(ContainerControl) && BackgroundColor.A <= 0.0f) // Go through transparency
+                return false;
+            return base.ContainsPoint(ref location, precise);
+        }
+
+        /// <inheritdoc />
         public override void PerformLayout(bool force = false)
         {
             if (_isLayoutLocked && !force)


### PR DESCRIPTION
Fixes #3083

By adding raycast-first priority selection to the UI Editor Gizmo. 
Also, added ray cast support to the container controller itself. Using a general background-only check may have side effects on other controls like `ColorSelector`, so added a type check too.


https://github.com/user-attachments/assets/79ef3c41-2c37-4e8b-97ec-bfb2e68713d8

