### PR TITLE
Add some visual feedback on ranged value slider knob hover

### DIFF
--- a/Source/Editor/GUI/Input/SliderControl.cs
+++ b/Source/Editor/GUI/Input/SliderControl.cs
@@ -71,19 +71,24 @@ namespace FlaxEditor.GUI.Input
             public Action ValueChanged;
 
             /// <summary>
-            /// The color of the slider track line
+            /// The color of the slider track line.
             /// </summary>
             public Color TrackLineColor { get; set; }
 
             /// <summary>
-            /// The color of the slider thumb when it's not selected
+            /// The color of the slider thumb when it's not selected.
             /// </summary>
             public Color ThumbColor { get; set; }
 
             /// <summary>
-            /// The color of the slider thumb when it's selected
+            /// The color of the slider thumb when it's selected.
             /// </summary>
             public Color ThumbColorSelected { get; set; }
+
+            /// <summary>
+            /// The color of the slider thumb when it's hovered.
+            /// </summary>
+            public Color ThumbColorHovered { get; set; }
 
             /// <summary>
             /// Gets a value indicating whether user is using a slider.
@@ -112,6 +117,7 @@ namespace FlaxEditor.GUI.Input
                 TrackLineColor = style.BackgroundHighlighted;
                 ThumbColor = style.BackgroundNormal;
                 ThumbColorSelected = style.BackgroundSelected;
+                ThumbColorHovered = style.BackgroundHighlighted;
             }
 
             private void UpdateThumb()
@@ -151,7 +157,7 @@ namespace FlaxEditor.GUI.Input
                 Render2D.FillRectangle(lineRect, TrackLineColor);
 
                 // Draw thumb
-                Render2D.FillRectangle(_thumbRect, _isSliding ? ThumbColorSelected : ThumbColor);
+                Render2D.FillRectangle(_thumbRect, _isSliding ? ThumbColorSelected : (_thumbRect.Contains(PointFromWindow(Root.MousePosition)) ? ThumbColorHovered : ThumbColor));
             }
 
             /// <inheritdoc />


### PR DESCRIPTION
(Just imagine the mouse pointer directly over the slider knob)

Non hovered slider knob for reference:
![image](https://github.com/user-attachments/assets/766fa66f-b948-42e4-a356-108952e29ee1)


Before:
![image](https://github.com/user-attachments/assets/1b54e11b-d17a-4beb-af54-6c2c0e4b7cd0)



Now:
![image](https://github.com/user-attachments/assets/42d8ce4d-9cb5-4709-a420-36e741f91605)
