### PR TITLE
Fix missing C#-only project configurations when platform SDK is missing

### DIFF
--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -121,17 +121,28 @@ namespace Flax.Build
                         string configurationName = configuration.ToString();
                         foreach (var architecture in target.GetArchitectures(targetPlatform))
                         {
+                            string configurationText = targetName + '.' + platformName + '.' + configurationName;
                             if (!Platform.IsPlatformSupported(targetPlatform, architecture))
                                 continue;
                             var platform = Platform.GetPlatform(targetPlatform, true);
                             if (platform == null)
                                 continue;
                             if (!platform.HasRequiredSDKsInstalled && (!projectInfo.IsCSharpOnlyProject || platform != Platform.BuildPlatform))
+                            {
+                                Log.Verbose($"Skipping configuration {configurationText} for {architecture}: Missing platform SDK");
                                 continue;
-                            if (!platform.CanBuildArchitecture(architecture))
+                            }
+                            if (!projectInfo.IsCSharpOnlyProject && !platform.CanBuildArchitecture(architecture))
+                            {
+                                Log.Verbose($"Skipping configuration {configurationText} for {architecture}: Unsupported target architecture");
                                 continue;
+                            }
+                            if (projectInfo.IsCSharpOnlyProject && !Platform.IsPlatformSupported(platform.Target, architecture))
+                            {
+                                Log.Verbose($"Skipping configuration {configurationText} for {architecture}: Unsupported target architecture");
+                                continue;
+                            }
 
-                            string configurationText = targetName + '.' + platformName + '.' + configurationName;
                             string architectureName = architecture.ToString();
                             if (platform is IProjectCustomizer customizer)
                                 customizer.GetProjectArchitectureName(project, platform, architecture, ref architectureName);

--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -266,6 +266,7 @@ namespace Flax.Build
                     if (targetGroup.Project == null && target is ProjectTarget projectTarget)
                         targetGroup.Project = projectTarget.Project;
                     targetGroup.Targets.Add(target);
+                    Log.Verbose($"Found target {target}");
                 }
                 foreach (var targetGroup in targetGroups)
                 {
@@ -294,6 +295,7 @@ namespace Flax.Build
                         var projectInfo = e.Project;
 
                         // Create project
+                        Log.Verbose($"Found project {projectName}");
                         Project mainProject;
                         var binaryModules = new Dictionary<string, HashSet<Module>>();
                         var modulesBuildOptions = new Dictionary<Module, BuildOptions>();
@@ -401,11 +403,17 @@ namespace Flax.Build
 
                             // Skip bindings projects for prebuilt targets (eg. no sources to build/view - just binaries)
                             if (targets[0].IsPreBuilt)
+                            {
+                                Log.Verbose($"Skipping prebuilt module {binaryModuleName}");
                                 continue;
+                            }
 
                             // Skip if project of that name has been already added
                             if (projects.Any(x => x.OutputType == TargetOutputType.Library && x.Type == TargetType.DotNetCore && x.BaseName == binaryModuleName))
+                            {
+                                Log.Verbose($"Skipping already added module {binaryModuleName}");
                                 continue;
+                            }
 
                             using (new ProfileEventScope(binaryModuleName))
                             {
@@ -554,6 +562,7 @@ namespace Flax.Build
                     }
                     if (flaxDependencyToRemove != null)
                     {
+                        Log.Verbose($"Removing project reference {flaxDependencyToRemove.Name}");
                         projects.Remove(flaxDependencyToRemove);
                         foreach (var project in projects)
                             project.Dependencies.Remove(flaxDependencyToRemove);
@@ -569,7 +578,7 @@ namespace Flax.Build
                 {
                     foreach (var project in projects)
                     {
-                        Log.Verbose(project.Name + " -> " + project.Path);
+                        Log.Verbose($"Project {project.Name} -> {project.Path}");
                         project.Generate(solutionPath, project == mainSolutionProject);
                     }
                 }
@@ -648,7 +657,7 @@ namespace Flax.Build
                     // Generate project
                     using (new ProfileEventScope("GenerateProject"))
                     {
-                        Log.Verbose("Project " + rulesProjectName + " -> " + project.Path);
+                        Log.Verbose($"Project {rulesProjectName} -> {project.Path}");
                         dotNetProjectGenerator.GenerateProject(project, solutionPath, project == mainSolutionProject);
                     }
 


### PR DESCRIPTION
The native platform SDK should not be a hard dependency for building C#-only project. In this particular case projects should be generated if Rider and .NET SDK are installed without VC++ tooling on Windows.