### PR TITLE
Fix Content Search (Ctrl + O) not clearing search string

### DIFF
--- a/Source/Editor/Windows/Search/ContentFinder.cs
+++ b/Source/Editor/Windows/Search/ContentFinder.cs
@@ -161,7 +161,7 @@ namespace FlaxEditor.Windows.Search
 
             // Setup
             _resultPanel.ScrollViewTo(Float2.Zero);
-            _searchBox.Text = string.Empty;
+            _searchBox.SelectionRange = new TextRange(0, _searchBox.TextLength);
             _searchBox.Focus();
         }
 


### PR DESCRIPTION
A few commits ago the Content Search search box started to keep around the search string, even after it was closed and reopened.

At first this was really irritating, but I have grown to love this behavior. It allows you to search for assets with similar names more efficiently.

This pr tweaks this behavior a bit, the old prompt will now be fully selected when the window reopens, so typing any key on the keyboard will essentially clear it. However, this also allows for the user to press the arrow keys (or click the desired position with the mouse), to re- use and/ or modify the previous prompt:

https://github.com/user-attachments/assets/f495de8e-ad32-41fe-a2c2-a3e954f92efa

I also removed old code that was supposed to handle clearing the searchbox.