### PR TITLE
Add Scaled Time to Material Time node.

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1386,10 +1386,11 @@ namespace FlaxEditor.Surface.Archetypes
                 Title = "Time",
                 Description = "Game time constant",
                 Flags = NodeFlags.MaterialGraph,
-                Size = new Float2(110, 20),
+                Size = new Float2(110, 40),
                 Elements = new[]
                 {
-                    NodeElementArchetype.Factory.Output(0, "", typeof(float), 0),
+                    NodeElementArchetype.Factory.Output(0, "Scaled Time", typeof(float), 0),
+                    NodeElementArchetype.Factory.Output(1, "Unscaled Time", typeof(float), 1),
                 }
             },
             new NodeArchetype

--- a/Source/Engine/Graphics/Materials/GUIMaterialShader.cpp
+++ b/Source/Engine/Graphics/Materials/GUIMaterialShader.cpp
@@ -55,7 +55,7 @@ void GUIMaterialShader::Bind(BindParameters& params)
         materialData->ViewPos = Float3::Zero;
         materialData->ViewFar = 0.0f;
         materialData->ViewDir = Float3::Forward;
-        materialData->TimeParam = params.TimeParam;
+        materialData->TimeParam = params.UnscaledTimeParam;
         materialData->ViewInfo = Float4::Zero;
         auto& viewport = Render2D::GetViewport();
         materialData->ScreenSize = Float4(viewport.Width, viewport.Height, 1.0f / viewport.Width, 1.0f / viewport.Height);

--- a/Source/Engine/Graphics/Materials/IMaterial.h
+++ b/Source/Engine/Graphics/Materials/IMaterial.h
@@ -148,7 +148,8 @@ public:
         const ::DrawCall* DrawCall = nullptr;
         MaterialParamsLink* ParamsLink = nullptr;
         void* CustomData = nullptr;
-        float TimeParam;
+        float UnscaledTimeParam;
+        float ScaledTimeParam;
         bool Instanced = false;
 
         /// <summary>

--- a/Source/Engine/Graphics/Materials/MaterialShader.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialShader.cpp
@@ -30,7 +30,8 @@ GPU_CB_STRUCT(MaterialShaderDataPerView {
     Float3 ViewPos;
     float ViewFar;
     Float3 ViewDir;
-    float TimeParam;
+    float UnscaledTimeParam;
+    float ScaledTimeParam;
     Float4 ViewInfo;
     Float4 ScreenSize;
     Float4 TemporalAAJitter;
@@ -41,7 +42,8 @@ GPU_CB_STRUCT(MaterialShaderDataPerView {
 IMaterial::BindParameters::BindParameters(::GPUContext* context, const ::RenderContext& renderContext)
     : GPUContext(context)
     , RenderContext(renderContext)
-    , TimeParam(Time::Draw.UnscaledTime.GetTotalSeconds())
+    , UnscaledTimeParam(Time::Draw.UnscaledTime.GetTotalSeconds())
+    , ScaledTimeParam(Time::Draw.Time.GetTotalSeconds())
 {
 }
 
@@ -49,7 +51,8 @@ IMaterial::BindParameters::BindParameters(::GPUContext* context, const ::RenderC
     : GPUContext(context)
     , RenderContext(renderContext)
     , DrawCall(&drawCall)
-    , TimeParam(Time::Draw.UnscaledTime.GetTotalSeconds())
+    , UnscaledTimeParam(Time::Draw.UnscaledTime.GetTotalSeconds())
+    , ScaledTimeParam(Time::Draw.Time.GetTotalSeconds())
     , Instanced(instanced)
 {
 }
@@ -77,7 +80,8 @@ void IMaterial::BindParameters::BindViewData()
     cb.ViewPos = view.Position;
     cb.ViewFar = view.Far;
     cb.ViewDir = view.Direction;
-    cb.TimeParam = TimeParam;
+    cb.UnscaledTimeParam = UnscaledTimeParam;
+    cb.ScaledTimeParam = ScaledTimeParam;
     cb.ViewInfo = view.ViewInfo;
     cb.ScreenSize = view.ScreenSize;
     cb.TemporalAAJitter = view.TemporalAAJitter;

--- a/Source/Engine/Graphics/Materials/PostFxMaterialShader.cpp
+++ b/Source/Engine/Graphics/Materials/PostFxMaterialShader.cpp
@@ -51,7 +51,7 @@ void PostFxMaterialShader::Bind(BindParameters& params)
         materialData->ViewPos = view.Position;
         materialData->ViewFar = view.Far;
         materialData->ViewDir = view.Direction;
-        materialData->TimeParam = params.TimeParam;
+        materialData->TimeParam = params.UnscaledTimeParam;
         materialData->ViewInfo = view.ViewInfo;
         materialData->ScreenSize = view.ScreenSize;
         materialData->TemporalAAJitter = view.TemporalAAJitter;

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Tools.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Tools.cpp
@@ -49,7 +49,19 @@ void MaterialGenerator::ProcessGroupTools(Box* box, Node* node, Value& value)
     // Time
     case 3:
     {
-        value = getTime;
+        switch (box->ID)
+        {
+        // Scaled Time
+        case 0:
+            value = getScaledTime;
+            break;
+        // Unscaled Time
+        case 1:
+            value = getUnscaledTime;
+            break;
+        default:
+            break;
+        }
         break;
     }
     // Panner
@@ -57,7 +69,7 @@ void MaterialGenerator::ProcessGroupTools(Box* box, Node* node, Value& value)
     {
         // Get inputs
         const Value uv = tryGetValue(node->GetBox(0), getUVs).AsFloat2();
-        const Value time = tryGetValue(node->GetBox(1), getTime).AsFloat();
+        const Value time = tryGetValue(node->GetBox(1), getUnscaledTime).AsFloat();
         const Value speed = tryGetValue(node->GetBox(2), Value::One).AsFloat2();
         const bool useFractionalPart = (bool)node->Values[0];
 

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.cpp
@@ -106,7 +106,8 @@ bool FeatureData::Init()
 }
 
 MaterialValue MaterialGenerator::getUVs(VariantType::Float2, TEXT("input.TexCoord"));
-MaterialValue MaterialGenerator::getTime(VariantType::Float, TEXT("TimeParam"));
+MaterialValue MaterialGenerator::getUnscaledTime(VariantType::Float, TEXT("UnscaledTimeParam"));
+MaterialValue MaterialGenerator::getScaledTime(VariantType::Float, TEXT("ScaledTimeParam"));
 MaterialValue MaterialGenerator::getNormal(VariantType::Float3, TEXT("input.TBN[2]"));
 MaterialValue MaterialGenerator::getNormalZero(VariantType::Float3, TEXT("float3(0, 0, 1)"));
 MaterialValue MaterialGenerator::getVertexColor(VariantType::Float4, TEXT("GetVertexColor(input)"));

--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.h
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.h
@@ -120,7 +120,6 @@ private:
     MaterialValue _ddx, _ddy, _cameraVector;
 
 public:
-
     MaterialGenerator();
     ~MaterialGenerator();
 
@@ -210,7 +209,8 @@ private:
 public:
 
     static MaterialValue getUVs;
-    static MaterialValue getTime;
+    static MaterialValue getUnscaledTime;
+    static MaterialValue getScaledTime;
     static MaterialValue getNormal;
     static MaterialValue getNormalZero;
     static MaterialValue getVertexColor;

--- a/Source/Shaders/MaterialCommon.hlsl
+++ b/Source/Shaders/MaterialCommon.hlsl
@@ -167,7 +167,8 @@ cbuffer ViewData : register(b1)
     float3 ViewPos;
     float ViewFar;
     float3 ViewDir;
-    float TimeParam;
+    float UnscaledTimeParam;
+    float ScaledTimeParam;
     float4 ViewInfo;
     float4 ScreenSize;
     float4 TemporalAAJitter;


### PR DESCRIPTION
Closes #3299.

This is a breaking change to existing materials that use  the Time node. Another options to make this less of a breaking change is to add another node for scaled time and leave the existing time node as is.