### PR TITLE
Add a hint to the Output Log if there are no messages shown because of filters

### DIFF
--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -767,6 +767,24 @@ namespace FlaxEditor.Windows
             }
         }
 
+        /// <inheritdoc/>
+        public override void Draw()
+        {
+            base.Draw();
+
+            bool showHint = (((int)LogType.Info & _logTypeShowMask) == 0 &&
+                            ((int)LogType.Warning & _logTypeShowMask) == 0 &&
+                            ((int)LogType.Error & _logTypeShowMask) == 0) ||
+                            String.IsNullOrEmpty(_output.Text);
+
+            if (showHint)
+            {
+                var textRect = _output.Bounds;
+                var style = Style.Current;
+                Render2D.DrawText(style.FontMedium, "No log level filter active or no entries that apply to the current filter exist.", textRect, style.ForegroundGrey, TextAlignment.Center, TextAlignment.Center, TextWrapping.WrapWords);
+            }
+        }
+
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {


### PR DESCRIPTION
The warning will show if either there are no filters enabled or there are no log entries that can be shown given the current filter.

![image](https://github.com/user-attachments/assets/1ec7fb3e-d573-4fad-9a72-15900a5b8ed4)
