### PR TITLE
Refactor .NET version detection error reporting

### DIFF
--- a/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/DotNetSdk.cs
@@ -283,8 +283,10 @@ namespace Flax.Build
             Log.Verbose($"Found the following .NET SDK versions: {string.Join(", ", dotnetSdkVersions)}");
             Log.Verbose($"Found the following .NET runtime versions: {string.Join(", ", dotnetRuntimeVersions)}");
 
+            string configuredDotnetVersion = Configuration.Dotnet;
             var dotnetSdkVersion = GetVersion(dotnetSdkVersions);
             var dotnetRuntimeVersion = GetVersion(dotnetRuntimeVersions);
+
             if (!string.IsNullOrEmpty(dotnetSdkVersion) && !string.IsNullOrEmpty(dotnetRuntimeVersion) && ParseVersion(dotnetRuntimeVersion).Major > ParseVersion(dotnetSdkVersion).Major)
             {
                 // Make sure the reference assemblies are not newer than the SDK itself
@@ -296,21 +298,24 @@ namespace Flax.Build
                 } while (!string.IsNullOrEmpty(dotnetRuntimeVersion) && ParseVersion(dotnetRuntimeVersion).Major > ParseVersion(dotnetSdkVersion).Major);
             }
             
-            var minVer = string.IsNullOrEmpty(Configuration.Dotnet) ? MinimumVersion.ToString() : Configuration.Dotnet;
             if (string.IsNullOrEmpty(dotnetSdkVersion))
             {
-                if (dotnetSdkVersions.Any())
-                    Log.Warning($"Unsupported .NET SDK versions found: {string.Join(", ", dotnetSdkVersions)}. Minimum version required is .NET {minVer}.");
-                else
-                    Log.Warning($"Missing .NET SDK. Minimum version required is .NET {minVer}.");
+                string installedVersionsText = dotnetSdkVersions.Any()
+                    ? $"{string.Join(", ", dotnetSdkVersions)}"
+                    : "None";
+                Log.Warning(!string.IsNullOrEmpty(configuredDotnetVersion)
+                    ? $"Configured .NET SDK '{configuredDotnetVersion}' not found. Installed versions: {installedVersionsText}."
+                    : $"No compatible .NET SDK found within the supported range: .NET {MinimumVersion.ToString()} - {MaximumVersion.ToString()}. Installed versions: {installedVersionsText}.");
                 return;
             }
             if (string.IsNullOrEmpty(dotnetRuntimeVersion))
             {
-                if (dotnetRuntimeVersions.Any())
-                    Log.Warning($"Unsupported .NET runtime versions found: {string.Join(", ", dotnetRuntimeVersions)}. Minimum version required is .NET {minVer}.");
-                else
-                    Log.Warning($"Missing .NET runtime. Minimum version required is .NET {minVer}.");
+                string installedRuntimeVersionsText = dotnetRuntimeVersions.Any()
+                    ? $"{string.Join(", ", dotnetRuntimeVersions)}"
+                    : "None";
+                Log.Warning(!string.IsNullOrEmpty(configuredDotnetVersion)
+                    ? $"Configured .NET runtime version '{configuredDotnetVersion}' not found. Installed versions: {installedRuntimeVersionsText}."
+                    : $"No compatible .NET runtime found within the supported range: .NET {MinimumVersion.ToString()} - {MaximumVersion.ToString()}. Installed versions: {installedRuntimeVersionsText}.");
                 return;
             }
             RootPath = dotnetPath;


### PR DESCRIPTION
This PR improves the clarity of error messages when detecting .NET SDK and runtime versions.

### Background
When a specific .NET version is configured, the tool should use exactly that version, not a higher one. Previously, error messages were confusing when higher versions were installed but not the specifically the configured one. For example, if .NET 9 was installed but .NET 8 was configured, the log would say "Unsupported .NET SDK versions found: 9.0.101. Minimum version required is 8" which incorrectly suggested a bug in version detection.

The PR originally aimed to fix version detection while it was pointed out that it's the error message that needs to be updated. Leaving previous PR description below.

<details>
<summary>Previous PR Description</summary>
The current logic in `DotNetSdk.GetVersion` incorrectly filters out potentially valid higher versions of the .NET SDK when `Configuration.Dotnet` is set to only a major version number (e.g., "8" or "7").

When `Configuration.Dotnet` is "8":
1.  `ParseVersion(Configuration.Dotnet)` returns `null` because "8" isn't a full version string.
2.  The `int.TryParse` fallback goes in motion, and `dotnetVerNum` is correctly set to `8`.
3.  The code then enters iterates through available SDK versions.
4.  The check `if (dotnetVerNum != v.Major) continue;` is executed on every version. The check incorrectly causes the loop to `continue` for any installed SDK version where the major version `v.Major` is *not equal* to `dotnetVerNum` (e.g., it skips .NET 9 when `dotnetVerNum` is 8, while .NET 9 is an allowed maximum .NET version).

This prevents the selection of a valid, installed higher SDK version (like .NET 9) even if it falls within the acceptable range defined by `MinimumVersion` and `MaximumVersion`. 

**Solution:**

A simple change in version comparison does the trick:

```csharp
if (dotnetVerNum > v.Major)
    continue;
```

This change ensures that we only skip SDK versions whose major version is *lower* than the specified `dotnetVerNum`. Versions with a major version *equal to or greater than* `dotnetVerNum` will now correctly proceed to the subsequent check:

```csharp
if (v.Major >= MinimumVersion.Major && v.Major <= MaximumVersion.Major)
    return version;
```

Other option would be to remove the `if (dotnetVerNum != v.Major)` check completely, though I'm not sure if it served some other purpose.
</details>