### PR TITLE
Put terrain info into own Properties panel group

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/TerrainEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/TerrainEditor.cs
@@ -2,6 +2,7 @@
 
 using FlaxEditor.Utilities;
 using FlaxEngine;
+using FlaxEngine.GUI;
 
 namespace FlaxEditor.CustomEditors.Dedicated
 {
@@ -33,8 +34,12 @@ namespace FlaxEditor.CustomEditors.Dedicated
                                             totalSize.X / Units.Meters2Units * 0.001f,
                                             totalSize.Z / Units.Meters2Units * 0.001f
                 );
-                var label = layout.Label(text);
+
+                var group = layout.Group("Info");
+                var label = group.Label(text);
                 label.Label.AutoHeight = true;
+                // Add a bit of padding to make it look nicer
+                label.Label.Margin = new Margin(3);
             }
         }
     }


### PR DESCRIPTION
Imo this looks way cleaner.

Before:
![image](https://github.com/user-attachments/assets/c2417980-57aa-4979-92e0-113ee395fded)

Now:
![image](https://github.com/user-attachments/assets/e46c1871-d75b-4401-adb0-315692c0ab4b)

If there are any other places in Flax that do stuff like this, lemme know.
