### PR TITLE
Move box collider utility in own Properties Panel category

### DIFF
--- a/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
+++ b/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
@@ -26,11 +26,13 @@ namespace FlaxEditor.SceneGraph.Actors
         {
             base.Initialize(layout);
 
-            layout.Space(20f);
-            var checkbox = layout.Checkbox("Keep Local Orientation", "Keeps the local orientation when resizing.").CheckBox;
+            var group = layout.Group("Utility");
+            var checkbox = group.Checkbox("Keep Local Orientation", "Keeps the local orientation when resizing.").CheckBox;
             checkbox.Checked = _keepLocalOrientation;
             checkbox.StateChanged += box => _keepLocalOrientation = box.Checked;
-            layout.Button("Resize to Fit", Editor.Instance.CodeDocs.GetTooltip(new ScriptMemberInfo(typeof(BoxCollider).GetMethod("AutoResize")))).Button.Clicked += OnResizeClicked;
+            group.Button("Resize to Fit", Editor.Instance.CodeDocs.GetTooltip(new ScriptMemberInfo(typeof(BoxCollider).GetMethod("AutoResize")))).Button.Clicked += OnResizeClicked;
+            // This adds a bit of space between the button and the bottom of the group - even with a height of 0
+            group.Space(0);
         }
 
         private void OnResizeClicked()


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/5ff8f842-1ab7-426a-9119-fba417091a8f)


Now:
![image](https://github.com/user-attachments/assets/f0f20111-3b35-4e7e-a0bd-00dd5e913ccb)
