### PR TITLE
ZaP-object-editor-inner-exception-log

### DIFF
--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -851,6 +851,11 @@ namespace FlaxEditor
         {
             LogWarning("Exception: " + ex.Message);
             LogWarning(ex.StackTrace);
+            if (ex.InnerException != null)
+            {
+                LogWarning("Cause: " + ex.InnerException.Message);
+                LogWarning(ex.InnerException.StackTrace);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes https://github.com/FlaxEngine/FlaxEngine/issues/3287

Not sure if this is out of scope.