### PR TITLE
Update DebugLog documentation

### DIFF
--- a/Source/Engine/Debug/DebugLog.h
+++ b/Source/Engine/Debug/DebugLog.h
@@ -19,7 +19,7 @@ public:
     static void Log(LogType type, const StringView& message);
 
     /// <summary>
-    /// A variant of Debug.Log that logs a warning message to the console.
+    /// A variant of Debug.Log that logs an info message to the console.
     /// </summary>
     /// <param name="message">The text message to display.</param>
     FORCE_INLINE static void Log(const StringView& message)


### PR DESCRIPTION
This pr updates documentation on static Log method in DebugLog class to better reflect method's purpose and avoid possible confusion