### PR TITLE
Add info on docs source being available to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Flax Engine is a high quality modern 3D game engine written in C++ and C#.
 From stunning graphics to powerful scripts, it's designed for fast workflow with many ready-to-use features waiting for you right now. To learn more see the website ([www.flaxengine.com](https://flaxengine.com)).
 
-This repository contains full source code of the Flax Engine (excluding NDA-protected platforms support). Anyone is welcome to contribute or use the modified source in Flax-based games.
+This repository contains full source code of the Flax Engine (excluding NDA-protected platforms support). Documentation source is also available in a separate repository. Anyone is welcome to contribute or use the modified source in Flax-based games.
 
 # Development
 


### PR DESCRIPTION
I noticed a few people who didn't know/ where surprised of the fact that the documentation is also available on github and that they can contribute and submit issues.

Hopefully this added sentence in the readme makes more people (who look at the git repo) aware of that.

![image](https://github.com/user-attachments/assets/60c8bfa9-7f4a-416e-85f4-141b2f77bfa4)
