### PR TITLE
Reduce allocations in text rendering related functions

### DIFF
--- a/Source/Engine/Render2D/Font.cpp
+++ b/Source/Engine/Render2D/Font.cpp
@@ -119,7 +119,7 @@ void Font::Invalidate()
     _characters.Clear();
 }
 
-void Font::ProcessText(const StringView& text, Array<FontLineCache>& outputLines, const TextLayoutOptions& layout)
+void Font::ProcessText(const StringView& text, Array<FontLineCache, InlinedAllocation<8>>& outputLines, const TextLayoutOptions& layout)
 {
     int32 textLength = text.Length();
     if (textLength == 0)
@@ -311,7 +311,7 @@ Float2 Font::MeasureText(const StringView& text, const TextLayoutOptions& layout
         return Float2::Zero;
 
     // Process text
-    Array<FontLineCache> lines;
+    Array<FontLineCache, InlinedAllocation<8>> lines;
     ProcessText(text, lines, layout);
 
     // Calculate bounds
@@ -332,7 +332,7 @@ int32 Font::HitTestText(const StringView& text, const Float2& location, const Te
         return 0;
 
     // Process text
-    Array<FontLineCache> lines;
+    Array<FontLineCache, InlinedAllocation<8>> lines;
     ProcessText(text, lines, layout);
     ASSERT(lines.HasItems());
     float scale = layout.Scale / FontManager::FontScale;
@@ -417,7 +417,7 @@ Float2 Font::GetCharPosition(const StringView& text, int32 index, const TextLayo
     }
 
     // Process text
-    Array<FontLineCache> lines;
+    Array<FontLineCache, InlinedAllocation<8>> lines;
     ProcessText(text, lines, layout);
     ASSERT(lines.HasItems());
     float scale = layout.Scale / FontManager::FontScale;

--- a/Source/Engine/Render2D/Font.h
+++ b/Source/Engine/Render2D/Font.h
@@ -344,7 +344,7 @@ public:
     /// <param name="text">The input text.</param>
     /// <param name="layout">The layout properties.</param>
     /// <param name="outputLines">The output lines list.</param>
-    void ProcessText(const StringView& text, Array<FontLineCache>& outputLines, API_PARAM(Ref) const TextLayoutOptions& layout);
+    void ProcessText(const StringView& text, Array<FontLineCache, InlinedAllocation<8>>& outputLines, API_PARAM(Ref) const TextLayoutOptions& layout);
 
     /// <summary>
     /// Processes text to get cached lines for rendering.
@@ -352,9 +352,9 @@ public:
     /// <param name="text">The input text.</param>
     /// <param name="layout">The layout properties.</param>
     /// <returns>The output lines list.</returns>
-    API_FUNCTION() Array<FontLineCache> ProcessText(const StringView& text, API_PARAM(Ref) const TextLayoutOptions& layout)
+    API_FUNCTION() Array<FontLineCache, InlinedAllocation<8>> ProcessText(const StringView& text, API_PARAM(Ref) const TextLayoutOptions& layout)
     {
-        Array<FontLineCache> lines;
+        Array<FontLineCache, InlinedAllocation<8>> lines;
         ProcessText(text, lines, layout);
         return lines;
     }
@@ -366,9 +366,9 @@ public:
     /// <param name="textRange">The input text range (substring range of the input text parameter).</param>
     /// <param name="layout">The layout properties.</param>
     /// <returns>The output lines list.</returns>
-    API_FUNCTION() Array<FontLineCache> ProcessText(const StringView& text, API_PARAM(Ref) const TextRange& textRange, API_PARAM(Ref) const TextLayoutOptions& layout)
+    API_FUNCTION() Array<FontLineCache, InlinedAllocation<8>> ProcessText(const StringView& text, API_PARAM(Ref) const TextRange& textRange, API_PARAM(Ref) const TextLayoutOptions& layout)
     {
-        Array<FontLineCache> lines;
+        Array<FontLineCache, InlinedAllocation<8>> lines;
         ProcessText(textRange.Substring(text), lines, layout);
         return lines;
     }
@@ -378,7 +378,7 @@ public:
     /// </summary>
     /// <param name="text">The input text.</param>
     /// <returns>The output lines list.</returns>
-    API_FUNCTION() FORCE_INLINE Array<FontLineCache> ProcessText(const StringView& text)
+    API_FUNCTION() FORCE_INLINE Array<FontLineCache, InlinedAllocation<8>> ProcessText(const StringView& text)
     {
         return ProcessText(text, TextLayoutOptions());
     }
@@ -389,7 +389,7 @@ public:
     /// <param name="text">The input text.</param>
     /// <param name="textRange">The input text range (substring range of the input text parameter).</param>
     /// <returns>The output lines list.</returns>
-    API_FUNCTION() FORCE_INLINE Array<FontLineCache> ProcessText(const StringView& text, API_PARAM(Ref) const TextRange& textRange)
+    API_FUNCTION() FORCE_INLINE Array<FontLineCache, InlinedAllocation<8>> ProcessText(const StringView& text, API_PARAM(Ref) const TextRange& textRange)
     {
         return ProcessText(textRange.Substring(text), TextLayoutOptions());
     }

--- a/Source/Engine/Render2D/Render2D.cpp
+++ b/Source/Engine/Render2D/Render2D.cpp
@@ -194,7 +194,7 @@ namespace
 
     // Drawing
     Array<Render2DDrawCall> DrawCalls;
-    Array<FontLineCache> Lines;
+    Array<FontLineCache, InlinedAllocation<8>> Lines;
     Array<Float2> Lines2;
     bool IsScissorsRectEmpty;
     bool IsScissorsRectEnabled;

--- a/Source/Engine/UI/TextRender.cpp
+++ b/Source/Engine/UI/TextRender.cpp
@@ -176,7 +176,7 @@ void TextRender::UpdateLayout()
     int32 kerning;
 
     // Perform layout
-    Array<FontLineCache> lines;
+    Array<FontLineCache, InlinedAllocation<8>> lines;
     font->ProcessText(text, lines, _layoutOptions);
 
     // Prepare buffers capacity


### PR DESCRIPTION
Most allocations during a typical frame when running the game in Editor consists of these short-lived `FontLineCache` arrays (during ~2400 frames):
![image](https://github.com/user-attachments/assets/8140d238-4c07-4000-a59b-86470fbef5e3)

Use inlined allocations in most common cases (1-8 lines of text) to avoid allocating on heap.