### PR TITLE
Disable create file dialog create button if asset can't be created

### DIFF
--- a/Source/Editor/Content/Create/CreateFileEntry.cs
+++ b/Source/Editor/Content/Create/CreateFileEntry.cs
@@ -14,6 +14,11 @@ namespace FlaxEditor.Content.Create
         public string ResultUrl { get; }
 
         /// <summary>
+        /// Gets or sets wether a file can be created based on the current settings.
+        /// </summary>
+        public abstract bool CanBeCreated { get; }
+
+        /// <summary>
         /// Gets a value indicating whether this entry has settings to modify.
         /// </summary>
         public virtual bool HasSettings => Settings != null;

--- a/Source/Editor/Content/Create/CreateFileEntry.cs
+++ b/Source/Editor/Content/Create/CreateFileEntry.cs
@@ -14,7 +14,7 @@ namespace FlaxEditor.Content.Create
         public string ResultUrl { get; }
 
         /// <summary>
-        /// Gets or sets wether a file can be created based on the current settings.
+        /// Gets a value indicating wether a file can be created based on the current settings.
         /// </summary>
         public abstract bool CanBeCreated { get; }
 

--- a/Source/Editor/Content/Create/CreateFilesDialog.cs
+++ b/Source/Editor/Content/Create/CreateFilesDialog.cs
@@ -60,7 +60,8 @@ namespace FlaxEditor.Content.Create
                 Text = "Create",
                 AnchorPreset = AnchorPresets.BottomRight,
                 Offsets = new Margin(-ButtonsWidth - ButtonsMargin, ButtonsWidth, -ButtonsHeight - ButtonsMargin, ButtonsHeight),
-                Parent = this
+                Parent = this,
+                Enabled = entry.CanBeCreated,
             };
             createButton.Clicked += OnSubmit;
             var cancelButton = new Button
@@ -68,7 +69,7 @@ namespace FlaxEditor.Content.Create
                 Text = "Cancel",
                 AnchorPreset = AnchorPresets.BottomRight,
                 Offsets = new Margin(-ButtonsWidth - ButtonsMargin - ButtonsWidth - ButtonsMargin, ButtonsWidth, -ButtonsHeight - ButtonsMargin, ButtonsHeight),
-                Parent = this
+                Parent = this,
             };
             cancelButton.Clicked += OnCancel;
 
@@ -77,7 +78,7 @@ namespace FlaxEditor.Content.Create
             {
                 AnchorPreset = AnchorPresets.HorizontalStretchTop,
                 Offsets = new Margin(2, 2, infoLabel.Bottom + 2, EditorHeight),
-                Parent = this
+                Parent = this,
             };
 
             // Settings editor
@@ -87,6 +88,7 @@ namespace FlaxEditor.Content.Create
             _dialogSize = new Float2(TotalWidth, panel.Bottom);
 
             _settingsEditor.Select(_entry.Settings);
+            _settingsEditor.Modified += () => createButton.Enabled = _entry.CanBeCreated;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Content/Create/ParticleEmitterCreateEntry.cs
+++ b/Source/Editor/Content/Create/ParticleEmitterCreateEntry.cs
@@ -12,6 +12,9 @@ namespace FlaxEditor.Content.Create
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     public class ParticleEmitterCreateEntry : CreateFileEntry
     {
+        /// <inheritdoc/>
+        public override bool CanBeCreated => true;
+
         /// <summary>
         /// Types of the emitter templates that can be created.
         /// </summary>

--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -14,6 +14,8 @@ namespace FlaxEditor.Content.Create
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     public class PrefabCreateEntry : CreateFileEntry
     {
+        public override bool CanBeCreated => _options.RootActorType != null;
+
         /// <summary>
         /// The create options.
         /// </summary>
@@ -73,6 +75,9 @@ namespace FlaxEditor.Content.Create
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     public class WidgetCreateEntry : CreateFileEntry
     {
+        /// <inheritdoc/>
+        public override bool CanBeCreated => _options.RootControlType != null;
+
         /// <summary>
         /// The create options.
         /// </summary>

--- a/Source/Editor/Content/Create/SettingsCreateEntry.cs
+++ b/Source/Editor/Content/Create/SettingsCreateEntry.cs
@@ -17,6 +17,8 @@ namespace FlaxEditor.Content.Create
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     internal class SettingsCreateEntry : CreateFileEntry
     {
+        public override bool CanBeCreated => _options.Type != null;
+
         internal class Options
         {
             [Tooltip("The settings type.")]

--- a/Source/Editor/Content/Create/VisualScriptCreateEntry.cs
+++ b/Source/Editor/Content/Create/VisualScriptCreateEntry.cs
@@ -11,6 +11,9 @@ namespace FlaxEditor.Content.Create
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     public class VisualScriptCreateEntry : CreateFileEntry
     {
+        /// <inheritdoc/>
+        public override bool CanBeCreated => _options.BaseClass != null;
+
         /// <summary>
         /// The create options.
         /// </summary>

--- a/Source/Editor/Content/Proxy/JsonAssetProxy.cs
+++ b/Source/Editor/Content/Proxy/JsonAssetProxy.cs
@@ -65,6 +65,9 @@ namespace FlaxEditor.Content
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     public class GenericJsonCreateEntry : CreateFileEntry
     {
+        /// <inheritdoc/>
+        public override bool CanBeCreated => _options.Type != null; 
+
         /// <summary>
         /// The create options.
         /// </summary>

--- a/Source/Editor/Windows/Assets/CollisionDataWindow.cs
+++ b/Source/Editor/Windows/Assets/CollisionDataWindow.cs
@@ -102,6 +102,8 @@ namespace FlaxEditor.Windows.Assets
 
             private class CookData : CreateFileEntry
             {
+                public override bool CanBeCreated => true;
+
                 public PropertiesProxy Proxy;
                 public CollisionDataType Type;
                 public ModelBase Model;


### PR DESCRIPTION
This pr makes the "Create" button in the "Create file settings" dialog if the file can not be created with the current options.

![image](https://github.com/user-attachments/assets/3ad75f7d-faf4-499f-84fa-fc48f761e9ad)
![image](https://github.com/user-attachments/assets/a3a2be0e-a104-476a-9de1-233e75452b22)

This results in:
- *(Thing (when it can be created))*
- Particle (always)
- Prefab (if root is not null)
- Settings (if type is not null)
- Visual Script (if base is not null)
- JSON Asset (if type is not null)
- Collision Data (always)

This also gets rid of an error that would show when trying to create a new file with invalid options (see old behavior video)

*Old behavior:*

https://github.com/user-attachments/assets/9b1536b6-4bed-4579-afb7-6b77203a5528

*New behavior*

https://github.com/user-attachments/assets/81e35068-2b03-4724-a88e-b1a2eb0aff32



