### PR TITLE
Add editor options for tab height, hiding one tab window tab title bars and sort interface options a bit better

### DIFF
--- a/Source/Editor/GUI/Docking/DockHintWindow.cs
+++ b/Source/Editor/GUI/Docking/DockHintWindow.cs
@@ -215,8 +215,8 @@ namespace FlaxEditor.GUI.Docking
             switch (state)
             {
             case DockState.DockFill:
-                result.Location.Y += DockPanel.DefaultHeaderHeight;
-                result.Size.Y -= DockPanel.DefaultHeaderHeight;
+                result.Location.Y += Editor.Instance.Options.Options.Interface.TabHeight;
+                result.Size.Y -= Editor.Instance.Options.Options.Interface.TabHeight;
                 break;
             case DockState.DockTop:
                 result.Size.Y *= DockPanel.DefaultSplitterValue;

--- a/Source/Editor/GUI/Docking/DockPanelProxy.cs
+++ b/Source/Editor/GUI/Docking/DockPanelProxy.cs
@@ -14,11 +14,11 @@ namespace FlaxEditor.GUI.Docking
     {
         private DockPanel _panel;
         private double _dragEnterTime = -1;
-    #if PLATFORM_WINDOWS
-        private const bool HideTabForSingleTab = true;
-    #else
-        private const bool HideTabForSingleTab = false;
-    #endif
+#if PLATFORM_WINDOWS
+        private readonly bool _hideTabForSingleTab = Editor.Instance.Options.Options.Interface.HideSingleTabWindowTabBars;
+#else
+        private readonly bool _hideTabForSingleTab = false;
+#endif
 
         /// <summary>
         /// The is mouse down flag (left button).
@@ -57,6 +57,7 @@ namespace FlaxEditor.GUI.Docking
 
         private Rectangle HeaderRectangle => new Rectangle(0, 0, Width, DockPanel.DefaultHeaderHeight);
         private bool IsSingleFloatingWindow => HideTabForSingleTab && _panel.TabsCount == 1 && _panel.IsFloating && _panel.ChildPanelsCount == 0;
+        private bool IsSingleFloatingWindow => _hideTabForSingleTab && _panel.TabsCount == 1 && _panel.IsFloating && _panel.ChildPanelsCount == 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DockPanelProxy"/> class.

--- a/Source/Editor/GUI/Docking/DockPanelProxy.cs
+++ b/Source/Editor/GUI/Docking/DockPanelProxy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2024 Wojciech Figat. All rights reserved.
 
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -14,6 +15,7 @@ namespace FlaxEditor.GUI.Docking
     {
         private DockPanel _panel;
         private double _dragEnterTime = -1;
+        private float _tabHeight = Editor.Instance.Options.Options.Interface.TabHeight;
 #if PLATFORM_WINDOWS
         private readonly bool _hideTabForSingleTab = Editor.Instance.Options.Options.Interface.HideSingleTabWindowTabBars;
 #else
@@ -54,9 +56,7 @@ namespace FlaxEditor.GUI.Docking
         /// The start drag asynchronous window.
         /// </summary>
         public DockWindow StartDragAsyncWindow;
-
-        private Rectangle HeaderRectangle => new Rectangle(0, 0, Width, DockPanel.DefaultHeaderHeight);
-        private bool IsSingleFloatingWindow => HideTabForSingleTab && _panel.TabsCount == 1 && _panel.IsFloating && _panel.ChildPanelsCount == 0;
+        private Rectangle HeaderRectangle => new Rectangle(0, 0, Width, _tabHeight);
         private bool IsSingleFloatingWindow => _hideTabForSingleTab && _panel.TabsCount == 1 && _panel.IsFloating && _panel.ChildPanelsCount == 0;
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace FlaxEditor.GUI.Docking
             var tabsCount = _panel.TabsCount;
             if (tabsCount == 1)
             {
-                var crossRect = new Rectangle(Width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
+                var crossRect = new Rectangle(Width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (HeaderRectangle.Height - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
                 if (HeaderRectangle.Contains(position))
                 {
                     closeButton = crossRect.Contains(position);
@@ -97,11 +97,11 @@ namespace FlaxEditor.GUI.Docking
                     var titleSize = tab.TitleSize;
                     var iconWidth = tab.Icon.IsValid ? DockPanel.DefaultButtonsSize + DockPanel.DefaultLeftTextMargin : 0;
                     var width = titleSize.X + DockPanel.DefaultButtonsSize + 2 * DockPanel.DefaultButtonsMargin + DockPanel.DefaultLeftTextMargin + DockPanel.DefaultRightTextMargin + iconWidth;
-                    var tabRect = new Rectangle(x, 0, width, DockPanel.DefaultHeaderHeight);
+                    var tabRect = new Rectangle(x, 0, width, HeaderRectangle.Height);
                     var isMouseOver = tabRect.Contains(position);
                     if (isMouseOver)
                     {
-                        var crossRect = new Rectangle(x + width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
+                        var crossRect = new Rectangle(x + width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (HeaderRectangle.Height - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
                         closeButton = crossRect.Contains(position);
                         result = tab;
                         break;
@@ -133,7 +133,7 @@ namespace FlaxEditor.GUI.Docking
                     float width = titleSize.X + DockPanel.DefaultButtonsSize + 2 * DockPanel.DefaultButtonsMargin + DockPanel.DefaultLeftTextMargin + DockPanel.DefaultRightTextMargin;
                     if (tab == win)
                     {
-                        bounds = new Rectangle(x, 0, width, DockPanel.DefaultHeaderHeight);
+                        bounds = new Rectangle(x, 0, width, HeaderRectangle.Height);
                         return;
                     }
                     x += width;
@@ -213,7 +213,7 @@ namespace FlaxEditor.GUI.Docking
                 {
                     Render2D.DrawSprite(
                         tab.Icon,
-                        new Rectangle(DockPanel.DefaultLeftTextMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize),
+                        new Rectangle(DockPanel.DefaultLeftTextMargin, (HeaderRectangle.Height - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize),
                         style.Foreground);
 
                 }
@@ -222,13 +222,13 @@ namespace FlaxEditor.GUI.Docking
                 Render2D.DrawText(
                     style.FontMedium,
                     tab.Title,
-                    new Rectangle(DockPanel.DefaultLeftTextMargin + iconWidth, 0, Width - DockPanel.DefaultLeftTextMargin - DockPanel.DefaultButtonsSize - 2 * DockPanel.DefaultButtonsMargin, DockPanel.DefaultHeaderHeight),
+                    new Rectangle(DockPanel.DefaultLeftTextMargin + iconWidth, 0, Width - DockPanel.DefaultLeftTextMargin - DockPanel.DefaultButtonsSize - 2 * DockPanel.DefaultButtonsMargin, HeaderRectangle.Height),
                     style.Foreground,
                     TextAlignment.Near,
                     TextAlignment.Center);
 
                 // Draw cross
-                var crossRect = new Rectangle(Width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
+                var crossRect = new Rectangle(Width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (HeaderRectangle.Height - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
                 bool isMouseOverCross = isMouseOver && crossRect.Contains(MousePosition);
                 if (isMouseOverCross)
                     Render2D.FillRectangle(crossRect, (containsFocus ? style.BackgroundSelected : style.LightBackground) * 1.3f);
@@ -249,7 +249,7 @@ namespace FlaxEditor.GUI.Docking
                     var titleSize = tab.TitleSize;
                     var iconWidth = tab.Icon.IsValid ? DockPanel.DefaultButtonsSize + DockPanel.DefaultLeftTextMargin : 0;
                     var width = titleSize.X + DockPanel.DefaultButtonsSize + 2 * DockPanel.DefaultButtonsMargin + DockPanel.DefaultLeftTextMargin + DockPanel.DefaultRightTextMargin + iconWidth;
-                    var tabRect = new Rectangle(x, 0, width, DockPanel.DefaultHeaderHeight);
+                    var tabRect = new Rectangle(x, 0, width, headerRect.Height);
                     var isMouseOver = tabRect.Contains(MousePosition);
                     var isSelected = _panel.SelectedTab == tab;
 
@@ -276,7 +276,7 @@ namespace FlaxEditor.GUI.Docking
                     {
                         Render2D.DrawSprite(
                             tab.Icon,
-                            new Rectangle(x + DockPanel.DefaultLeftTextMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize),
+                            new Rectangle(x + DockPanel.DefaultLeftTextMargin, (HeaderRectangle.Height - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize),
                             style.Foreground);
 
                     }
@@ -285,7 +285,7 @@ namespace FlaxEditor.GUI.Docking
                     Render2D.DrawText(
                         style.FontMedium,
                         tab.Title,
-                        new Rectangle(x + DockPanel.DefaultLeftTextMargin + iconWidth, 0, 10000, DockPanel.DefaultHeaderHeight),
+                        new Rectangle(x + DockPanel.DefaultLeftTextMargin + iconWidth, 0, 10000, HeaderRectangle.Height),
                         style.Foreground,
                         TextAlignment.Near,
                         TextAlignment.Center);
@@ -293,7 +293,7 @@ namespace FlaxEditor.GUI.Docking
                     // Draw cross
                     if (isSelected || isMouseOver)
                     {
-                        var crossRect = new Rectangle(x + width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (DockPanel.DefaultHeaderHeight - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
+                        var crossRect = new Rectangle(x + width - DockPanel.DefaultButtonsSize - DockPanel.DefaultButtonsMargin, (HeaderRectangle.Height - DockPanel.DefaultButtonsSize) / 2, DockPanel.DefaultButtonsSize, DockPanel.DefaultButtonsSize);
                         bool isMouseOverCross = isMouseOver && crossRect.Contains(MousePosition);
                         if (isMouseOverCross)
                             Render2D.FillRectangle(crossRect, tabColor * 1.3f);
@@ -305,7 +305,7 @@ namespace FlaxEditor.GUI.Docking
                 }
 
                 // Draw selected tab strip
-                Render2D.FillRectangle(new Rectangle(0, DockPanel.DefaultHeaderHeight - 2, Width, 2), containsFocus ? style.BackgroundSelected : style.BackgroundNormal);
+                Render2D.FillRectangle(new Rectangle(0, HeaderRectangle.Height - 2, Width, 2), containsFocus ? style.BackgroundSelected : style.BackgroundNormal);
             }
         }
 
@@ -523,7 +523,7 @@ namespace FlaxEditor.GUI.Docking
             if (IsSingleFloatingWindow)
                 rect = new Rectangle(0, 0, Width, Height);
             else
-                rect = new Rectangle(0, DockPanel.DefaultHeaderHeight, Width, Height - DockPanel.DefaultHeaderHeight);
+                rect = new Rectangle(0, HeaderRectangle.Height, Width, Height - HeaderRectangle.Height);
         }
 
         private DragDropEffect TrySelectTabUnderLocation(ref Float2 location)

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -261,6 +261,13 @@ namespace FlaxEditor.Options
 #endif
 
         /// <summary>
+        /// Gets or sets a value indicating the height of window tabs. Editor restart required.
+        /// </summary>
+        [DefaultValue(20.0f), Limit(15.0f, 40.0f)]
+        [EditorDisplay("Tabs & Windows"), EditorOrder(100)]
+        public float TabHeight { get; set; } = 20.0f;
+
+        /// <summary>
         /// Gets or sets a value indicating whether center mouse position on window focus in play mode. Helps when working with games that lock mouse cursor.
         /// </summary>
         [DefaultValue(false)]

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -167,35 +167,12 @@ namespace FlaxEditor.Options
         [EditorDisplay("Interface"), EditorOrder(10), Tooltip("Editor User Interface scale. Applied to all UI elements, windows and text. Can be used to scale the interface up on a bigger display. Editor restart required.")]
         public float InterfaceScale { get; set; } = 1.0f;
 
-#if PLATFORM_WINDOWS
-        /// <summary>
-        /// Gets or sets a value indicating whether use native window title bar. Editor restart required.
-        /// </summary>
-        [DefaultValue(false)]
-        [EditorDisplay("Interface"), EditorOrder(70), Tooltip("Determines whether use native window title bar. Editor restart required.")]
-        public bool UseNativeWindowSystem { get; set; } = false;
-#endif
-
         /// <summary>
         /// Gets or sets a value indicating whether show selected camera preview in the editor window.
         /// </summary>
         [DefaultValue(true)]
         [EditorDisplay("Interface"), EditorOrder(80), Tooltip("Determines whether show selected camera preview in the edit window.")]
         public bool ShowSelectedCameraPreview { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether center mouse position on window focus in play mode. Helps when working with games that lock mouse cursor.
-        /// </summary>
-        [DefaultValue(false)]
-        [EditorDisplay("Interface", "Center Mouse On Game Window Focus"), EditorOrder(100), Tooltip("Determines whether center mouse position on window focus in play mode. Helps when working with games that lock mouse cursor.")]
-        public bool CenterMouseOnGameWinFocus { get; set; } = false;
-
-        /// <summary>
-        /// Gets or sets the method window opening.
-        /// </summary>
-        [DefaultValue(DockStateProxy.Float)]
-        [EditorDisplay("Interface", "New Window Location"), EditorOrder(150), Tooltip("Define the opening method for new windows, open in a new tab by default.")]
-        public DockStateProxy NewWindowLocation { get; set; } = DockStateProxy.Float;
 
         /// <summary>
         /// Gets or sets the editor icons scale. Editor restart required.
@@ -264,6 +241,38 @@ namespace FlaxEditor.Options
         [DefaultValue(true)]
         [EditorDisplay("Interface"), EditorOrder(322)]
         public bool ScrollToScriptOnAdd { get; set; } = true;
+
+#if PLATFORM_WINDOWS
+        /// <summary>
+        /// Gets or sets a value indicating whether use native window title bar. Editor restart required.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Tabs & Windows"), EditorOrder(70), Tooltip("Determines whether use native window title bar. Editor restart required.")]
+        public bool UseNativeWindowSystem { get; set; } = false;
+#endif
+
+#if PLATFORM_WINDOWS
+        /// <summary>
+        /// Gets or sets a value indicating whether a window containing a single tabs hides the tab bar. Editor restart recommended.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Tabs & Windows", "Hide Single-Tab Window Tab Bars"), EditorOrder(71)]
+        public bool HideSingleTabWindowTabBars { get; set; } = true;
+#endif
+
+        /// <summary>
+        /// Gets or sets a value indicating whether center mouse position on window focus in play mode. Helps when working with games that lock mouse cursor.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Tabs & Windows", "Center Mouse On Game Window Focus"), EditorOrder(101), Tooltip("Determines whether center mouse position on window focus in play mode. Helps when working with games that lock mouse cursor.")]
+        public bool CenterMouseOnGameWinFocus { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the method window opening.
+        /// </summary>
+        [DefaultValue(DockStateProxy.Float)]
+        [EditorDisplay("Tabs & Windows", "New Window Location"), EditorOrder(150), Tooltip("Define the opening method for new windows, open in a new tab by default.")]
+        public DockStateProxy NewWindowLocation { get; set; } = DockStateProxy.Float;
 
         /// <summary>
         /// Gets or sets the timestamps prefix mode for output log messages.


### PR DESCRIPTION
This pr adds an option to disable hiding the tab bar on single tab windows. This is useful, because some panels like for example the Game panel have important options in the tab title bar right click menu. This change allows the user to decide between saving a bit of space or having those options always available, even if the tab is undocked as a single tab.

This also adds an option to set the height of tabs. This closes #3213.
The height is limited between 15 and 40, and the default value is at 20, like it was before. The reason for the limit is to prevent very small tabs and very large tabs, which both could render the editor hard to use/ unusable.

*Maximum tab height*
![image](https://github.com/user-attachments/assets/64be3203-b779-47a2-bc3a-5b2274af0241)
*Minimum tab height*
![image](https://github.com/user-attachments/assets/d49936ba-8691-41a1-9a74-599e63269c82)

Additionally I added a new category ("Tabs & Windows")to the interface options which has all of the settings related to tabs and windows:
![image](https://github.com/user-attachments/assets/e63ab239-4223-44c5-8c28-04c7ba32b4df)
