### PR TITLE
high level API for compute shader's

### DIFF
--- a/Source/Engine/Graphics/HL_API_Compute/ComputeBuffer.cs
+++ b/Source/Engine/Graphics/HL_API_Compute/ComputeBuffer.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using FlaxEngine;
 
 namespace FlaxEngine
 {
@@ -36,13 +34,13 @@ namespace FlaxEngine
         public enum Type
         {
             /// <summary>
-            /// Default ComputeBuffer type maps to Buffer&lt;T&gt; / RWBuffer&lt;T&gt; in hlsl.
+            /// Default ComputeBuffer type maps to Buffer or RWBuffer in hlsl.
             /// <br> note: </br>
-            /// <br> Buffer and RWBuffer support only 32-bit formats: float, int and uint.</br>
+            /// <br> Buffer support only 32-bit formats: <see langword="float"/>, <see langword="int"/> and <see langword="uint"/>.</br>
             /// </summary>
             Default,
             /// <summary>
-            /// ComputeBuffer that you can use as a structured buffer maps to StructuredBuffer&lt;T&gt; / RWStructuredBuffer&lt;T&gt; in hlsl.
+            /// ComputeBuffer that you can use as a structured buffer maps to StructuredBuffer or RWStructuredBuffer in hlsl.
             /// </summary>
             Structured,
             /// <summary>
@@ -472,6 +470,85 @@ namespace FlaxEngine
             {
                 //massage here
             }
+        }
+
+        //--------------------------------------------------------------------
+        //static helper funcions
+        //--------------------------------------------------------------------
+
+        /// <summary>
+        /// Creates the Buffer&lt;<typeparamref name="T"/>&gt;. and set the data
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">The values.</param>
+        /// <param name="Immutable">if set to <c>true</c> [immutable].</param>
+        /// <returns>new instance of the <see cref="ComputeBuffer"/> class</returns>
+        public static ComputeBuffer CreateConstantBuffer<T>(T value, bool Immutable = true)
+        {
+            var buff = new ComputeBuffer(1, Unsafe.SizeOf<T>(), Type.Constant, Immutable ? Mode.Immutable : Mode.DynamicWriteOnly);
+            buff.SetData(value);
+            return buff;
+        }
+
+        /// <summary>
+        /// Creates the Buffer&lt;<typeparamref name="T"/>&gt;. and set the data
+        /// <br> note: </br>
+        /// <br> Buffer support only 32-bit formats: <see langword="float"/>, <see langword="int"/> and <see langword="uint"/>.</br>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="values">The values.</param>
+        /// <param name="Immutable">if set to <c>true</c> [immutable].</param>
+        /// <returns>new instance of the <see cref="ComputeBuffer"/> class</returns>
+        public static ComputeBuffer CreateBuffer<T>(T[] values,bool Immutable = true) 
+        {
+            var buff = new ComputeBuffer(values.Length, Unsafe.SizeOf<T>(), Type.Default, Immutable ? Mode.Immutable : Mode.DynamicWriteOnly);
+            buff.SetData(values);
+            return buff;
+        }
+        /// <summary>
+        /// Creates the Buffer&lt;<typeparamref name = "T" />&gt;. and set the data if <paramref name="CPUReadOnly"/> is false
+        /// <br> Note: </br>
+        /// <br> Buffer support only 32-bit formats: <see langword="float"/>, <see langword="int"/> and <see langword="uint"/>.</br>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="values">The values.</param>
+        /// <param name="CPUReadOnly">if set to <c>true</c> [cpu read only].</param>
+        /// <returns>new instance of the <see cref="ComputeBuffer"/> class</returns>
+        public static ComputeBuffer CreateRWBuffer<T>(T[] values, bool CPUReadOnly = false)
+        {
+            var buff = new ComputeBuffer(values.Length, Unsafe.SizeOf<T>(), Type.Default, CPUReadOnly ? Mode.DynamicReadOnly : Mode.DynamicReadWrite);
+            if (!CPUReadOnly)
+                buff.SetData(values);
+            return buff;
+        }
+
+        /// <summary>
+        /// Creates the StructuredBuffer&lt;<typeparamref name="T"/>&gt;. and set the data
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="values">The values.</param>
+        /// <param name="Immutable">if set to <c>true</c> [immutable].</param>
+        /// <returns>new instance of the <see cref="ComputeBuffer"/> class</returns>
+        public static ComputeBuffer CreateStructuredBuffer<T>(T[] values, bool Immutable = true)
+        {
+            var buff = new ComputeBuffer(values.Length, Unsafe.SizeOf<T>(), Type.Structured, Immutable ? Mode.Immutable : Mode.DynamicWriteOnly);
+            buff.SetData(values);
+            return buff;
+        }
+
+        /// <summary>
+        /// Creates the RWStructuredBuffer&lt;<typeparamref name = "T" />&gt;. and set the data if <paramref name="CPUReadOnly"/> is false
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="values">The values.</param>
+        /// <param name="CPUReadOnly">if set to <c>true</c> [cpu read only].</param>
+        /// <returns>new instance of the <see cref="ComputeBuffer"/> class</returns>
+        public static ComputeBuffer CreateRWStructuredBuffer<T>(T[] values, bool CPUReadOnly = false)
+        {
+            var buff = new ComputeBuffer(values.Length, Unsafe.SizeOf<T>(), Type.Structured, CPUReadOnly ? Mode.DynamicReadOnly : Mode.DynamicReadWrite);
+            if (!CPUReadOnly)
+                buff.SetData(values);
+            return buff;
         }
     }
 }

--- a/Source/Engine/Graphics/HL_API_Compute/ComputeBuffer.cs
+++ b/Source/Engine/Graphics/HL_API_Compute/ComputeBuffer.cs
@@ -1,0 +1,400 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using FlaxEngine;
+
+namespace FlaxEngine
+{
+    /// <summary>
+    /// ComputeBuffer class.
+    /// </summary>
+    public class ComputeBuffer
+    {
+        private Dictionary<System.Type, PixelFormat> RWBufferFromats = new Dictionary<System.Type, PixelFormat>()
+        {
+            { typeof(float),    PixelFormat.R32_Float },
+            { typeof(int),      PixelFormat.R32_SInt },
+            { typeof(uint),     PixelFormat.R32_UInt },
+        };
+
+
+//can be null depends on the usage
+private GPUBuffer m_GraphicStageingBuffer;
+        //never null unless somfing went very wrong
+        private GPUBuffer m_GraphicBuffer;
+        internal readonly Type m_Type;
+        internal readonly Mode m_Mode;
+        private byte[] m_MemoryBuffer = null;
+        private PixelFormat pixelFormat = PixelFormat.MAX;
+        //--------------------------------------------------------------------
+        public enum Type
+        {
+            // Default ComputeBuffer type maps to Buffer<> / RWBuffer<> in hlsl.
+            Default,
+            // ComputeBuffer that you can use as a structured buffer maps to StructuredBuffer<> / RWStructuredBuffer<> in hlsl.
+            Structured,
+            // ComputeBuffer that you can use as a constant buffer(uniform buffer).
+            Constant,
+        }
+        public enum Mode
+        {
+            // Static buffer, only initial upload allowed by the CPU
+            Immutable,
+            // Dynamic buffer. can be only Write Only by the CPU
+            DynamicWriteOnly,
+            // Dynamic buffer. can be only Read Only by the CPU
+            DynamicReadOnly,
+            // Dynamic buffer. allows for read and write by the CPU
+            DynamicReadWrite,
+        }
+        //--------------------------------------------------------------------
+
+        // The debug label for the compute buffer.
+        public string Name
+        {
+            set
+            {
+                if (m_GraphicStageingBuffer != null)
+                    m_GraphicStageingBuffer.Name = "ComputeStageingBuffer" + value;
+                if (m_GraphicBuffer != null)
+                    m_GraphicBuffer.Name = "ComputeBuffer " + value;
+            }
+        }
+        // Size of one element in the buffer in bytes.
+        public readonly uint Stride;
+        // Number of elements in the buffer.
+        public readonly uint Count;
+        public uint SizeInBytes => Stride * Count;
+
+        public ComputeBuffer(int count, int stride) : this(count, stride, Type.Default) { }
+        public ComputeBuffer(int count, int stride, Type type) : this(count, stride, Type.Default, Mode.Immutable) { }
+        public ComputeBuffer(int count, int stride, Type type, Mode mode)
+        {
+            if (count == 0)
+            {
+                Debug.LogException(new Exception("faled to construct ComputeBuffer, Count is out of range expects more then 0 element"));
+                return;
+            }
+            if (!Mathf.IsInRange(stride, 1, 1024))
+            {
+                Debug.LogException(new Exception("faled to construct ComputeBuffer, Stride is out of range exected 1 to 1024"));
+                return;
+            }
+            Count = (uint)count;
+            Stride = (uint)stride;
+            m_Mode = mode;
+            m_Type = type;
+        }
+        public void SetData<T>(T data)
+        {
+            SetData(new T[] {data});
+        }
+        public void SetData<T>(T[] data)
+        {
+            //let guard this funcion 
+
+            //... yes :D (it is cheked in consructor)
+            if (Count == 0)
+            {
+                Debug.LogException(new Exception("faled to SetData, Count is out of range expects more then 0 element"));
+                return;
+            }
+            if (!Mathf.IsInRange(Stride, 1, 1024))
+            {
+                Debug.LogException(new Exception("faled to SetData, Stride is out of range exected 1 to 1024"));
+                return;
+            }
+            //cheak if data is valid
+            if (data == null)
+            {
+                Debug.LogException(new ArgumentNullException(nameof(data)));
+                return;
+            }
+            if (data.Length == 0)
+            {
+                Debug.LogException(new ArgumentOutOfRangeException(nameof(data)));
+                return;
+            }
+            //cheak if <T> size is same side as stride
+            var pSrcStride = Unsafe.SizeOf<T>();
+            if (Stride != pSrcStride)
+            {
+                Debug.LogException(new Exception(string.Format(
+                    "faled to SetData, Stride size mismatch expected {0} but got {1}",
+                    Stride,
+                    pSrcStride
+                    )));
+                return;
+            }
+            //are we done with the guard ? nope :D
+
+            //find the format
+            PixelFormat pf = PixelFormat.MAX;
+            if (ChekaAndGetFormat<T>("SetData", ref pf))
+            {
+                pixelFormat = pf;
+            }
+            else
+            {
+                return;
+            }
+
+            //are we done with the guard yet ? a hell no :D
+
+            switch (m_Mode)
+            {
+                case Mode.DynamicReadOnly:
+                    Debug.LogException(new Exception("faled to SetData, Can't upload data to dynamic read only buffer"));
+                    return;
+                case Mode.Immutable:
+                    if (m_MemoryBuffer != null)
+                    {
+                        Debug.LogException(new Exception("faled to SetData, Can't upload data to Immutable buffer"));
+                        return;
+                    }
+                    break;
+            }
+
+            //now we are safe :)
+
+            //aloc only if is null
+            m_MemoryBuffer ??= new byte[Count * Stride];
+            //copy data to local buffer we are not poking araund with dangling pointers
+            unsafe
+            {
+                //the C# way of doing a memcoppy ?
+                var pSrc = Unsafe.AsPointer(ref data[0]);
+                var pDest = Unsafe.AsPointer(ref m_MemoryBuffer[0]);
+                Buffer.MemoryCopy(pSrc, pDest, SizeInBytes, SizeInBytes);
+            }
+            if (m_Type == Type.Constant)
+                return;//we are done data is inside the buffer on cpu when computer will get dispatched it can be pulled
+
+            if (m_GraphicBuffer == null)
+                CreateGPUBuffers();
+            else if (m_Mode == Mode.DynamicWriteOnly || m_Mode == Mode.DynamicReadWrite)
+            {
+                //write to the GPU buffer vita GraphicStageingBuffer
+                //this place might explode
+
+                var pBuff = m_GraphicStageingBuffer.Map(GPUResourceMapMode.ReadWrite);
+                if (pBuff != nint.Zero)
+                {
+                    unsafe
+                    {
+                        //the C# way of doing a memcoppy ?
+                        var pSrc = Unsafe.AsPointer(ref m_MemoryBuffer[0]);
+                        var pDest = pBuff.ToPointer();
+                        Buffer.MemoryCopy(pSrc, pDest, SizeInBytes, SizeInBytes);
+                    }
+                    m_GraphicStageingBuffer.Unmap();
+                    GPUDevice.Instance.MainContext.CopyBuffer(m_GraphicBuffer, m_GraphicStageingBuffer, SizeInBytes);
+                }
+                else
+                {
+                    Debug.LogError("can't write to the buffer ? if u see this massage somfing went wrong on the back end ?");
+                }
+            }
+        }
+
+        public T[] GetData<T>()
+        {
+            //let guard this funcion 
+            //it is good because it will be smaller compered to SetData :D
+
+            //find the format
+            PixelFormat pf = PixelFormat.MAX;
+            if (ChekaAndGetFormat<T>("GetData", ref pf))
+            {
+                pixelFormat = pf;
+            }
+            else
+            {
+                return null;
+            }
+
+            if (m_Mode == Mode.DynamicReadOnly || m_Mode == Mode.DynamicReadWrite)
+            {
+                var readmode = m_Mode == Mode.DynamicReadOnly ? GPUResourceMapMode.Read : GPUResourceMapMode.ReadWrite;
+
+                T[] data = new T[Count];
+                GPUDevice.Instance.MainContext.CopyBuffer(m_GraphicStageingBuffer, m_GraphicBuffer, SizeInBytes);
+                var pBuff = m_GraphicStageingBuffer.Map(readmode);
+                if (pBuff != nint.Zero)
+                {
+                    unsafe
+                    {
+                        //the C# way of doing a memcoppy ?
+                        var pDest = Unsafe.AsPointer(ref data[0]);
+                        var pSrc = pBuff.ToPointer();
+                        Buffer.MemoryCopy(pSrc, pDest, SizeInBytes, SizeInBytes);
+                    }
+                    m_GraphicStageingBuffer.Unmap();
+                }
+                else
+                {
+                    Debug.LogError("can't write to the buffer ? if u see this massage somfing went wrong on the back end ?");
+                }
+                return data;
+            }
+            return null;
+        }
+
+
+        private void CreateGPUBuffers()
+        {
+            GPUBufferDescription description = new();
+            description.Format = pixelFormat;
+            description.Usage = GPUResourceUsage.Default;
+            description.InitData = GetDataPointer();
+            description.Flags = GPUBufferFlags.ShaderResource;
+            description.Stride = Stride;
+            description.Size = SizeInBytes;
+            switch (m_Type)
+            {
+                case Type.Default:
+                    if (m_Mode != Mode.Immutable)
+                        description.Flags |= GPUBufferFlags.UnorderedAccess;
+                    break;
+                case Type.Structured:
+                    if (m_Mode != Mode.Immutable)
+                        description.Flags |= GPUBufferFlags.UnorderedAccess | GPUBufferFlags.Structured;
+                    break;
+            }
+
+            m_GraphicBuffer = new GPUBuffer();
+            m_GraphicBuffer.Init(ref description);
+            switch (m_Mode)
+            {
+                case Mode.DynamicReadOnly:
+                    {
+                        m_GraphicStageingBuffer = new GPUBuffer();
+                        var descriptionStageingBuffer = description.ToStagingUpload();
+                        m_GraphicStageingBuffer.Init(ref descriptionStageingBuffer);
+                    }
+                    break;
+                case Mode.DynamicWriteOnly:
+                    {
+                        m_GraphicStageingBuffer = new GPUBuffer();
+                        var descriptionStageingBuffer = description.ToStagingReadback();
+                        m_GraphicStageingBuffer.Init(ref descriptionStageingBuffer);
+                    }
+                    break;
+                case Mode.DynamicReadWrite:
+                    {
+                        m_GraphicStageingBuffer = new GPUBuffer();
+                        var descriptionStageingBuffer = description.ToStaging();
+                        m_GraphicStageingBuffer.Init(ref descriptionStageingBuffer);
+                    }
+                    break;
+            }
+        }
+
+
+        private bool ChekaAndGetFormat<T>(string fun, ref PixelFormat pf)
+        {
+            if (RWBufferFromats.TryGetValue(typeof(T), out var f))
+            {
+                pf = f;
+                return true;
+            }
+            else if (typeof(T).IsSubclassOf(typeof(ValueType)))
+            {
+                if (m_Type == Type.Structured)
+                {
+                    pf = PixelFormat.Unknown;
+                }
+                else if (m_Type != Type.Constant)
+                {
+                    Debug.LogException(new Exception("Wrong buffer type expected Structured but got " + m_Type.ToString()));
+                    return false;
+                }
+            }
+            else
+            {
+                Debug.LogException(new Exception(string.Format(
+                @"
+                faled to {1}, Unsuported type passed to {1}<T={1}> only blittable ValueType's are suported
+                see:
+                https://learn.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types ,
+                https://learn.microsoft.com/en-us/dotnet/api/system.valuetype?view=net-9.0"
+                , fun
+                , typeof(T).Name
+                )));
+                return false;
+            }
+
+            if (pixelFormat != PixelFormat.MAX)
+            {
+                if (pf != pixelFormat)
+                {
+                    Debug.LogException(new Exception(string.Format(
+                        "faled to {2}, PixelFormat was set before with first funcion call to PixelFormat.{0} but now it got the PixelFormat.{1}"
+                        , pixelFormat.ToString()
+                        , pf.ToString(), fun
+                        )));
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        internal void BindUA(int slot, GPUContext context)
+        {
+            if (m_GraphicBuffer != null)
+            {
+                context.BindUA(slot, m_GraphicBuffer.View());
+            }
+        }
+        internal void BindSR(int slot, GPUContext context)
+        {
+            if (m_GraphicBuffer != null)
+            {
+                context.BindSR(slot, m_GraphicBuffer.View());
+            }
+        }
+        internal nint GetDataPointer()
+        {
+            unsafe
+            {
+                return new nint(Unsafe.AsPointer(ref m_MemoryBuffer[0]));
+            }
+        }
+
+        internal GPUBuffer GetGPUBuffer()
+        {
+            return m_GraphicBuffer;
+        }
+
+        ~ComputeBuffer()
+        {
+            m_GraphicStageingBuffer?.ReleaseGPU();
+            m_GraphicBuffer?.ReleaseGPU();
+        }
+
+        public void Coppy(ComputeBuffer destination) // to do allow for sub data coppy
+        {
+            if (destination == null)
+            {
+                //massage here
+                return;
+            }
+            if (m_GraphicBuffer == null)
+            {
+                //massage here
+                return;
+            }
+            if (destination.SizeInBytes == SizeInBytes)
+            {
+                var source = m_GraphicBuffer;
+                var dest = destination.GetGPUBuffer();
+                GPUDevice.Instance.MainContext.CopyBuffer(dest, source, SizeInBytes);
+            }
+            else
+            {
+                //massage here
+            }
+        }
+    }
+}

--- a/Source/Engine/Graphics/HL_API_Compute/ComputeShader.cs
+++ b/Source/Engine/Graphics/HL_API_Compute/ComputeShader.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Xml.Linq;
 
 namespace FlaxEngine
 {
@@ -27,10 +26,12 @@ namespace FlaxEngine
             }
             public string GetName()
             {
+#if !BUILD_RELEASE
                 if (t != null)
                     return t.Name;
                 if (b != null)
                     return b.Name;
+#endif
                 return "";
             }
             public bool IsBuffer() { return b != null; }
@@ -48,7 +49,11 @@ namespace FlaxEngine
             bindings.Add(new Bind() { ID = id });
             return ret;
         }
-
+        /// <summary>
+        /// Sets the constant buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        /// <returns></returns>
         public void SetConstantBuffer(ComputeBuffer buffer)
         {
             if (buffer == null)
@@ -64,6 +69,12 @@ namespace FlaxEngine
             }
             constantBuffer = buffer;
         }
+        /// <summary>
+        /// Sets the buffer.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <param name="buffer">The buffer.</param>
+        /// <returns></returns>
         public void SetBuffer(int id, ComputeBuffer buffer)
         {
             if (buffer == null)
@@ -91,6 +102,12 @@ namespace FlaxEngine
             bind.IsUA = isUA;
             bindings[bindid] = bind;
         }
+        /// <summary>
+        /// Sets the texture.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <param name="texture">The texture.</param>
+        /// <returns></returns>
         public void SetTexture(int id, GPUTexture texture)
         {
             if (texture == null)
@@ -113,6 +130,13 @@ namespace FlaxEngine
             bind.IsUA = isUA;
             bindings[bindid] = bind;
         }
+        /// <summary>
+        /// Determines whether the specified name has kernel.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified name has kernel; otherwise, <c>false</c>.
+        /// </returns>
         public bool HasKernel(string name)
         {
             return shader.GPU.GetCS(name) != nint.Zero;

--- a/Source/Engine/Graphics/HL_API_Compute/ComputeShader.cs
+++ b/Source/Engine/Graphics/HL_API_Compute/ComputeShader.cs
@@ -1,0 +1,227 @@
+﻿using FlaxEditor.Surface.Archetypes;
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace FlaxEngine
+{
+    /// <summary>
+    /// </summary>
+    /// <seealso cref="FlaxEngine.Shader" />
+    public class ComputeShader(Shader shader)
+    {
+        private Shader shader = shader; //todo use shader as a base class and remove this
+        private ComputeBuffer constantBuffer = null;
+        private struct Bind
+        {
+            public int ID;
+            public GPUBuffer b;
+            public GPUTexture t;
+            public bool IsUA;
+            public GPUResourceView GetView()
+            {
+                if (t != null)
+                    return t.View();
+                if (b != null)
+                    return b.View();
+                return null;
+            }
+            public string GetName()
+            {
+                if (t != null)
+                    return t.Name;
+                if (b != null)
+                    return b.Name;
+                return "";
+            }
+            public bool IsBuffer() { return b != null; }
+            public bool IsTexture() { return t != null; }
+        }
+        private readonly List<Bind> bindings = [];
+        private int GetSlotID(int id)
+        {
+            foreach (var binding in bindings)
+            {
+                if (binding.ID == id)
+                    return id;
+            }
+            var ret = bindings.Count;
+            bindings.Add(new Bind() { ID = id });
+            return ret;
+        }
+
+        public void SetConstantBuffer(ComputeBuffer buffer)
+        {
+            if (buffer == null)
+            {
+                Debug.Logger.LogException(new Exception("u forgot sometfing the ComputeBuffer is null"));
+                return;
+            }
+
+            if (buffer.m_Type != ComputeBuffer.Type.Constant)
+            {
+                Debug.Logger.LogException(new Exception("Sorry wrong buffer type use ComputeBuffer.Type.Constant insted"));
+                return;
+            }
+            constantBuffer = buffer;
+        }
+        public void SetBuffer(int id, ComputeBuffer buffer)
+        {
+            if (buffer == null)
+            {
+                Debug.Logger.LogException(new Exception("u forgot sometfing the ComputeBuffer is null"));
+                return;
+            }
+            GPUBuffer b = buffer.GetGPUBuffer();
+            if (b == null)
+            {
+                return;//cant bind do to errors
+            }
+            int bindid = GetSlotID(id);
+            var bind = bindings[bindid];
+            if (bind.IsTexture())
+            {
+                //avoid double bind.
+                //SetTexture(0,...);
+                //SetBuffer(0,...);
+                Debug.Logger.LogException(new Exception(id.ToString() + " slot is bound to the texture allredy"));
+                return;
+            }
+            var isUA = b.Description.Flags.HasFlag(GPUBufferFlags.UnorderedAccess);
+            bind.b = b;
+            bind.IsUA = isUA;
+            bindings[bindid] = bind;
+        }
+        public void SetTexture(int id, GPUTexture texture)
+        {
+            if (texture == null)
+            {
+                Debug.Logger.LogException(new Exception("u forgot sometfing the GPUTexture is null"));
+                return;
+            }
+            int bindid = GetSlotID(id);
+            var bind = bindings[bindid];
+            if (bind.IsBuffer())
+            {
+                //avoid double bind.
+                //SetBuffer(0,...);
+                //SetTexture(0,...);
+                Debug.Logger.LogException(new Exception(id.ToString() + " slot is bound to the buffer allredy"));
+                return;
+            }
+            var isUA = texture.Description.Flags.HasFlag(GPUTextureFlags.UnorderedAccess);
+            bind.t = texture;
+            bind.IsUA = isUA;
+            bindings[bindid] = bind;
+        }
+        public bool HasKernel(string name)
+        {
+            return shader.GPU.GetCS(name) != nint.Zero;
+        }
+        /// <summary>
+        /// shader goes brrrrrrrrr maybe<br/>
+        /// </summary>
+        /// <param name="kernelName">The kernelName.</param>
+        /// <param name="threadGroupsX">The thread groups x.</param>
+        /// <param name="threadGroupsY">The thread groups y.</param>
+        /// <param name="threadGroupsZ">The thread groups z.</param>
+        public void Dispatch(string kernelName, int threadGroupsX, int threadGroupsY, int threadGroupsZ)
+        {
+            var context = GPUDevice.Instance.MainContext;
+            Dispatch(context, kernelName, (uint)threadGroupsX, (uint)threadGroupsY, (uint)threadGroupsZ);
+        }
+        /// <summary>
+        /// shader goes brrrrrrrrr maybe<br/>
+        /// </summary>
+        /// <param name="kernelName">The kernelName.</param>
+        /// <param name="threadGroupsX">The thread groups x.</param>
+        /// <param name="threadGroupsY">The thread groups y.</param>
+        /// <param name="threadGroupsZ">The thread groups z.</param>
+        public void Dispatch(string kernelName, uint threadGroupsX, uint threadGroupsY = 1u, uint threadGroupsZ = 1u)
+        {
+            var context = GPUDevice.Instance.MainContext;
+            Dispatch(context, kernelName, threadGroupsX, threadGroupsY, threadGroupsZ);
+        }
+
+        /// <summary>
+        /// Dispatches the specified context.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="kernelName">The kernelName.</param>
+        /// <param name="threadGroupsX">The thread groups x.</param>
+        /// <param name="threadGroupsY">The thread groups y.</param>
+        /// <param name="threadGroupsZ">The thread groups z.</param>
+        private void Dispatch(GPUContext context, string kernelName, uint threadGroupsX, uint threadGroupsY, uint threadGroupsZ)
+        {
+            if (!GPUDevice.Instance.Limits.HasCompute)
+            {
+                Debug.Logger.LogException(new Exception("GPUDevice is not suporting Compute,can't run the Dispatch"));
+                return;
+            }
+            if (!(shader && shader.IsLoaded))
+            {
+                Debug.Logger.LogException(new Exception("shader is null or not Loaded,can't run the Dispatch"));
+                return;
+            }
+
+            var massange = string.Format("ComputeShader.Dispatch {0} ThreadGroupsCount[{1},{2},{3}]", kernelName, threadGroupsX.ToString(), threadGroupsY.ToString(), threadGroupsZ.ToString());
+            Debug.Logger.Log(massange + " Has been called");
+            Profiler.BeginEvent(massange);
+
+            var kernal = shader.GPU.GetCS(kernelName);
+            if (kernal == nint.Zero)
+            {
+                Debug.LogException(new System.Exception("Faled to find kernal with name of : " + kernelName));
+                return;
+            }
+            if (constantBuffer != null)
+            {
+                var cb = shader.GPU.GetCB(0);
+                if (cb != IntPtr.Zero)
+                {
+                    var ptr = constantBuffer.GetDataPointer();
+                    if (ptr != IntPtr.Zero)
+                    {
+                        context.UpdateCB(cb, ptr);
+                        context.BindCB(0, cb);
+                    }
+                    else
+                    {
+                        Debug.LogException(new System.Exception("Faled to Dispatch constantBuffer is empty"));
+                    }
+                }
+                else
+                {
+                    Debug.LogException(new System.Exception("Faled to Dispatch reqested a constant but go noting"));
+                }
+            }
+            foreach (var bind in bindings)
+            {
+                if (bind.IsUA)
+                {
+                    //bind unordered acces resource
+                    context.BindUA(bind.ID, bind.GetView());
+                    //Debug.Log("Resource has ben bound <" + bind.ID.ToString() + "," + bind.GetName() + "> as unordered acces ");
+                }
+                else
+                {
+                    //bind shader resource
+                    context.BindSR(bind.ID, bind.GetView());
+                }
+            }
+
+            //clamp threadGroups
+            threadGroupsX = Mathf.Max(threadGroupsX, 1);
+            threadGroupsY = Mathf.Max(threadGroupsY, 1);
+            threadGroupsZ = Mathf.Max(threadGroupsZ, 1);
+            context.Dispatch(kernal, threadGroupsX, threadGroupsY, threadGroupsZ);
+
+            //clear state
+            context.ResetUA();
+            context.ResetSR();
+            context.ResetCB();
+
+            Profiler.EndEvent();
+        }
+    }
+}

--- a/Source/Engine/Graphics/HL_API_Compute/ComputeShader.cs
+++ b/Source/Engine/Graphics/HL_API_Compute/ComputeShader.cs
@@ -1,5 +1,4 @@
-﻿using FlaxEditor.Surface.Archetypes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 


### PR DESCRIPTION
> [!NOTE]
> work on this pr has been stoped 
> awaits for https://github.com/FlaxEngine/FlaxEngine/pull/3205 to be complited


simplify the workflow with compute shaders a lot
c# only

added compute buffer wraper araund stageing buffer and GPU buffer
added shader wraper araund the shader

Suproted binds
Buffer - probably works
RWBuffer  - tested
StructuredBuffer - probably works
RWStructuredBuffer - tested
RWTexture2D  - tested
Texture2D - probably works
Constant's  - tested works

# Documentaction
1. creating buffer bound to `Buffer<float>`
```c#
buffer = new ComputeBuffer(array.Length, sizof(float), ComputeBuffer.Type.Default, ComputeBuffer.Mode.DynamicWriteOnly);
//or
buffer = new ComputeBuffer(array.Length, sizof(float), ComputeBuffer.Type.Default, ComputeBuffer.Mode.Immutable);
```

2. creating  buffer bound to `RWBuffer<float>`
```c#
buffer = new ComputeBuffer(array.Length, sizof(float), ComputeBuffer.Type.Default, ComputeBuffer.Mode.DynamicReadWrite);
//or
buffer = new ComputeBuffer(array.Length, sizof(float), ComputeBuffer.Type.Default, ComputeBuffer.Mode.DynamicReadOnly);
```

3. creating  buffer bound to `StructuredBuffer<float3>`
```c#
buffer = new ComputeBuffer(array.Length, Unsafe.SizeOf<Float3>(), ComputeBuffer.Type.Structured, ComputeBuffer.Mode.DynamicWriteOnly);
//or
buffer = new ComputeBuffer(array.Length, Unsafe.SizeOf<Float3>(), ComputeBuffer.Type.Structured, ComputeBuffer.Mode.Immutable);
```

4. creating  buffer bound to `RWStructuredBuffer<float3>`
```c#
buffer = new ComputeBuffer(array.Length, Unsafe.SizeOf<Float3>(), ComputeBuffer.Type.Structured, ComputeBuffer.Mode.DynamicReadWrite);
//or
buffer = new ComputeBuffer(array.Length, Unsafe.SizeOf<Float3>(), ComputeBuffer.Type.Structured, ComputeBuffer.Mode.DynamicReadOnly);
```
5.  creating  buffer bound to Constant `META_CB_BEGIN(0, Data) ... META_CB_END`

```c#
cbuffer = new ComputeBuffer(1, Unsafe.SizeOf<Data>(), ComputeBuffer.Type.Constant,ComputeBuffer.Mode.Immutable);
//or
cbuffer = new ComputeBuffer(1, Unsafe.SizeOf<Data>(), ComputeBuffer.Type.Constant,ComputeBuffer.Mode.DynamicWriteOnly);
```
seting data to the buffer regardles of the type calling is more then ones on `ComputeBuffer.Mode.Immutable` will result in error
```c#
buffer.SetData(array);
```
## creating compute shader
(ps. ths needs to be changed) see comment in the ComputeShader code
```c#
public Shader Shader;
private ComputeShader computeShader;
void CreateCompute(){
computeShader ??= new ComputeShader(shader);
}
```
## binding resources to compute
```c#
   computeShader.SetConstantBuffer(cbuffer);
   computeShader.SetBuffer(0, buffer);
   computeShader.SetTexture(1, RWTexture); // RWTexture is standart code 
```
## runing compute
```c#
computeShader.Dispatch("CS_Main", 1, 1,1);
 ```
 ## geting data back from GPU
 ```c#
 array = buffer.GetData<Float3>();
 ```
 ## summary
as u can see there is no need for creating a render task

computeShader.Dispatch is automaticly handeling the binding of resources and reseting the GPU UA,CB,SR
there is no need for poking with the pointers in C#
the compute buffer is managing 2 buffers calling the ReleaseGPU on GC
a lot of code is guarded by ifs so driver will not slap the user but there are some cases with are not handled
## example code
C#
```c#
[ExecuteInEditMode]
public class Compute : Script
{
    private ComputeShader computeShader;
    public Shader shader;

    public GPUTexture RWTexture = null;

    public MaterialInstance mi;
    public Int2 size;

    private ComputeBuffer buffer;
    private ComputeBuffer cbuffer;
    private Float3[] verts;

    [StructLayout(LayoutKind.Sequential)]
    struct Data
    {
        public uint x;
        public uint y;
    };

    public bool Run;
    public override void OnUpdate()
    {
        if (!Run)
            return;
        Run = false;

        SetUpResources();
        RunCompute();
    }
    private void SetUpResources()
    {
        verts ??= new Float3[size.X * size.Y];
        if (verts.Length != size.X * size.Y || buffer == null || RWTexture == null)
        {
            verts = new Float3[size.X * size.Y];
            buffer = new ComputeBuffer(verts.Length, Unsafe.SizeOf<Float3>(), ComputeBuffer.Type.Structured, ComputeBuffer.Mode.DynamicWriteOnly);
            
            
            var desc = GPUTextureDescription.New2D(size.X, size.Y, PixelFormat.R8G8B8A8_Typeless, GPUTextureFlags.ShaderResource | GPUTextureFlags.UnorderedAccess);
            RWTexture = new GPUTexture();
            RWTexture.Init(ref desc);
            cbuffer = new ComputeBuffer(1, Unsafe.SizeOf<Data>(), ComputeBuffer.Type.Constant,ComputeBuffer.Mode.DynamicWriteOnly);



            for (int i = 0; i < verts.Length; i++)
            {
                if ((i + (i / size.X)) % 2 == 0)
                {
                    verts[i] = new Float3(1,0,0);
                }
                else
                {
                    verts[i] = new Float3(0,0,1);
                }
            }

        }
    }

    public void RunCompute()
    {
        computeShader ??= new ComputeShader(shader);
        //construct buffer,cbuffer,RWTexture and fill up the verts array
        SetUpResources();

        //write data
        buffer.SetData(verts);
        cbuffer.SetData(new Data
        {
            x = (uint)Mathf.Max(size.X, 0),
            y = (uint)Mathf.Max(size.Y, 0)
        });
        //bind resources
        computeShader.SetConstantBuffer(cbuffer);
        computeShader.SetBuffer(0, buffer);
        computeShader.SetTexture(1, RWTexture);

        //calculate group thread count
        uint dgcx = (uint)size.X / 32;
        uint dgcy = (uint)size.Y / 32;
        //dispatch compute with kernal name : CS_Main
        computeShader.Dispatch("CS_Main", dgcx, dgcy);
        //read data
        verts = buffer.GetData<Float3>();
        //show texture
        mi.SetParameterValue("_main", RWTexture);
    }
}
```
Shader
```hlsl
#include "./Flax/Common.hlsl"

META_CB_BEGIN(0, Data)
uint2 Size;
META_CB_END


RWStructuredBuffer<float3> RWSBuff	: register(u0);
RWTexture2D<float4> RWtex : register(u1);

META_CS(true, FEATURE_LEVEL_SM5)
[numthreads(32, 32, 1)]
void CS_Main(uint3 dispatchThreadID : SV_DispatchThreadID, uint3 groupID : SV_GroupID, uint3 groupThreadID : SV_GroupThreadID)
{
	uint3 worldcords = dispatchThreadID;
	if(worldcords.x >= Size.x || worldcords.y >= Size.y){
        RWtex[int2(worldcords.x,worldcords.y)] = float4(0,0,1,1);
		return;
	}
    int id = worldcords.x * Size.x + worldcords.y;
    RWtex[int2(worldcords.x,worldcords.y)] = float4(RWSBuff[id].xyz,1);
    RWSBuff[id] = 1 - RWSBuff[id];

}
```