### PR TITLE
Increase width of "Size" box to fit max collection size

### DIFF
--- a/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
@@ -557,7 +557,7 @@ namespace FlaxEditor.CustomEditors.Editors
                     MinValue = _minCount,
                     MaxValue = _maxCount,
                     AnchorPreset = AnchorPresets.TopRight,
-                    Bounds = new Rectangle(-40 - dropPanel.ItemsMargin.Right, y, 40, height),
+                    Bounds = new Rectangle(-55 - dropPanel.ItemsMargin.Right, y, 55, height),
                     Parent = dropPanel,
                 };
 
@@ -566,7 +566,7 @@ namespace FlaxEditor.CustomEditors.Editors
                     Text = "Size",
                     AnchorPreset = AnchorPresets.TopRight,
                     Bounds = new Rectangle(-_sizeBox.Width - 40 - dropPanel.ItemsMargin.Right - 2, y, 40, height),
-                    Parent = dropPanel
+                    Parent = dropPanel,
                 };
 
                 if (!_canResize || (NotNullItems && size == 0))


### PR DESCRIPTION
Addresses https://discord.com/channels/437989205315158016/538664104856911883/1356002487919837374

Adjusts the width of the "Size" int box to fit the max collection size (65535).

Before:
![image](https://github.com/user-attachments/assets/a65b0be0-cbe4-4630-a62c-dbe37a5ff4c5)

Now:
![image](https://github.com/user-attachments/assets/ec9a7aeb-e6fa-427e-9951-a5b35ee61e10)
