### PR TITLE
Clean up actor Add context menu in the scene tree

### DIFF
--- a/Source/Engine/Animations/SceneAnimations/SceneAnimationPlayer.h
+++ b/Source/Engine/Animations/SceneAnimations/SceneAnimationPlayer.h
@@ -11,7 +11,7 @@
 /// <summary>
 /// The scene animation playback actor.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Other/Scene Animation\"), ActorToolbox(\"Other\", \"Scene Animation\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Animation/Scene Animation\"), ActorToolbox(\"Other\", \"Scene Animation\")")
 class FLAXENGINE_API SceneAnimationPlayer : public Actor, public IPostFxSettingsProvider
 {
     DECLARE_SCENE_OBJECT(SceneAnimationPlayer);

--- a/Source/Engine/Level/Actors/AnimatedModel.h
+++ b/Source/Engine/Level/Actors/AnimatedModel.h
@@ -12,7 +12,7 @@
 /// <summary>
 /// Performs an animation and renders a skinned model.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Other/Animated Model\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Animation/Animated Model\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API AnimatedModel : public ModelInstanceActor
 {
     DECLARE_SCENE_OBJECT(AnimatedModel);

--- a/Source/Engine/Level/Actors/BoneSocket.h
+++ b/Source/Engine/Level/Actors/BoneSocket.h
@@ -7,7 +7,7 @@
 /// <summary>
 /// Actor that links to the animated model skeleton node transformation.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Other/Bone Socket\"), ActorToolbox(\"Other\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Animation/Bone Socket\"), ActorToolbox(\"Other\")")
 class FLAXENGINE_API BoneSocket : public Actor
 {
     DECLARE_SCENE_OBJECT(BoneSocket);

--- a/Source/Engine/Level/Actors/BoxBrush.h
+++ b/Source/Engine/Level/Actors/BoxBrush.h
@@ -65,7 +65,7 @@ public:
 /// <summary>
 /// Performs CSG box brush operation that adds or removes geometry.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Other/Box Brush\"), ActorToolbox(\"Other\", \"CSG Box Brush\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Other/CSG Box Brush\"), ActorToolbox(\"Other\", \"CSG Box Brush\")")
 class FLAXENGINE_API BoxBrush : public Actor, public CSG::Brush
 {
     DECLARE_SCENE_OBJECT(BoxBrush);

--- a/Source/Engine/Level/Actors/EnvironmentProbe.h
+++ b/Source/Engine/Level/Actors/EnvironmentProbe.h
@@ -10,7 +10,7 @@
 /// <summary>
 /// Environment Probe can capture space around the objects to provide reflections.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & Effects/Environment Probe\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & PostFX/Environment Probe\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API EnvironmentProbe : public Actor
 {
     DECLARE_SCENE_OBJECT(EnvironmentProbe);

--- a/Source/Engine/Level/Actors/EnvironmentProbe.h
+++ b/Source/Engine/Level/Actors/EnvironmentProbe.h
@@ -10,7 +10,7 @@
 /// <summary>
 /// Environment Probe can capture space around the objects to provide reflections.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Environment Probe\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & Effects/Environment Probe\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API EnvironmentProbe : public Actor
 {
     DECLARE_SCENE_OBJECT(EnvironmentProbe);

--- a/Source/Engine/Level/Actors/ExponentialHeightFog.h
+++ b/Source/Engine/Level/Actors/ExponentialHeightFog.h
@@ -12,7 +12,7 @@
 /// <summary>
 /// Used to create fogging effects such as clouds but with a density that is related to the height of the fog.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Exponential Height Fog\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & Effects/Exponential Height Fog\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API ExponentialHeightFog : public Actor, public IFogRenderer
 {
     DECLARE_SCENE_OBJECT(ExponentialHeightFog);

--- a/Source/Engine/Level/Actors/ExponentialHeightFog.h
+++ b/Source/Engine/Level/Actors/ExponentialHeightFog.h
@@ -12,7 +12,7 @@
 /// <summary>
 /// Used to create fogging effects such as clouds but with a density that is related to the height of the fog.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & Effects/Exponential Height Fog\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & PostFX/Exponential Height Fog\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API ExponentialHeightFog : public Actor, public IFogRenderer
 {
     DECLARE_SCENE_OBJECT(ExponentialHeightFog);

--- a/Source/Engine/Level/Actors/PostFxVolume.h
+++ b/Source/Engine/Level/Actors/PostFxVolume.h
@@ -9,7 +9,7 @@
 /// <summary>
 /// A special type of volume that blends custom set of post process settings into the rendering.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Post Fx Volume\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & Effects/Post Fx Volume\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API PostFxVolume : public BoxVolume, public IPostFxSettingsProvider
 {
     DECLARE_SCENE_OBJECT(PostFxVolume);

--- a/Source/Engine/Level/Actors/PostFxVolume.h
+++ b/Source/Engine/Level/Actors/PostFxVolume.h
@@ -9,7 +9,7 @@
 /// <summary>
 /// A special type of volume that blends custom set of post process settings into the rendering.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & Effects/Post Fx Volume\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Lighting & PostFX/Post Fx Volume\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API PostFxVolume : public BoxVolume, public IPostFxSettingsProvider
 {
     DECLARE_SCENE_OBJECT(PostFxVolume);

--- a/Source/Engine/Level/Actors/Sky.h
+++ b/Source/Engine/Level/Actors/Sky.h
@@ -14,7 +14,7 @@ class GPUPipelineState;
 /// <summary>
 /// Sky actor renders atmosphere around the scene with fog and sky.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Sky\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Sky/Sky\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API Sky : public Actor, public IAtmosphericFogRenderer, public ISkyRenderer
 {
     DECLARE_SCENE_OBJECT(Sky);

--- a/Source/Engine/Level/Actors/Skybox.h
+++ b/Source/Engine/Level/Actors/Skybox.h
@@ -11,7 +11,7 @@
 /// <summary>
 /// Skybox actor renders sky using custom cube texture or material.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Sky Box\"), ActorToolbox(\"Visuals\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Visuals/Sky/Sky Box\"), ActorToolbox(\"Visuals\")")
 class FLAXENGINE_API Skybox : public Actor, public ISkyRenderer
 {
     DECLARE_SCENE_OBJECT(Skybox);

--- a/Source/Engine/Navigation/NavLink.h
+++ b/Source/Engine/Navigation/NavLink.h
@@ -7,7 +7,7 @@
 /// <summary>
 /// The off-mesh link objects used to define a custom point-to-point edge within the navigation graph. An off-mesh connection is a user defined traversable connection made up to two vertices, at least one of which resides within a navigation mesh polygon allowing movement outside the navigation mesh.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Other/Nav Link\"), ActorToolbox(\"Other\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Navigation/Nav Link\"), ActorToolbox(\"Other\")")
 class FLAXENGINE_API NavLink : public Actor
 {
     DECLARE_SCENE_OBJECT(NavLink);

--- a/Source/Engine/Navigation/NavMesh.h
+++ b/Source/Engine/Navigation/NavMesh.h
@@ -14,7 +14,8 @@ class NavMeshRuntime;
 /// <summary>
 /// The navigation mesh actor that holds a navigation data for a scene.
 /// </summary>
-API_CLASS() class FLAXENGINE_API NavMesh : public Actor
+API_CLASS(Attributes = "ActorContextMenu(\"New/Navigation/Nav Mesh\")") 
+class FLAXENGINE_API NavMesh : public Actor
 {
     DECLARE_SCENE_OBJECT(NavMesh);
 public:

--- a/Source/Engine/Navigation/NavMeshBoundsVolume.h
+++ b/Source/Engine/Navigation/NavMeshBoundsVolume.h
@@ -8,7 +8,7 @@
 /// <summary>
 /// A special type of volume that defines the area of the scene in which navigation meshes are generated.
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Other/Nav Mesh Bounds Volume\"), ActorToolbox(\"Other\")")
+API_CLASS(Attributes="ActorContextMenu(\"New/Navigation/Nav Mesh Bounds Volume\"), ActorToolbox(\"Other\")")
 class FLAXENGINE_API NavMeshBoundsVolume : public BoxVolume
 {
     DECLARE_SCENE_OBJECT(NavMeshBoundsVolume);

--- a/Source/Engine/Navigation/NavModifierVolume.h
+++ b/Source/Engine/Navigation/NavModifierVolume.h
@@ -8,7 +8,7 @@
 /// <summary>
 /// A special type of volume that defines the area of the scene in which navigation is restricted (eg. higher traversal cost or dynamic obstacle block).
 /// </summary>
-API_CLASS(Attributes="ActorContextMenu(\"New/Other/Nav Modifier Volume\"), ActorToolbox(\"Other\")") class FLAXENGINE_API NavModifierVolume : public BoxVolume
+API_CLASS(Attributes="ActorContextMenu(\"New/Navigation/Nav Modifier Volume\"), ActorToolbox(\"Other\")") class FLAXENGINE_API NavModifierVolume : public BoxVolume
 {
     DECLARE_SCENE_OBJECT(NavModifierVolume);
 public:


### PR DESCRIPTION
This cleans up the actor add context menu:



https://github.com/user-attachments/assets/21ff821b-c502-4ace-81c7-2125e0740b6e




I think these changes make the menu easier and faster to navigate, but I'm open for feedback on that.

Closes #2887.

