### PR TITLE
Use exact component value equality checks in equality comparisons

### DIFF
--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -145,7 +145,7 @@ namespace FlaxEditor.Content.GUI
             set
             {
                 value = Mathf.Clamp(value, 0.3f, 3.0f);
-                if (!Mathf.NearEqual(value, _viewScale))
+                if (value != _viewScale)
                 {
                     _viewScale = value;
                     ViewScaleChanged?.Invoke();

--- a/Source/Editor/CustomEditors/GUI/PropertiesList.cs
+++ b/Source/Editor/CustomEditors/GUI/PropertiesList.cs
@@ -45,7 +45,7 @@ namespace FlaxEditor.CustomEditors.GUI
             set
             {
                 value = Mathf.Clamp(value, 0.05f, 0.95f);
-                if (!Mathf.NearEqual(_splitterValue, value))
+                if (_splitterValue != value)
                 {
                     _splitterValue = value;
                     UpdateSplitRect();

--- a/Source/Editor/GUI/CurveEditor.cs
+++ b/Source/Editor/GUI/CurveEditor.cs
@@ -385,7 +385,7 @@ namespace FlaxEditor.GUI
             get => _fps;
             set
             {
-                if (_fps.HasValue == value.HasValue && (!value.HasValue || Mathf.NearEqual(_fps.Value, value.Value)))
+                if (_fps.HasValue == value.HasValue && (!value.HasValue || _fps.Value == value.Value))
                     return;
 
                 _fps = value;

--- a/Source/Editor/GUI/Input/DoubleValueBox.cs
+++ b/Source/Editor/GUI/Input/DoubleValueBox.cs
@@ -41,7 +41,7 @@ namespace FlaxEditor.GUI.Input
             get => _min;
             set
             {
-                if (!Mathd.NearEqual(_min, value))
+                if (_min != value)
                 {
                     if (value > _max)
                         throw new ArgumentException();
@@ -58,7 +58,7 @@ namespace FlaxEditor.GUI.Input
             get => _max;
             set
             {
-                if (!Mathd.NearEqual(_max, value))
+                if (_max != value)
                 {
                     if (value < _min)
                         throw new ArgumentException();

--- a/Source/Editor/GUI/Input/FloatValueBox.cs
+++ b/Source/Editor/GUI/Input/FloatValueBox.cs
@@ -38,7 +38,7 @@ namespace FlaxEditor.GUI.Input
             get => _min;
             set
             {
-                if (!Mathf.NearEqual(_min, value))
+                if (_min != value)
                 {
                     if (value > _max)
                         throw new ArgumentException();
@@ -54,7 +54,7 @@ namespace FlaxEditor.GUI.Input
             get => _max;
             set
             {
-                if (!Mathf.NearEqual(_max, value))
+                if (_max != value)
                 {
                     if (value < _min)
                         throw new ArgumentException();

--- a/Source/Editor/GUI/Input/SliderControl.cs
+++ b/Source/Editor/GUI/Input/SliderControl.cs
@@ -54,7 +54,7 @@ namespace FlaxEditor.GUI.Input
                 set
                 {
                     value = Mathf.Clamp(value, Minimum, Maximum);
-                    if (!Mathf.NearEqual(value, _value))
+                    if (value != _value)
                     {
                         _value = value;
 
@@ -311,7 +311,7 @@ namespace FlaxEditor.GUI.Input
             get => _min;
             set
             {
-                if (!Mathf.NearEqual(_min, value))
+                if (_min != value)
                 {
                     if (value > _max)
                         throw new ArgumentException();
@@ -330,7 +330,7 @@ namespace FlaxEditor.GUI.Input
             get => _max;
             set
             {
-                if (!Mathf.NearEqual(_max, value))
+                if (_max != value)
                 {
                     if (value < _min)
                         throw new ArgumentException();

--- a/Source/Editor/GUI/Table.cs
+++ b/Source/Editor/GUI/Table.cs
@@ -28,7 +28,7 @@ namespace FlaxEditor.GUI
             set
             {
                 value = Mathf.Max(value, 1);
-                if (!Mathf.NearEqual(value, _headerHeight))
+                if (value != _headerHeight)
                 {
                     _headerHeight = value;
                     PerformLayout();

--- a/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
+++ b/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
@@ -692,7 +692,7 @@ namespace FlaxEditor.GUI
             get => _fps;
             set
             {
-                if (_fps.HasValue == value.HasValue && (!value.HasValue || Mathf.NearEqual(_fps.Value, value.Value)))
+                if (_fps.HasValue == value.HasValue && (!value.HasValue || _fps.Value == value.Value))
                     return;
 
                 _fps = value;

--- a/Source/Editor/GUI/Timeline/Timeline.cs
+++ b/Source/Editor/GUI/Timeline/Timeline.cs
@@ -319,7 +319,7 @@ namespace FlaxEditor.GUI.Timeline
             set
             {
                 value = Mathf.Clamp(value, 0.1f, 1000.0f);
-                if (Mathf.NearEqual(_framesPerSecond, value))
+                if (_framesPerSecond == value)
                     return;
 
                 Undo?.AddAction(new EditFpsAction(this, _framesPerSecond, value));
@@ -508,7 +508,7 @@ namespace FlaxEditor.GUI.Timeline
             set
             {
                 value = Mathf.Clamp(value, 0.00001f, 1000.0f);
-                if (Mathf.NearEqual(_zoom, value))
+                if (_zoom == value)
                     return;
 
                 _zoom = value;

--- a/Source/Editor/GUI/Timeline/Tracks/AudioTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/AudioTrack.cs
@@ -41,7 +41,7 @@ namespace FlaxEditor.GUI.Timeline.Tracks
             get => Preview.ViewOffset;
             set
             {
-                if (Mathf.NearEqual(Preview.ViewOffset, value))
+                if (Preview.ViewOffset == value)
                     return;
                 Preview.ViewOffset = value;
                 Timeline?.MarkAsEdited();

--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -214,7 +214,7 @@ namespace FlaxEditor.GUI.Tree
             get => _headerHeight;
             set
             {
-                if (!Mathf.NearEqual(_headerHeight, value))
+                if (_headerHeight != value)
                 {
                     _headerHeight = value;
                     PerformLayout();

--- a/Source/Editor/Tools/Foliage/FoliageTypesTab.cs
+++ b/Source/Editor/Tools/Foliage/FoliageTypesTab.cs
@@ -107,7 +107,7 @@ namespace FlaxEditor.Tools.Foliage
                 get => _type.CullDistance;
                 set
                 {
-                    if (Mathf.NearEqual(_type.CullDistance, value))
+                    if (_type.CullDistance == value)
                         return;
                     _type.CullDistance = value;
                     Foliage.UpdateCullDistance();
@@ -120,7 +120,7 @@ namespace FlaxEditor.Tools.Foliage
                 get => _type.CullDistanceRandomRange;
                 set
                 {
-                    if (Mathf.NearEqual(_type.CullDistanceRandomRange, value))
+                    if (_type.CullDistanceRandomRange == value)
                         return;
                     _type.CullDistanceRandomRange = value;
                     Foliage.UpdateCullDistance();
@@ -174,7 +174,7 @@ namespace FlaxEditor.Tools.Foliage
                 get => _type.DensityScalingScale;
                 set
                 {
-                    if (Mathf.NearEqual(_type.DensityScalingScale, value))
+                    if (_type.DensityScalingScale == value)
                         return;
                     _type.DensityScalingScale = value;
                     Foliage.RebuildClusters();

--- a/Source/Editor/Viewport/Previews/CubeTexturePreview.cs
+++ b/Source/Editor/Viewport/Previews/CubeTexturePreview.cs
@@ -95,7 +95,7 @@ namespace FlaxEditor.Viewport.Previews
             get => _mipLevel;
             set
             {
-                if (!Mathf.NearEqual(_mipLevel, value))
+                if (_mipLevel == value)
                 {
                     _mipLevel = value;
                     _previewMaterial.SetParameterValue("Mip", value);

--- a/Source/Editor/Viewport/Previews/ParticleEmitterPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleEmitterPreview.cs
@@ -42,7 +42,7 @@ namespace FlaxEditor.Viewport.Previews
             set
             {
                 value = Mathf.Clamp(value, 0.1f, 100000000000.0f);
-                if (Mathf.NearEqual(_playbackDuration, value))
+                if (_playbackDuration == value)
                     return;
 
                 _playbackDuration = value;

--- a/Source/Editor/Viewport/Previews/TexturePreview.cs
+++ b/Source/Editor/Viewport/Previews/TexturePreview.cs
@@ -303,7 +303,7 @@ namespace FlaxEditor.Viewport.Previews
             get => _mipLevel;
             set
             {
-                if (!Mathf.NearEqual(_mipLevel, value))
+                if (_mipLevel != value)
                 {
                     _mipLevel = value;
                     _previewMaterial.SetParameterValue("Mip", value);

--- a/Source/Engine/Animations/Curve.h
+++ b/Source/Engine/Animations/Curve.h
@@ -58,7 +58,7 @@ public:
     
     bool operator==(const StepCurveKeyframe& other) const
     {
-        return Math::NearEqual(Time, other.Time) && Math::NearEqual(Value, other.Value);
+        return Time == other.Time && Value == other.Value;
     }
 } PACK_END();
 
@@ -113,7 +113,7 @@ public:
 
     bool operator==(const LinearCurveKeyframe& other) const
     {
-        return Math::NearEqual(Time, other.Time) && Math::NearEqual(Value, other.Value);
+        return Time == other.Time && Value == other.Value;
     }
 } PACK_END();
 
@@ -188,7 +188,7 @@ public:
     
     bool operator==(const HermiteCurveKeyframe& other) const
     {
-        return Math::NearEqual(Time, other.Time) && Math::NearEqual(Value, other.Value) && Math::NearEqual(TangentIn, other.TangentIn) && Math::NearEqual(TangentOut, other.TangentOut);
+        return Time == other.Time && Value == other.Value && TangentIn == other.TangentIn && TangentOut == other.TangentOut;
     }
 } PACK_END();
 
@@ -276,7 +276,7 @@ public:
 
     bool operator==(const BezierCurveKeyframe& other) const
     {
-        return Math::NearEqual(Time, other.Time) && Math::NearEqual(Value, other.Value) && Math::NearEqual(TangentIn, other.TangentIn) && Math::NearEqual(TangentOut, other.TangentOut);
+        return Time == other.Time && Value == other.Value && TangentIn == other.TangentIn && TangentOut == other.TangentOut;
     }
 } PACK_END();
 

--- a/Source/Engine/Audio/Audio.cpp
+++ b/Source/Engine/Audio/Audio.cpp
@@ -219,7 +219,7 @@ void AudioService::Update()
         // Mute audio if app has no user focus
         masterVolume = 0.0f;
     }
-    if (Math::NotNearEqual(Volume, masterVolume))
+    if (Volume != masterVolume)
     {
         Volume = masterVolume;
         AudioBackend::SetVolume(masterVolume);

--- a/Source/Engine/Audio/AudioSource.cpp
+++ b/Source/Engine/Audio/AudioSource.cpp
@@ -29,7 +29,7 @@ AudioSource::AudioSource(const SpawnParams& params)
 void AudioSource::SetVolume(float value)
 {
     value = Math::Saturate(value);
-    if (Math::NearEqual(_volume, value))
+    if (_volume == value)
         return;
     _volume = value;
     if (SourceID)
@@ -39,7 +39,7 @@ void AudioSource::SetVolume(float value)
 void AudioSource::SetPitch(float value)
 {
     value = Math::Clamp(value, 0.5f, 2.0f);
-    if (Math::NearEqual(_pitch, value))
+    if (_pitch == value)
         return;
     _pitch = value;
     if (SourceID)
@@ -49,7 +49,7 @@ void AudioSource::SetPitch(float value)
 void AudioSource::SetPan(float value)
 {
     value = Math::Clamp(value, -1.0f, 1.0f);
-    if (Math::NearEqual(_pan, value))
+    if (_pan == value)
         return;
     _pan = value;
     if (SourceID)
@@ -80,7 +80,7 @@ void AudioSource::SetStartTime(float value)
 void AudioSource::SetMinDistance(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(_minDistance, value))
+    if (_minDistance == value)
         return;
     _minDistance = value;
     if (SourceID)
@@ -90,7 +90,7 @@ void AudioSource::SetMinDistance(float value)
 void AudioSource::SetAttenuation(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(_attenuation, value))
+    if (_attenuation == value)
         return;
     _attenuation = value;
     if (SourceID)
@@ -100,7 +100,7 @@ void AudioSource::SetAttenuation(float value)
 void AudioSource::SetDopplerFactor(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(_dopplerFactor, value))
+    if (_dopplerFactor == value)
         return;
     _dopplerFactor = value;
     if (SourceID)
@@ -401,7 +401,7 @@ void AudioSource::Update()
         _startingToPlay = false;
     }
 
-    if (!UseStreaming() && Math::NearEqual(GetTime(), 0.0f) && _isActuallyPlayingSth && !_startingToPlay)
+    if (!UseStreaming() && GetTime() == 0.0f && _isActuallyPlayingSth && !_startingToPlay)
     {
         int32 queuedBuffers;
         AudioBackend::Source::GetQueuedBuffersCount(SourceID, queuedBuffers);

--- a/Source/Engine/ContentImporters/CreateMaterial.cpp
+++ b/Source/Engine/ContentImporters/CreateMaterial.cpp
@@ -20,7 +20,7 @@ namespace
     template<typename T>
     ShaderGraphNode<>* AddValueNode(MaterialLayer* layer, const float& value, const float& defaultValue)
     {
-        if (Math::NearEqual(value, defaultValue))
+        if (value == defaultValue)
             return nullptr;
         auto& node = layer->Graph.Nodes.AddOne();
         node.ID = layer->Graph.Nodes.Count();

--- a/Source/Engine/Core/Math/BoundingBox.cs
+++ b/Source/Engine/Core/Math/BoundingBox.cs
@@ -673,23 +673,23 @@ namespace FlaxEngine
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(ref BoundingBox value)
+        public bool Equals(ref BoundingBox other)
         {
-            return Minimum == value.Minimum && Maximum == value.Maximum;
+            return Minimum == other.Minimum && Maximum == other.Maximum;
         }
 
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(BoundingBox value)
+        public bool Equals(BoundingBox other)
         {
-            return Equals(ref value);
+            return Equals(ref other);
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/BoundingSphere.cs
+++ b/Source/Engine/Core/Math/BoundingSphere.cs
@@ -487,23 +487,23 @@ namespace FlaxEngine
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(ref BoundingSphere value)
+        public bool Equals(ref BoundingSphere other)
         {
-            return (Center == value.Center) && (Radius == value.Radius);
+            return Center == other.Center && Radius == other.Radius;
         }
 
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(BoundingSphere value)
+        public bool Equals(BoundingSphere other)
         {
-            return Equals(ref value);
+            return Equals(ref other);
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/Color.cs
+++ b/Source/Engine/Core/Math/Color.cs
@@ -197,12 +197,9 @@ namespace FlaxEngine
         }
 
         /// <inheritdoc />
-        public override bool Equals(object other)
+        public override bool Equals(object value)
         {
-            if (!(other is Color))
-                return false;
-            var color = (Color)other;
-            return Equals(ref color);
+            return value is Color other && Equals(ref other);
         }
 
         /// <summary>
@@ -213,7 +210,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Color other)
         {
-            return Mathf.NearEqual(other.R, R) && Mathf.NearEqual(other.G, G) && Mathf.NearEqual(other.B, B) && Mathf.NearEqual(other.A, A);
+            return R == other.R && G == other.G && B == other.B && A == other.A;
         }
 
         /// <inheritdoc />
@@ -661,23 +658,23 @@ namespace FlaxEngine
         /// <summary>
         /// Compares two colors.
         /// </summary>
-        /// <param name="lhs">The left.</param>
-        /// <param name="rhs">The right.</param>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
         /// <returns>True if colors are equal, otherwise false.</returns>
-        public static bool operator ==(Color lhs, Color rhs)
+        public static bool operator ==(Color left, Color right)
         {
-            return lhs.Equals(ref rhs);
+            return left.Equals(ref right);
         }
 
         /// <summary>
         /// Compares two colors.
         /// </summary>
-        /// <param name="lhs">The left.</param>
-        /// <param name="rhs">The right.</param>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
         /// <returns>True if colors are not equal, otherwise false.</returns>
-        public static bool operator !=(Color lhs, Color rhs)
+        public static bool operator !=(Color left, Color right)
         {
-            return !lhs.Equals(ref rhs);
+            return !left.Equals(ref right);
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/Double2.cs
+++ b/Source/Engine/Core/Math/Double2.cs
@@ -1464,7 +1464,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Double2 left, Double2 right)
         {
-            return Mathd.NearEqual(left.X, right.X) && Mathd.NearEqual(left.Y, right.Y);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1476,7 +1476,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(Double2 left, Double2 right)
         {
-            return !Mathd.NearEqual(left.X, right.X) || !Mathd.NearEqual(left.Y, right.Y);
+            return !left.Equals(ref right);
         }
 
         /// <summary>
@@ -1582,7 +1582,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Double2 other)
         {
-            return Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y);
+            return X == other.X && Y == other.Y;
         }
 
         /// <summary>
@@ -1590,7 +1590,7 @@ namespace FlaxEngine
         /// </summary>
         public static bool Equals(ref Double2 a, ref Double2 b)
         {
-            return Mathd.NearEqual(a.X, b.X) && Mathd.NearEqual(a.Y, b.Y);
+            return a.Equals(ref b);
         }
 
         /// <summary>
@@ -1601,7 +1601,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Double2 other)
         {
-            return Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1611,7 +1611,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Double2 other && Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y);
+            return value is Double2 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Double3.cs
+++ b/Source/Engine/Core/Math/Double3.cs
@@ -1759,7 +1759,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Double3 left, Double3 right)
         {
-            return Mathd.NearEqual(left.X, right.X) && Mathd.NearEqual(left.Y, right.Y) && Mathd.NearEqual(left.Z, right.Z);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1771,7 +1771,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(Double3 left, Double3 right)
         {
-            return !Mathd.NearEqual(left.X, right.X) || !Mathd.NearEqual(left.Y, right.Y) || !Mathd.NearEqual(left.Z, right.Z);
+            return !left.Equals(ref right);
         }
 
         /// <summary>
@@ -1880,7 +1880,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Double3 other)
         {
-            return Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z);
+            return X == other.X && Y == other.Y && Z == other.Z;
         }
 
         /// <summary>
@@ -1891,7 +1891,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Double3 other)
         {
-            return Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1901,7 +1901,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Double3 other && Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z);
+            return value is Double3 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Double4.cs
+++ b/Source/Engine/Core/Math/Double4.cs
@@ -1258,7 +1258,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Double4 left, Double4 right)
         {
-            return Mathd.NearEqual(left.X, right.X) && Mathd.NearEqual(left.Y, right.Y) && Mathd.NearEqual(left.Z, right.Z) && Mathd.NearEqual(left.W, right.W);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1379,7 +1379,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="Double4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Double4 other)
         {
-            return Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z) && Mathd.NearEqual(other.W, W);
+            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
         }
 
         /// <summary>
@@ -1390,7 +1390,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Double4 other)
         {
-            return Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z) && Mathd.NearEqual(other.W, W);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1400,7 +1400,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Double4 other && Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z) && Mathd.NearEqual(other.W, W);
+            return value is Double4 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Float2.cs
+++ b/Source/Engine/Core/Math/Float2.cs
@@ -1540,7 +1540,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Float2 left, Float2 right)
         {
-            return Mathf.NearEqual(left.X, right.X) && Mathf.NearEqual(left.Y, right.Y);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1552,7 +1552,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(Float2 left, Float2 right)
         {
-            return !Mathf.NearEqual(left.X, right.X) || !Mathf.NearEqual(left.Y, right.Y);
+            return !left.Equals(ref right);
         }
 
         /// <summary>
@@ -1658,7 +1658,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Float2 other)
         {
-            return Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y);
+            return X == other.X && Y == other.Y;
         }
 
         /// <summary>
@@ -1666,7 +1666,7 @@ namespace FlaxEngine
         /// </summary>
         public static bool Equals(ref Float2 a, ref Float2 b)
         {
-            return Mathf.NearEqual(a.X, b.X) && Mathf.NearEqual(a.Y, b.Y);
+            return a.Equals(ref b);
         }
 
         /// <summary>
@@ -1677,7 +1677,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Float2 other)
         {
-            return Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1687,7 +1687,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Float2 other && Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y);
+            return value is Float2 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Float3.cs
+++ b/Source/Engine/Core/Math/Float3.cs
@@ -1791,7 +1791,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Float3 left, Float3 right)
         {
-            return Mathf.NearEqual(left.X, right.X) && Mathf.NearEqual(left.Y, right.Y) && Mathf.NearEqual(left.Z, right.Z);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1803,7 +1803,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(Float3 left, Float3 right)
         {
-            return !Mathf.NearEqual(left.X, right.X) || !Mathf.NearEqual(left.Y, right.Y) || !Mathf.NearEqual(left.Z, right.Z);
+            return !left.Equals(ref right);
         }
 
         /// <summary>
@@ -1912,7 +1912,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Float3 other)
         {
-            return Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z);
+            return X == other.X && Y == other.Y && Z == other.Z;
         }
 
         /// <summary>
@@ -1923,7 +1923,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Float3 other)
         {
-            return Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1933,7 +1933,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Float3 other && Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z);
+            return value is Float3 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Float4.cs
+++ b/Source/Engine/Core/Math/Float4.cs
@@ -1288,7 +1288,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Float4 left, Float4 right)
         {
-            return Mathf.NearEqual(left.X, right.X) && Mathf.NearEqual(left.Y, right.Y) && Mathf.NearEqual(left.Z, right.Z) && Mathf.NearEqual(left.W, right.W);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1419,7 +1419,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="Float4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Float4 other)
         {
-            return Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z) && Mathf.NearEqual(other.W, W);
+            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
         }
 
         /// <summary>
@@ -1430,7 +1430,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Float4 other)
         {
-            return Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z) && Mathf.NearEqual(other.W, W);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1440,7 +1440,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Float4 other && Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z) && Mathf.NearEqual(other.W, W);
+            return value is Float4 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Matrix.cpp
+++ b/Source/Engine/Core/Math/Matrix.cpp
@@ -163,7 +163,7 @@ bool Matrix::operator==(const Matrix& other) const
 {
     for (int32 i = 0; i < 16; i++)
     {
-        if (Math::NotNearEqual(other.Raw[i], Raw[i]))
+        if (other.Raw[i] != Raw[i])
             return false;
     }
     return true;

--- a/Source/Engine/Core/Math/Matrix.cs
+++ b/Source/Engine/Core/Math/Matrix.cs
@@ -3236,22 +3236,22 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="Matrix" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Matrix other)
         {
-            return Mathf.NearEqual(other.M11, M11) &&
-                   Mathf.NearEqual(other.M12, M12) &&
-                   Mathf.NearEqual(other.M13, M13) &&
-                   Mathf.NearEqual(other.M14, M14) &&
-                   Mathf.NearEqual(other.M21, M21) &&
-                   Mathf.NearEqual(other.M22, M22) &&
-                   Mathf.NearEqual(other.M23, M23) &&
-                   Mathf.NearEqual(other.M24, M24) &&
-                   Mathf.NearEqual(other.M31, M31) &&
-                   Mathf.NearEqual(other.M32, M32) &&
-                   Mathf.NearEqual(other.M33, M33) &&
-                   Mathf.NearEqual(other.M34, M34) &&
-                   Mathf.NearEqual(other.M41, M41) &&
-                   Mathf.NearEqual(other.M42, M42) &&
-                   Mathf.NearEqual(other.M43, M43) &&
-                   Mathf.NearEqual(other.M44, M44);
+            return other.M11 == M11 &&
+                   other.M12 == M12 &&
+                   other.M13 == M13 &&
+                   other.M14 == M14 &&
+                   other.M21 == M21 &&
+                   other.M22 == M22 &&
+                   other.M23 == M23 &&
+                   other.M24 == M24 &&
+                   other.M31 == M31 &&
+                   other.M32 == M32 &&
+                   other.M33 == M33 &&
+                   other.M34 == M34 &&
+                   other.M41 == M41 &&
+                   other.M42 == M42 &&
+                   other.M43 == M43 &&
+                   other.M44 == M44;
         }
 
         /// <summary>
@@ -3272,10 +3272,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            if (!(value is Matrix))
-                return false;
-            var v = (Matrix)value;
-            return Equals(ref v);
+            return value is Matrix other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Matrix2x2.cs
+++ b/Source/Engine/Core/Math/Matrix2x2.cs
@@ -483,7 +483,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="Matrix2x2"/> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Matrix2x2 other)
         {
-            return Mathf.NearEqual(other.M11, M11) && Mathf.NearEqual(other.M12, M12) && Mathf.NearEqual(other.M21, M21) && Mathf.NearEqual(other.M22, M22);
+            return M11 == other.M11 && M12 == other.M12 && M21 == other.M21 && M22 == other.M22;
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace FlaxEngine
         /// </summary>
         public static bool Equals(ref Matrix2x2 a, ref Matrix2x2 b)
         {
-            return Mathf.NearEqual(a.M11, b.M11) && Mathf.NearEqual(a.M12, b.M12) && Mathf.NearEqual(a.M21, b.M21) && Mathf.NearEqual(a.M22, b.M22);
+            return a.Equals(ref b);
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/Matrix3x3.cpp
+++ b/Source/Engine/Core/Math/Matrix3x3.cpp
@@ -242,14 +242,13 @@ void Matrix3x3::Decompose(Float3& scale, Quaternion& rotation) const
 
 bool Matrix3x3::operator==(const Matrix3x3& other) const
 {
-    return
-            Math::NearEqual(M11, other.M11) &&
-            Math::NearEqual(M12, other.M12) &&
-            Math::NearEqual(M13, other.M13) &&
-            Math::NearEqual(M21, other.M21) &&
-            Math::NearEqual(M22, other.M22) &&
-            Math::NearEqual(M23, other.M23) &&
-            Math::NearEqual(M31, other.M31) &&
-            Math::NearEqual(M32, other.M32) &&
-            Math::NearEqual(M33, other.M33);
+    return  M11 == other.M11 &&
+            M12 == other.M12 &&
+            M13 == other.M13 &&
+            M21 == other.M21 &&
+            M22 == other.M22 &&
+            M23 == other.M23 &&
+            M31 == other.M31 &&
+            M32 == other.M32 &&
+            M33 == other.M33;
 }

--- a/Source/Engine/Core/Math/Matrix3x3.cs
+++ b/Source/Engine/Core/Math/Matrix3x3.cs
@@ -2125,15 +2125,15 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="Matrix3x3"/> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Matrix3x3 other)
         {
-            return (Mathf.NearEqual(other.M11, M11) &&
-                    Mathf.NearEqual(other.M12, M12) &&
-                    Mathf.NearEqual(other.M13, M13) &&
-                    Mathf.NearEqual(other.M21, M21) &&
-                    Mathf.NearEqual(other.M22, M22) &&
-                    Mathf.NearEqual(other.M23, M23) &&
-                    Mathf.NearEqual(other.M31, M31) &&
-                    Mathf.NearEqual(other.M32, M32) &&
-                    Mathf.NearEqual(other.M33, M33));
+            return  M11 == other.M11 &&
+                    M12 == other.M12 &&
+                    M13 == other.M13 &&
+                    M21 == other.M21 &&
+                    M22 == other.M22 &&
+                    M23 == other.M23 &&
+                    M31 == other.M31 &&
+                    M32 == other.M32 &&
+                    M33 == other.M33;
         }
 
         /// <summary>
@@ -2152,17 +2152,7 @@ namespace FlaxEngine
         /// </summary>
         public static bool Equals(ref Matrix3x3 a, ref Matrix3x3 b)
         {
-            return
-            Mathf.NearEqual(a.M11, b.M11) &&
-            Mathf.NearEqual(a.M12, b.M12) &&
-            Mathf.NearEqual(a.M13, b.M13) &&
-            Mathf.NearEqual(a.M21, b.M21) &&
-            Mathf.NearEqual(a.M22, b.M22) &&
-            Mathf.NearEqual(a.M23, b.M23) &&
-            Mathf.NearEqual(a.M31, b.M31) &&
-            Mathf.NearEqual(a.M32, b.M32) &&
-            Mathf.NearEqual(a.M33, b.M33)
-            ;
+            return a.Equals(ref b);
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/OrientedBoundingBox.cs
+++ b/Source/Engine/Core/Math/OrientedBoundingBox.cs
@@ -397,7 +397,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref OrientedBoundingBox value)
         {
-            return (Extents == value.Extents) && (Transformation == value.Transformation);
+            return Extents == value.Extents && Transformation == value.Transformation;
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/Plane.cs
+++ b/Source/Engine/Core/Math/Plane.cs
@@ -582,23 +582,23 @@ namespace FlaxEngine
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(ref Plane value)
+        public bool Equals(ref Plane other)
         {
-            return Normal == value.Normal && D == value.D;
+            return Normal == other.Normal && D == other.D;
         }
 
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(Plane value)
+        public bool Equals(Plane other)
         {
-            return Equals(ref value);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -608,10 +608,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            if (!(value is Plane))
-                return false;
-            var strongValue = (Plane)value;
-            return Equals(ref strongValue);
+            return value is Plane other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Quaternion.cs
+++ b/Source/Engine/Core/Math/Quaternion.cs
@@ -1602,7 +1602,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Quaternion left, Quaternion right)
         {
-            return Dot(ref left, ref right) > Tolerance;
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1614,7 +1614,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(Quaternion left, Quaternion right)
         {
-            return Dot(ref left, ref right) <= Tolerance;
+            return !left.Equals(ref right);
         }
 
         /// <summary>
@@ -1714,8 +1714,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Quaternion other)
         {
-            //return Dot(ref this, ref other) > Tolerance;
-            return Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z) && Mathf.NearEqual(other.W, W);
+            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
         }
 
         /// <summary>
@@ -1736,10 +1735,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            if (!(value is Quaternion))
-                return false;
-            var strongValue = (Quaternion)value;
-            return Equals(ref strongValue);
+            return value is Quaternion other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Quaternion.h
+++ b/Source/Engine/Core/Math/Quaternion.h
@@ -348,7 +348,7 @@ public:
     /// <returns><c>true</c> if the specified <see cref="Quaternion" /> is equal to this instance; otherwise, <c>false</c>.</returns>
     FORCE_INLINE bool operator==(const Quaternion& other) const
     {
-        return Dot(*this, other) > Tolerance;
+        return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
     }
 
     /// <summary>
@@ -358,7 +358,7 @@ public:
     /// <returns><c>true</c> if the specified <see cref="Quaternion" /> isn't equal to this instance; otherwise, <c>false</c>.</returns>
     FORCE_INLINE bool operator!=(const Quaternion& other) const
     {
-        return Dot(*this, other) < Tolerance;
+        return X != other.X || Y != other.Y || Z != other.Z || W != other.W;
     }
 
 public:

--- a/Source/Engine/Core/Math/Ray.cs
+++ b/Source/Engine/Core/Math/Ray.cs
@@ -428,23 +428,23 @@ namespace FlaxEngine
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(ref Ray value)
+        public bool Equals(ref Ray other)
         {
-            return (Position == value.Position) && (Direction == value.Direction);
+            return Position == other.Position && Direction == other.Direction;
         }
 
         /// <summary>
         /// Determines whether the specified <see cref="Vector4" /> is equal to this instance.
         /// </summary>
-        /// <param name="value">The <see cref="Vector4" /> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Vector4" /> to compare with this instance.</param>
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(Ray value)
+        public bool Equals(Ray other)
         {
-            return Equals(ref value);
+            return Equals(ref other);
         }
 
         /// <summary>

--- a/Source/Engine/Core/Math/Rectangle.cs
+++ b/Source/Engine/Core/Math/Rectangle.cs
@@ -499,21 +499,19 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Rectangle other)
         {
-            return Location.Equals(ref other.Location) && Size.Equals(ref other.Size);
+            return Location == other.Location && Size == other.Size;
         }
 
         /// <inheritdoc />
         public bool Equals(Rectangle other)
         {
-            return Location.Equals(ref other.Location) && Size.Equals(ref other.Size);
+            return Equals(ref other);
         }
 
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-                return false;
-            return obj is Rectangle && Equals((Rectangle)obj);
+            return obj is Rectangle other && Equals(ref other);
         }
 
         /// <inheritdoc />

--- a/Source/Engine/Core/Math/Vector2.cs
+++ b/Source/Engine/Core/Math/Vector2.cs
@@ -1654,7 +1654,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Vector2 left, Vector2 right)
         {
-            return Mathr.NearEqual(left.X, right.X) && Mathr.NearEqual(left.Y, right.Y);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1666,7 +1666,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(Vector2 left, Vector2 right)
         {
-            return !Mathr.NearEqual(left.X, right.X) || !Mathr.NearEqual(left.Y, right.Y);
+            return !left.Equals(ref right);
         }
 
         /// <summary>
@@ -1782,7 +1782,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Vector2 other)
         {
-            return Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y);
+            return X == other.X && Y == other.Y;
         }
 
         /// <summary>
@@ -1790,7 +1790,7 @@ namespace FlaxEngine
         /// </summary>
         public static bool Equals(ref Vector2 a, ref Vector2 b)
         {
-            return Mathr.NearEqual(a.X, b.X) && Mathr.NearEqual(a.Y, b.Y);
+            return a.Equals(ref b);
         }
 
         /// <summary>
@@ -1801,7 +1801,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Vector2 other)
         {
-            return Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1811,7 +1811,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Vector2 other && Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y);
+            return value is Vector2 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -2010,7 +2010,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Vector3 left, Vector3 right)
         {
-            return Mathr.NearEqual(left.X, right.X) && Mathr.NearEqual(left.Y, right.Y) && Mathr.NearEqual(left.Z, right.Z);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -2022,7 +2022,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(Vector3 left, Vector3 right)
         {
-            return !Mathr.NearEqual(left.X, right.X) || !Mathr.NearEqual(left.Y, right.Y) || !Mathr.NearEqual(left.Z, right.Z);
+            return !left.Equals(ref right);
         }
 
         /// <summary>
@@ -2141,7 +2141,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ref Vector3 other)
         {
-            return Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z);
+            return X == other.X && Y == other.Y && Z == other.Z;
         }
 
         /// <summary>
@@ -2152,7 +2152,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Vector3 other)
         {
-            return Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -2162,7 +2162,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Vector3 other && Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z);
+            return value is Vector3 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Vector4.cs
+++ b/Source/Engine/Core/Math/Vector4.cs
@@ -1362,7 +1362,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Vector4 left, Vector4 right)
         {
-            return Mathr.NearEqual(left.X, right.X) && Mathr.NearEqual(left.Y, right.Y) && Mathr.NearEqual(left.Z, right.Z) && Mathr.NearEqual(left.W, right.W);
+            return left.Equals(ref right);
         }
 
         /// <summary>
@@ -1493,7 +1493,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="Vector4" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Vector4 other)
         {
-            return Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z) && Mathr.NearEqual(other.W, W);
+            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
         }
 
         /// <summary>
@@ -1504,7 +1504,7 @@ namespace FlaxEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Vector4 other)
         {
-            return Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z) && Mathr.NearEqual(other.W, W);
+            return Equals(ref other);
         }
 
         /// <summary>
@@ -1514,7 +1514,7 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object value)
         {
-            return value is Vector4 other && Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z) && Mathr.NearEqual(other.W, W);
+            return value is Vector4 other && Equals(ref other);
         }
     }
 }

--- a/Source/Engine/Core/Math/Viewport.cs
+++ b/Source/Engine/Core/Math/Viewport.cs
@@ -173,12 +173,12 @@ namespace FlaxEngine
         /// <returns><c>true</c> if the specified <see cref="Viewport"/> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Viewport other)
         {
-            return Mathf.NearEqual(X, other.X) &&
-                   Mathf.NearEqual(Y, other.Y) &&
-                   Mathf.NearEqual(Width, other.Width) &&
-                   Mathf.NearEqual(Height, other.Height) &&
-                   Mathf.NearEqual(MinDepth, other.MinDepth) &&
-                   Mathf.NearEqual(MaxDepth, other.MaxDepth);
+            return X == other.X &&
+                   Y == other.Y &&
+                   Width == other.Width &&
+                   Height == other.Height &&
+                   MinDepth == other.MinDepth &&
+                   MaxDepth == other.MaxDepth;
         }
 
         /// <summary>

--- a/Source/Engine/Core/Types/Variant.cpp
+++ b/Source/Engine/Core/Types/Variant.cpp
@@ -1162,9 +1162,9 @@ bool Variant::operator==(const Variant& other) const
         case VariantType::Enum:
             return AsEnum == other.AsEnum;
         case VariantType::Float:
-            return Math::NearEqual(AsFloat, other.AsFloat);
+            return AsFloat == other.AsFloat;
         case VariantType::Double:
-            return Math::Abs(AsDouble - other.AsDouble) < ZeroTolerance;
+            return AsDouble == other.AsDouble;
         case VariantType::Pointer:
             return AsPointer == other.AsPointer;
         case VariantType::String:

--- a/Source/Engine/Foliage/Foliage.cpp
+++ b/Source/Engine/Foliage/Foliage.cpp
@@ -1013,7 +1013,7 @@ bool UpdateFoliageDensityScaling(Actor* actor)
 void Foliage::SetGlobalDensityScale(float value)
 {
     value = Math::Saturate(value);
-    if (Math::NearEqual(value, GlobalDensityScale))
+    if (value == GlobalDensityScale)
         return;
 
     PROFILE_CPU();

--- a/Source/Engine/Foliage/FoliageInstance.h
+++ b/Source/Engine/Foliage/FoliageInstance.h
@@ -52,7 +52,7 @@ API_STRUCT(NoPod) struct FLAXENGINE_API FoliageInstance
 public:
     bool operator==(const FoliageInstance& v) const
     {
-        return Type == v.Type && Math::NearEqual(Random, v.Random) && Transform == v.Transform;
+        return Type == v.Type && Random == v.Random && Transform == v.Transform;
     }
 
     /// <summary>

--- a/Source/Engine/Graphics/Materials/MaterialInfo.cs
+++ b/Source/Engine/Graphics/Materials/MaterialInfo.cs
@@ -64,8 +64,8 @@ namespace FlaxEngine
                    && DecalBlendingMode == other.DecalBlendingMode
                    && TransparentLightingMode == other.TransparentLightingMode
                    && PostFxLocation == other.PostFxLocation
-                   && Mathf.NearEqual(MaskThreshold, other.MaskThreshold)
-                   && Mathf.NearEqual(OpacityThreshold, other.OpacityThreshold)
+                   && MaskThreshold == other.MaskThreshold
+                   && OpacityThreshold == other.OpacityThreshold
                    && TessellationMode == other.TessellationMode
                    && MaxTessellationFactor == other.MaxTessellationFactor;
         }

--- a/Source/Engine/Graphics/Materials/MaterialParams.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialParams.cpp
@@ -24,8 +24,8 @@ bool MaterialInfo8::operator==(const MaterialInfo8& other) const
             && TransparentLighting == other.TransparentLighting
             && DecalBlendingMode == other.DecalBlendingMode
             && PostFxLocation == other.PostFxLocation
-            && Math::NearEqual(MaskThreshold, other.MaskThreshold)
-            && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
+            && MaskThreshold == other.MaskThreshold
+            && OpacityThreshold == other.OpacityThreshold
             && Flags == other.Flags
             && TessellationMode == other.TessellationMode
             && MaxTessellationFactor == other.MaxTessellationFactor;
@@ -89,8 +89,8 @@ bool MaterialInfo9::operator==(const MaterialInfo9& other) const
             && DecalBlendingMode == other.DecalBlendingMode
             && PostFxLocation == other.PostFxLocation
             && CullMode == other.CullMode
-            && Math::NearEqual(MaskThreshold, other.MaskThreshold)
-            && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
+            && MaskThreshold == other.MaskThreshold
+            && OpacityThreshold == other.OpacityThreshold
             && TessellationMode == other.TessellationMode
             && MaxTessellationFactor == other.MaxTessellationFactor;
 }
@@ -123,8 +123,8 @@ bool MaterialInfo::operator==(const MaterialInfo& other) const
             && TransparentLightingMode == other.TransparentLightingMode
             && PostFxLocation == other.PostFxLocation
             && CullMode == other.CullMode
-            && Math::NearEqual(MaskThreshold, other.MaskThreshold)
-            && Math::NearEqual(OpacityThreshold, other.OpacityThreshold)
+            && MaskThreshold == other.MaskThreshold
+            && OpacityThreshold == other.OpacityThreshold
             && TessellationMode == other.TessellationMode
             && MaxTessellationFactor == other.MaxTessellationFactor;
 }

--- a/Source/Engine/Graphics/Textures/GPUSamplerDescription.cs
+++ b/Source/Engine/Graphics/Textures/GPUSamplerDescription.cs
@@ -40,9 +40,9 @@ namespace FlaxEngine
                    AddressU == other.AddressU &&
                    AddressV == other.AddressV &&
                    AddressW == other.AddressW &&
-                   Mathf.NearEqual(MipBias, other.MipBias) &&
-                   Mathf.NearEqual(MinMipLevel, other.MinMipLevel) &&
-                   Mathf.NearEqual(MaxMipLevel, other.MaxMipLevel) &&
+                   MipBias == other.MipBias &&
+                   MinMipLevel == other.MinMipLevel &&
+                   MaxMipLevel == other.MaxMipLevel &&
                    MaxAnisotropy == other.MaxAnisotropy &&
                    BorderColor == other.BorderColor &&
                    ComparisonFunction == other.ComparisonFunction;

--- a/Source/Engine/Input/Input.cpp
+++ b/Source/Engine/Input/Input.cpp
@@ -1216,7 +1216,7 @@ void InputService::Update()
     {
         for (auto i = Axes.Begin(); i.IsNotEnd(); ++i)
         {
-            if (Math::NotNearEqual(i->Value.Value, i->Value.PrevValue))
+            if (i->Value.Value != i->Value.PrevValue)
             {
                 Input::AxisValueChanged(i->Key);
             }

--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -660,7 +660,7 @@ void Actor::SetStaticFlags(StaticFlags value)
 void Actor::SetTransform(const Transform& value)
 {
     CHECK(!value.IsNanOrInfinity());
-    if (!(Vector3::NearEqual(_transform.Translation, value.Translation) && Quaternion::NearEqual(_transform.Orientation, value.Orientation, ACTOR_ORIENTATION_EPSILON) && Float3::NearEqual(_transform.Scale, value.Scale)))
+    if (_transform.Translation != value.Translation && _transform.Orientation != value.Orientation && _transform.Scale != value.Scale)
     {
         if (_parent)
             _parent->_transform.WorldToLocal(value, _localTransform);
@@ -673,7 +673,7 @@ void Actor::SetTransform(const Transform& value)
 void Actor::SetPosition(const Vector3& value)
 {
     CHECK(!value.IsNanOrInfinity());
-    if (!Vector3::NearEqual(_transform.Translation, value))
+    if (_transform.Translation != value)
     {
         if (_parent)
             _localTransform.Translation = _parent->_transform.WorldToLocal(value);
@@ -686,7 +686,7 @@ void Actor::SetPosition(const Vector3& value)
 void Actor::SetOrientation(const Quaternion& value)
 {
     CHECK(!value.IsNanOrInfinity());
-    if (!Quaternion::NearEqual(_transform.Orientation, value, ACTOR_ORIENTATION_EPSILON))
+    if (_transform.Orientation != value)
     {
         if (_parent)
             _parent->_transform.WorldToLocal(value, _localTransform.Orientation);
@@ -699,7 +699,7 @@ void Actor::SetOrientation(const Quaternion& value)
 void Actor::SetScale(const Float3& value)
 {
     CHECK(!value.IsNanOrInfinity());
-    if (!Float3::NearEqual(_transform.Scale, value))
+    if (_transform.Scale != value)
     {
         if (_parent)
             Float3::Divide(value, _parent->_transform.Scale, _localTransform.Scale);
@@ -748,7 +748,7 @@ void Actor::ResetLocalTransform()
 void Actor::SetLocalTransform(const Transform& value)
 {
     CHECK(!value.IsNanOrInfinity());
-    if (!(Vector3::NearEqual(_localTransform.Translation, value.Translation) && Quaternion::NearEqual(_localTransform.Orientation, value.Orientation, ACTOR_ORIENTATION_EPSILON) && Float3::NearEqual(_localTransform.Scale, value.Scale)))
+    if (_localTransform.Translation != value.Translation || _localTransform.Orientation != value.Orientation || _localTransform.Scale != value.Scale)
     {
         _localTransform = value;
         OnTransformChanged();
@@ -758,7 +758,7 @@ void Actor::SetLocalTransform(const Transform& value)
 void Actor::SetLocalPosition(const Vector3& value)
 {
     CHECK(!value.IsNanOrInfinity());
-    if (!Vector3::NearEqual(_localTransform.Translation, value))
+    if (_localTransform.Translation != value)
     {
         _localTransform.Translation = value;
         OnTransformChanged();
@@ -770,7 +770,7 @@ void Actor::SetLocalOrientation(const Quaternion& value)
     CHECK(!value.IsNanOrInfinity());
     Quaternion v = value;
     v.Normalize();
-    if (!Quaternion::NearEqual(_localTransform.Orientation, v, ACTOR_ORIENTATION_EPSILON))
+    if (_localTransform.Orientation != value)
     {
         _localTransform.Orientation = v;
         OnTransformChanged();
@@ -780,7 +780,7 @@ void Actor::SetLocalOrientation(const Quaternion& value)
 void Actor::SetLocalScale(const Float3& value)
 {
     CHECK(!value.IsNanOrInfinity());
-    if (!Float3::NearEqual(_localTransform.Scale, value))
+    if (_localTransform.Scale != value)
     {
         _localTransform.Scale = value;
         OnTransformChanged();

--- a/Source/Engine/Level/Actors/BoxBrush.cpp
+++ b/Source/Engine/Level/Actors/BoxBrush.cpp
@@ -65,7 +65,7 @@ void BoxBrush::SetMode(BrushMode value)
 
 void BoxBrush::SetCenter(const Vector3& value)
 {
-    if (Vector3::NearEqual(value, _center))
+    if (value == _center)
         return;
 
     _center = value;
@@ -77,7 +77,7 @@ void BoxBrush::SetCenter(const Vector3& value)
 
 void BoxBrush::SetSize(const Vector3& value)
 {
-    if (Vector3::NearEqual(value, _size))
+    if (value == _size)
         return;
 
     _size = value;

--- a/Source/Engine/Level/Actors/BoxVolume.cpp
+++ b/Source/Engine/Level/Actors/BoxVolume.cpp
@@ -12,7 +12,7 @@ BoxVolume::BoxVolume(const SpawnParams& params)
 
 void BoxVolume::SetSize(const Vector3& value)
 {
-    if (!Vector3::NearEqual(value, _size))
+    if (value != _size)
     {
         const auto prevBounds = _box;
         _size = value;

--- a/Source/Engine/Level/Actors/Camera.cpp
+++ b/Source/Engine/Level/Actors/Camera.cpp
@@ -70,7 +70,7 @@ float Camera::GetFieldOfView() const
 void Camera::SetFieldOfView(float value)
 {
     value = Math::Clamp(value, 1.0f, 179.9f);
-    if (Math::NotNearEqual(_fov, value))
+    if (_fov != value)
     {
         _fov = value;
         UpdateCache();
@@ -85,7 +85,7 @@ float Camera::GetCustomAspectRatio() const
 void Camera::SetCustomAspectRatio(float value)
 {
     value = Math::Clamp(value, 0.0f, 100.0f);
-    if (Math::NotNearEqual(_customAspectRatio, value))
+    if (_customAspectRatio != value)
     {
         _customAspectRatio = value;
         UpdateCache();
@@ -100,7 +100,7 @@ float Camera::GetNearPlane() const
 void Camera::SetNearPlane(float value)
 {
     value = Math::Clamp(value, 0.001f, _far - 1.0f);
-    if (Math::NotNearEqual(_near, value))
+    if (_near != value)
     {
         _near = value;
         UpdateCache();
@@ -115,7 +115,7 @@ float Camera::GetFarPlane() const
 void Camera::SetFarPlane(float value)
 {
     value = Math::Max(value, _near + 1.0f);
-    if (Math::NotNearEqual(_far, value))
+    if (_far != value)
     {
         _far = value;
         UpdateCache();
@@ -130,7 +130,7 @@ float Camera::GetOrthographicSize() const
 void Camera::SetOrthographicSize(float value)
 {
     value = Math::Clamp(value, 0.0f, 1000000.0f);
-    if (Math::NotNearEqual(_orthoSize, value))
+    if (_orthoSize != value)
     {
         _orthoSize = value;
         UpdateCache();
@@ -145,7 +145,7 @@ float Camera::GetOrthographicScale() const
 void Camera::SetOrthographicScale(float value)
 {
     value = Math::Clamp(value, 0.0001f, 1000000.0f);
-    if (Math::NotNearEqual(_orthoScale, value))
+    if (_orthoScale != value)
     {
         _orthoScale = value;
         UpdateCache();

--- a/Source/Engine/Level/Actors/EnvironmentProbe.cpp
+++ b/Source/Engine/Level/Actors/EnvironmentProbe.cpp
@@ -41,7 +41,7 @@ float EnvironmentProbe::GetRadius() const
 void EnvironmentProbe::SetRadius(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(value, _radius))
+    if (value == _radius)
         return;
 
     _radius = value;

--- a/Source/Engine/Level/Actors/PointLight.cpp
+++ b/Source/Engine/Level/Actors/PointLight.cpp
@@ -49,7 +49,7 @@ float PointLight::GetScaledRadius() const
 void PointLight::SetRadius(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(value, _radius))
+    if (value == _radius)
         return;
 
     _radius = value;

--- a/Source/Engine/Level/Actors/SkyLight.cpp
+++ b/Source/Engine/Level/Actors/SkyLight.cpp
@@ -26,7 +26,7 @@ SkyLight::SkyLight(const SpawnParams& params)
 void SkyLight::SetRadius(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(value, _radius))
+    if (value == _radius)
         return;
 
     _radius = value;

--- a/Source/Engine/Level/Actors/SplineModel.cpp
+++ b/Source/Engine/Level/Actors/SplineModel.cpp
@@ -59,7 +59,7 @@ float SplineModel::GetQuality() const
 void SplineModel::SetQuality(float value)
 {
     value = Math::Clamp(value, 0.0f, 100.0f);
-    if (Math::NearEqual(value, _quality))
+    if (value == _quality)
         return;
     _quality = value;
     OnSplineUpdated();
@@ -72,7 +72,7 @@ float SplineModel::GetBoundsScale() const
 
 void SplineModel::SetBoundsScale(float value)
 {
-    if (Math::NearEqual(_boundsScale, value))
+    if (_boundsScale == value)
         return;
     _boundsScale = value;
     OnSplineUpdated();

--- a/Source/Engine/Level/Actors/SpotLight.cpp
+++ b/Source/Engine/Level/Actors/SpotLight.cpp
@@ -57,7 +57,7 @@ float SpotLight::GetScaledRadius() const
 void SpotLight::SetRadius(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(value, _radius))
+    if (value == _radius)
         return;
 
     _radius = value;
@@ -70,7 +70,7 @@ void SpotLight::SetOuterConeAngle(float value)
     value = Math::Clamp(value, 0.0f, 89.0f);
 
     // Check if value will change
-    if (!Math::NearEqual(value, _outerConeAngle))
+    if (value != _outerConeAngle)
     {
         // Change values
         _innerConeAngle = Math::Min(_innerConeAngle, value - ZeroTolerance);
@@ -86,7 +86,7 @@ void SpotLight::SetInnerConeAngle(float value)
     value = Math::Clamp(value, 0.0f, 89.0f);
 
     // Check if value will change
-    if (!Math::NearEqual(value, _innerConeAngle))
+    if (value != _innerConeAngle)
     {
         // Change values
         _innerConeAngle = value;

--- a/Source/Engine/Level/Actors/StaticModel.cpp
+++ b/Source/Engine/Level/Actors/StaticModel.cpp
@@ -60,7 +60,7 @@ float StaticModel::GetBoundsScale() const
 
 void StaticModel::SetBoundsScale(float value)
 {
-    if (Math::NearEqual(_boundsScale, value))
+    if (_boundsScale == value)
         return;
 
     _boundsScale = value;

--- a/Source/Engine/Navigation/NavMeshRuntime.cpp
+++ b/Source/Engine/Navigation/NavMeshRuntime.cpp
@@ -292,7 +292,7 @@ void NavMeshRuntime::SetTileSize(float tileSize)
     ScopeLock lock(Locker);
 
     // Skip if the same or invalid
-    if (Math::NearEqual(_tileSize, tileSize) || tileSize < 1)
+    if (_tileSize == tileSize || tileSize < 1)
         return;
 
     // Dispose the existing mesh (its invalid)

--- a/Source/Engine/Navigation/Navigation.cpp
+++ b/Source/Engine/Navigation/Navigation.cpp
@@ -107,7 +107,7 @@ Color NavMeshRuntime::NavAreasColors[64];
 
 bool NavAgentProperties::operator==(const NavAgentProperties& other) const
 {
-    return Math::NearEqual(Radius, other.Radius) && Math::NearEqual(Height, other.Height) && Math::NearEqual(StepHeight, other.StepHeight) && Math::NearEqual(MaxSlopeAngle, other.MaxSlopeAngle) && Math::NearEqual(MaxSpeed, other.MaxSpeed) && Math::NearEqual(CrowdSeparationWeight, other.CrowdSeparationWeight);
+    return Radius == other.Radius && Height == other.Height && StepHeight == other.StepHeight && MaxSlopeAngle == other.MaxSlopeAngle && MaxSpeed == other.MaxSpeed && CrowdSeparationWeight == other.CrowdSeparationWeight;
 }
 
 bool NavAgentMask::IsAgentSupported(int32 agentIndex) const
@@ -148,12 +148,12 @@ bool NavAgentMask::operator==(const NavAgentMask& other) const
 
 bool NavAreaProperties::operator==(const NavAreaProperties& other) const
 {
-    return Name == other.Name && Id == other.Id && Math::NearEqual(Cost, other.Cost);
+    return Name == other.Name && Id == other.Id && Cost == other.Cost;
 }
 
 bool NavMeshProperties::operator==(const NavMeshProperties& other) const
 {
-    return Name == other.Name && Quaternion::NearEqual(Rotation, other.Rotation, 0.001f) && Agent == other.Agent && Vector3::NearEqual(DefaultQueryExtent, other.DefaultQueryExtent);
+    return Name == other.Name && Rotation == other.Rotation && Agent == other.Agent && DefaultQueryExtent == other.DefaultQueryExtent;
 }
 
 class NavigationService : public EngineService

--- a/Source/Engine/Physics/Actors/RigidBody.cpp
+++ b/Source/Engine/Physics/Actors/RigidBody.cpp
@@ -44,7 +44,7 @@ void RigidBody::SetIsKinematic(const bool value)
 
 void RigidBody::SetLinearDamping(float value)
 {
-    if (Math::NearEqual(value, _linearDamping))
+    if (value == _linearDamping)
         return;
     _linearDamping = value;
     if (_actor)
@@ -53,7 +53,7 @@ void RigidBody::SetLinearDamping(float value)
 
 void RigidBody::SetAngularDamping(float value)
 {
-    if (Math::NearEqual(value, _angularDamping))
+    if (value == _angularDamping)
         return;
     _angularDamping = value;
     if (_actor)
@@ -108,7 +108,7 @@ void RigidBody::SetUpdateMassWhenScaleChanges(bool value)
 
 void RigidBody::SetMaxAngularVelocity(float value)
 {
-    if (Math::NearEqual(value, _maxAngularVelocity))
+    if (value == _maxAngularVelocity)
         return;
     _maxAngularVelocity = value;
     if (_actor)
@@ -135,7 +135,7 @@ float RigidBody::GetMass() const
 
 void RigidBody::SetMass(float value)
 {
-    if (Math::NearEqual(value, _mass))
+    if (value == _mass)
         return;
     _mass = value;
     _overrideMass = true;
@@ -149,7 +149,7 @@ float RigidBody::GetMassScale() const
 
 void RigidBody::SetMassScale(float value)
 {
-    if (Math::NearEqual(value, _massScale))
+    if (value == _massScale)
         return;
     _massScale = value;
     UpdateMass();
@@ -157,7 +157,7 @@ void RigidBody::SetMassScale(float value)
 
 void RigidBody::SetCenterOfMassOffset(const Float3& value)
 {
-    if (Float3::NearEqual(value, _centerOfMassOffset))
+    if (value == _centerOfMassOffset)
         return;
     _centerOfMassOffset = value;
     if (_actor)
@@ -380,7 +380,7 @@ void RigidBody::UpdateBounds()
 void RigidBody::UpdateScale()
 {
     const Float3 scale = GetScale();
-    if (Float3::NearEqual(_cachedScale, scale))
+    if (_cachedScale == scale)
         return;
     _cachedScale = scale;
 

--- a/Source/Engine/Physics/Colliders/BoxCollider.cpp
+++ b/Source/Engine/Physics/Colliders/BoxCollider.cpp
@@ -12,7 +12,7 @@ BoxCollider::BoxCollider(const SpawnParams& params)
 
 void BoxCollider::SetSize(const Float3& value)
 {
-    if (Float3::NearEqual(value, _size))
+    if (value == _size)
         return;
     _size = value;
 

--- a/Source/Engine/Physics/Colliders/CapsuleCollider.cpp
+++ b/Source/Engine/Physics/Colliders/CapsuleCollider.cpp
@@ -11,7 +11,7 @@ CapsuleCollider::CapsuleCollider(const SpawnParams& params)
 
 void CapsuleCollider::SetRadius(const float value)
 {
-    if (Math::NearEqual(value, _radius))
+    if (value == _radius)
         return;
 
     _radius = value;
@@ -22,7 +22,7 @@ void CapsuleCollider::SetRadius(const float value)
 
 void CapsuleCollider::SetHeight(const float value)
 {
-    if (Math::NearEqual(value, _height))
+    if (value == _height)
         return;
 
     _height = value;

--- a/Source/Engine/Physics/Colliders/CharacterController.cpp
+++ b/Source/Engine/Physics/Colliders/CharacterController.cpp
@@ -33,7 +33,7 @@ float CharacterController::GetRadius() const
 
 void CharacterController::SetRadius(const float value)
 {
-    if (Math::NearEqual(value, _radius))
+    if (value == _radius)
         return;
 
     _radius = value;
@@ -49,7 +49,7 @@ float CharacterController::GetHeight() const
 
 void CharacterController::SetHeight(const float value)
 {
-    if (Math::NearEqual(value, _height))
+    if (value == _height)
         return;
 
     _height = value;
@@ -66,7 +66,7 @@ float CharacterController::GetSlopeLimit() const
 void CharacterController::SetSlopeLimit(float value)
 {
     value = Math::Clamp(value, 0.0f, 89.0f);
-    if (Math::NearEqual(value, _slopeLimit))
+    if (value == _slopeLimit)
         return;
     _slopeLimit = value;
     if (_controller)
@@ -94,7 +94,7 @@ float CharacterController::GetStepOffset() const
 
 void CharacterController::SetStepOffset(float value)
 {
-    if (Math::NearEqual(value, _stepOffset))
+    if (value == _stepOffset)
         return;
 
     _stepOffset = value;
@@ -384,7 +384,7 @@ void CharacterController::OnTransformChanged()
     {
         PhysicsBackend::SetControllerPosition(_controller, position);
         const Float3 scale = GetScale();
-        if (!Float3::NearEqual(_cachedScale, scale))
+        if (_cachedScale != scale)
             UpdateGeometry();
         UpdateBounds();
     }

--- a/Source/Engine/Physics/Colliders/Collider.cpp
+++ b/Source/Engine/Physics/Colliders/Collider.cpp
@@ -49,7 +49,7 @@ void Collider::SetIsTrigger(bool value)
 
 void Collider::SetCenter(const Vector3& value)
 {
-    if (Vector3::NearEqual(value, _center))
+    if (value == _center)
         return;
     _center = value;
     if (_staticActor)
@@ -62,7 +62,7 @@ void Collider::SetCenter(const Vector3& value)
 void Collider::SetContactOffset(float value)
 {
     value = Math::Clamp(value, 0.0f, 100.0f);
-    if (Math::NearEqual(value, _contactOffset))
+    if (value == _contactOffset)
         return;
     _contactOffset = value;
     if (_shape)
@@ -428,7 +428,7 @@ void Collider::OnTransformChanged()
     }
 
     const Float3 scale = GetScale();
-    if (!Float3::NearEqual(_cachedScale, scale))
+    if (_cachedScale != scale)
         UpdateGeometry();
     UpdateBounds();
 }

--- a/Source/Engine/Physics/Colliders/SphereCollider.cpp
+++ b/Source/Engine/Physics/Colliders/SphereCollider.cpp
@@ -10,7 +10,7 @@ SphereCollider::SphereCollider(const SpawnParams& params)
 
 void SphereCollider::SetRadius(const float value)
 {
-    if (Math::NearEqual(value, _radius))
+    if (value == _radius)
         return;
 
     _radius = value;

--- a/Source/Engine/Physics/Joints/DistanceJoint.cpp
+++ b/Source/Engine/Physics/Joints/DistanceJoint.cpp
@@ -25,7 +25,7 @@ void DistanceJoint::SetFlags(DistanceJointFlag value)
 void DistanceJoint::SetMinDistance(float value)
 {
     value = Math::Clamp(value, 0.0f, _maxDistance);
-    if (Math::NearEqual(value, _minDistance))
+    if (value == _minDistance)
         return;
     _minDistance = value;
     if (_joint)
@@ -35,7 +35,7 @@ void DistanceJoint::SetMinDistance(float value)
 void DistanceJoint::SetMaxDistance(float value)
 {
     value = Math::Max(_minDistance, value);
-    if (Math::NearEqual(value, _maxDistance))
+    if (value == _maxDistance)
         return;
     _maxDistance = value;
     if (_joint)
@@ -45,7 +45,7 @@ void DistanceJoint::SetMaxDistance(float value)
 void DistanceJoint::SetTolerance(float value)
 {
     value = Math::Max(0.1f, value);
-    if (Math::NearEqual(value, _tolerance))
+    if (value == _tolerance)
         return;
     _tolerance = value;
     if (_joint)

--- a/Source/Engine/Physics/Joints/HingeJoint.h
+++ b/Source/Engine/Physics/Joints/HingeJoint.h
@@ -59,7 +59,7 @@ API_STRUCT() struct HingeJointDrive
 public:
     bool operator==(const HingeJointDrive& other) const
     {
-        return Math::NearEqual(Velocity, other.Velocity) && Math::NearEqual(ForceLimit, other.ForceLimit) && Math::NearEqual(GearRatio, other.GearRatio) && FreeSpin == other.FreeSpin;
+        return Velocity == other.Velocity && ForceLimit == other.ForceLimit && GearRatio == other.GearRatio && FreeSpin == other.FreeSpin;
     }
 };
 

--- a/Source/Engine/Physics/Joints/Joint.cpp
+++ b/Source/Engine/Physics/Joints/Joint.cpp
@@ -24,7 +24,7 @@ Joint::Joint(const SpawnParams& params)
 
 void Joint::SetBreakForce(float value)
 {
-    if (Math::NearEqual(value, _breakForce))
+    if (value == _breakForce)
         return;
     _breakForce = value;
     if (_joint)
@@ -33,7 +33,7 @@ void Joint::SetBreakForce(float value)
 
 void Joint::SetBreakTorque(float value)
 {
-    if (Math::NearEqual(value, _breakTorque))
+    if (value == _breakTorque)
         return;
     _breakTorque = value;
     if (_joint)
@@ -61,7 +61,7 @@ void Joint::SetEnableAutoAnchor(bool value)
 
 void Joint::SetTargetAnchor(const Vector3& value)
 {
-    if (Vector3::NearEqual(value, _targetAnchor))
+    if (value == _targetAnchor)
         return;
     _targetAnchor = value;
     if (_joint && !_enableAutoAnchor)

--- a/Source/Engine/Render2D/TextLayoutOptions.h
+++ b/Source/Engine/Render2D/TextLayoutOptions.h
@@ -108,8 +108,8 @@ DECLARE_SCRIPTING_TYPE_MINIMAL(TextLayoutOptions);
                 && HorizontalAlignment == other.HorizontalAlignment
                 && VerticalAlignment == other.VerticalAlignment
                 && TextWrapping == other.TextWrapping
-                && Math::NearEqual(Scale, other.Scale)
-                && Math::NearEqual(BaseLinesGapScale, other.BaseLinesGapScale);
+                && Scale == other.Scale
+                && BaseLinesGapScale == other.BaseLinesGapScale;
     }
 
     FORCE_INLINE bool operator!=(const TextLayoutOptions& other) const

--- a/Source/Engine/Renderer/ShadowsPass.cpp
+++ b/Source/Engine/Renderer/ShadowsPass.cpp
@@ -236,9 +236,9 @@ struct ShadowAtlasLight
     {
         if (!Cache.StaticValid || !Cache.DynamicValid)
             return;
-        if (!Math::NearEqual(Cache.Distance, light.ShadowsDistance) ||
-            !Math::NearEqual(Cache.ShadowsUpdateRate, light.ShadowsUpdateRate) ||
-            !Math::NearEqual(Cache.ShadowsUpdateRateAtDistance, light.ShadowsUpdateRateAtDistance) ||
+        if (Cache.Distance != light.ShadowsDistance ||
+            Cache.ShadowsUpdateRate != light.ShadowsUpdateRate ||
+            Cache.ShadowsUpdateRateAtDistance != light.ShadowsUpdateRateAtDistance ||
             Cache.ShadowFrame != light.ShadowFrame ||
             Cache.ShadowsResolution != light.ShadowsResolution ||
             Float3::Dot(Cache.Direction, light.Direction) < SHADOWS_ROTATION_ERROR)
@@ -250,7 +250,7 @@ struct ShadowAtlasLight
         {
             // Sun
             if (!Float3::NearEqual(Cache.Position, view.Position, SHADOWS_POSITION_ERROR) ||
-                !Float4::NearEqual(Cache.CascadeSplits, CascadeSplits) ||
+                Cache.CascadeSplits != CascadeSplits ||
                 Float3::Dot(Cache.ViewDirection, view.Direction) < SHADOWS_ROTATION_ERROR)
             {
                 // Invalidate
@@ -262,12 +262,12 @@ struct ShadowAtlasLight
             // Local light
             const auto& localLight = (const RenderLocalLightData&)light;
             if (!Float3::NearEqual(Cache.Position, light.Position, SHADOWS_POSITION_ERROR) ||
-                !Math::NearEqual(Cache.Radius, localLight.Radius))
+                Cache.Radius != localLight.Radius)
             {
                 // Invalidate
                 Cache.StaticValid = false;
             }
-            if (light.IsSpotLight && !Math::NearEqual(Cache.OuterConeAngle, ((const RenderSpotLightData&)light).OuterConeAngle))
+            if (light.IsSpotLight && Cache.OuterConeAngle != ((const RenderSpotLightData&)light).OuterConeAngle)
             {
                 // Invalidate
                 Cache.StaticValid = false;

--- a/Source/Engine/Terrain/Terrain.cpp
+++ b/Source/Engine/Terrain/Terrain.cpp
@@ -260,7 +260,7 @@ void Terrain::SetScaleInLightmap(float value)
 
 void Terrain::SetBoundsExtent(const Vector3& value)
 {
-    if (Vector3::NearEqual(_boundsExtent, value))
+    if (_boundsExtent == value)
         return;
 
     _boundsExtent = value;
@@ -891,7 +891,7 @@ void Terrain::OnTransformChanged()
         auto patch = _patches[i];
         patch->UpdateTransform();
     }
-    if (!Float3::NearEqual(_cachedScale, _transform.Scale))
+    if (_cachedScale != _transform.Scale)
     {
         _cachedScale = _transform.Scale;
         for (int32 i = 0; i < _patches.Count(); i++)

--- a/Source/Engine/Tests/TestFloatR10G10B10A2.cs
+++ b/Source/Engine/Tests/TestFloatR10G10B10A2.cs
@@ -11,13 +11,13 @@ namespace FlaxEngine.Tests
         [Test]
         public void TestConversion()
         {
-            Assert.AreEqual(Float4.Zero, new FloatR10G10B10A2(Float4.Zero).ToFloat4());
-            Assert.AreEqual(Float4.One, new FloatR10G10B10A2(Float4.One).ToFloat4());
-            Assert.AreEqual(new Float4(0.5004888f, 0.5004888f, 0.5004888f, 0.666667f), new FloatR10G10B10A2(new Float4(0.5f)).ToFloat4());
-            Assert.AreEqual(new Float4(1, 0, 0, 0), new FloatR10G10B10A2(new Float4(1, 0, 0, 0)).ToFloat4());
-            Assert.AreEqual(new Float4(0, 1, 0, 0), new FloatR10G10B10A2(new Float4(0, 1, 0, 0)).ToFloat4());
-            Assert.AreEqual(new Float4(0, 0, 1, 0), new FloatR10G10B10A2(new Float4(0, 0, 1, 0)).ToFloat4());
-            Assert.AreEqual(new Float4(0, 0, 0, 1), new FloatR10G10B10A2(new Float4(0, 0, 0, 1)).ToFloat4());
+            Assert.IsTrue(Float4.NearEqual(Float4.Zero, new FloatR10G10B10A2(Float4.Zero).ToFloat4()));
+            Assert.IsTrue(Float4.NearEqual(Float4.One, new FloatR10G10B10A2(Float4.One).ToFloat4()));
+            Assert.IsTrue(Float4.NearEqual(new Float4(0.5004888f, 0.5004888f, 0.5004888f, 0.666667f), new FloatR10G10B10A2(new Float4(0.5f)).ToFloat4()));
+            Assert.IsTrue(Float4.NearEqual(new Float4(1, 0, 0, 0), new FloatR10G10B10A2(new Float4(1, 0, 0, 0)).ToFloat4()));
+            Assert.IsTrue(Float4.NearEqual(new Float4(0, 1, 0, 0), new FloatR10G10B10A2(new Float4(0, 1, 0, 0)).ToFloat4()));
+            Assert.IsTrue(Float4.NearEqual(new Float4(0, 0, 1, 0), new FloatR10G10B10A2(new Float4(0, 0, 1, 0)).ToFloat4()));
+            Assert.IsTrue(Float4.NearEqual(new Float4(0, 0, 0, 1), new FloatR10G10B10A2(new Float4(0, 0, 0, 1)).ToFloat4()));
         }
     }
 }

--- a/Source/Engine/Tests/TestFloatR11G11B10.cs
+++ b/Source/Engine/Tests/TestFloatR11G11B10.cs
@@ -11,13 +11,13 @@ namespace FlaxEngine.Tests
         [Test]
         public void TestConversion()
         {
-            Assert.AreEqual(Float3.Zero, new FloatR11G11B10(Float3.Zero).ToFloat3());
-            Assert.AreEqual(Float3.One, new FloatR11G11B10(Float3.One).ToFloat3());
-            Assert.AreEqual(new Float3(0.5f, 0.5f, 0.5f), new FloatR11G11B10(new Float3(0.5f)).ToFloat3());
-            Assert.AreEqual(new Float3(1, 0, 0), new FloatR11G11B10(new Float3(1, 0, 0)).ToFloat3());
-            Assert.AreEqual(new Float3(0, 1, 0), new FloatR11G11B10(new Float3(0, 1, 0)).ToFloat3());
-            Assert.AreEqual(new Float3(0, 0, 1), new FloatR11G11B10(new Float3(0, 0, 1)).ToFloat3());
-            Assert.AreEqual(new Float3(10, 11, 12), new FloatR11G11B10(new Float3(10, 11, 12)).ToFloat3());
+            Assert.IsTrue(Float3.NearEqual(Float3.Zero, new FloatR11G11B10(Float3.Zero).ToFloat3()));
+            Assert.IsTrue(Float3.NearEqual(Float3.One, new FloatR11G11B10(Float3.One).ToFloat3()));
+            Assert.IsTrue(Float3.NearEqual(new Float3(0.5f, 0.5f, 0.5f), new FloatR11G11B10(new Float3(0.5f)).ToFloat3()));
+            Assert.IsTrue(Float3.NearEqual(new Float3(1, 0, 0), new FloatR11G11B10(new Float3(1, 0, 0)).ToFloat3()));
+            Assert.IsTrue(Float3.NearEqual(new Float3(0, 1, 0), new FloatR11G11B10(new Float3(0, 1, 0)).ToFloat3()));
+            Assert.IsTrue(Float3.NearEqual(new Float3(0, 0, 1), new FloatR11G11B10(new Float3(0, 0, 1)).ToFloat3()));
+            Assert.IsTrue(Float3.NearEqual(new Float3(10, 11, 12), new FloatR11G11B10(new Float3(10, 11, 12)).ToFloat3()));
         }
     }
 }

--- a/Source/Engine/Tests/TestQuaternion.cs
+++ b/Source/Engine/Tests/TestQuaternion.cs
@@ -17,10 +17,10 @@ namespace FlaxEngine.Tests
         [Test]
         public void TestEuler()
         {
-            Assert.AreEqual(Quaternion.Euler(90, 0, 0), new Quaternion(0.7071068f, 0, 0, 0.7071068f));
-            Assert.AreEqual(Quaternion.Euler(25, 0, 10), new Quaternion(0.215616f, -0.018864f, 0.0850898f, 0.9725809f));
-            Assert.AreEqual(new Float3(25, 0, 10), Quaternion.Euler(25, 0, 10).EulerAngles);
-            Assert.AreEqual(new Float3(25, -5, 10), Quaternion.Euler(25, -5, 10).EulerAngles);
+            Assert.IsTrue(Quaternion.NearEqual(Quaternion.Euler(90, 0, 0), new Quaternion(0.7071068f, 0, 0, 0.7071068f)));
+            Assert.IsTrue(Quaternion.NearEqual(Quaternion.Euler(25, 0, 10), new Quaternion(0.215616f, -0.018864f, 0.0850898f, 0.9725809f)));
+            Assert.IsTrue(Float3.NearEqual(new Float3(25, 0, 10), Quaternion.Euler(25, 0, 10).EulerAngles, 0.00001f));
+            Assert.IsTrue(Float3.NearEqual(new Float3(25, -5, 10), Quaternion.Euler(25, -5, 10).EulerAngles, 0.00001f));
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace FlaxEngine.Tests
             var delta = Quaternion.Euler(0, 10, 0);
             for (int i = 0; i < 9; i++)
                 q *= delta;
-            Assert.AreEqual(Quaternion.Euler(0, 90, 0), q);
+            Assert.IsTrue(Quaternion.NearEqual(Quaternion.Euler(0, 90, 0), q));
         }
     }
 }

--- a/Source/Engine/Tests/TestTransform.cs
+++ b/Source/Engine/Tests/TestTransform.cs
@@ -68,9 +68,9 @@ namespace FlaxEngine.Tests
             t1.LocalToWorld(new Vector3[1] { t2.Translation }, a4T);
             Vector3 a4 = a4T[0];
 
-            Assert.AreEqual(a1.Translation, a2);
-            Assert.AreEqual(a2, a3);
-            Assert.AreEqual(a2, a4);
+            Assert.IsTrue(Vector3.NearEqual(a1.Translation, a2));
+            Assert.IsTrue(Vector3.NearEqual(a2, a3));
+            Assert.IsTrue(Vector3.NearEqual(a2, a4));
         }
 
         /// <summary>
@@ -100,9 +100,9 @@ namespace FlaxEngine.Tests
             t1.WorldToLocal(new Vector3[1] { t2.Translation }, a4T);
             Float3 a4 = a4T[0];
 
-            Assert.AreEqual((Float3)a1.Translation, a2);
-            Assert.AreEqual(a2, a3);
-            Assert.AreEqual(a2, a4);
+            Assert.IsTrue(Float3.NearEqual((Float3)a1.Translation, a2));
+            Assert.IsTrue(Float3.NearEqual(a2, a3, 0.0001f));
+            Assert.IsTrue(Float3.NearEqual(a2, a4));
         }
 
         /// <summary>
@@ -113,28 +113,28 @@ namespace FlaxEngine.Tests
         {
             Transform trans = new Transform(new Vector3(1, 2, 3));
 
-            Assert.AreEqual(new Float3(1, 2, 3), (Float3)trans.LocalToWorld(new Float3(0, 0, 0)));
-            Assert.AreEqual(new Float3(4, 4, 4), (Float3)trans.LocalToWorld(new Float3(3, 2, 1)));
-            Assert.AreEqual(new Float3(-1, -2, -3), (Float3)trans.WorldToLocal(new Float3(0, 0, 0)));
-            Assert.AreEqual(new Float3(0, 0, 0), (Float3)trans.WorldToLocal(new Float3(1, 2, 3)));
+            Assert.IsTrue(Float3.NearEqual(new Float3(1, 2, 3), (Float3)trans.LocalToWorld(new Float3(0, 0, 0))));
+            Assert.IsTrue(Float3.NearEqual(new Float3(4, 4, 4), (Float3)trans.LocalToWorld(new Float3(3, 2, 1))));
+            Assert.IsTrue(Float3.NearEqual(new Float3(-1, -2, -3), (Float3)trans.WorldToLocal(new Float3(0, 0, 0))));
+            Assert.IsTrue(Float3.NearEqual(new Float3(0, 0, 0), (Float3)trans.WorldToLocal(new Float3(1, 2, 3))));
 
             trans = new Transform(Vector3.Zero, Quaternion.Euler(0, 90, 0));
-            Assert.AreEqual(new Float3(0, 2, -1), (Float3)trans.LocalToWorld(new Float3(1, 2, 0)));
+            Assert.IsTrue(Float3.NearEqual(new Float3(0, 2, -1), (Float3)trans.LocalToWorld(new Float3(1, 2, 0))));
 
             trans.Translation = new Vector3(1, 0, 0);
             trans.Orientation = Quaternion.RotationX((float)Math.PI * 0.5f);
             trans.Scale = new Vector3(2, 2, 2);
-            Assert.AreEqual(new Float3(1, 0, 2), (Float3)trans.LocalToWorld(new Float3(0, 1, 0)));
+            Assert.IsTrue(Float3.NearEqual(new Float3(1, 0, 2), (Float3)trans.LocalToWorld(new Float3(0, 1, 0))));
 
             Transform t1 = trans.LocalToWorld(Transform.Identity);
-            Assert.AreEqual(new Float3(1.0f, 0, 0), (Float3)t1.Translation);
-            Assert.AreEqual(Quaternion.RotationX((float)Math.PI * 0.5f), t1.Orientation);
-            Assert.AreEqual(new Float3(2.0f, 2.0f, 2.0f), t1.Scale);
+            Assert.IsTrue(Float3.NearEqual(new Float3(1.0f, 0, 0), (Float3)t1.Translation));
+            Assert.IsTrue(Quaternion.NearEqual(Quaternion.RotationX((float)Math.PI * 0.5f), t1.Orientation));
+            Assert.IsTrue(Float3.NearEqual(new Float3(2.0f, 2.0f, 2.0f), t1.Scale));
 
             Transform t2 = trans.WorldToLocal(Transform.Identity);
-            Assert.AreEqual(new Float3(-0.5f, 0, 0), (Float3)t2.Translation);
-            Assert.AreEqual(Quaternion.RotationX((float)Math.PI * -0.5f), t2.Orientation);
-            Assert.AreEqual(new Float3(0.5f, 0.5f, 0.5f), t2.Scale);
+            Assert.IsTrue(Float3.NearEqual(new Float3(-0.5f, 0, 0), (Float3)t2.Translation));
+            Assert.IsTrue(Quaternion.NearEqual(Quaternion.RotationX((float)Math.PI * -0.5f), t2.Orientation));
+            Assert.IsTrue(Float3.NearEqual(new Float3(0.5f, 0.5f, 0.5f), t2.Scale));
 
             var rand = new Random(10);
             for (int i = 0; i < 10; i++)

--- a/Source/Engine/UI/GUI/CanvasScaler.cs
+++ b/Source/Engine/UI/GUI/CanvasScaler.cs
@@ -132,7 +132,7 @@ namespace FlaxEngine.GUI
             get => _scaleFactor;
             set
             {
-                if (Mathf.NearEqual(_scaleFactor, value))
+                if (_scaleFactor == value)
                     return;
                 _scaleFactor = value;
                 PerformLayout();
@@ -175,7 +175,7 @@ namespace FlaxEngine.GUI
             get => _physicalUnitSize;
             set
             {
-                if (Mathf.NearEqual(_physicalUnitSize, value))
+                if (_physicalUnitSize == value)
                     return;
                 _physicalUnitSize = value;
                 PerformLayout();
@@ -212,7 +212,7 @@ namespace FlaxEngine.GUI
             set
             {
                 value = Float2.Max(value, Float2.One);
-                if (Float2.NearEqual(ref _resolutionMin, ref value))
+                if (_resolutionMin == value)
                     return;
                 _resolutionMin = value;
                 PerformLayout();
@@ -231,7 +231,7 @@ namespace FlaxEngine.GUI
             set
             {
                 value = Float2.Max(value, Float2.One);
-                if (Float2.NearEqual(ref _resolutionMax, ref value))
+                if (_resolutionMax == value)
                     return;
                 _resolutionMax = value;
                 PerformLayout();

--- a/Source/Engine/UI/GUI/Common/ProgressBar.cs
+++ b/Source/Engine/UI/GUI/Common/ProgressBar.cs
@@ -140,7 +140,7 @@ namespace FlaxEngine.GUI
             set
             {
                 value = Mathf.Clamp(value, _minimum, _maximum);
-                if (!Mathf.NearEqual(value, _value))
+                if (value != _value)
                 {
                     _value = value;
                     if (!UseSmoothing || _firstUpdate)

--- a/Source/Engine/UI/GUI/Common/Slider.cs
+++ b/Source/Engine/UI/GUI/Common/Slider.cs
@@ -114,7 +114,7 @@ public class Slider : ContainerControl
             value = Mathf.Clamp(value, Minimum, Maximum);
             if (WholeNumbers)
                 value = Mathf.RoundToInt(value);
-            if (!Mathf.NearEqual(value, _value))
+            if (value != _value)
             {
                 _value = value;
 

--- a/Source/Engine/UI/GUI/Control.Bounds.cs
+++ b/Source/Engine/UI/GUI/Control.Bounds.cs
@@ -189,7 +189,7 @@ namespace FlaxEngine.GUI
             get => _bounds.Size.X;
             set
             {
-                if (Mathf.NearEqual(_bounds.Size.X, value))
+                if (_bounds.Size.X == value)
                     return;
                 var bounds = new Rectangle(_bounds.Location, value, _bounds.Size.Y);
                 if (_pivotRelativeSizing)
@@ -210,7 +210,7 @@ namespace FlaxEngine.GUI
             get => _bounds.Size.Y;
             set
             {
-                if (Mathf.NearEqual(_bounds.Size.Y, value))
+                if (_bounds.Size.Y == value)
                     return;
                 var bounds = new Rectangle(_bounds.Location, _bounds.Size.X, value);
                 if (_pivotRelativeSizing)
@@ -412,7 +412,7 @@ namespace FlaxEngine.GUI
             get => _rotation;
             set
             {
-                if (!Mathf.NearEqual(_rotation, value))
+                if (_rotation != value)
                 {
                     SetRotationInternal(value);
                 }
@@ -598,8 +598,7 @@ namespace FlaxEngine.GUI
                     var anchorMin = AnchorPresetsData[i].Min;
                     var anchorMax = AnchorPresetsData[i].Max;
                     var bounds = _bounds;
-                    if (!Float2.NearEqual(ref _anchorMin, ref anchorMin) ||
-                        !Float2.NearEqual(ref _anchorMax, ref anchorMax))
+                    if (_anchorMin != anchorMin || _anchorMax != anchorMax)
                     {
                         // Disable scrolling for anchored controls (by default but can be manually restored)
                         if (!anchorMin.IsZero || !anchorMax.IsZero)

--- a/Source/Engine/UI/GUI/Margin.cs
+++ b/Source/Engine/UI/GUI/Margin.cs
@@ -251,10 +251,10 @@ namespace FlaxEngine.GUI
         /// <returns><c>true</c> if the specified <see cref="Margin" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(ref Margin other)
         {
-            return Mathf.NearEqual(other.Left, Left) &&
-                   Mathf.NearEqual(other.Right, Right) &&
-                   Mathf.NearEqual(other.Top, Top) &&
-                   Mathf.NearEqual(other.Bottom, Bottom);
+            return other.Left == Left &&
+                   other.Right == Right &&
+                   other.Top == Top &&
+                   other.Bottom == Bottom;
         }
 
         /// <summary>

--- a/Source/Engine/UI/GUI/Panels/DropPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/DropPanel.cs
@@ -71,7 +71,7 @@ namespace FlaxEngine.GUI
             get => _headerHeight;
             set
             {
-                if (!Mathf.NearEqual(_headerHeight, value))
+                if (_headerHeight != value)
                 {
                     _headerHeight = value;
                     PerformLayout();

--- a/Source/Engine/UI/GUI/Panels/Panel.cs
+++ b/Source/Engine/UI/GUI/Panels/Panel.cs
@@ -129,7 +129,7 @@ namespace FlaxEngine.GUI
             get => _scrollBarsSize;
             set
             {
-                if (Mathf.NearEqual(_scrollBarsSize, value))
+                if (_scrollBarsSize == value)
                     return;
                 _scrollBarsSize = value;
                 PerformLayout();

--- a/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
+++ b/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
@@ -44,7 +44,7 @@ namespace FlaxEngine.GUI
             get => _margin.Left;
             set
             {
-                if (!Mathf.NearEqual(_margin.Left, value))
+                if (_margin.Left != value)
                 {
                     _margin.Left = value;
                     PerformLayout();
@@ -61,7 +61,7 @@ namespace FlaxEngine.GUI
             get => _margin.Right;
             set
             {
-                if (!Mathf.NearEqual(_margin.Right, value))
+                if (_margin.Right != value)
                 {
                     _margin.Right = value;
                     PerformLayout();
@@ -78,7 +78,7 @@ namespace FlaxEngine.GUI
             get => _margin.Top;
             set
             {
-                if (!Mathf.NearEqual(_margin.Top, value))
+                if (_margin.Top != value)
                 {
                     _margin.Top = value;
                     PerformLayout();
@@ -95,7 +95,7 @@ namespace FlaxEngine.GUI
             get => _margin.Bottom;
             set
             {
-                if (!Mathf.NearEqual(_margin.Bottom, value))
+                if (_margin.Bottom != value)
                 {
                     _margin.Bottom = value;
                     PerformLayout();
@@ -112,7 +112,7 @@ namespace FlaxEngine.GUI
             get => _spacing;
             set
             {
-                if (!Mathf.NearEqual(_spacing, value))
+                if (_spacing != value)
                 {
                     _spacing = value;
                     PerformLayout();
@@ -129,7 +129,7 @@ namespace FlaxEngine.GUI
             get => _offset;
             set
             {
-                if (!Float2.NearEqual(ref _offset, ref value))
+                if (_offset != value)
                 {
                     _offset = value;
                     PerformLayout();

--- a/Source/Engine/UI/GUI/Panels/ScrollBar.cs
+++ b/Source/Engine/UI/GUI/Panels/ScrollBar.cs
@@ -132,7 +132,7 @@ namespace FlaxEngine.GUI
             set
             {
                 value = Mathf.Clamp(value, _minimum, _maximum);
-                if (!Mathf.NearEqual(value, _targetValue))
+                if (value != _targetValue)
                 {
                     _targetValue = value;
                     _startValue = _value;
@@ -163,7 +163,7 @@ namespace FlaxEngine.GUI
             set
             {
                 value = Mathf.Clamp(value, _minimum, _maximum);
-                if (!Mathf.NearEqual(value, _targetValue))
+                if (value != _targetValue)
                 {
                     _targetValue = value;
                     _value = value;
@@ -237,7 +237,7 @@ namespace FlaxEngine.GUI
         /// </summary>
         public void FastScroll()
         {
-            if (!Mathf.NearEqual(_value, _targetValue))
+            if (_value != _targetValue)
             {
                 _value = _targetValue = _startValue;
                 _scrollAnimationProgress = 0f;

--- a/Source/Engine/UI/GUI/Panels/SplitPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/SplitPanel.cs
@@ -67,7 +67,7 @@ namespace FlaxEngine.GUI
             set
             {
                 value = Mathf.Saturate(value);
-                if (!Mathf.NearEqual(_splitterValue, value))
+                if (_splitterValue != value)
                 {
                     // Set new value
                     _splitterValue = value;

--- a/Source/Engine/Video/VideoPlayer.cpp
+++ b/Source/Engine/Video/VideoPlayer.cpp
@@ -42,7 +42,7 @@ void VideoPlayer::SetIsAudioSpatial(bool value)
 void VideoPlayer::SetAudioVolume(float value)
 {
     value = Math::Saturate(value);
-    if (Math::NearEqual(_volume, value))
+    if (_volume == value)
         return;
     _volume = value;
     UpdateInfo();
@@ -51,7 +51,7 @@ void VideoPlayer::SetAudioVolume(float value)
 void VideoPlayer::SetAudioPan(float value)
 {
     value = Math::Clamp(value, -1.0f, 1.0f);
-    if (Math::NearEqual(_pan, value))
+    if (_pan == value)
         return;
     _pan = value;
     UpdateInfo();
@@ -60,7 +60,7 @@ void VideoPlayer::SetAudioPan(float value)
 void VideoPlayer::SetAudioMinDistance(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(_minDistance, value))
+    if (_minDistance == value)
         return;
     _minDistance = value;
     UpdateInfo();
@@ -69,7 +69,7 @@ void VideoPlayer::SetAudioMinDistance(float value)
 void VideoPlayer::SetAudioAttenuation(float value)
 {
     value = Math::Max(0.0f, value);
-    if (Math::NearEqual(_attenuation, value))
+    if (_attenuation == value)
         return;
     _attenuation = value;
     UpdateInfo();


### PR DESCRIPTION
`==`-operators and `Equals`-methods should always use exact component-wise equality checks to determine if the objects are equal instead of using epsilon-based checks to determine equality. If fuzzy checks are preferred, `NearEquals` should be used explicitly in those cases.

Caching related functionality should also use precise checks to determine if the cached value has changed. More importantly in Actor Transform related caching, any micro adjustments to orientation or position should always invalidate the cached values, so precise check is enough in these cases.

Partially fixes #3388 when the camera is close to world origin point.