### PR TITLE
Add search operator tooltip to scene tree search bar

### DIFF
--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -62,6 +62,7 @@ namespace FlaxEditor.Windows
                 AnchorPreset = AnchorPresets.HorizontalStretchMiddle,
                 Parent = headerPanel,
                 Bounds = new Rectangle(4, 4, headerPanel.Width - 8, 18),
+                TooltipText = "Search the scene tree.\n\nYou can prefix your search with different search operators:\ns: -> Actor with script of type\na: -> Actor type\nc: -> Control type",
             };
             _searchBox.TextChanged += OnSearchBoxTextChanged;
 


### PR DESCRIPTION
Addresses https://discord.com/channels/437989205315158016/438033006016462849/1351760929863503923.

![image](https://github.com/user-attachments/assets/ed3ef900-1be0-4b72-bb25-d1e5142a3af0)


This isn't an ideal but it's *a* solution, maybe we can do something better for 1.11?

I forget the search operators all the time and I'd much rather have this tooltip than nothing, so I think this is an improvement.