### PR TITLE
Make script compilation failed warning a bit nicer

### DIFF
--- a/Source/Engine/Level/Level.cpp
+++ b/Source/Engine/Level/Level.cpp
@@ -884,9 +884,9 @@ bool Level::loadScene(rapidjson_flax::Value& data, int32 engineBuild, Scene** ou
         if (!CommandLine::Options.Headless.IsTrue())
         {
             if (ScriptsBuilder::LastCompilationFailed())
-                MessageBox::Show(TEXT("Scripts compilation failed. Cannot load scene without game script modules. Please fix the compilation issues. See logs for more info."), TEXT("Failed to compile scripts"), MessageBoxButtons::OK, MessageBoxIcon::Error);
+                MessageBox::Show(TEXT("Script compilation failed.\n\nCannot load scene without game script modules. Please fix any compilation issues.\n\nSee Output Log or logs for more info."), TEXT("Failed to compile scripts"), MessageBoxButtons::OK, MessageBoxIcon::Error);
             else
-                MessageBox::Show(TEXT("Failed to load scripts. Cannot load scene without game script modules. See logs for more info."), TEXT("Missing game modules"), MessageBoxButtons::OK, MessageBoxIcon::Error);
+                MessageBox::Show(TEXT("Failed to load scripts.\n\nCannot load scene without game script modules.\n\nSee logs for more info."), TEXT("Missing game modules"), MessageBoxButtons::OK, MessageBoxIcon::Error);
         }
 #endif
         return true;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e1a2ac4e-6c17-4d64-a193-2cd80d2665ea)


Now:
![image](https://github.com/user-attachments/assets/9bd9cb75-c338-4488-903a-cf1033af72be)

I think the added linebreaks make it easier to read the message.