### PR TITLE
Add option for the duration of the PropertiesList Group open close animation

### DIFF
--- a/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
@@ -25,6 +25,7 @@ namespace FlaxEditor.CustomEditors.Elements
             ItemsMargin = new Margin(7, 7, 3, 3),
             HeaderHeight = 18.0f,
             EnableContainmentLines = true,
+            CloseAnimationTime = Editor.Instance.Options.Options.Interface.PropertiesDopdownAnimationTime,
         };
 
         /// <summary>
@@ -34,6 +35,12 @@ namespace FlaxEditor.CustomEditors.Elements
 
         /// <inheritdoc />
         public override ContainerControl ContainerControl => Panel;
+
+        /// <inheritdoc />
+        public GroupElement()
+        {
+            Editor.Instance.Options.OptionsChanged += options => { Panel.CloseAnimationTime = options.Interface.PropertiesDopdownAnimationTime; };
+        }
 
         /// <summary>
         /// Adds utility settings button to the group header.

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -233,6 +233,13 @@ namespace FlaxEditor.Options
         public bool SeparateValueAndUnit { get; set; }
 
         /// <summary>
+        /// Gets or sets the duration (in seconds) of the open/ close animation of property list groups. Set to 0 to disable the animation.
+        /// </summary>
+        [DefaultValue(0.2f)]
+        [EditorDisplay("Interface"), EditorOrder(312), Limit(0.0f, 1.0f)]
+        public float PropertiesDopdownAnimationTime { get; set; }
+
+        /// <summary>
         /// Gets or sets tree line visibility.
         /// </summary>
         [DefaultValue(true)]


### PR DESCRIPTION
I prefer this animation to be as quick as possible, but I can see other people wanting this animation to be a bit longer.

The editor order of this option is 312 because 311 is already used by `AutoSizePropertiesPanelSplitter` in #3295.