### PR TITLE
Add input event and input axis to Cpp scripting.

### DIFF
--- a/Source/Editor/CustomEditors/CustomEditorsUtil.cs
+++ b/Source/Editor/CustomEditors/CustomEditorsUtil.cs
@@ -84,6 +84,14 @@ namespace FlaxEditor.CustomEditors
 
                 return new ArrayEditor();
             }
+            
+            // Use custom attribute alias editor
+            var attributes = targetType.GetAttributes(false);
+            var customEditorAliasAttribute = (CustomEditorAliasAttribute)attributes.FirstOrDefault(x => x is CustomEditorAliasAttribute);
+            if (customEditorAliasAttribute != null)
+                return (CustomEditor)Activator.CreateInstance(TypeUtils.GetType(customEditorAliasAttribute.TypeName).Type);
+            
+            // Use asset or object ref
             var targetTypeType = TypeUtils.GetType(targetType);
             if (canUseRefPicker)
             {
@@ -110,7 +118,6 @@ namespace FlaxEditor.CustomEditors
             }
 
             // Use attribute editor
-            var attributes = targetType.GetAttributes(false);
             var customEditorAttribute = (CustomEditorAttribute)attributes.FirstOrDefault(x => x is CustomEditorAttribute);
             if (customEditorAttribute != null)
                 return (CustomEditor)Activator.CreateInstance(customEditorAttribute.Type);

--- a/Source/Editor/CustomEditors/CustomEditorsUtil.cs
+++ b/Source/Editor/CustomEditors/CustomEditorsUtil.cs
@@ -89,7 +89,11 @@ namespace FlaxEditor.CustomEditors
             var attributes = targetType.GetAttributes(false);
             var customEditorAliasAttribute = (CustomEditorAliasAttribute)attributes.FirstOrDefault(x => x is CustomEditorAliasAttribute);
             if (customEditorAliasAttribute != null)
-                return (CustomEditor)Activator.CreateInstance(TypeUtils.GetType(customEditorAliasAttribute.TypeName).Type);
+            {
+                var scriptType = TypeUtils.GetType(customEditorAliasAttribute.TypeName);
+                if (scriptType != null)
+                    return (CustomEditor)Activator.CreateInstance(scriptType.Type);
+            }
             
             // Use asset or object ref
             var targetTypeType = TypeUtils.GetType(targetType);

--- a/Source/Editor/CustomEditors/CustomEditorsUtil.cs
+++ b/Source/Editor/CustomEditors/CustomEditorsUtil.cs
@@ -92,7 +92,7 @@ namespace FlaxEditor.CustomEditors
             {
                 var scriptType = TypeUtils.GetType(customEditorAliasAttribute.TypeName);
                 if (scriptType != null)
-                    return (CustomEditor)Activator.CreateInstance(scriptType.Type);
+                    return (CustomEditor)scriptType.CreateInstance();
             }
             
             // Use asset or object ref

--- a/Source/Engine/Engine/InputAxis.cs
+++ b/Source/Engine/Engine/InputAxis.cs
@@ -7,70 +7,15 @@ namespace FlaxEngine
     /// <summary>
     /// Virtual input axis binding. Helps with listening for a selected axis input.
     /// </summary>
-    public class InputAxis : IComparable, IComparable<InputAxis>
+    public partial class InputAxis : IComparable, IComparable<InputAxis>
     {
-        /// <summary>
-        /// The name of the axis to use. See <see cref="Input.AxisMappings"/>.
-        /// </summary>
-        [Tooltip("The name of the axis to use.")]
-        public string Name;
-
-        /// <summary>
-        /// Gets the current axis value.
-        /// </summary>
-        public float Value => Input.GetAxis(Name);
-
-        /// <summary>
-        /// Gets the current axis raw value.
-        /// </summary>
-        public float ValueRaw => Input.GetAxisRaw(Name);
-
-        /// <summary>
-        /// Occurs when axis is changed. Called before scripts update.
-        /// </summary>
-        public event Action ValueChanged;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InputAxis"/> class.
-        /// </summary>
-        public InputAxis()
-        {
-            Input.AxisValueChanged += Handler;
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InputAxis"/> class.
         /// </summary>
         /// <param name="name">The axis name.</param>
         public InputAxis(string name)
         {
-            Input.AxisValueChanged += Handler;
             Name = name;
-        }
-
-        private void Handler(string name)
-        {
-            if (string.Equals(Name, name, StringComparison.OrdinalIgnoreCase))
-                ValueChanged?.Invoke();
-        }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="InputAxis"/> class.
-        /// </summary>
-        ~InputAxis()
-        {
-            Input.AxisValueChanged -= Handler;
-            ValueChanged = null;
-        }
-
-        /// <summary>
-        /// Releases this object.
-        /// </summary>
-        public void Dispose()
-        {
-            Input.AxisValueChanged -= Handler;
-            ValueChanged = null;
-            GC.SuppressFinalize(this);
         }
 
         /// <inheritdoc />

--- a/Source/Engine/Engine/InputEvent.cs
+++ b/Source/Engine/Engine/InputEvent.cs
@@ -7,108 +7,15 @@ namespace FlaxEngine
     /// <summary>
     /// Virtual input action binding. Helps with listening for a selected input event.
     /// </summary>
-    public class InputEvent : IComparable, IComparable<InputEvent>
+    public partial class InputEvent : IComparable, IComparable<InputEvent>
     {
-        /// <summary>
-        /// The name of the action to use. See <see cref="Input.ActionMappings"/>.
-        /// </summary>
-        [Tooltip("The name of the action to use.")]
-        public string Name;
-
-        /// <summary>
-        /// Returns true if the event has been triggered during the current frame (e.g. user pressed a key). Use <see cref="Pressed"/> to catch events without active waiting.
-        /// </summary>
-        public bool Active => Input.GetAction(Name);
-
-        /// <summary>
-        /// Returns the event state. Use <see cref="Pressed"/>, <see cref="Pressing"/>, <see cref="Released"/> to catch events without active waiting.
-        /// </summary>
-        public InputActionState State => Input.GetActionState(Name);
-
-        /// <summary>
-        /// Occurs when event is triggered (e.g. user pressed a key). Called before scripts update.
-        /// </summary>
-        [System.Obsolete("Use Pressed instead")]
-        public event Action Triggered;
-
-        /// <summary>
-        /// Occurs when event is pressed (e.g. user pressed a key). Called before scripts update.
-        /// </summary>
-        public event Action Pressed;
-
-        /// <summary>
-        /// Occurs when event is being pressing (e.g. user pressing a key). Called before scripts update.
-        /// </summary>
-        public event Action Pressing;
-
-        /// <summary>
-        /// Occurs when event is released (e.g. user releases a key). Called before scripts update.
-        /// </summary>
-        public event Action Released;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InputEvent"/> class.
-        /// </summary>
-        public InputEvent()
-        {
-            Input.ActionTriggered += Handler;
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InputEvent"/> class.
         /// </summary>
         /// <param name="name">The action name.</param>
         public InputEvent(string name)
         {
-            Input.ActionTriggered += Handler;
             Name = name;
-        }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="InputEvent"/> class.
-        /// </summary>
-        ~InputEvent()
-        {
-            Input.ActionTriggered -= Handler;
-            Triggered = null;
-            Pressed = null;
-            Pressing = null;
-            Released = null;
-        }
-
-        private void Handler(string name, InputActionState state)
-        {
-            if (!string.Equals(name, Name, StringComparison.OrdinalIgnoreCase))
-                return;
-            switch (state)
-            {
-            case InputActionState.None: break;
-            case InputActionState.Waiting: break;
-            case InputActionState.Pressing:
-                Pressing?.Invoke();
-                break;
-            case InputActionState.Press:
-                Triggered?.Invoke();
-                Pressed?.Invoke();
-                break;
-            case InputActionState.Release:
-                Released?.Invoke();
-                break;
-            default: break;
-            }
-        }
-
-        /// <summary>
-        /// Releases this object.
-        /// </summary>
-        public void Dispose()
-        {
-            Input.ActionTriggered -= Handler;
-            Triggered = null;
-            Pressed = null;
-            Pressing = null;
-            Released = null;
-            GC.SuppressFinalize(this);
         }
 
         /// <inheritdoc />
@@ -140,5 +47,6 @@ namespace FlaxEngine
         {
             return Name;
         }
+        
     }
 }

--- a/Source/Engine/Input/InputAxis.cpp
+++ b/Source/Engine/Input/InputAxis.cpp
@@ -1,0 +1,32 @@
+﻿#include "InputAxis.h"
+
+InputAxis::InputAxis(const SpawnParams& params)
+    : ScriptingObject(params)
+{
+    Input::AxisValueChanged.Bind<InputAxis, &InputAxis::Handler>(this);
+}
+
+InputAxis::InputAxis(String name)
+    : ScriptingObject(SpawnParams(Guid::New(), GetTypeHandle()))
+{
+    Input::AxisValueChanged.Bind<InputAxis, &InputAxis::Handler>(this);
+    Name = name;
+}
+
+InputAxis::~InputAxis()
+{
+    Input::AxisValueChanged.Unbind<InputAxis, &InputAxis::Handler>(this);
+    ValueChanged.UnbindAll();
+}
+
+void InputAxis::Dispose()
+{
+    Input::AxisValueChanged.Unbind<InputAxis, &InputAxis::Handler>(this);
+    ValueChanged.UnbindAll();
+}
+
+void InputAxis::Handler(StringView name)
+{
+    if (name.Compare(StringView(Name), StringSearchCase::IgnoreCase) == 0)
+        ValueChanged();
+}

--- a/Source/Engine/Input/InputAxis.h
+++ b/Source/Engine/Input/InputAxis.h
@@ -1,0 +1,48 @@
+﻿#pragma once
+#include "Input.h"
+
+#include "Engine/Core/ISerializable.h"
+
+API_CLASS() class FLAXENGINE_API InputAxis : public ScriptingObject, public ISerializable
+{
+    API_AUTO_SERIALIZATION();
+    DECLARE_SCRIPTING_TYPE(InputAxis);
+
+public:
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InputEvent"/> class.
+    /// </summary>
+    /// <param name="name">The action name.</param>
+    InputAxis(String name);
+
+    ~InputAxis();
+
+    /// <summary>
+    /// The name of the axis to use. See <see cref="Input.AxisMappings"/>.
+    /// </summary>
+    API_FIELD() String Name;
+
+    /// <summary>
+    /// Gets the current axis value.
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE float GetValue() const { return Input::GetAxis(Name); }
+
+    /// <summary>
+    /// Gets the current axis raw value.
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE float GetValueRaw() const { return Input::GetAxisRaw(Name); }
+
+    /// <summary>
+    /// Occurs when axis is changed. Called before scripts update.
+    /// </summary>
+    API_EVENT() Action ValueChanged;
+
+    /// <summary>
+    /// Dispose of this object.
+    /// </summary>
+    API_FUNCTION() void Dispose();
+
+private:
+    void Handler(StringView name);
+};

--- a/Source/Engine/Input/InputAxis.h
+++ b/Source/Engine/Input/InputAxis.h
@@ -3,7 +3,7 @@
 
 #include "Engine/Core/ISerializable.h"
 
-API_CLASS() class FLAXENGINE_API InputAxis : public ScriptingObject, public ISerializable
+API_CLASS(Attributes="CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.InputAxisEditor\")") class FLAXENGINE_API InputAxis : public ScriptingObject, public ISerializable
 {
     API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE(InputAxis);

--- a/Source/Engine/Input/InputEvent.cpp
+++ b/Source/Engine/Input/InputEvent.cpp
@@ -1,0 +1,51 @@
+﻿#include "InputEvent.h"
+
+InputEvent::InputEvent(const SpawnParams& params)
+    : ScriptingObject(params)
+{
+    Input::ActionTriggered.Bind<InputEvent, &InputEvent::Handler>(this);
+}
+
+InputEvent::InputEvent(String name)
+    : ScriptingObject(SpawnParams(Guid::New(), GetTypeHandle()))
+{
+    Input::ActionTriggered.Bind<InputEvent, &InputEvent::Handler>(this);
+    Name = name;
+}
+
+InputEvent::~InputEvent()
+{
+    Input::ActionTriggered.Unbind<InputEvent, &InputEvent::Handler>(this);
+    Pressed.UnbindAll();
+    Pressing.UnbindAll();
+    Released.UnbindAll();
+}
+
+void InputEvent::Dispose()
+{
+    Input::ActionTriggered.Unbind<InputEvent, &InputEvent::Handler>(this);
+    Pressed.UnbindAll();
+    Pressing.UnbindAll();
+    Released.UnbindAll();
+}
+
+void InputEvent::Handler(StringView name, InputActionState state)
+{
+    if (name.Compare(StringView(Name), StringSearchCase::IgnoreCase) != 0)
+        return;
+    switch (state)
+    {
+    case InputActionState::None: break;
+    case InputActionState::Waiting: break;
+    case InputActionState::Pressing:
+        Pressing();
+        break;
+    case InputActionState::Press:
+        Pressed();
+        break;
+    case InputActionState::Release:
+        Released();
+        break;
+    default: break;
+    }
+}

--- a/Source/Engine/Input/InputEvent.h
+++ b/Source/Engine/Input/InputEvent.h
@@ -3,7 +3,7 @@
 
 #include "Engine/Core/ISerializable.h"
 
-API_CLASS() class FLAXENGINE_API InputEvent : public ScriptingObject, public ISerializable
+API_CLASS(Attributes="CustomEditorAlias(\"FlaxEditor.CustomEditors.Editors.InputEventEditor\")") class FLAXENGINE_API InputEvent : public ScriptingObject, public ISerializable
 {
     API_AUTO_SERIALIZATION();
     DECLARE_SCRIPTING_TYPE(InputEvent);

--- a/Source/Engine/Input/InputEvent.h
+++ b/Source/Engine/Input/InputEvent.h
@@ -1,0 +1,58 @@
+﻿#pragma once
+#include "Input.h"
+
+#include "Engine/Core/ISerializable.h"
+
+API_CLASS() class FLAXENGINE_API InputEvent : public ScriptingObject, public ISerializable
+{
+    API_AUTO_SERIALIZATION();
+    DECLARE_SCRIPTING_TYPE(InputEvent);
+
+public:
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InputEvent"/> class.
+    /// </summary>
+    /// <param name="name">The action name.</param>
+    InputEvent(String name);
+
+    ~InputEvent();
+
+    /// <summary>
+    /// The name of the action to use. See <see cref="Input.ActionMappings"/>.
+    /// </summary>
+    API_FIELD() String Name;
+
+    /// <summary>
+    /// Returns true if the event has been triggered during the current frame (e.g. user pressed a key). Use <see cref="Pressed"/> to catch events without active waiting.
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE bool GetActive() const { return Input::GetAction(Name); }
+
+    /// <summary>
+    /// Returns the event state. Use <see cref="Pressed"/>, <see cref="Pressing"/>, <see cref="Released"/> to catch events without active waiting.
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE InputActionState GetState() const { return Input::GetActionState(Name); }
+
+    /// <summary>
+    /// Occurs when event is pressed (e.g. user pressed a key). Called before scripts update.
+    /// </summary>
+    API_EVENT() Action Pressed;
+
+    /// <summary>
+    /// Occurs when event is being pressing (e.g. user pressing a key). Called before scripts update.
+    /// </summary>
+    API_EVENT() Action Pressing;
+
+    /// <summary>
+    /// Occurs when event is released (e.g. user releases a key). Called before scripts update.
+    /// </summary>
+    API_EVENT() Action Released;
+
+    /// <summary>
+    /// Dispose of this object.
+    /// </summary>
+    API_FUNCTION() void Dispose();
+    
+private:
+    void Handler(StringView name, InputActionState state);
+};


### PR DESCRIPTION
Also removes Triggered from input event.

I had to implement using the custom editor alias before the flax obj reference to make the editor work once moving it to C++. I think there should be a better way to pick between a reference or not.