### PR TITLE
Add auto selecting first item in item list context menu if no selection and the user presses enter

### DIFF
--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -611,6 +611,16 @@ namespace FlaxEditor.GUI
                     OnClickItem(focusedItem);
                     return true;
                 }
+                else
+                {
+                    // Select first item if no item is focused (most likely to be the best result), saves the user from pressing arrow down first
+                    var visibleItems = GetVisibleItems();
+                    if (visibleItems.Count > 0)
+                    {
+                        OnClickItem(visibleItems[0]);
+                        return true;
+                    }
+                }
                 break;
             }
 


### PR DESCRIPTION
Addresses #3067.

https://github.com/user-attachments/assets/e9f6233a-8e7e-41cb-afaf-69151cd7bf50


There could be some visual hints added for this functionality, but the current implementation also works as a more power user oriented thing.

This can not be implemented by automatically selecting (`Focus()`- ing) the first item, because that will take away focus from the search bar.