### PR TITLE
Decrease `Grid Panel` fill slider sensitivity

### DIFF
--- a/Source/Engine/UI/GUI/Panels/GridPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/GridPanel.cs
@@ -35,7 +35,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// The cells heights in container height percentage (from top to bottom). Use negative values to set fixed widths for the cells.
         /// </summary>
-        [EditorOrder(10), Tooltip("The cells heights in container height percentage (from top to bottom). Use negative values to set fixed height for the cells.")]
+        [EditorOrder(10), Limit(float.MinValue, float.MaxValue, 0.001f), Tooltip("The cells heights in container height percentage (from top to bottom). Use negative values to set fixed height for the cells.")]
         public float[] RowFill
         {
             get => _cellsV;
@@ -49,7 +49,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// The cells heights in container width percentage (from left to right). Use negative values to set fixed heights for the cells.
         /// </summary>
-        [EditorOrder(20), Tooltip("The cells heights in container width percentage (from left to right). Use negative values to set fixed width for the cells.")]
+        [EditorOrder(20), Limit(float.MinValue, float.MaxValue, 0.001f), Tooltip("The cells heights in container width percentage (from left to right). Use negative values to set fixed width for the cells.")]
         public float[] ColumnFill
         {
             get => _cellsH;


### PR DESCRIPTION
The slider sensitivity is now much more reasonable and allows to actually adjust the fill by dragging the slider.

This is me dragging at ~ the same speed:

https://github.com/user-attachments/assets/9567c782-1455-40f0-976d-ee24ee63079c


https://github.com/user-attachments/assets/54d07b34-cfb9-489c-b5ea-04c4fdf1bcd5

