### PR TITLE
Improve AssetEditorWindow behaviour during scripting reload

### DIFF
--- a/Source/Editor/Content/Items/ContentItem.cs
+++ b/Source/Editor/Content/Items/ContentItem.cs
@@ -872,6 +872,8 @@ namespace FlaxEditor.Content
             }
 
             base.OnDestroy();
+
+            Root?.SyncCallbacks();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/ContextMenu/ContextMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenu.cs
@@ -363,6 +363,23 @@ namespace FlaxEditor.GUI.ContextMenu
                 separator.Dispose();
 
             base.Show(parent, location, direction);
+
+            // Ensure context menus for custom asset items (ShowContextMenuForItem) are destroyed during hot-reload
+            if (Tag != null && Tag.GetType().IsCollectible)
+                ScriptsBuilder.ScriptsReload += OnScriptsReload;
+        }
+
+        private void OnScriptsReload()
+        {
+            OnDestroy();
+        }
+
+        /// <inheritdoc />
+        public override void OnDestroy()
+        {
+            ScriptsBuilder.ScriptsReload -= OnScriptsReload;
+
+            base.OnDestroy();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/Source/Editor/SceneGraph/GUI/ActorTreeNode.cs
@@ -882,6 +882,7 @@ namespace FlaxEditor.SceneGraph.GUI
             _dragHandlers?.Clear();
             _dragHandlers = null;
             _highlights = null;
+            _actorNode = null;
 
             base.OnDestroy();
         }

--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -59,7 +59,7 @@ namespace FlaxEditor.Windows.Assets
 
             UpdateTitle();
 
-            ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+            ScriptsBuilder.ScriptsReloadEnd += OnScriptsReloadEnd;
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace FlaxEditor.Windows.Assets
         /// <inheritdoc />
         protected override void OnClose()
         {
-            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
+            ScriptsBuilder.ScriptsReloadEnd -= OnScriptsReloadEnd;
 
             if (_item != null)
             {
@@ -155,7 +155,7 @@ namespace FlaxEditor.Windows.Assets
         /// <inheritdoc />
         public override void OnDestroy()
         {
-            ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
+            ScriptsBuilder.ScriptsReloadEnd -= OnScriptsReloadEnd;
 
             if (_item != null)
             {
@@ -167,18 +167,8 @@ namespace FlaxEditor.Windows.Assets
         }
 
         /// <inheritdoc />
-        protected virtual void OnScriptsReloadBegin()
+        protected virtual void OnScriptsReloadEnd()
         {
-            if (!IsHidden)
-            {
-                if (IsEdited && _item != null)
-                {
-                    Editor.Log($"Auto-saving local changes to asset '{_item.Path}' before reloading code");
-                    Save();
-                }
-                Editor.Instance.Windows.AddToRestore(this);
-                Close();
-            }
         }
 
         #region IEditable Implementation
@@ -269,19 +259,19 @@ namespace FlaxEditor.Windows.Assets
         /// <inheritdoc />
         public void OnItemDeleted(ContentItem item)
         {
-            if (item == _item)
-            {
-                Close();
-            }
+            if (item != _item)
+                return;
+
+            Close();
         }
 
         /// <inheritdoc />
         public void OnItemRenamed(ContentItem item)
         {
-            if (item == _item)
-            {
-                UpdateTitle();
-            }
+            if (item != _item)
+                return;
+
+            UpdateTitle();
         }
 
         /// <inheritdoc />
@@ -290,12 +280,12 @@ namespace FlaxEditor.Windows.Assets
         }
 
         /// <inheritdoc />
-        public void OnItemDispose(ContentItem item)
+        public virtual void OnItemDispose(ContentItem item)
         {
-            if (item == _item)
-            {
-                Close();
-            }
+            if (item != _item)
+                return;
+
+            Close();
         }
 
         #endregion

--- a/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
+++ b/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
@@ -268,11 +268,8 @@ namespace FlaxEditor.Windows.Assets
             UpdateKnowledge();
         }
 
-        /// <inheritdoc />
-        protected override void OnScriptsReloadBegin()
+        private void OnScriptsReloadBegin()
         {
-            base.OnScriptsReloadBegin();
-
             // TODO: impl hot-reload for BT to nicely refresh state (save asset, clear undo/properties, reload surface)
             Close();
         }

--- a/Source/Editor/Windows/Assets/JsonAssetWindow.cs
+++ b/Source/Editor/Windows/Assets/JsonAssetWindow.cs
@@ -124,10 +124,8 @@ namespace FlaxEditor.Windows.Assets
             UpdateToolstrip();
         }
 
-        /// <inheritdoc />
-        protected override void OnScriptsReloadBegin()
+        private void OnScriptsReloadBegin()
         {
-            base.OnScriptsReloadBegin();
             Close();
         }
 

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using FlaxEditor.Content;
 using FlaxEditor.CustomEditors;
@@ -42,6 +43,7 @@ namespace FlaxEditor.Windows.Assets
         private bool _focusCamera;
         private bool _liveReload = false;
         private bool _isUpdatingSelection, _isScriptsReloading;
+        private Guid[] _restoreSelection = [];
         private DateTime _modifiedTime = DateTime.MinValue;
         private bool _isDropping = false;
 
@@ -73,7 +75,7 @@ namespace FlaxEditor.Windows.Assets
         /// <summary>
         /// The local scene nodes graph used by the prefab editor.
         /// </summary>
-        public readonly LocalSceneGraph Graph;
+        public LocalSceneGraph Graph;
 
         /// <summary>
         /// Indication of if the prefab window selection is locked on specific objects.
@@ -304,10 +306,8 @@ namespace FlaxEditor.Windows.Assets
             return false;
         }
 
-        /// <inheritdoc />
-        protected override void OnScriptsReloadBegin()
+        private void OnScriptsReloadBegin()
         {
-            base.OnScriptsReloadBegin();
             _isScriptsReloading = true;
 
             if (_asset == null || !_asset.IsLoaded)
@@ -330,11 +330,52 @@ namespace FlaxEditor.Windows.Assets
                 }
             }
 
+            // Restore current selection after scripts reload
+            _restoreSelection = Selection.OfType<ActorNode>().Select(x => x.Actor.PrefabObjectID).ToArray();
+
             // Cleanup
             Deselect();
-            Graph.MainActor = null;
+            _tree.RemoveChild(Graph.Root.TreeNode);
+            Graph.Dispose();
+            Graph = null;
             _viewport.Prefab = null;
             _undo?.Clear(); // TODO: maybe don't clear undo?
+        }
+
+        /// <inheritdoc />
+        protected override void OnScriptsReloadEnd()
+        {
+            base.OnScriptsReloadEnd();
+
+            // Flush the old nodes from cache
+            Graph = new LocalSceneGraph(new CustomRootNode(this));
+            Graph.Root.TreeNode.Expand(true);
+            _tree.AddChild(Graph.Root.TreeNode);
+
+            // Restore graph and previous selections
+            _viewport.Prefab = _asset;
+            Graph.MainActor = _viewport.Instance;
+            var nodes = Graph.Root.GetAllChildActorNodes().ToDictionary(x => x.Actor.PrefabObjectID, y => y);
+            foreach (var id in _restoreSelection)
+            {
+                if (nodes.TryGetValue(id, out var node) && node != null)
+                    Selection.Add(node);
+            }
+            if (Selection.Any())
+                OnSelectionChanged([]);
+        }
+
+        /// <inheritdoc />
+        public override void OnItemDispose(ContentItem item)
+        {
+            if (item != _item)
+                return;
+
+            if (_viewport.Prefab == null)
+            {
+                // When hot-reload is in progress, keep the window open
+                return;
+            }
 
             Close();
         }
@@ -367,6 +408,7 @@ namespace FlaxEditor.Windows.Assets
                 _viewport.SetInitialUIMode(value);
             else
                 _viewport.SetInitialUIMode(_viewport._hasUILinked);
+            _viewport.UIModeToggled -= OnUIModeToggled;
             _viewport.UIModeToggled += OnUIModeToggled;
             Graph.MainActor = _viewport.Instance;
             Selection.Clear();
@@ -452,7 +494,7 @@ namespace FlaxEditor.Windows.Assets
 
             OnPrefabOpened();
             _focusCamera = true;
-            _undo.Clear();
+            _undo?.Clear();
             ClearEditedFlag();
 
             base.OnAssetLoaded();
@@ -462,7 +504,8 @@ namespace FlaxEditor.Windows.Assets
         protected override void UnlinkItem()
         {
             Deselect();
-            Graph.MainActor = null;
+            if (Graph != null)
+                Graph.MainActor = null;
             _viewport.Prefab = null;
             _undo?.Clear();
 

--- a/Source/Engine/UI/GUI/RootControl.cs
+++ b/Source/Engine/UI/GUI/RootControl.cs
@@ -125,11 +125,11 @@ namespace FlaxEngine.GUI
 
         #endregion
 
-        /// <inheritdoc />
-        public override void Update(float deltaTime)
+        /// <summary>
+        /// Flushes update callback requests.
+        /// </summary>
+        public void SyncCallbacks()
         {
-            base.Update(deltaTime);
-
             // Flush requests
             Profiler.BeginEvent("RootControl.SyncCallbacks");
             for (int i = 0; i < UpdateCallbacksToAdd.Count; i++)
@@ -143,6 +143,14 @@ namespace FlaxEngine.GUI
             }
             UpdateCallbacksToRemove.Clear();
             Profiler.EndEvent();
+        }
+
+        /// <inheritdoc />
+        public override void Update(float deltaTime)
+        {
+            base.Update(deltaTime);
+
+            SyncCallbacks();
 
             // Perform the UI update
             try

--- a/Source/Engine/UI/GUI/Tooltip.cs
+++ b/Source/Engine/UI/GUI/Tooltip.cs
@@ -1,5 +1,4 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
-
 using System;
 
 namespace FlaxEngine.GUI
@@ -107,7 +106,18 @@ namespace FlaxEngine.GUI
             Visible = true;
             _window.Show();
             _showTarget.OnTooltipShown(this);
+
+#if FLAX_EDITOR
+            FlaxEditor.ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
+#endif
         }
+
+#if FLAX_EDITOR
+        private void OnScriptsReloadBegin()
+        {
+            Hide();
+        }
+#endif
 
         /// <summary>
         /// Hides the popup.
@@ -132,6 +142,9 @@ namespace FlaxEngine.GUI
 
             // Hide
             Visible = false;
+#if FLAX_EDITOR
+            FlaxEditor.ScriptsBuilder.ScriptsReloadBegin -= OnScriptsReloadBegin;
+#endif
         }
 
         /// <summary>

--- a/Source/Engine/UI/GUI/WindowRootControl.cs
+++ b/Source/Engine/UI/GUI/WindowRootControl.cs
@@ -338,5 +338,14 @@ namespace FlaxEngine.GUI
 
             base.OnMouseMove(location);
         }
+
+        /// <inheritdoc />
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+
+            _focusedControl = null;
+            _trackingControl = null;
+        }
     }
 }


### PR DESCRIPTION
Keep the window open while hot-reloading, but remove any possible rooting references preventing scripting ALC from unloading.