### PR TITLE
Add runtime input mapping helpers.

### DIFF
--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -614,6 +614,210 @@ float Input::GetAxisRaw(const StringView& name)
     return e ? e->ValueRaw : false;
 }
 
+void Input::SetInputMappingFromSettings(const JsonAssetReference<InputSettings>& settings)
+{
+    ActionMappings.Clear();
+    auto actionMappings = settings.GetInstance()->ActionMappings;
+    ActionMappings.Resize(actionMappings.Count(), false);
+    for (int i = 0; i < actionMappings.Count(); i++)
+    {
+        ActionMappings[i] = actionMappings.At(i);
+    }
+
+    auto axisMappings = settings.GetInstance()->AxisMappings;
+    AxisMappings.Resize(axisMappings.Count(), false);
+    for (int i = 0; i < axisMappings.Count(); i++)
+    {
+        AxisMappings[i] = axisMappings.At(i);
+    }
+    Axes.Clear();
+    Actions.Clear();
+}
+
+void Input::SetInputMappingToDefaultSettings()
+{
+    InputSettings* settings = InputSettings::Get();
+    if (settings)
+    {
+        ActionMappings = settings->ActionMappings;
+        AxisMappings = settings->AxisMappings;
+        Axes.Clear();
+        Actions.Clear();
+    }
+}
+
+ActionConfig Input::GetActionConfigByName(const StringView& name)
+{
+    ActionConfig config = {};
+    for (const auto& a : ActionMappings)
+    {
+        if (a.Name == name)
+        {
+            config = a;
+            return config;
+        }
+    }
+    return config;
+}
+
+Array<ActionConfig> Input::GetAllActionConfigsByName(const StringView& name)
+{
+    Array<ActionConfig> actionConfigs;
+    for (const auto& a : ActionMappings)
+    {
+        if (a.Name == name)
+            actionConfigs.Add(a);
+    }
+    return actionConfigs;
+}
+
+AxisConfig Input::GetAxisConfigByName(const StringView& name)
+{
+    AxisConfig config = {};
+    for (const auto& a : AxisMappings)
+    {
+        if (a.Name == name)
+        {
+            config = a;
+            return config;
+        }
+    }
+    return config;
+}
+
+Array<AxisConfig> Input::GetAllAxisConfigsByName(const StringView& name)
+{
+    Array<AxisConfig> actionConfigs;
+    for (const auto& a : AxisMappings)
+    {
+        if (a.Name == name)
+            actionConfigs.Add(a);
+    }
+    return actionConfigs;
+}
+
+void Input::SetAxisConfigByName(const StringView& name, AxisConfig& config, bool all)
+{
+    for (int i = 0; i < AxisMappings.Count(); ++i)
+    {
+        auto& mapping = AxisMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0)
+        {
+            if (config.Name.IsEmpty())
+                config.Name = name;
+            mapping = config;
+            if (!all)
+                break;
+        }
+    }
+}
+
+void Input::SetAxisConfigByName(const StringView& name, InputAxisType inputType, const KeyboardKeys positiveButton, const KeyboardKeys negativeButton, bool all)
+{
+    for (int i = 0; i < AxisMappings.Count(); ++i)
+    {
+        auto& mapping = AxisMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0 && mapping.Axis == inputType)
+        {
+            mapping.PositiveButton = positiveButton;
+            mapping.NegativeButton = negativeButton;
+            if (!all)
+                break;
+        }
+    }
+}
+
+void Input::SetAxisConfigByName(const StringView& name, InputAxisType inputType, const GamepadButton positiveButton, const GamepadButton negativeButton, InputGamepadIndex gamepadIndex, bool all)
+{
+    for (int i = 0; i < AxisMappings.Count(); ++i)
+    {
+        auto& mapping = AxisMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0 && mapping.Gamepad == gamepadIndex && mapping.Axis == inputType)
+        {
+            mapping.GamepadPositiveButton = positiveButton;
+            mapping.GamepadNegativeButton = negativeButton;
+            if (!all)
+                break;
+        }
+    }
+}
+
+void Input::SetAxisConfigByName(const StringView& name, InputAxisType inputType, const float gravity, const float deadZone, const float sensitivity, const float scale, const bool snap, bool all)
+{
+    for (int i = 0; i < AxisMappings.Count(); ++i)
+    {
+        auto& mapping = AxisMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0 && mapping.Axis == inputType)
+        {
+            mapping.Gravity = gravity;
+            mapping.DeadZone = deadZone;
+            mapping.Sensitivity = sensitivity;
+            mapping.Scale = scale;
+            mapping.Snap = snap;
+            if (!all)
+                break;
+        }
+    }
+}
+
+void Input::SetActionConfigByName(const StringView& name, const KeyboardKeys key, bool all)
+{
+    for (int i = 0; i < ActionMappings.Count(); ++i)
+    {
+        auto& mapping = ActionMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0)
+        {
+            mapping.Key = key;
+            if (!all)
+                break;
+        }
+    }
+}
+
+void Input::SetActionConfigByName(const StringView& name, const MouseButton mouseButton, bool all)
+{
+    for (int i = 0; i < ActionMappings.Count(); ++i)
+    {
+        auto& mapping = ActionMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0)
+        {
+            mapping.MouseButton = mouseButton;
+            if (!all)
+                break;
+        }
+    }
+}
+
+void Input::SetActionConfigByName(const StringView& name, const GamepadButton gamepadButton, InputGamepadIndex gamepadIndex, bool all)
+{
+    for (int i = 0; i < ActionMappings.Count(); ++i)
+    {
+        auto& mapping = ActionMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0 && mapping.Gamepad == gamepadIndex)
+        {
+            mapping.GamepadButton = gamepadButton;
+            if (!all)
+                break;
+        }
+    }
+}
+
+void Input::SetActionConfigByName(const StringView& name, ActionConfig& config, bool all)
+{
+    for (int i = 0; i < ActionMappings.Count(); ++i)
+    {
+        auto& mapping = ActionMappings.At(i);
+        if (mapping.Name.Compare(name.ToString()) == 0)
+        {
+            if (config.Name.IsEmpty())
+                config.Name = name;
+            mapping = config;
+            if (!all)
+                break;
+        }
+    }
+}
+
 void InputService::Update()
 {
     PROFILE_CPU();

--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -616,7 +616,6 @@ float Input::GetAxisRaw(const StringView& name)
 
 void Input::SetInputMappingFromSettings(const JsonAssetReference<InputSettings>& settings)
 {
-    ActionMappings.Clear();
     auto actionMappings = settings.GetInstance()->ActionMappings;
     ActionMappings.Resize(actionMappings.Count(), false);
     for (int i = 0; i < actionMappings.Count(); i++)

--- a/Source/Engine/Input/Input.h
+++ b/Source/Engine/Input/Input.h
@@ -9,6 +9,7 @@
 #include "KeyboardKeys.h"
 #include "Enums.h"
 #include "VirtualInput.h"
+#include "Engine/Content/JsonAssetReference.h"
 
 class Mouse;
 class Keyboard;
@@ -332,4 +333,114 @@ public:
     /// <returns>The current axis value (e.g for gamepads it's in the range -1..1). No smoothing applied.</returns>
     /// <seealso cref="AxisMappings"/>
     API_FUNCTION() static float GetAxisRaw(const StringView& name);
+
+    /// <summary>
+    /// Sets and overwrites the Action and Axis mappings with the values from a new InputSettings.
+    /// </summary>
+    /// <param name="settings">The input settings.</param>
+    API_FUNCTION() static void SetInputMappingFromSettings(const JsonAssetReference<class InputSettings>& settings);
+
+    /// <summary>
+    /// Sets and overwrites the Action and Axis mappings with the values from the InputSettings in GameSettings.
+    /// </summary>
+    API_FUNCTION() static void SetInputMappingToDefaultSettings();
+
+    /// <summary>
+    /// Gets the first action configuration by name.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    API_FUNCTION() static ActionConfig GetActionConfigByName(const StringView& name);
+
+    /// <summary>
+    /// Gets all the action configurations by name.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    API_FUNCTION() static Array<ActionConfig> GetAllActionConfigsByName(const StringView& name);
+
+    /// <summary>
+    /// Sets the action configuration keyboard key by name.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="key">The key to set.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetActionConfigByName(const StringView& name, const KeyboardKeys key, bool all = false);
+
+    /// <summary>
+    /// Sets the action configuration mouse button by name.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="mouseButton">The mouse button to set.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetActionConfigByName(const StringView& name, const MouseButton mouseButton, bool all = false);
+
+    /// <summary>
+    /// Sets the action configuration gamepad button by name and index.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="gamepadButton">The gamepad button to set.</param>
+    /// <param name="gamepadIndex">The gamepad index used to find the correct config.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetActionConfigByName(const StringView& name, const GamepadButton gamepadButton, InputGamepadIndex gamepadIndex, bool all = false);
+
+    /// <summary>
+    /// Sets the action configuration by name.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="config">The action configuration to set. Leave the config name empty to use set name.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetActionConfigByName(const StringView& name, ActionConfig& config, bool all = false);
+
+    /// <summary>
+    /// Gets the first axis configurations by name.
+    /// </summary>
+    /// <param name="name">The name of the axis config.</param>
+    API_FUNCTION() static AxisConfig GetAxisConfigByName(const StringView& name);
+
+    /// <summary>
+    /// Gets all the axis configurations by name.
+    /// </summary>
+    /// <param name="name">The name of the axis config.</param>
+    API_FUNCTION() static Array<AxisConfig> GetAllAxisConfigsByName(const StringView& name);
+
+    /// <summary>
+    /// Sets the axis configuration keyboard key by name and type.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="config">The configuration to set. Leave the config name empty to use set name.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetAxisConfigByName(const StringView& name, AxisConfig& config, bool all = false);
+
+    /// <summary>
+    /// Sets the axis configuration keyboard key buttons by name and type.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="inputType">The type to sort by.</param>
+    /// <param name="positiveButton">The positive key button.</param>
+    /// <param name="negativeButton">The negative key button.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetAxisConfigByName(const StringView& name, InputAxisType inputType, const KeyboardKeys positiveButton, const KeyboardKeys negativeButton, bool all = false);
+
+    /// <summary>
+    /// Sets the axis configuration gamepad buttons by name, type, and index.
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="inputType">The type to sort by.</param>
+    /// <param name="positiveButton">The positive gamepad button.</param>
+    /// <param name="negativeButton">The negative gamepad button.</param>
+    /// <param name="gamepadIndex">The gamepad index to sort by.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetAxisConfigByName(const StringView& name, InputAxisType inputType, const GamepadButton positiveButton, const GamepadButton negativeButton, InputGamepadIndex gamepadIndex, bool all = false);
+
+    /// <summary>
+    /// Sets the axis configuration accessories by name, and type..
+    /// </summary>
+    /// <param name="name">The name of the action config.</param>
+    /// <param name="inputType">The type to sort by.</param>
+    /// <param name="gravity">The gravity to set.</param>
+    /// <param name="deadZone">The dead zone to set.</param>
+    /// <param name="sensitivity">The sensitivity to set.</param>
+    /// <param name="scale">The scale to set.</param>
+    /// <param name="snap">The snap to set.</param>
+    /// <param name="all">Whether to set only the first config found or all of them.</param>
+    API_FUNCTION() static void SetAxisConfigByName(const StringView& name, InputAxisType inputType, const float gravity, const float deadZone, const float sensitivity, const float scale, const bool snap, bool all = false);
 };

--- a/Source/Engine/Input/Input.h
+++ b/Source/Engine/Input/Input.h
@@ -349,12 +349,14 @@ public:
     /// Gets the first action configuration by name.
     /// </summary>
     /// <param name="name">The name of the action config.</param>
+    /// <returns>The first Action configuration with the name. Empty configuration if not found.</returns>
     API_FUNCTION() static ActionConfig GetActionConfigByName(const StringView& name);
 
     /// <summary>
     /// Gets all the action configurations by name.
     /// </summary>
     /// <param name="name">The name of the action config.</param>
+    /// <returns>The Action configurations with the name.</returns>
     API_FUNCTION() static Array<ActionConfig> GetAllActionConfigsByName(const StringView& name);
 
     /// <summary>
@@ -394,12 +396,14 @@ public:
     /// Gets the first axis configurations by name.
     /// </summary>
     /// <param name="name">The name of the axis config.</param>
+    /// <returns>The first Axis configuration with the name. Empty configuration if not found.</returns>
     API_FUNCTION() static AxisConfig GetAxisConfigByName(const StringView& name);
 
     /// <summary>
     /// Gets all the axis configurations by name.
     /// </summary>
     /// <param name="name">The name of the axis config.</param>
+    /// <returns>The axis configurations with the name.</returns>
     API_FUNCTION() static Array<AxisConfig> GetAllAxisConfigsByName(const StringView& name);
 
     /// <summary>
@@ -432,7 +436,7 @@ public:
     API_FUNCTION() static void SetAxisConfigByName(const StringView& name, InputAxisType inputType, const GamepadButton positiveButton, const GamepadButton negativeButton, InputGamepadIndex gamepadIndex, bool all = false);
 
     /// <summary>
-    /// Sets the axis configuration accessories by name, and type..
+    /// Sets the axis configuration accessories by name, and type.
     /// </summary>
     /// <param name="name">The name of the action config.</param>
     /// <param name="inputType">The type to sort by.</param>


### PR DESCRIPTION
Add some helper methods for changing input mapping at runtime.

- Method to set mappings using a different `InputSettings` asset.
- Method to set all mappings back to default
- Methods for setting individual keys, buttons, etc where possible.
- Methods for getting the configs by name.