### PR TITLE
Unify zoom behavior when zooming in and out

### DIFF
--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -369,24 +369,14 @@ namespace FlaxEditor.Surface
             }
 
             // Change scale (disable scaling during selecting nodes)
-            if (IsMouseOver && !_leftMouseDown && !IsPrimaryMenuOpened)
+            if (IsMouseOver && !_leftMouseDown && !_rightMouseDown && !IsPrimaryMenuOpened)
             {
                 var nextViewScale = ViewScale + delta * 0.1f;
 
-                if (delta > 0 && !_rightMouseDown)
-                {
-                    // Scale towards mouse when zooming in
-                    var nextCenterPosition = ViewPosition + location / ViewScale;
-                    ViewScale = nextViewScale;
-                    ViewPosition = nextCenterPosition - (location / ViewScale);
-                }
-                else
-                {
-                    // Scale while keeping center position when zooming out or when dragging view
-                    var viewCenter = ViewCenterPosition;
-                    ViewScale = nextViewScale;
-                    ViewCenterPosition = viewCenter;
-                }
+                // Scale towards/ away from mouse when zooming in/ out
+                var nextCenterPosition = ViewPosition + location / ViewScale;
+                ViewScale = nextViewScale;
+                ViewPosition = nextCenterPosition - (location / ViewScale);
 
                 return true;
             }


### PR DESCRIPTION
This pr fixes zoom out behavior in visject editors. It now zooms out from the mouse cursor instead of from the middle of the surface.

I'd post a video showing what this changed, but it's hard to convey via video.