### PR TITLE
Add editor option for disabled transform gizmo brightness

### DIFF
--- a/Source/Editor/Gizmo/TransformGizmoBase.Draw.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.Draw.cs
@@ -21,12 +21,16 @@ namespace FlaxEditor.Gizmo
         private MaterialInstance _materialAxisY;
         private MaterialInstance _materialAxisZ;
         private MaterialInstance _materialAxisFocus;
-        private MaterialInstance _materialAxisLocked;
         private MaterialBase _materialSphere;
 
         // Material Parameter Names
         const String _brightnessParamName = "Brightness";
         const String _opacityParamName = "Opacity";
+
+        /// <summary>
+        /// Used for example when the selection can't be moved because one actor is static.
+        /// </summary>
+        private bool _isDisabled;
 
         private void InitDrawing()
         {
@@ -42,7 +46,6 @@ namespace FlaxEditor.Gizmo
             _materialAxisY = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisY");
             _materialAxisZ = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisZ");
             _materialAxisFocus = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisFocus");
-            _materialAxisLocked = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialAxisLocked");
             _materialSphere = FlaxEngine.Content.LoadAsyncInternal<MaterialInstance>("Editor/Gizmo/MaterialSphere");
 
             // Ensure that every asset was loaded
@@ -67,17 +70,41 @@ namespace FlaxEditor.Gizmo
 
         private void OnEditorOptionsChanged(EditorOptions options)
         {
-            float brightness = options.Visual.TransformGizmoBrightness;
-            _materialAxisX.SetParameterValue(_brightnessParamName, brightness);
-            _materialAxisY.SetParameterValue(_brightnessParamName, brightness);
-            _materialAxisZ.SetParameterValue(_brightnessParamName, brightness);
-            _materialAxisLocked.SetParameterValue(_brightnessParamName, brightness);
-            
+            UpdateGizmoBrightness(options);
+
             float opacity = options.Visual.TransformGizmoOpacity;
             _materialAxisX.SetParameterValue(_opacityParamName, opacity);
             _materialAxisY.SetParameterValue(_opacityParamName, opacity);
             _materialAxisZ.SetParameterValue(_opacityParamName, opacity);
-            _materialAxisLocked.SetParameterValue(_opacityParamName, opacity);
+        }
+
+        private void UpdateGizmoBrightness(EditorOptions options)
+        {
+            _isDisabled = ShouldGizmoBeLocked();
+
+            float brightness = _isDisabled ? options.Visual.TransformGizmoBrighnessDisabled : options.Visual.TransformGizmoBrightness;
+            _materialAxisX.SetParameterValue(_brightnessParamName, brightness);
+            _materialAxisY.SetParameterValue(_brightnessParamName, brightness);
+            _materialAxisZ.SetParameterValue(_brightnessParamName, brightness);
+        }
+
+        private bool ShouldGizmoBeLocked()
+        {
+            bool gizmoLocked = false;
+
+            if (Editor.Instance.StateMachine.IsPlayMode)
+            {
+                foreach (SceneGraphNode obj in Editor.Instance.SceneEditing.Selection)
+                {
+                    if (obj.CanTransform == false)
+                    {
+                        gizmoLocked = true;
+                        break;
+                    }
+                }
+            }
+
+            return gizmoLocked;
         }
 
         /// <inheritdoc />
@@ -88,20 +115,8 @@ namespace FlaxEditor.Gizmo
             if (!_modelCube || !_modelCube.IsLoaded)
                 return;
 
-            // Find out if any of the selected objects can not be moved
-            bool gizmoLocked = false;
-            if (Editor.Instance.StateMachine.IsPlayMode)
-            {
-                for (int i = 0; i < SelectionCount; i++)
-                {
-                    var obj = GetSelectedObject(i);
-                    if (obj.CanTransform == false)
-                    {
-                        gizmoLocked = true;
-                        break;
-                    }
-                }
-            }
+            // Update the gizmo brightness every frame to ensure it updates correctly
+            UpdateGizmoBrightness(Editor.Instance.Options.Options);
 
             // As all axisMesh have the same pivot, add a little offset to the x axisMesh, this way SortDrawCalls is able to sort the draw order
             // https://github.com/FlaxEngine/FlaxEngine/issues/680
@@ -136,37 +151,37 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationY(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance xAxisMaterialTransform = gizmoLocked ? _materialAxisLocked : (isXAxis ? _materialAxisFocus : _materialAxisX);
+                MaterialInstance xAxisMaterialTransform = (isXAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisX;
                 transAxisMesh.Draw(ref renderContext, xAxisMaterialTransform, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Y axis
                 Matrix.RotationX(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance yAxisMaterialTransform = gizmoLocked ? _materialAxisLocked : (isYAxis ? _materialAxisFocus : _materialAxisY);
+                MaterialInstance yAxisMaterialTransform = (isYAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisY;
                 transAxisMesh.Draw(ref renderContext, yAxisMaterialTransform, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Z axis
                 Matrix.RotationX(Mathf.Pi, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance zAxisMaterialTransform = gizmoLocked ? _materialAxisLocked : (isZAxis ? _materialAxisFocus : _materialAxisZ);
+                MaterialInstance zAxisMaterialTransform = (isZAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisZ;
                 transAxisMesh.Draw(ref renderContext, zAxisMaterialTransform, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // XY plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationX(Mathf.PiOverTwo), new Vector3(boxSize * boxScale, boxSize * boxScale, 0.0f));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance xyPlaneMaterialTransform = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX);
+                MaterialInstance xyPlaneMaterialTransform = (_activeAxis == Axis.XY && !_isDisabled) ? _materialAxisFocus : _materialAxisX;
                 cubeMesh.Draw(ref renderContext, xyPlaneMaterialTransform, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // ZX plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.Identity, new Vector3(boxSize * boxScale, 0.0f, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance zxPlaneMaterialTransform = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisY);
+                MaterialInstance zxPlaneMaterialTransform = (_activeAxis == Axis.ZX && !_isDisabled) ? _materialAxisFocus : _materialAxisY;
                 cubeMesh.Draw(ref renderContext, zxPlaneMaterialTransform, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // YZ plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationZ(Mathf.PiOverTwo), new Vector3(0.0f, boxSize * boxScale, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance yzPlaneMaterialTransform = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisZ);
+                MaterialInstance yzPlaneMaterialTransform = (_activeAxis == Axis.YZ && !_isDisabled) ? _materialAxisFocus : _materialAxisZ;
                 cubeMesh.Draw(ref renderContext, yzPlaneMaterialTransform, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Center sphere
@@ -186,17 +201,17 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationZ(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance xAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isXAxis ? _materialAxisFocus : _materialAxisX);
+                MaterialInstance xAxisMaterialRotate = (isXAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisX;
                 rotationAxisMesh.Draw(ref renderContext, xAxisMaterialRotate, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Y axis
-                MaterialInstance yAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isYAxis ? _materialAxisFocus : _materialAxisY);
+                MaterialInstance yAxisMaterialRotate = (isYAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisY;
                 rotationAxisMesh.Draw(ref renderContext, yAxisMaterialRotate, ref m1, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Z axis
                 Matrix.RotationX(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance zAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isZAxis ? _materialAxisFocus : _materialAxisZ);
+                MaterialInstance zAxisMaterialRotate = (isZAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisZ;
                 rotationAxisMesh.Draw(ref renderContext, zAxisMaterialRotate, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Center box
@@ -216,37 +231,37 @@ namespace FlaxEditor.Gizmo
                 // X axis
                 Matrix.RotationY(-Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref mx1, out m3);
-                MaterialInstance xAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isXAxis ? _materialAxisFocus : _materialAxisX);
+                MaterialInstance xAxisMaterialRotate = (isXAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisX;
                 scaleAxisMesh.Draw(ref renderContext, xAxisMaterialRotate, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Y axis
                 Matrix.RotationX(Mathf.PiOverTwo, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance yAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isYAxis ? _materialAxisFocus : _materialAxisY);
+                MaterialInstance yAxisMaterialRotate = (isYAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisY;
                 scaleAxisMesh.Draw(ref renderContext, yAxisMaterialRotate, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Z axis
                 Matrix.RotationX(Mathf.Pi, out m2);
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance zAxisMaterialRotate = gizmoLocked ? _materialAxisLocked : (isZAxis ? _materialAxisFocus : _materialAxisZ);
+                MaterialInstance zAxisMaterialRotate = (isZAxis && !_isDisabled) ? _materialAxisFocus : _materialAxisZ;
                 scaleAxisMesh.Draw(ref renderContext, zAxisMaterialRotate, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // XY plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationX(Mathf.PiOverTwo), new Vector3(boxSize * boxScale, boxSize * boxScale, 0.0f));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance xyPlaneMaterialScale = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.XY ? _materialAxisFocus : _materialAxisX);
+                MaterialInstance xyPlaneMaterialScale = (_activeAxis == Axis.XY && !_isDisabled) ? _materialAxisFocus : _materialAxisX;
                 cubeMesh.Draw(ref renderContext, xyPlaneMaterialScale, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // ZX plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.Identity, new Vector3(boxSize * boxScale, 0.0f, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance zxPlaneMaterialScale = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.ZX ? _materialAxisFocus : _materialAxisZ);
+                MaterialInstance zxPlaneMaterialScale = (_activeAxis == Axis.ZX && !_isDisabled) ? _materialAxisFocus : _materialAxisZ;
                 cubeMesh.Draw(ref renderContext, zxPlaneMaterialScale, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // YZ plane
                 m2 = Matrix.Transformation(new Vector3(boxSize, boxSize * 0.1f, boxSize), Quaternion.RotationZ(Mathf.PiOverTwo), new Vector3(0.0f, boxSize * boxScale, boxSize * boxScale));
                 Matrix.Multiply(ref m2, ref m1, out m3);
-                MaterialInstance yzPlaneMaterialScale = gizmoLocked ? _materialAxisLocked : (_activeAxis == Axis.YZ ? _materialAxisFocus : _materialAxisY);
+                MaterialInstance yzPlaneMaterialScale = (_activeAxis == Axis.YZ && !_isDisabled) ? _materialAxisFocus : _materialAxisY;
                 cubeMesh.Draw(ref renderContext, yzPlaneMaterialScale, ref m3, StaticFlags.None, true, DrawPass.Default, 0.0f, sortOrder);
 
                 // Center box

--- a/Source/Editor/Options/VisualOptions.cs
+++ b/Source/Editor/Options/VisualOptions.cs
@@ -82,6 +82,13 @@ namespace FlaxEditor.Options
         public float TransformGizmoOpacity { get; set; } = 1f;
 
         /// <summary>
+        /// Gets or set a value indicating how bright the transform gizmo is when it is disabled, for example when one of the selected actors is static in play mode. Use a value of 0 to make the gizmo fully gray. Value over 1 will result in the gizmo emitting light.
+        /// </summary>
+        [DefaultValue(0.25f), Range(0f, 5f)]
+        [EditorDisplay("Transform Gizmo", "Disabled Gizmo Brightness"), EditorOrder(212)]
+        public float TransformGizmoBrighnessDisabled { get; set; } = 0.25f;
+
+        /// <summary>
         /// Gets or sets a value indicating whether enable MSAA for DebugDraw primitives rendering. Helps with pixel aliasing but reduces performance.
         /// </summary>
         [DefaultValue(true)]


### PR DESCRIPTION
*Old color/ behavior on static actor*
![image](https://github.com/user-attachments/assets/a94b289e-102b-40d8-9863-9f2e61551ed3)

*New color/ behavior on static actor with the "Disabled transform gizmo brightness" setting set to the default of 0.25*
![image](https://github.com/user-attachments/assets/c2ededd7-49a0-495e-bba0-5a7c3931e7c9)

Allows the disabled transform gizmo to still have a light color. Addresses https://discord.com/channels/437989205315158016/438033006016462849/1365778018819117126.

Something similar to the old behavior can still be achieved by setting the brightness to 0.

Could be improved by only updating the gizmo brightness when it actually needs to be updated (selection changes, editor options change and static flags of selected actors change), the first of the three I have figure out, but I think due to the last one it's better to update the gizmo brightness every frame. 

**This means `/Flax/Content/Editor/Gizmo/MaterialAxisLocked` will no longer be needed and can be deleted**

### TODO (optional lol)
- [ ] Gizmo in prefabs will inherit color from main editor. It used to do this before with the old behavior where it would just be grayed out when a static actor is selected.
A simple check for if the gizmo is in a prefab editor would fix this, but I couldn't figure out how to check it that's the case. 