### PR TITLE
Fix some typos in Font.h and a comment typo in ActorTreeNode.cs

### DIFF
--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -166,7 +166,7 @@ namespace FlaxEditor.SceneGraph.GUI
         /// <param name="filterText">The filter text.</param>
         public void UpdateFilter(string filterText)
         {
-            // SKip hidden actors
+            // Skip hidden actors
             var actor = Actor;
             if (actor != null && (actor.HideFlags & HideFlags.HideInHierarchy) != 0)
                 return;

--- a/Source/Engine/Render2D/Font.h
+++ b/Source/Engine/Render2D/Font.h
@@ -399,7 +399,7 @@ public:
     /// </summary>
     /// <param name="text">The input text to test.</param>
     /// <param name="layout">The layout properties.</param>
-    /// <returns>The minimum size for that text and fot to render properly.</returns>
+    /// <returns>The minimum size for that text and font to render properly.</returns>
     API_FUNCTION() Float2 MeasureText(const StringView& text, API_PARAM(Ref) const TextLayoutOptions& layout);
 
     /// <summary>
@@ -408,7 +408,7 @@ public:
     /// <param name="text">The input text to test.</param>
     /// <param name="textRange">The input text range (substring range of the input text parameter).</param>
     /// <param name="layout">The layout properties.</param>
-    /// <returns>The minimum size for that text and fot to render properly.</returns>
+    /// <returns>The minimum size for that text and font to render properly.</returns>
     API_FUNCTION() Float2 MeasureText(const StringView& text, API_PARAM(Ref) const TextRange& textRange, API_PARAM(Ref) const TextLayoutOptions& layout)
     {
         return MeasureText(textRange.Substring(text), layout);
@@ -418,7 +418,7 @@ public:
     /// Measures minimum size of the rectangle that will be needed to draw given text
     /// </summary>.
     /// <param name="text">The input text to test.</param>
-    /// <returns>The minimum size for that text and fot to render properly.</returns>
+    /// <returns>The minimum size for that text and font to render properly.</returns>
     API_FUNCTION() FORCE_INLINE Float2 MeasureText(const StringView& text)
     {
         return MeasureText(text, TextLayoutOptions());
@@ -429,7 +429,7 @@ public:
     /// </summary>.
     /// <param name="text">The input text to test.</param>
     /// <param name="textRange">The input text range (substring range of the input text parameter).</param>
-    /// <returns>The minimum size for that text and fot to render properly.</returns>
+    /// <returns>The minimum size for that text and font to render properly.</returns>
     API_FUNCTION() FORCE_INLINE Float2 MeasureText(const StringView& text, API_PARAM(Ref) const TextRange& textRange)
     {
         return MeasureText(textRange.Substring(text), TextLayoutOptions());


### PR DESCRIPTION
See changed files for the typos that are fixed.

Idk if this is the only thing I need to do to fix them, the C# api reference comments in vsc would still show up with the typos after I build from this commit.

If there is something else I need to do to fix these please tell me :)