### PR TITLE
Add using c: in search filtering to find control types.

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -238,12 +238,32 @@ namespace FlaxEditor.SceneGraph.GUI
                         }
                         else
                         {
-                            if (Actor !=null)
+                            if (Actor != null)
                             {
                                 var actorTypeText = trimmedFilter.Replace("a:", "", StringComparison.OrdinalIgnoreCase).Trim();
                                 var name = TypeUtils.GetTypeDisplayName(Actor.GetType());
                                 var nameNoSpaces = name.Replace(" ", "");
                                 if (name.Contains(actorTypeText, StringComparison.OrdinalIgnoreCase) || nameNoSpaces.Contains(actorTypeText, StringComparison.OrdinalIgnoreCase))
+                                    hasFilter = true;
+                            }
+                        }
+                    }
+                    // Check for control type
+                    else if (trimmedFilter.Contains("c:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (trimmedFilter.Equals("c:", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (Actor != null)
+                                hasFilter = true;
+                        }
+                        else
+                        {
+                            if (Actor != null && Actor is UIControl uic && uic.Control != null)
+                            {
+                                var controlTypeText = trimmedFilter.Replace("c:", "", StringComparison.OrdinalIgnoreCase).Trim();
+                                var name = TypeUtils.GetTypeDisplayName(uic.Control.GetType());
+                                var nameNoSpaces = name.Replace(" ", "");
+                                if (name.Contains(controlTypeText, StringComparison.OrdinalIgnoreCase) || nameNoSpaces.Contains(controlTypeText, StringComparison.OrdinalIgnoreCase))
                                     hasFilter = true;
                             }
                         }


### PR DESCRIPTION
usage:

`c:Image` to find all `UIControl`s with the control type of image

We will need to add this one to the docs once it is added.