### PR TITLE
Add primitive meshes to toolbox search

### DIFF
--- a/Source/Editor/Windows/ToolboxWindow.cs
+++ b/Source/Editor/Windows/ToolboxWindow.cs
@@ -101,6 +101,7 @@ namespace FlaxEditor.Windows
         private TextBox _searchBox;
         private ContainerControl _groupSearch;
         private Tabs _actorGroups;
+        private ContainerControl groupPrimitives;
 
         /// <summary>
         /// The editor instance.
@@ -192,13 +193,13 @@ namespace FlaxEditor.Windows
             }
 
             // Setup primitives tabs
-            var groupBasicModels = CreateGroupWithList(_actorGroups, "Basic Models");
-            groupBasicModels.AddChild(CreateEditorAssetItem("Cube", "Primitives/Cube.flax"));
-            groupBasicModels.AddChild(CreateEditorAssetItem("Sphere", "Primitives/Sphere.flax"));
-            groupBasicModels.AddChild(CreateEditorAssetItem("Plane", "Primitives/Plane.flax"));
-            groupBasicModels.AddChild(CreateEditorAssetItem("Cylinder", "Primitives/Cylinder.flax"));
-            groupBasicModels.AddChild(CreateEditorAssetItem("Cone", "Primitives/Cone.flax"));
-            groupBasicModels.AddChild(CreateEditorAssetItem("Capsule", "Primitives/Capsule.flax"));
+            groupPrimitives = CreateGroupWithList(_actorGroups, "Primitives");
+            groupPrimitives.AddChild(CreateEditorAssetItem("Cube", "Primitives/Cube.flax"));
+            groupPrimitives.AddChild(CreateEditorAssetItem("Sphere", "Primitives/Sphere.flax"));
+            groupPrimitives.AddChild(CreateEditorAssetItem("Plane", "Primitives/Plane.flax"));
+            groupPrimitives.AddChild(CreateEditorAssetItem("Cylinder", "Primitives/Cylinder.flax"));
+            groupPrimitives.AddChild(CreateEditorAssetItem("Cone", "Primitives/Cone.flax"));
+            groupPrimitives.AddChild(CreateEditorAssetItem("Capsule", "Primitives/Capsule.flax"));
 
             // Created first to order specific tabs
             CreateGroupWithList(_actorGroups, "Lights");
@@ -346,7 +347,35 @@ namespace FlaxEditor.Windows
                 }
                 item.SetHighlights(highlights);
             }
-            
+
+            // Hack primitive models into the search results
+            foreach (var child in groupPrimitives.Children)
+            {
+                if (child is Item primitiveAssetItem)
+                {
+                    String text = primitiveAssetItem.Text;
+
+                    if (!QueryFilterHelper.Match(filterText, text, out QueryFilterHelper.Range[] ranges))
+                        continue;
+
+                    // Rebuild the path based on item name (it would be better to convert the drag data back to a string somehow)
+                    string path = $"Primitives/{text}.flax";
+                    var item = _groupSearch.AddChild(CreateEditorAssetItem(text, path));
+
+                    var highlights = new List<Rectangle>(ranges.Length);
+                    var style = Style.Current;
+                    var font = style.FontSmall;
+                    var textRect = item.TextRect;
+                    for (int i = 0; i < ranges.Length; i++)
+                    {
+                        var start = font.GetCharPosition(text, ranges[i].StartIndex);
+                        var end = font.GetCharPosition(text, ranges[i].EndIndex);
+                        highlights.Add(new Rectangle(start.X + textRect.X, textRect.Y, end.X - start.X, textRect.Height));
+                    }
+                    item.SetHighlights(highlights);
+                }
+            }
+
             if (string.IsNullOrEmpty(filterText))
                 _groupSearch.SortChildren();
 
@@ -357,8 +386,10 @@ namespace FlaxEditor.Windows
 
         private Item CreateEditorAssetItem(string name, string path)
         {
-            path = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor", path);
-            return new Item(name, GUI.Drag.DragItems.GetDragData(path));
+            string globalPath = StringUtils.CombinePaths(Globals.EngineContentFolder, "Editor", path);
+            Item item = new Item(name, GUI.Drag.DragItems.GetDragData(globalPath));
+            item.TooltipText = $"{path}\nActor with a {name} asset.";
+            return item;
         }
 
         private Item CreateActorItem(string name, ScriptType type)


### PR DESCRIPTION
This adds the primitive models/ basic models to the search in the Toolbox search:

https://github.com/user-attachments/assets/9e9406bc-6e5d-41fc-b65c-52921170c753

I also renamed the tab from "Basic Models" to "Primitives" as imo that name fits a bit better, and I added a tooltip to the primitives.

One thing that could be improved is how this rebuilds the path in L 362. Is there any way of converting the drag data back to a string?

This also closes/ addresses #3209

