### PR TITLE
Fix C# projects not compiling in VS with native code plugins present

### DIFF
--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -559,7 +559,7 @@ namespace Flax.Build
                     foreach (var project in projects)
                     {
                         Log.Verbose(project.Name + " -> " + project.Path);
-                        project.Generate(solutionPath);
+                        project.Generate(solutionPath, project == mainSolutionProject);
                     }
                 }
 
@@ -638,7 +638,7 @@ namespace Flax.Build
                     using (new ProfileEventScope("GenerateProject"))
                     {
                         Log.Verbose("Project " + rulesProjectName + " -> " + project.Path);
-                        dotNetProjectGenerator.GenerateProject(project, solutionPath);
+                        dotNetProjectGenerator.GenerateProject(project, solutionPath, project == mainSolutionProject);
                     }
 
                     projects.Add(project);

--- a/Source/Tools/Flax.Build/Projects/Project.cs
+++ b/Source/Tools/Flax.Build/Projects/Project.cs
@@ -253,9 +253,9 @@ namespace Flax.Build.Projects
         /// <summary>
         /// Generates the project.
         /// </summary>
-        public virtual void Generate(string solutionPath)
+        public virtual void Generate(string solutionPath, bool isMainProject)
         {
-            Generator.GenerateProject(this, solutionPath);
+            Generator.GenerateProject(this, solutionPath, isMainProject);
         }
 
         /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Projects/ProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/ProjectGenerator.cs
@@ -52,7 +52,7 @@ namespace Flax.Build.Projects
         /// Generates the project.
         /// </summary>
         /// <param name="project">The project.</param>
-        public abstract void GenerateProject(Project project, string solutionPath);
+        public abstract void GenerateProject(Project project, string solutionPath, bool isMainProject);
 
         /// <summary>
         /// Generates the solution.

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
@@ -26,7 +26,7 @@ namespace Flax.Build.Projects.VisualStudio
         public override TargetType? Type => TargetType.DotNet;
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project, string solutionPath)
+        public override void GenerateProject(Project project, string solutionPath, bool isMainProject)
         {
             var csProjectFileContent = new StringBuilder();
 

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -26,7 +26,7 @@ namespace Flax.Build.Projects.VisualStudio
         public override TargetType? Type => TargetType.DotNetCore;
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project, string solutionPath)
+        public override void GenerateProject(Project project, string solutionPath, bool isMainProject)
         {
             var dotnetSdk = DotNetSdk.Instance;
             var csProjectFileContent = new StringBuilder();
@@ -109,8 +109,7 @@ namespace Flax.Build.Projects.VisualStudio
 
             //csProjectFileContent.AppendLine("    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>"); // TODO: use it to reduce burden of framework libs
 
-            // Custom .targets file for overriding MSBuild build tasks, only invoke Flax.Build once per Flax project
-            bool isMainProject = Globals.Project.IsCSharpOnlyProject && Globals.Project.ProjectFolderPath == project.WorkspaceRootPath && project.Name != "BuildScripts" && (Globals.Project.Name != "Flax" || project.Name != "FlaxEngine");
+            // Custom .targets file for overriding MSBuild build tasks, only invoke Flax.Build once per Flax project           
             var flaxBuildTargetsFilename = isMainProject ? "Flax.Build.CSharp.targets" : "Flax.Build.CSharp.SkipBuild.targets";
             var cacheProjectsPath = Utilities.MakePathRelativeTo(Path.Combine(Globals.Root, "Cache", "Projects"), projectDirectory);
             var flaxBuildTargetsPath = !string.IsNullOrEmpty(cacheProjectsPath) ? Path.Combine(cacheProjectsPath, flaxBuildTargetsFilename) : flaxBuildTargetsFilename;

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
@@ -55,7 +55,7 @@ namespace Flax.Build.Projects.VisualStudio
         }
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project, string solutionPath)
+        public override void GenerateProject(Project project, string solutionPath, bool isMainProject)
         {
             var vcProjectFileContent = new StringBuilder();
             var vcFiltersFileContent = new StringBuilder();

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
@@ -22,7 +22,7 @@ namespace Flax.Build.Projects.VisualStudio
             public override Guid ProjectTypeGuid => ProjectTypeGuids.Android;
 
             /// <inheritdoc />
-            public override void Generate(string solutionPath)
+            public override void Generate(string solutionPath, bool isMainProject)
             {
                 // Try to reuse the existing project guid from existing files
                 ProjectGuid = GetProjectGuid(Path, Name);

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -38,7 +38,7 @@ namespace Flax.Build.Projects.VisualStudioCode
         }
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project, string solutionPath)
+        public override void GenerateProject(Project project, string solutionPath, bool isMainProject)
         {
             // Not used, solution contains all projects definitions
         }

--- a/Source/Tools/Flax.Build/Projects/XCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/XCodeProjectGenerator.cs
@@ -42,7 +42,7 @@ namespace Flax.Build.Projects
         }
 
         /// <inheritdoc />
-        public override void GenerateProject(Project project, string solutionPath)
+        public override void GenerateProject(Project project, string solutionPath, bool isMainProject)
         {
         }
 


### PR DESCRIPTION
`Globals.Project.IsCSharpOnlyProject` was expected to be true for C#-only game projects, but this also includes plugins which may have native modules present, so this can't be used with the main project detection. Use instead the same value that is used to select the start up project for VS solution projects.