### PR TITLE
Add holding down the shift key to skip auto resizing a box collider on actor add

### DIFF
--- a/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
+++ b/Source/Editor/SceneGraph/Actors/BoxColliderNode.cs
@@ -78,7 +78,7 @@ namespace FlaxEditor.SceneGraph.Actors
         {
             base.PostSpawn();
 
-            if (Actor.HasPrefabLink)
+            if (Actor.HasPrefabLink || Input.GetKey(KeyboardKeys.Shift))
             {
                 return;
             }


### PR DESCRIPTION
Does exactly what the title says.

The reason for this pr is that sometimes I don't want the collider to auto resize.