### PR TITLE
Fix issue with re-loading scene and toolstip not updating.

### DIFF
--- a/Source/Editor/States/ChangingScenesState.cs
+++ b/Source/Editor/States/ChangingScenesState.cs
@@ -164,10 +164,21 @@ namespace FlaxEditor.States
         {
             Assert.AreEqual(Guid.Empty, _lastSceneFromRequest, "Invalid state.");
 
-            // Bind events
-            Level.SceneLoaded += OnSceneEvent;
-            Level.SceneLoadError += OnSceneEvent;
-            Level.SceneUnloaded += OnSceneEvent;
+            // Bind events, only bind loading event and error if re-loading the same scene to avoid issues.
+            if (_scenesToUnload.Count == 1 && _scenesToLoad.Count == 1)
+            {
+                if (_scenesToLoad[0] == _scenesToUnload[0].ID)
+                {
+                    Level.SceneLoaded += OnSceneEvent;
+                    Level.SceneLoadError += OnSceneEvent;
+                }
+            }
+            else
+            {
+                Level.SceneLoaded += OnSceneEvent;
+                Level.SceneLoadError += OnSceneEvent;
+                Level.SceneUnloaded += OnSceneEvent;
+            }
 
             // Push scenes changing requests
             for (int i = 0; i < _scenesToUnload.Count; i++)


### PR DESCRIPTION
Fix #3285 

If you think of a better fix, feel free to close this one. The other option I came up with was to continuously call `UpdateToolStrip` on update, but that seemed inefficient.