### PR TITLE
Fix new messages being cut off in Debug Log

### DIFF
--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -707,13 +707,13 @@ namespace FlaxEditor.Windows
                     // Scroll to the new entry (if any added to view)
                     if (scrollView && anyVisible)
                     {
-                        panelScroll.ScrollViewTo(newEntry);
+                        panelScroll.ScrollViewTo(newEntry, true);
 
                         bool scrollViewNew = (panelScroll.VScrollBar.Maximum - panelScroll.VScrollBar.TargetValue) < LogEntry.DefaultHeight * 1.5f;
                         if (scrollViewNew != scrollView)
                         {
                             // Make sure scrolling doesn't stop in case too many entries were added at once
-                            panelScroll.ScrollViewTo(new Float2(float.MaxValue, float.MaxValue));
+                            panelScroll.ScrollViewTo(new Float2(float.MaxValue, float.MaxValue), true);
                         }
                     }
                 }


### PR DESCRIPTION
This happens when there are a lot of messages logged at once. Notice how the bottom message is always cut off:

https://github.com/user-attachments/assets/d7dcdf4b-f290-40c0-90fe-f1f1db52f7f6

This pr disables smooths scrolling when the panel auto scrolls to new messages, which fixes that problem:


https://github.com/user-attachments/assets/f4754d6d-ab27-460c-a4e1-759291618c34

