### PR TITLE
Add move script to top and bottom buttons to script editor

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -968,8 +968,11 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 Tag = script
             };
             cm.AddButton("Remove", OnClickRemove).Icon = Editor.Instance.Icons.Cross12;
+            cm.AddSeparator();
+            cm.AddButton("Move to top", OnClickMoveToTop).Enabled = script.OrderInParent > 0;
             cm.AddButton("Move up", OnClickMoveUp).Enabled = script.OrderInParent > 0;
             cm.AddButton("Move down", OnClickMoveDown).Enabled = script.OrderInParent < script.Actor.Scripts.Length - 1;
+            cm.AddButton("Move to bottom", OnClickMoveToBottom).Enabled = script.OrderInParent < script.Actor.Scripts.Length - 1;
             // TODO: copy script
             // TODO: paste script values
             // TODO: paste script as new
@@ -991,6 +994,14 @@ namespace FlaxEditor.CustomEditors.Dedicated
             Presenter.Undo?.AddAction(action);
         }
 
+        private void OnClickMoveToTop(ContextMenuButton button)
+        {
+            var script = (Script)button.ParentContextMenu.Tag;
+            var action = ChangeScriptAction.ChangeOrder(script, 0);
+            action.Do();
+            Presenter.Undo?.AddAction(action);
+        }
+
         private void OnClickMoveUp(ContextMenuButton button)
         {
             var script = (Script)button.ParentContextMenu.Tag;
@@ -1003,6 +1014,14 @@ namespace FlaxEditor.CustomEditors.Dedicated
         {
             var script = (Script)button.ParentContextMenu.Tag;
             var action = ChangeScriptAction.ChangeOrder(script, script.OrderInParent + 1);
+            action.Do();
+            Presenter.Undo?.AddAction(action);
+        }
+
+        private void OnClickMoveToBottom(ContextMenuButton button)
+        {
+            var script = (Script)button.ParentContextMenu.Tag;
+            var action = ChangeScriptAction.ChangeOrder(script, script.Actor.Scripts.Length);
             action.Do();
             Presenter.Undo?.AddAction(action);
         }

--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -1000,6 +1000,12 @@ namespace FlaxEditor.CustomEditors.Dedicated
             var action = ChangeScriptAction.ChangeOrder(script, 0);
             action.Do();
             Presenter.Undo?.AddAction(action);
+
+            if (Presenter.Panel.Parent is Panel p)
+            {
+                var loc = Layout.Control.UpperLeft;
+                p.ScrollViewTo(loc, true);
+            }
         }
 
         private void OnClickMoveUp(ContextMenuButton button)
@@ -1024,6 +1030,12 @@ namespace FlaxEditor.CustomEditors.Dedicated
             var action = ChangeScriptAction.ChangeOrder(script, script.Actor.Scripts.Length);
             action.Do();
             Presenter.Undo?.AddAction(action);
+
+            if (Presenter.Panel.Parent is Panel p)
+            {
+                var loc = Layout.Control.BottomLeft;
+                p.ScrollViewTo(loc, true);
+            }
         }
 
         private void OnClickCopyTypeName(ContextMenuButton button)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d6e5cc1a-5401-45cb-b095-5336c8944e57)


Closes #3186.

For an explanation on why see: #3186.

I think this is the best order in which to put the buttons, but I'm open to feedback for that.