### PR TITLE
Improve UX of and expand on new add collision options

### DIFF
--- a/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
+++ b/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
@@ -28,6 +28,26 @@ namespace FlaxEditor.SceneGraph.Actors
         private Transform _selectionPointsTransform;
         private Model _selectionPointsModel;
 
+        /// <summary>
+        /// Wether the model of the static model is one of the primitive models.
+        /// </summary>
+        public bool IsPrimitive
+        {
+            get
+            {
+                Model model = ((StaticModel)Actor).Model;
+
+                if (!model)
+                    return false;
+
+                string modelPath = model.Path;
+                return modelPath.EndsWith("/Primitives/Cube.flax", StringComparison.Ordinal) ||
+                modelPath.EndsWith("/Primitives/Sphere.flax", StringComparison.Ordinal) ||
+                modelPath.EndsWith("/Primitives/Plane.flax", StringComparison.Ordinal) ||
+                modelPath.EndsWith("/Primitives/Capsule.flax", StringComparison.Ordinal);
+            }
+        }
+
         /// <inheritdoc />
         public StaticModelNode(Actor actor)
         : base(actor)
@@ -101,12 +121,43 @@ namespace FlaxEditor.SceneGraph.Actors
         {
             base.OnContextMenu(contextMenu, window);
 
+            // Check that every selected node is a primitive...
+            var selection = Array.Empty<SceneGraphNode>();
+            if (window is SceneTreeWindow)
+                selection = Editor.Instance.SceneEditing.Selection.ToArray();
+            else if (window is PrefabWindow prefabWindow)
+                selection = prefabWindow.Selection.ToArray();
+
+            bool autoOptionEnabled = true;
+            foreach (var node in selection)
+            {
+                if (node is not StaticModelNode staticModelNode)
+                    continue;
+                var actor = (StaticModel)staticModelNode.Actor;
+                var model = ((StaticModel)staticModelNode.Actor).Model;
+                if (!model)
+                    continue;
+                if (!staticModelNode.IsPrimitive)
+                {
+                    autoOptionEnabled = false;
+                    break;
+                }
+            }            
+
             var menu = contextMenu.AddChildMenu("Add collider");
             menu.Enabled = ((StaticModel)Actor).Model != null;
-            menu.ContextMenu.AddButton("Box", () => OnAddCollider(window, CreateBox));
-            menu.ContextMenu.AddButton("Sphere", () => OnAddCollider(window, CreateSphere));
-            menu.ContextMenu.AddButton("Convex", () => OnAddCollider(window, CreateConvex));
-            menu.ContextMenu.AddButton("Triangle Mesh", () => OnAddCollider(window, CreateTriangle));
+            var b = menu.ContextMenu.AddButton("Auto", () => OnAddCollider(window, CreateAuto));
+            b.TooltipText = "Add the best fitting collider to every model that uses an in-built Editor primitive.";
+            // ... and if not, disable the "Auto" option
+            b.Enabled = autoOptionEnabled;
+            b = menu.ContextMenu.AddButton("Box", () => OnAddCollider(window, CreateBox));
+            b.TooltipText = "Add a box collider to every selected model that will auto resize based on the model bounds.";
+            b = menu.ContextMenu.AddButton("Sphere", () => OnAddCollider(window, CreateSphere));
+            b.TooltipText = "Add a sphere collider to every selected model that will auto resize based on the model bounds.";
+            b = menu.ContextMenu.AddButton("Convex", () => OnAddCollider(window, CreateConvex));
+            b.TooltipText = "Generate and add a convex collider for every selected model.";
+            b = menu.ContextMenu.AddButton("Triangle Mesh", () => OnAddCollider(window, CreateTriangle));
+            b.TooltipText = "Generate and add a triangle mesh collider for every selected model.";
         }
 
         /// <inheritdoc />
@@ -150,6 +201,50 @@ namespace FlaxEditor.SceneGraph.Actors
 
         private delegate void Spawner(Collider collider);
         private delegate void CreateCollider(StaticModel actor, Spawner spawner, bool singleNode);
+
+        private void CreateAuto(StaticModel actor, Spawner spawner, bool singleNode)
+        {
+            // Special case for in-built Editor models that can use analytical collision
+            Model model = actor.Model;
+            var modelPath = model.Path;
+            if (modelPath.EndsWith("/Primitives/Cube.flax", StringComparison.Ordinal))
+            {
+                var collider = new BoxCollider
+                {
+                    Transform = actor.Transform,
+                };
+                spawner(collider);
+            }
+            else if (modelPath.EndsWith("/Primitives/Sphere.flax", StringComparison.Ordinal))
+            {
+                var collider = new SphereCollider
+                {
+                    Transform = actor.Transform,
+                };
+                spawner(collider);
+                collider.LocalTransform = Transform.Identity;
+            }
+            else if (modelPath.EndsWith("/Primitives/Plane.flax", StringComparison.Ordinal))
+            {
+                spawner(new BoxCollider
+                {
+                    Transform = actor.Transform,
+                    Size = new Float3(100.0f, 100.0f, 1.0f),
+                });
+            }
+            else if (modelPath.EndsWith("/Primitives/Capsule.flax", StringComparison.Ordinal))
+            {
+                var collider = new CapsuleCollider
+                {
+                    Transform = actor.Transform,
+                    Radius = 25.0f,
+                    Height = 50.0f,
+                };
+                spawner(collider);
+                collider.LocalPosition = new Vector3(0, 50.0f, 0);
+                collider.LocalOrientation = Quaternion.Euler(0, 0, 90.0f);
+            }
+        }
 
         private void CreateBox(StaticModel actor, Spawner spawner, bool singleNode)
         {
@@ -226,50 +321,6 @@ namespace FlaxEditor.SceneGraph.Actors
                     var colliderNode = window is PrefabWindow prefabWindow ? prefabWindow.Graph.Root.Find(collider) : Editor.Instance.Scene.GetActorNode(collider);
                     createdNodes.Add(colliderNode);
                 };
-
-                // Special case for in-built Editor models that can use analytical collision
-                var modelPath = model.Path;
-                if (modelPath.EndsWith("/Primitives/Cube.flax", StringComparison.Ordinal))
-                {
-                    var collider = new BoxCollider
-                    {
-                        Transform = actor.Transform,
-                    };
-                    spawner(collider);
-                    continue;
-                }
-                if (modelPath.EndsWith("/Primitives/Sphere.flax", StringComparison.Ordinal))
-                {
-                    var collider = new SphereCollider
-                    {
-                        Transform = actor.Transform,
-                    };
-                    spawner(collider);
-                    collider.LocalTransform = Transform.Identity;
-                    continue;
-                }
-                if (modelPath.EndsWith("/Primitives/Plane.flax", StringComparison.Ordinal))
-                {
-                    spawner(new BoxCollider
-                    {
-                        Transform = actor.Transform,
-                        Size = new Float3(100.0f, 100.0f, 1.0f),
-                    });
-                    continue;
-                }
-                if (modelPath.EndsWith("/Primitives/Capsule.flax", StringComparison.Ordinal))
-                {
-                    var collider = new CapsuleCollider
-                    {
-                        Transform = actor.Transform,
-                        Radius = 25.0f,
-                        Height = 50.0f,
-                    };
-                    spawner(collider);
-                    collider.LocalPosition = new Vector3(0, 50.0f, 0);
-                    collider.LocalOrientation = Quaternion.Euler(0, 0, 90.0f);
-                    continue;
-                }
 
                 createCollider(actor, spawner, selection.Length == 1);
             }

--- a/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
+++ b/Source/Editor/SceneGraph/Actors/StaticModelNode.cs
@@ -133,9 +133,7 @@ namespace FlaxEditor.SceneGraph.Actors
             {
                 if (node is not StaticModelNode staticModelNode)
                     continue;
-                var actor = (StaticModel)staticModelNode.Actor;
-                var model = ((StaticModel)staticModelNode.Actor).Model;
-                if (!model)
+                if (!((StaticModel)staticModelNode.Actor).Model)
                     continue;
                 if (!staticModelNode.IsPrimitive)
                 {


### PR DESCRIPTION
The new add collision option is great, but I found it kinda unintuitive that the Box and Sphere options add a shape based on the selected primitive type (-> that's what the "Auto" option now does)

This pr does the following:
- Makes the Box and Sphere buttons add a box and sphere no matter what primitive the model is
- Adds an auto option to add either a Sphere, Box, Capsule or "Plane" collider to every selected model based on what primitive it is
- Disable the "Auto" option if the selection contains one or more non- primitive models
- Add tooltips

This
![image](https://github.com/user-attachments/assets/b66525a4-8794-451b-b66d-afbcf816c822)

results in the pressed collider type being (generated &) added to every selected model.

This 
![image](https://github.com/user-attachments/assets/4facb6f5-b451-4bca-ae77-5e34747b4f08)

either do the above, or, when the "Auto" button is pressed, it will add the best fitting primitive collider based on the primitive type.