### PR TITLE
Fix profiler memory propagation

### DIFF
--- a/Source/Editor/Windows/Profiler/CPU.cs
+++ b/Source/Editor/Windows/Profiler/CPU.cs
@@ -492,7 +492,7 @@ namespace FlaxEditor.Windows.Profiler
                         {
                             break;
                         }
-                        subEventsMemoryTotal += sub.ManagedMemoryAllocation + e.NativeMemoryAllocation;
+                        subEventsMemoryTotal += sub.ManagedMemoryAllocation + sub.NativeMemoryAllocation;
                     }
 
                     string name = e.Name.Replace("::", ".");


### PR DESCRIPTION
This fixes the memory allocation not propagating from children to parents

Before (note the 0 B on all rows for memory column):
![2025-04-26_21-33](https://github.com/user-attachments/assets/146a86c6-a990-4bf1-bb13-911093ed3ce4)

After:
![2025-04-26_21-38](https://github.com/user-attachments/assets/b0b661bf-b42c-482b-a50a-0f0499c7235e)
