### PR TITLE
FinishGPUCommands (Force exec and sync)

### DIFF
--- a/Source/Engine/Graphics/GPUContext.h
+++ b/Source/Engine/Graphics/GPUContext.h
@@ -618,6 +618,8 @@ public:
     /// </summary>
     API_FUNCTION() virtual void Flush() = 0;
 
+    API_FUNCTION() virtual void  FinishGPUCommands() = 0;
+
     /// <summary>
     /// Sets the state of the resource (or subresource).
     /// </summary>

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUContextDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUContextDX11.cpp
@@ -754,6 +754,25 @@ void GPUContextDX11::Flush()
         _context->Flush();
 }
 
+void GPUContextDX11::FinishGPUCommands()
+{
+    // Create a query object to wait for GPU completion
+    D3D11_QUERY_DESC queryDesc = {};
+    queryDesc.Query = D3D11_QUERY_EVENT;
+
+    ID3D11Query* query;
+    HRESULT hr = _device->GetDevice()->CreateQuery(&queryDesc, &query);
+    if (FAILED(hr)) return;
+
+    // End the query after issuing commands
+    _context->End(query);
+
+    // Wait for the GPU to finish commands
+    while (_context->GetData(query, nullptr, 0, 0) != S_OK) {
+        // Optionally: yield the CPU or sleep briefly to avoid tight loop
+        Sleep(0);
+    }
+}
 void GPUContextDX11::UpdateBuffer(GPUBuffer* buffer, const void* data, uint32 size, uint32 offset)
 {
     ASSERT(data);

--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUContextDX11.h
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUContextDX11.h
@@ -152,6 +152,8 @@ public:
     void ClearState() override;
     void FlushState() override;
     void Flush() override;
+    void FinishGPUCommands() override;
+
     void UpdateBuffer(GPUBuffer* buffer, const void* data, uint32 size, uint32 offset) override;
     void CopyBuffer(GPUBuffer* dstBuffer, GPUBuffer* srcBuffer, uint32 size, uint32 dstOffset, uint32 srcOffset) override;
     void UpdateTexture(GPUTexture* texture, int32 arrayIndex, int32 mipIndex, const void* data, uint32 rowPitch, uint32 slicePitch) override;

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUContextDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUContextDX12.cpp
@@ -1256,6 +1256,14 @@ void GPUContextDX12::Flush()
     Reset();
 }
 
+void GPUContextDX12::FinishGPUCommands()
+{
+    FenceDX12 fence(_device);
+    fence.Init();
+    fence.Signal(_device->_commandQueue);
+    fence.WaitCPU(0);
+}
+
 void GPUContextDX12::UpdateBuffer(GPUBuffer* buffer, const void* data, uint32 size, uint32 offset)
 {
     ASSERT(data);

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUContextDX12.h
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUContextDX12.h
@@ -196,6 +196,8 @@ public:
     void ClearState() override;
     void FlushState() override;
     void Flush() override;
+    void FinishGPUCommands() override;
+
     void UpdateBuffer(GPUBuffer* buffer, const void* data, uint32 size, uint32 offset) override;
     void CopyBuffer(GPUBuffer* dstBuffer, GPUBuffer* srcBuffer, uint32 size, uint32 dstOffset, uint32 srcOffset) override;
     void UpdateTexture(GPUTexture* texture, int32 arrayIndex, int32 mipIndex, const void* data, uint32 rowPitch, uint32 slicePitch) override;

--- a/Source/Engine/GraphicsDevice/Null/GPUContextNull.h
+++ b/Source/Engine/GraphicsDevice/Null/GPUContextNull.h
@@ -188,6 +188,7 @@ public:
     void Flush() override
     {
     }
+    void FinishGPUCommands() override {};
 
     void UpdateBuffer(GPUBuffer* buffer, const void* data, uint32 size, uint32 offset) override
     {

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
@@ -18,7 +18,7 @@
 #include "Engine/Graphics/PixelFormatExtensions.h"
 #include "Engine/Debug/Exceptions/NotImplementedException.h"
 
-#include "Engine\GraphicsDevice\Vulkan\QueueVulkan.h"
+#include "Engine/GraphicsDevice/Vulkan/QueueVulkan.h"
 
 // Ensure to match the indirect commands arguments layout
 static_assert(sizeof(GPUDispatchIndirectArgs) == sizeof(VkDispatchIndirectCommand), "Wrong size of GPUDrawIndirectArgs.");

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
@@ -1316,7 +1316,7 @@ void GPUContextVulkan::FinishGPUCommands()
 {
     auto f = _device->FenceManager.AllocateFence();
     Flush();
-    _device->FenceManager.WaitAndReleaseFence(f, INFINITE);
+    _device->FenceManager.WaitAndReleaseFence(f, 0xFFFFFFFF);
 }
 
 void GPUContextVulkan::UpdateBuffer(GPUBuffer* buffer, const void* data, uint32 size, uint32 offset)

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.h
@@ -188,6 +188,8 @@ public:
     void ClearState() override;
     void FlushState() override;
     void Flush() override;
+    void FinishGPUCommands() override;
+
     void UpdateBuffer(GPUBuffer* buffer, const void* data, uint32 size, uint32 offset) override;
     void CopyBuffer(GPUBuffer* dstBuffer, GPUBuffer* srcBuffer, uint32 size, uint32 dstOffset, uint32 srcOffset) override;
     void UpdateTexture(GPUTexture* texture, int32 arrayIndex, int32 mipIndex, const void* data, uint32 rowPitch, uint32 slicePitch) override;

--- a/Source/Engine/GraphicsDevice/Vulkan/QueueVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/QueueVulkan.h
@@ -24,7 +24,6 @@ private:
     CriticalSection _locker;
     CmdBufferVulkan* _lastSubmittedCmdBuffer;
     uint64 _lastSubmittedCmdBufferFenceCounter;
-
 public:
     QueueVulkan(GPUDeviceVulkan* device, uint32 familyIndex);
 

--- a/Source/Engine/GraphicsDevice/Vulkan/QueueVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/QueueVulkan.h
@@ -24,6 +24,7 @@ private:
     CriticalSection _locker;
     CmdBufferVulkan* _lastSubmittedCmdBuffer;
     uint64 _lastSubmittedCmdBufferFenceCounter;
+
 public:
     QueueVulkan(GPUDeviceVulkan* device, uint32 familyIndex);
 


### PR DESCRIPTION
force sync GPU-> CPU

dx11 tested works
dx12 crash not on (FinishGPUCommands)
vulkan crash  not on (FinishGPUCommands)

usage
```c#
GPUDevice.Instance.MainContext.CopyBuffer(NormalsReadback, NormalsGPUBuffer, sizeInBytes);
GPUDevice.Instance.MainContext.FinishGPUCommands();
var pBuff = NormalsReadback.Map(GPUResourceMapMode.Read);
```
with out this func Readback cant work explened in https://github.com/FlaxEngine/FlaxEngine/issues/3258

funcions not changed
|  broken funcions |   status                                                           |
|-----------------|-------------------------------------------------|
|GetData            | broken, sync point is missing result UB|
|DownloadData |  broken, sync point is missing result UB|


example project
[ComputeShadersExample.zip](https://github.com/user-attachments/files/20074434/ComputeShadersExample.zip)
