### PR TITLE
Auto resize PropertiesList splitter bar based on longest text

### DIFF
--- a/Source/Editor/CustomEditors/GUI/PropertiesList.cs
+++ b/Source/Editor/CustomEditors/GUI/PropertiesList.cs
@@ -14,6 +14,9 @@ namespace FlaxEditor.CustomEditors.GUI
     public class PropertiesList : PanelWithMargins
     {
         // TODO: sync splitter for whole presenter
+       
+        private const float splitterPadding = 15;
+        private const float editorsMinWdithRatio = 0.4f;
 
         /// <summary>
         /// The splitter size (in pixels).
@@ -32,6 +35,7 @@ namespace FlaxEditor.CustomEditors.GUI
         private Rectangle _splitterRect;
         private bool _splitterClicked, _mouseOverSplitter;
         private bool _cursorChanged;
+        private bool _hasCustomSplitterValue;
 
         /// <summary>
         /// Gets or sets the splitter value (always in range [0; 1]).
@@ -69,6 +73,26 @@ namespace FlaxEditor.CustomEditors.GUI
             _splitterValue = 0.4f;
             BottomMargin = TopMargin = RightMargin = SplitterMargin;
             UpdateSplitRect();
+        }
+
+        private void AutoSizeSplitter()
+        {
+            if (_hasCustomSplitterValue || !Editor.Instance.Options.Options.Interface.AutoSizePropertiesPanelSplitter)
+                return;
+
+            Font font = Style.Current.FontMedium;
+
+            float largestWidth = 0f;
+            for (int i = 0; i < _element.Labels.Count; i++)
+            {
+                Label currentLabel = _element.Labels[i];
+                Float2 dimensions = font.MeasureText(currentLabel.Text);
+                float width = dimensions.X + currentLabel.Margin.Left + splitterPadding;
+
+                largestWidth = Mathf.Max(largestWidth, width);
+            }
+
+            SplitterValue = Mathf.Clamp(largestWidth / Width, 0, 1 - editorsMinWdithRatio);
         }
 
         private void UpdateSplitRect()
@@ -127,6 +151,7 @@ namespace FlaxEditor.CustomEditors.GUI
                 SplitterValue = location.X / Width;
                 Cursor = CursorType.SizeWE;
                 _cursorChanged = true;
+                _hasCustomSplitterValue = true;
             }
             else if (_mouseOverSplitter)
             {
@@ -200,6 +225,7 @@ namespace FlaxEditor.CustomEditors.GUI
             // Refresh
             UpdateSplitRect();
             PerformLayout(true);
+            AutoSizeSplitter();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -233,6 +233,13 @@ namespace FlaxEditor.Options
         public bool SeparateValueAndUnit { get; set; }
 
         /// <summary>
+        /// Gets or sets the option to auto size the Properties panel splitter based on the longest property name. Editor restart recommended.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Interface"), EditorOrder(311)]
+        public bool AutoSizePropertiesPanelSplitter { get; set; }
+
+        /// <summary>
         /// Gets or sets tree line visibility.
         /// </summary>
         [DefaultValue(true)]


### PR DESCRIPTION
This pr adds an editor option to auto size the splitter bar in the Properties panel (and other places that use `PropertiesList`) based on the longest property name.

https://github.com/user-attachments/assets/3e6a531d-a400-4199-b5fc-39343b961d40

There is an editor option to turn this on/ off (off by default).
![image](https://github.com/user-attachments/assets/d95d9739-ff65-497d-b95d-e761b722947c)




This is a really specific feature, but I asked on [discord](https://discord.com/channels/437989205315158016/437989205315158018/1350880471185231922) and people seem to want this.
