### PR TITLE
Fix text box shift not working when selection start is at the text length.

### DIFF
--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -742,7 +742,7 @@ namespace FlaxEngine.GUI
             {
                 SetSelection(SelectionRight);
             }
-            else if (SelectionRight < TextLength)
+            else if (SelectionRight < TextLength || (_selectionEnd < _selectionStart && _selectionStart == TextLength))
             {
                 int position;
                 if (ctrl)


### PR DESCRIPTION
Fix #3283 