### PR TITLE
Fix error in LocalizationSettingsEditor after adding new locales

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/LocalizationSettingsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/LocalizationSettingsEditor.cs
@@ -137,7 +137,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                                 table.Entries = entries;
                                 if (!table.Save(path))
                                 {
-                                    Object.Destroy(table);
+                                    Object.DestroyNow(table);
                                     newTables.Add(FlaxEngine.Content.LoadAsync<LocalizedStringTable>(path));
                                 }
                             }
@@ -153,7 +153,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                             table.Locale = culture.Name;
                             if (!table.Save(path))
                             {
-                                Object.Destroy(table);
+                                Object.DestroyNow(table);
                                 newTables.Add(FlaxEngine.Content.LoadAsync<LocalizedStringTable>(path));
                             }
                         }

--- a/Source/Engine/Content/JsonAsset.cpp
+++ b/Source/Engine/Content/JsonAsset.cpp
@@ -172,7 +172,7 @@ bool JsonAssetBase::Save(const StringView& path)
     rapidjson_flax::StringBuffer buffer;
     PrettyJsonWriter writerObj(buffer);
     _isResaving = true;
-    Save(writerObj);
+    saveInternal(writerObj);
     _isResaving = false;
 
     // Save json to file
@@ -189,6 +189,12 @@ bool JsonAssetBase::Save(JsonWriter& writer) const
 {
     if (OnCheckSave())
         return true;
+    
+    return saveInternal(writer);
+}
+
+bool JsonAssetBase::saveInternal(JsonWriter& writer) const
+{
     ScopeLock lock(Locker);
 
     writer.StartObject();

--- a/Source/Engine/Content/JsonAsset.h
+++ b/Source/Engine/Content/JsonAsset.h
@@ -101,6 +101,7 @@ protected:
     void unload(bool isReloading) override;
 #if USE_EDITOR
     void onRename(const StringView& newPath) override;
+    bool saveInternal(JsonWriter& writer) const;
 #endif
 };
 


### PR DESCRIPTION
After the temporary asset is issued to be destroyed, attempting to load the new asset returns the temporary asset instead of trying to load the new one (both assets have the same ID, so assets registry still thinks the asset have been loaded already).