### PR TITLE
Update volume slider in game panel on menu show

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -691,7 +691,7 @@ namespace FlaxEditor.Windows
             {
                 var button = menu.AddButton("Audio Volume");
                 button.CloseMenuOnClick = false;
-                var slider = new FloatValueBox(1, 140, 2, 50, 0, 1) { Parent = button };
+                var slider = new FloatValueBox(AudioVolume, 140, 2, 50, 0, 1) { Parent = button };
                 slider.ValueChanged += () => AudioVolume = slider.Value;
             }
 


### PR DESCRIPTION
This pr fixes a bug in a pr I did previously (#2978). The volume slider now no longer shows 1 when the menu is created, it adjusts to the real value.

I talked to another user about this, and they mentioned that the slider might confuse people and make them think audio is broken, because the slider is tucked away in the rmb menu, so it's hard to see its value.

There is #2788, which would fix that problem, I think it would be cool if that was merged (I could add the audio slider and mute toggle to it).