### PR TITLE
Disable "Remove" option in collections editor context menu if collection can not be resized

### DIFF
--- a/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
@@ -81,7 +81,7 @@ namespace FlaxEditor.CustomEditors.Editors
                 b.Enabled = Index + 1 < Editor.Count && !Editor._readOnly;
 
                 b = menu.AddButton("Remove", OnRemoveClicked);
-                b.Enabled = !Editor._readOnly;
+                b.Enabled = !Editor._readOnly && Editor._canResize;
             }
 
             /// <inheritdoc />


### PR DESCRIPTION
```cs
[Collection(CanResize = false)]
public String[] MyStringArray = new String[] { "Hello", "World", "Flax" };
[Collection(CanResize = false)]
public List<String> MyStringList = new List<String>() { "Hello", "World", "Flax" };
```

Before:
![image](https://github.com/user-attachments/assets/32c491b7-afa6-4490-b0a8-e2e2de86599b)


Now:
![image](https://github.com/user-attachments/assets/a905baa0-7519-4503-813d-1f7beeef900e)

Removing an element from a collection also means changing its size, so it's a good idea to disable the Remove option if the collection can not be resized imo.

This also means the user can no longer do weird stuff like delete one of the terrain layers in the Layers and Tags options.
