### PR TITLE
Check for null in Actor node `IsActive`.

### DIFF
--- a/Source/Editor/SceneGraph/ActorNode.cs
+++ b/Source/Editor/SceneGraph/ActorNode.cs
@@ -215,10 +215,10 @@ namespace FlaxEditor.SceneGraph
         public override bool CanDuplicate => (_actor.HideFlags & HideFlags.HideInHierarchy) == 0;
 
         /// <inheritdoc />
-        public override bool IsActive => _actor.IsActive;
+        public override bool IsActive => _actor?.IsActive ?? false;
 
         /// <inheritdoc />
-        public override bool IsActiveInHierarchy => _actor.IsActiveInHierarchy;
+        public override bool IsActiveInHierarchy => _actor?.IsActiveInHierarchy ?? false;
 
         /// <inheritdoc />
         public override int OrderInParent


### PR DESCRIPTION
Closes #3165 

Not sure if there is some underlying issue here, but this should clear up this exception if it is thrown.