### PR TITLE
Fix .NET runtime and SDK compilation issues with newer runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Follow the instructions below to compile and run the engine from source.
 * Install Visual Studio 2022 or newer
 * Install Windows 8.1 SDK or newer (via Visual Studio Installer)
 * Install Microsoft Visual C++ 2015 v140 toolset or newer (via Visual Studio Installer)
-* Install .NET 8 SDK for **Windows x64** (via Visual Studio Installer or [from web](https://dotnet.microsoft.com/en-us/download/dotnet/8.0))
+* Install .NET 8 or 9 SDK for **Windows x64** (via Visual Studio Installer or [from web](https://dotnet.microsoft.com/en-us/download/dotnet/8.0))
 * Install Git with LFS
 * Clone repo (with LFS)
 * Run **GenerateProjectFiles.bat**
@@ -44,8 +44,9 @@ Follow the instructions below to compile and run the engine from source.
 ## Linux
 
 * Install Visual Studio Code
-* Install .NET 8 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0))
+* Install .NET 8 or 9 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0))
   * Ubuntu: `sudo apt install dotnet-sdk-8.0`
+  * Arch: `sudo pacman -S dotnet-sdk-8.0 dotnet-runtime-8.0 dotnet-targeting-pack-8.0 dotnet-host`
 * Install Vulkan SDK ([https://vulkan.lunarg.com/](https://vulkan.lunarg.com/))
   * Ubuntu: `sudo apt install vulkan-sdk`
   * Arch: `sudo pacman -S spirv-tools vulkan-headers vulkan-tools vulkan-validation-layers`
@@ -67,12 +68,12 @@ Follow the instructions below to compile and run the engine from source.
 ## Mac
 
 * Install XCode
-* Install .NET 8 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0))
+* Install .NET 8 or 9 SDK ([https://dotnet.microsoft.com/en-us/download/dotnet/8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0))
 * Install Vulkan SDK ([https://vulkan.lunarg.com/](https://vulkan.lunarg.com/))
 * Clone repo (with LFS)
 * Run `GenerateProjectFiles.command`
 * Open workspace with XCode or Visual Studio Code
-* Build and run (configuration  `Editor.Mac.Development`)
+* Build and run (configuration `Editor.Mac.Development`)
 
 #### Troubleshooting
 

--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -282,6 +282,17 @@ namespace Flax.Build
 
             var dotnetSdkVersion = GetVersion(dotnetSdkVersions);
             var dotnetRuntimeVersion = GetVersion(dotnetRuntimeVersions);
+            if (!string.IsNullOrEmpty(dotnetRuntimeVersion) && ParseVersion(dotnetRuntimeVersion).Major > ParseVersion(dotnetSdkVersion).Major)
+            {
+                // Make sure the reference assemblies are not newer than the SDK itself
+                var dotnetRuntimeVersionsRemaining = dotnetRuntimeVersions;
+                do
+                {
+                    dotnetRuntimeVersionsRemaining = dotnetRuntimeVersionsRemaining.Skip(1);
+                    dotnetRuntimeVersion = GetVersion(dotnetRuntimeVersionsRemaining);
+                } while (!string.IsNullOrEmpty(dotnetRuntimeVersion) && ParseVersion(dotnetRuntimeVersion).Major > ParseVersion(dotnetSdkVersion).Major);
+            }
+            
             var minVer = string.IsNullOrEmpty(Configuration.Dotnet) ? MinimumVersion.ToString() : Configuration.Dotnet;
             if (string.IsNullOrEmpty(dotnetSdkVersion))
             {


### PR DESCRIPTION
The C# assemblies failed to build if the .NET runtime major version is newer than the SDK (in this case .NET 9 runtime and .NET 8 SDK) with following types of errors:
```
warning CS9057: The analyzer assembly '/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/9.0.1/analyzers/dotnet/cs/Microsoft.Interop.LibraryImportGenerator.dll' references version '4.12.0.0' of the compiler, which is newer than the currently running version '4.8.0.0'.

/home/goalitium/dev/Flax/FlaxEnginePR/Cache/Intermediate/FlaxEditor/Linux/x64/Release/AI/AI.Bindings.Gen.cs(2856,40,2856,58): error CS8795: Partial method 'BehaviorTreeKnowledgeValuesConditionalDecorator.Internal_GetValueA(nint)' must have an implementation part because it has accessibility modifiers.
```