### PR TITLE
Improve custom Debug/ Output Log color options

### DIFF
--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -347,13 +347,6 @@ namespace FlaxEditor.Options
         }
 
         /// <summary>
-        /// Gets or sets the output log text color.
-        /// </summary>
-        [DefaultValue(typeof(Color), "1,1,1,1")]
-        [EditorDisplay("Output Log", "Text Color"), EditorOrder(430), Tooltip("The output log text color.")]
-        public Color OutputLogTextColor { get; set; } = Color.White;
-
-        /// <summary>
         /// Gets or sets the output log text shadow color.
         /// </summary>
         [DefaultValue(typeof(Color), "0,0,0,0.5")]
@@ -378,22 +371,6 @@ namespace FlaxEditor.Options
                 FocusOnPlayMode = value ? PlayModeFocus.GameWindow : PlayModeFocus.None;
             }
         }
-
-        /// <summary>
-        /// Gets or sets the output log text color for warnings
-        /// </summary>
-        [DefaultValue(typeof(Color), "1,1,0,1")]
-        [EditorDisplay("Output Log", "Warning Color"), EditorOrder(446), Tooltip("The output log text color for warnings.")]
-        public Color OutputLogWarningTextColor { get; set; } = Color.Yellow;
-
-
-        /// <summary>
-        /// Gets or sets the output log text color for errors
-        /// </summary>
-        [DefaultValue(typeof(Color), "1,0,0,1")]
-        [EditorDisplay("Output Log", "Error Color"), EditorOrder(445), Tooltip("The output log text color for errors.")]
-        public Color OutputLogErrorTextColor { get; set; } = Color.Red;
-
 
         /// <summary>
         /// Gets or sets a value indicating whether auto-focus output log window on code compilation error.

--- a/Source/Editor/Options/VisualOptions.cs
+++ b/Source/Editor/Options/VisualOptions.cs
@@ -115,5 +115,12 @@ namespace FlaxEditor.Options
         [DefaultValue(typeof(Color), "1,0,0,1")]
         [EditorDisplay("Log", "Error Color"), EditorOrder(1502), Tooltip("The color used for errors in the Debug and Output Log.")]
         public Color LogErrorColor { get; set; } = Color.Red;
+
+        /// <summary>
+        /// Gets or sets a value wether the Debug Log entry text color should use the set color.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Log", "Color Debug Log Text"), EditorOrder(1503), Tooltip("Wether to use the set colors in the text of a Debug Log entry.")]
+        public bool ColorDebugLogText = true;
     }
 }

--- a/Source/Editor/Options/VisualOptions.cs
+++ b/Source/Editor/Options/VisualOptions.cs
@@ -94,5 +94,26 @@ namespace FlaxEditor.Options
         [DefaultValue(true)]
         [EditorDisplay("Preview"), EditorOrder(1000)]
         public bool EnableParticlesPreview { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the output log text color.
+        /// </summary>
+        [DefaultValue(typeof(Color), "1,1,1,1")]
+        [EditorDisplay("Log", "Info Color"), EditorOrder(1500), Tooltip("The color used for info messages in the Debug and Output Log.")]
+        public Color LogInfoColor { get; set; } = Color.White;
+
+        /// <summary>
+        /// Gets or sets the output log text color for warnings
+        /// </summary>
+        [DefaultValue(typeof(Color), "1,1,0,1")]
+        [EditorDisplay("Log", "Warning Color"), EditorOrder(1501), Tooltip("The color used for warnings in the Debug and Output Log.")]
+        public Color LogWarningColor { get; set; } = Color.Yellow;
+
+        /// <summary>
+        /// Gets or sets the output log text color for errors
+        /// </summary>
+        [DefaultValue(typeof(Color), "1,0,0,1")]
+        [EditorDisplay("Log", "Error Color"), EditorOrder(1502), Tooltip("The color used for errors in the Debug and Output Log.")]
+        public Color LogErrorColor { get; set; } = Color.Red;
     }
 }

--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -125,7 +125,12 @@ namespace FlaxEditor.Windows
 
                 // Background
                 if (_window._selected == this)
-                    Render2D.FillRectangle(clientRect, IsFocused ? style.BackgroundSelected : style.LightBackground);
+                {
+                    Render2D.FillRectangle(clientRect, style.LightBackground);
+                    // Small rectangle to signal that entry is selected
+                    Rectangle selectionHighlightRect = clientRect with { Width = 5 };
+                    Render2D.FillRectangle(selectionHighlightRect, style.BackgroundSelected);
+                }
                 else if (IsMouseOver)
                     Render2D.FillRectangle(clientRect, style.BackgroundHighlighted);
                 else if (index % 2 == 0)
@@ -134,18 +139,19 @@ namespace FlaxEditor.Windows
                 var color = Group == LogGroup.Error ? _window._colorError : (Group == LogGroup.Warning ? _window._colorWarning : _window._colorInfo);
 
                 // Icon
-                Render2D.DrawSprite(Icon, new Rectangle(5, 0, 32, 32), color);
+                Render2D.DrawSprite(Icon, new Rectangle(8, 0, 32, 32), color);
 
                 // Title
-                var textRect = new Rectangle(38, 2, clientRect.Width - 40, clientRect.Height - 10);
+                var textRect = new Rectangle(43, 2, clientRect.Width - 40, clientRect.Height - 10);
                 Render2D.PushClip(ref clientRect);
+                bool coloredText = _window._colorDebugLogText;
                 if (LogCount == 1)
                 {
-                    Render2D.DrawText(style.FontMedium, Desc.Title, textRect, color);
+                    Render2D.DrawText(style.FontMedium, Desc.Title, textRect, coloredText ? color : style.Foreground);
                 }
                 else if (LogCount > 1)
                 {
-                    Render2D.DrawText(style.FontMedium, $"{Desc.Title} ({LogCount})", textRect, color);
+                    Render2D.DrawText(style.FontMedium, $"{Desc.Title} ({LogCount})", textRect, coloredText ? color : style.Foreground);
                 }
                 Render2D.PopClip();
             }
@@ -311,7 +317,8 @@ namespace FlaxEditor.Windows
         private Color _colorInfo;
         private Color _colorWarning;
         private Color _colorError;
-
+        private bool _colorDebugLogText;
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugLogWindow"/> class.
         /// </summary>
@@ -422,6 +429,7 @@ namespace FlaxEditor.Windows
             _colorInfo = options.Visual.LogInfoColor;
             _colorWarning = options.Visual.LogWarningColor;
             _colorError = options.Visual.LogErrorColor;
+            _colorDebugLogText = options.Visual.ColorDebugLogText;
         }
 
         /// <summary>

--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -419,9 +419,9 @@ namespace FlaxEditor.Windows
             _groupButtons[0].Checked = options.Interface.DebugLogShowErrorMessages;
             _groupButtons[1].Checked = options.Interface.DebugLogShowWarningMessages;
             _groupButtons[2].Checked = options.Interface.DebugLogShowInfoMessages;
-            _colorInfo = options.Interface.OutputLogTextColor;
-            _colorWarning = options.Interface.OutputLogWarningTextColor;
-            _colorError = options.Interface.OutputLogErrorTextColor;
+            _colorInfo = options.Visual.LogInfoColor;
+            _colorWarning = options.Visual.LogWarningColor;
+            _colorError = options.Visual.LogErrorColor;
         }
 
         /// <summary>

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -284,26 +284,26 @@ namespace FlaxEditor.Windows
             if (options.Interface.OutputLogTimestampsFormat == _timestampsFormats &&
                 options.Interface.OutputLogShowLogType == _showLogType &&
                 _output.DefaultStyle.Font == options.Interface.OutputLogTextFont &&
-                _output.DefaultStyle.Color == options.Interface.OutputLogTextColor &&
+                _output.DefaultStyle.Color == options.Visual.LogInfoColor &&
                 _output.DefaultStyle.ShadowColor == options.Interface.OutputLogTextShadowColor &&
                 _output.DefaultStyle.ShadowOffset == options.Interface.OutputLogTextShadowOffset &&
-                _output.WarningStyle.Color == options.Interface.OutputLogWarningTextColor &&
-                _output.ErrorStyle.Color == options.Interface.OutputLogErrorTextColor)
+                _output.WarningStyle.Color == options.Visual.LogWarningColor &&
+                _output.ErrorStyle.Color == options.Visual.LogErrorColor)
                 return;
 
             _output.DefaultStyle = new TextBlockStyle
             {
                 Font = options.Interface.OutputLogTextFont,
-                Color = options.Interface.OutputLogTextColor,
+                Color = options.Visual.LogInfoColor,
                 ShadowColor = options.Interface.OutputLogTextShadowColor,
                 ShadowOffset = options.Interface.OutputLogTextShadowOffset,
                 BackgroundSelectedBrush = new SolidColorBrush(Style.Current.BackgroundSelected),
             };
 
             _output.WarningStyle = _output.DefaultStyle;
-            _output.WarningStyle.Color = options.Interface.OutputLogWarningTextColor;
+            _output.WarningStyle.Color = options.Visual.LogWarningColor;
             _output.ErrorStyle = _output.DefaultStyle;
-            _output.ErrorStyle.Color = options.Interface.OutputLogErrorTextColor;
+            _output.ErrorStyle.Color = options.Visual.LogErrorColor;
 
             _timestampsFormats = options.Interface.OutputLogTimestampsFormat;
             _showLogType = options.Interface.OutputLogShowLogType;


### PR DESCRIPTION
I really like the new feature where you can customize the colors that are used for logging, but it made Debug Log entries hard to read in some cases (see Error message):
![image](https://github.com/user-attachments/assets/b75b0171-91db-4773-94be-6f9aab3c6f1d)

I am also not a huge fan of the text of the entry being colored as well, so I added an editor setting to toggle that behavior on/ off (on by default, can change that):
![image](https://github.com/user-attachments/assets/b0566774-9e2b-4de5-bc09-467acf227d32)
![image](https://github.com/user-attachments/assets/079c386f-8576-45af-b19d-bc640279b3e3)

Additionally, this pr moves all of the log color settings from the *Interface* editor settings category to "Visual". They make much more sense here, as they are a *visual* setting:
![image](https://github.com/user-attachments/assets/ae1bcc88-7d06-4161-a518-aefb1d8f3af5)

To further minimize the selection color clashing with the text color, this also changes how selected log entries are displayed.
Instead of coloring the whole entry in the selection color, there now is a small rectangle at the most left border of the entry and the entry is colored in a slightly brighter color than the rest:
![image](https://github.com/user-attachments/assets/309ce155-91b2-45e4-93f6-10ffbf56bcd6)

