### PR TITLE
Show "No parameters" text when no parameters to be displayed in Preview tab

### DIFF
--- a/Source/Editor/Windows/Assets/AnimationGraphWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationGraphWindow.cs
@@ -149,6 +149,10 @@ namespace FlaxEditor.Windows.Assets
                                                         (instance, parameter, tag) => ((AnimationGraphWindow)instance).PreviewActor.GetParameterValue(parameter.Identifier),
                                                         (instance, value, parameter, tag) => ((AnimationGraphWindow)instance).PreviewActor.SetParameterValue(parameter.Identifier, value),
                                                         Values);
+
+                    // Parameters will always have one element
+                    if (parameters.Length < 2)
+                        layout.Label("No parameters", TextAlignment.Center);
                 }
             }
         }

--- a/Source/Editor/Windows/Assets/ParticleEmitterWindow.cs
+++ b/Source/Editor/Windows/Assets/ParticleEmitterWindow.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FlaxEditor.Content;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.Scripting;
@@ -104,6 +105,9 @@ namespace FlaxEditor.Windows.Assets
                                                         (instance, parameter, tag) => ((ParticleEmitterWindow)instance).Preview.PreviewActor.GetParameterValue(string.Empty, parameter.Name),
                                                         (instance, value, parameter, tag) => ((ParticleEmitterWindow)instance).Preview.PreviewActor.SetParameterValue(string.Empty, parameter.Name, value),
                                                         Values);
+
+                    if (!parameters.Any())
+                        layout.Label("No parameters", TextAlignment.Center);
                 }
             }
         }


### PR DESCRIPTION
This already existed in the Particle System editor:
![image](https://github.com/user-attachments/assets/2627e42d-ad4d-49f0-b079-2e2dbab8bd85)


So I added it to the Particle emitter editor:
![image](https://github.com/user-attachments/assets/7a82b744-dd10-43b5-b616-d340ed37beb2)

And Anim graph editor:
![image](https://github.com/user-attachments/assets/b9271e5e-7497-4af1-8d77-5d745c73bd46)


