### PR TITLE
Add option to create a Canvas Scaler to the Widget create menu

### DIFF
--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -97,8 +97,8 @@ namespace FlaxEditor.Content.Create
             /// <summary>
             /// The mode used to initialize the widget.
             /// </summary>
-            [Tooltip("Whether to initialize the widget with a canvas or a control.")]
-            public WidgetMode WidgetInitializationMode = WidgetMode.Canvas;
+            [Tooltip("Whether to initialize the widget with a canvas or a control. Default value can be changed in the Interface Editor Options.")]
+            public WidgetMode WidgetInitializationMode = Editor.Instance.Options.Options.Interface.DefaultWidgetInitializationMode;
 
             bool ShowRoot => WidgetInitializationMode == WidgetMode.Control;
 

--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -109,6 +109,12 @@ namespace FlaxEditor.Content.Create
             [Tooltip("The control type of the root of the new Widget's root control."), VisibleIf(nameof(ShowRoot))]
             public Type RootControlType = typeof(Button);
 
+            /// <summary>
+            /// If a <see cref="CanvasScaler"/> should be added to the widget.
+            /// </summary>
+            [Tooltip("If checked, a Canvas Scaler will be added to the widget."), VisibleIf(nameof(ShowRoot), true)]
+            public bool AddCanvasScaler = true;
+
             private static bool IsValid(Type type)
             {
                 return (type.IsPublic || type.IsNestedPublic) && !type.IsAbstract && !type.IsGenericType;
@@ -158,6 +164,20 @@ namespace FlaxEditor.Content.Create
             else if (_options.WidgetInitializationMode == Options.WidgetMode.Canvas)
             {
                 actor = new UICanvas();
+                
+                if (_options.AddCanvasScaler)
+                {
+                    Actor canvasScaler;
+                    Control control = new CanvasScaler();
+
+                    canvasScaler = new UIControl
+                    {
+                        Control = control,
+                        Name = typeof(CanvasScaler).Name
+                    };
+
+                    canvasScaler.SetParent(actor, true);
+                }
             }
 
             if (actor == null)

--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -98,7 +98,7 @@ namespace FlaxEditor.Content.Create
             /// The mode used to initialize the widget.
             /// </summary>
             [Tooltip("Whether to initialize the widget with a canvas or a control.")]
-            public WidgetMode WidgetInitializationMode = WidgetMode.Control;
+            public WidgetMode WidgetInitializationMode = WidgetMode.Canvas;
 
             bool ShowRoot => WidgetInitializationMode == WidgetMode.Control;
 

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel;
+using FlaxEditor.Content.Create;
 using FlaxEditor.GUI.Docking;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -565,5 +566,11 @@ namespace FlaxEditor.Options
                     _smallFont = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets the default value used when creating a new widget.
+        /// </summary>
+        [EditorDisplay("Defaults"), EditorOrder(1000)]
+        public WidgetCreateEntry.Options.WidgetMode DefaultWidgetInitializationMode = WidgetCreateEntry.Options.WidgetMode.Control;
     }
 }


### PR DESCRIPTION
Closes #3272.

![image](https://github.com/user-attachments/assets/84629e22-32be-4d7d-b60b-154761c7d748)

This also changes the default mode to be `Canvas` instead of `Control`, I made [a poll on discord](https://discord.com/channels/437989205315158016/437989205315158018/1351329542584668160) to figure out what ppl prefer.

If Controls "wins" I will revert that change.
</br>
</br>
</br>
</br>
    
    
    

~~*(Maybe this could be made an editor setting so ppl can set their own default lmao)*~~
Haha guess what happened: Now they can