### PR TITLE
Add rmb menu entry to show item in Content Panel if there is a search

### DIFF
--- a/Source/Editor/Windows/ContentWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/ContentWindow.ContextMenu.cs
@@ -76,6 +76,15 @@ namespace FlaxEditor.Windows
                     });
 
                 cm.AddButton(Utilities.Constants.ShowInExplorer, () => FileSystem.ShowFileExplorer(System.IO.Path.GetDirectoryName(item.Path)));
+                
+                if (!String.IsNullOrEmpty(Editor.Instance.Windows.ContentWin._itemsSearchBox.Text))
+                {
+                    cm.AddButton("Show in Content Panel", () =>
+                    {
+                        Editor.Instance.Windows.ContentWin.ClearItemsSearch();
+                        Editor.Instance.Windows.ContentWin.Select(item);
+                    });
+                }
 
                 if (item.HasDefaultThumbnail == false)
                 {


### PR DESCRIPTION
This pr adds a button to the Content Panel item rmb menu which allows the user to open the item in the Content Panel and clear the search string ("Show in Content Panel"). The button only shows when there is a search query in the searchbox.

Technically it selects the item, but I think naming this "Show" instead of "Select" makes more sense given what it does, and it's consistent with the "Show in explorer option".

![image](https://github.com/user-attachments/assets/ec58b432-8931-4641-b7ec-2d13a2c7cf43)


### Why?
My motivation for this was that I frequently encounter situations where I don't remember where a file is located, but I remember another file and its name, which is located in that same folder.
This pr would allow me to search for the other files name and then use the "Show in Content Panel" button to navigate to that folder.


