### PR TITLE
Improve import path ui

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ModelPrefabEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ModelPrefabEditor.cs
@@ -54,7 +54,8 @@ public class ModelPrefabEditor : GenericEditor
         }
 
         // Creates the import path UI
-        Utilities.Utils.CreateImportPathUI(layout, modelPrefab.ImportPath, false);
+        var group = layout.Group("Import Path");
+        Utilities.Utils.CreateImportPathUI(group, modelPrefab.ImportPath, false);
 
         var button = layout.Button("Reimport", "Reimports the source asset as prefab.");
         _reimportButton = button.Button;

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -402,31 +402,31 @@ namespace FlaxEditor.Utilities
         /// <summary>
         /// Creates an Import path ui that show the asset import path and adds a button to show the folder in the file system.
         /// </summary>
-        /// <param name="group">The parent group element.</param>
+        /// <param name="parentLayout">The parent layout element.</param>
         /// <param name="assetItem">The asset item to get the import path of.</param>
-        public static void CreateImportPathUI(CustomEditors.Elements.GroupElement group, Content.BinaryAssetItem assetItem)
+        public static void CreateImportPathUI(CustomEditors.LayoutElementsContainer parentLayout, Content.BinaryAssetItem assetItem)
         {
             assetItem.GetImportPath(out var path);
-            CreateImportPathUI(group, path);
+            CreateImportPathUI(parentLayout, path);
         }
 
         /// <summary>
         /// Creates an Import path ui that show the import path and adds a button to show the folder in the file system.
         /// </summary>
-        /// <param name="group">The parent group element.</param>
+        /// <param name="parentLayout">The parent layout element.</param>
         /// <param name="path">The import path.</param>
         /// <param name="useInitialSpacing">Whether to use an initial layout space of 5 for separation.</param>
-        public static void CreateImportPathUI(CustomEditors.Elements.GroupElement group, string path, bool useInitialSpacing = true)
+        public static void CreateImportPathUI(CustomEditors.LayoutElementsContainer parentLayout, string path, bool useInitialSpacing = true)
         {
             if (!string.IsNullOrEmpty(path))
             {
                 if (useInitialSpacing)
-                    group.Space(0);
-                var textBox = group.TextBox().TextBox;
+                    parentLayout.Space(0);
+                var textBox = parentLayout.TextBox().TextBox;
                 textBox.TooltipText = "Source asset path. Can be relative or absolute to the project. Path is not editable here.";
                 textBox.IsReadOnly = true;
                 textBox.Text = path;
-                var button = group.Button(Constants.ShowInExplorer).Button;
+                var button = parentLayout.Button(Constants.ShowInExplorer).Button;
                 button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
             }
         }

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -402,33 +402,31 @@ namespace FlaxEditor.Utilities
         /// <summary>
         /// Creates an Import path ui that show the asset import path and adds a button to show the folder in the file system.
         /// </summary>
-        /// <param name="parentLayout">The parent layout container.</param>
+        /// <param name="group">The parent group element.</param>
         /// <param name="assetItem">The asset item to get the import path of.</param>
-        public static void CreateImportPathUI(CustomEditors.LayoutElementsContainer parentLayout, Content.BinaryAssetItem assetItem)
+        public static void CreateImportPathUI(CustomEditors.Elements.GroupElement group, Content.BinaryAssetItem assetItem)
         {
             assetItem.GetImportPath(out var path);
-            CreateImportPathUI(parentLayout, path);
+            CreateImportPathUI(group, path);
         }
 
         /// <summary>
         /// Creates an Import path ui that show the import path and adds a button to show the folder in the file system.
         /// </summary>
-        /// <param name="parentLayout">The parent layout container.</param>
+        /// <param name="group">The parent group element.</param>
         /// <param name="path">The import path.</param>
         /// <param name="useInitialSpacing">Whether to use an initial layout space of 5 for separation.</param>
-        public static void CreateImportPathUI(CustomEditors.LayoutElementsContainer parentLayout, string path, bool useInitialSpacing = true)
+        public static void CreateImportPathUI(CustomEditors.Elements.GroupElement group, string path, bool useInitialSpacing = true)
         {
             if (!string.IsNullOrEmpty(path))
             {
                 if (useInitialSpacing)
-                    parentLayout.Space(5);
-                parentLayout.Label("Import Path:").Label.TooltipText = "Source asset path (can be relative or absolute to the project)";
-                var textBox = parentLayout.TextBox().TextBox;
-                textBox.TooltipText = "Path is not editable here.";
+                    group.Space(0);
+                var textBox = group.TextBox().TextBox;
+                textBox.TooltipText = "Source asset path. Can be relative or absolute to the project. Path is not editable here.";
                 textBox.IsReadOnly = true;
                 textBox.Text = path;
-                parentLayout.Space(2);
-                var button = parentLayout.Button(Constants.ShowInExplorer).Button;
+                var button = group.Button(Constants.ShowInExplorer).Button;
                 button.Clicked += () => FileSystem.ShowFileExplorer(Path.GetDirectoryName(path));
             }
         }

--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -231,7 +231,8 @@ namespace FlaxEditor.Windows.Assets
                         group.Object(importSettingsValues);
 
                         // Creates the import path UI
-                        Utilities.Utils.CreateImportPathUI(layout, proxy.Window.Item as BinaryAssetItem);
+                        group = layout.Group("Import Path");
+                        Utilities.Utils.CreateImportPathUI(group, proxy.Window.Item as BinaryAssetItem);
 
                         layout.Space(5);
                         var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -6,6 +6,7 @@ using FlaxEditor.Content.Import;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.GUI;
+using FlaxEditor.Scripting;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -76,7 +77,8 @@ namespace FlaxEditor.Windows.Assets
             {
                 public override void Initialize(LayoutElementsContainer layout)
                 {
-                    var window = ((PropertiesProxy)Values[0])._window;
+                    var proxy = ((PropertiesProxy)Values[0]);
+                    var window = proxy._window;
                     if (window == null)
                     {
                         layout.Label("Loading...", TextAlignment.Center);
@@ -101,7 +103,8 @@ namespace FlaxEditor.Windows.Assets
                     base.Initialize(layout);
 
                     // Creates the import path UI
-                    Utilities.Utils.CreateImportPathUI(layout, window.Item as BinaryAssetItem);
+                    var pathGroup = layout.Group("Import Path");
+                    Utilities.Utils.CreateImportPathUI(pathGroup, window.Item as BinaryAssetItem);
 
                     layout.Space(5);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/CubeTextureWindow.cs
+++ b/Source/Editor/Windows/Assets/CubeTextureWindow.cs
@@ -55,10 +55,11 @@ namespace FlaxEditor.Windows.Assets
                     base.Initialize(layout);
 
                     // Creates the import path UI
-                    Utilities.Utils.CreateImportPathUI(layout, window.Item as BinaryAssetItem);
+                    var pathGroup = layout.Group("Import Path");
+                    Utilities.Utils.CreateImportPathUI(pathGroup, window.Item as BinaryAssetItem);
 
-                    layout.Space(5);
-                    var reimportButton = layout.Button("Reimport");
+                    pathGroup.Space(5);
+                    var reimportButton = pathGroup.Button("Reimport");
                     reimportButton.Button.Clicked += () => ((PropertiesProxy)Values[0]).Reimport();
                 }
             }

--- a/Source/Editor/Windows/Assets/ModelBaseWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelBaseWindow.cs
@@ -754,17 +754,18 @@ namespace FlaxEditor.Windows.Assets
                     if (Utilities.Utils.OnAssetProperties(layout, proxy.Asset))
                         return;
 
-                    var group = layout.Group("Import Settings");
+                    var importSettingsGroup = layout.Group("Import Settings");
 
                     var importSettingsField = typeof(ImportPropertiesProxyBase).GetField(nameof(ImportSettings), BindingFlags.NonPublic | BindingFlags.Instance);
                     var importSettingsValues = new ValueContainer(new ScriptMemberInfo(importSettingsField)) { proxy.ImportSettings };
-                    group.Object(importSettingsValues);
+                    importSettingsGroup.Object(importSettingsValues);
+                    importSettingsGroup.Space(3);
 
                     // Creates the import path UI
-                    Utilities.Utils.CreateImportPathUI(layout, proxy.Window.Item as BinaryAssetItem);
+                    var group = layout.Group("Import Path");
+                    Utilities.Utils.CreateImportPathUI(group, proxy.Window.Item as BinaryAssetItem);
 
-                    layout.Space(5);
-                    var reimportButton = group.Button("Reimport");
+                    var reimportButton = importSettingsGroup.Button("Reimport");
                     reimportButton.Button.Clicked += () => ((ImportPropertiesProxyBase)Values[0]).Reimport();
                 }
             }

--- a/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
+++ b/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
@@ -119,9 +119,10 @@ namespace FlaxEditor.Windows.Assets
                     }
                     
                     base.Initialize(layout);
-                    
+
                     // Creates the import path UI
-                    Utilities.Utils.CreateImportPathUI(layout, proxy._window.Item as BinaryAssetItem);
+                    var group = layout.Group("Import Path");
+                    Utilities.Utils.CreateImportPathUI(group, proxy._window.Item as BinaryAssetItem);
 
                     layout.Space(5);
                     var reimportButton = layout.Button("Reimport");

--- a/Source/Editor/Windows/Assets/TextureWindow.cs
+++ b/Source/Editor/Windows/Assets/TextureWindow.cs
@@ -143,7 +143,8 @@ namespace FlaxEditor.Windows.Assets
                     base.Initialize(layout);
 
                     // Creates the import path UI
-                    Utilities.Utils.CreateImportPathUI(layout, proxy._window.Item as BinaryAssetItem);
+                    var group = layout.Group("Import Path");
+                    Utilities.Utils.CreateImportPathUI(group, proxy._window.Item as BinaryAssetItem);
 
                     // Reimport
                     layout.Space(5);


### PR DESCRIPTION
This pr does the following things:

- The main reason for this pr: Add spacing between model import options and "Reimport" button (makes it stand out more, I always used to click the "Show in explorer" button by accident when I wanted to reimport a model)
- Group Import Path ui
- Removed "Import Path:" label as it is now redundant with the group title
- Fix `useInitialSpacing` space


![image](https://github.com/user-attachments/assets/7c06b646-9c7a-4739-bb74-ac0d00391f2e)

### TODO:

- [x] Revert some changes I made to the import path ui creation methods that are no longer really needed
