### PR TITLE
Improve how ColorValueBoxes draw transparent colors

### DIFF
--- a/Source/Editor/GUI/Input/ColorValueBox.cs
+++ b/Source/Editor/GUI/Input/ColorValueBox.cs
@@ -129,11 +129,20 @@ namespace FlaxEditor.GUI.Input
         {
             base.Draw();
 
-            var style = Style.Current;
-            var r = new Rectangle(0, 0, Width, Height);
+            bool isTransparent = _value.A < 1;
 
-            Render2D.FillRectangle(r, _value);
-            Render2D.DrawRectangle(r, IsMouseOver || IsNavFocused ? style.BackgroundSelected : Color.Black);
+            var style = Style.Current;
+            var fullRect = new Rectangle(0, 0, Width, Height);
+            var colorRect = new Rectangle(0, 0, isTransparent ? Width * 0.7f : Width, Height);
+
+            if (isTransparent)
+            {
+                var alphaRect = new Rectangle(colorRect.Right, 0, Width - colorRect.Right, Height);
+                Render2D.FillRectangle(alphaRect, _value);
+            }
+
+            Render2D.FillRectangle(colorRect, _value with { A = 1 });
+            Render2D.DrawRectangle(fullRect, IsMouseOver || IsNavFocused ? style.BackgroundSelected : Color.Black);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This pr aims to make it easier to recognize if a color has transparency or not.

For that, if the alpha < 1, a rectangle is displayed that shows the color with transparency.

I originally wanted to just draw a grid behind the color like Godot does it, but I think it's too distracting.
*Godot*
![image](https://github.com/user-attachments/assets/bbd37b21-c756-462d-8090-244e28c9ac80)

What could improve this even further is adding a grid behind the transparent part of the color, but idk how that would be performance wise because it'd be a bunch of rectangle draws. Maybe a shader would be a better fit here, but I don't even know where to start with that.

(#2691 could also benefit from such a shader since it uses transparency grids in a few places).

Before:
![image](https://github.com/user-attachments/assets/f06e3966-c241-4ccb-8653-588a11c8e614)


With this pr:
![image](https://github.com/user-attachments/assets/f3003c50-7c12-4458-a8f9-04e22a714d95)

