### PR TITLE
Add a broken link icon (used in actor scale editor)

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/ActorTransformEditor.cs
@@ -114,7 +114,6 @@ namespace FlaxEditor.CustomEditors.Editors
 
                 _linkButton = new Button
                 {
-                    BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Link32),
                     Parent = LinkedLabel,
                     Width = 18,
                     Height = 18,
@@ -201,6 +200,7 @@ namespace FlaxEditor.CustomEditors.Editors
                 _linkButton.SetColors(backgroundColor);
                 _linkButton.BorderColor = _linkButton.BorderColorSelected = _linkButton.BorderColorHighlighted = Color.Transparent;
                 _linkButton.TooltipText = LinkValues ? "Unlinks scale components from uniform scaling" : "Links scale components for uniform scaling";
+                _linkButton.BackgroundBrush = new SpriteBrush(LinkValues ? Editor.Instance.Icons.Link32 : Editor.Instance.Icons.BrokenLink32);
             }
         }
     }

--- a/Source/Editor/EditorIcons.cs
+++ b/Source/Editor/EditorIcons.cs
@@ -39,6 +39,7 @@ namespace FlaxEditor
         public SpriteHandle Globe32;
         public SpriteHandle CamSpeed32;
         public SpriteHandle Link32;
+        public SpriteHandle BrokenLink32;
         public SpriteHandle Add32;
         public SpriteHandle Left32;
         public SpriteHandle Right32;
@@ -94,6 +95,7 @@ namespace FlaxEditor
         public SpriteHandle Search64;
         public SpriteHandle Bone64;
         public SpriteHandle Link64;
+        public SpriteHandle BrokenLink64;
         public SpriteHandle Build64;
         public SpriteHandle Add64;
         public SpriteHandle ShipIt64;


### PR DESCRIPTION
I always have problems distinguishing between the linked and unlinked scale mode, so I made a new icon that shows when the scale is unlinked.

*Before*
![image](https://github.com/user-attachments/assets/89bd0053-54e7-4e69-8546-b01505589a95)
![image](https://github.com/user-attachments/assets/76e53d04-e37a-47c9-9bfd-8db09e5d3910)

*Now*
![image](https://github.com/user-attachments/assets/4a4f3c61-d58b-4679-9df0-0a9195e4504a)
![image](https://github.com/user-attachments/assets/e9389175-4a24-4f83-a63d-282934d54884)

Here's a zip folder with a .png, .psd and the .flax atlas:
[BrokenLink.zip](https://github.com/user-attachments/files/18759719/BrokenLink.zip)
