### PR TITLE
Genericized InputOptions, Allows MouseButton, KeyboardKeys, and MouseScroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Source/*.csproj
 PackageEditor_Cert.command
 PackageEditor_Cert.bat
 PackagePlatforms_Cert.bat
+*.flax
 
 # User-specific files
 *.suo

--- a/Content/Editor/Camera/M_Camera.flax
+++ b/Content/Editor/Camera/M_Camera.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4dc3a7d0a8287c7c2c26b7685b726583677f96e1fe86ccb5f8518cb189b51a92
-size 29407

--- a/Content/Editor/Camera/O_Camera.flax
+++ b/Content/Editor/Camera/O_Camera.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df80cdde1b74c2fc3fb5de2ab68c36118e3441d0b317aedaa54df8b4baac921c
-size 88545

--- a/Content/Editor/Camera/T_Camera.flax
+++ b/Content/Editor/Camera/T_Camera.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbb8bff552a5f261aa2119d52b9f97cd8f16eb28ecbbcd5915ad41aa4b4b5f5f
-size 3105

--- a/Content/Editor/CubeTexturePreviewMaterial.flax
+++ b/Content/Editor/CubeTexturePreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:857edec8daa8bbd5bf16c839f65042df7a921154dcf48c1ac7a06aab4e40eab6
-size 30999

--- a/Content/Editor/DebugMaterials/DDGIDebugProbes.flax
+++ b/Content/Editor/DebugMaterials/DDGIDebugProbes.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb32df5fa9255c8d27f968819ab7f59236640661c83ae33588733542ea635b0f
-size 40232

--- a/Content/Editor/DebugMaterials/SingleColor/Decal.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Decal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fddc7cd2d8732f8eef008d0a2bdc47948b87a14849d9e6fabcfe60ddb218aa42
-size 7617

--- a/Content/Editor/DebugMaterials/SingleColor/Particle.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Particle.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e06851af881852106892b2bd03df0127c84db3a601abd9d7aaac7baf40343369
-size 32040

--- a/Content/Editor/DebugMaterials/SingleColor/Surface.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Surface.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34080fbc40ed62bc5501969640403013291b3104dbb4374d9268994f3902e5a8
-size 29180

--- a/Content/Editor/DebugMaterials/SingleColor/SurfaceAdditive.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/SurfaceAdditive.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71acbd5242dd2d2f02554af0e5a95da9a5bd90d77aef80dc6fcdaefb88251d23
-size 31365

--- a/Content/Editor/DebugMaterials/SingleColor/Terrain.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Terrain.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcc185a2ec2e02ee9f52c806ba3756827c6d12f586c91a12b44295a95dd093dc
-size 21331

--- a/Content/Editor/DefaultFontMaterial.flax
+++ b/Content/Editor/DefaultFontMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1500a05e700f3b12d7e3984a978773c61f4c9ecc34ec96720fae724a87bab8e
-size 29501

--- a/Content/Editor/EditorIcon.flax
+++ b/Content/Editor/EditorIcon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5ff94d35d9615450a4c3ee32a6d254d4eb1887bf34c1be62a5bd267c7c9f00b
-size 6206

--- a/Content/Editor/Fonts/Inconsolata-Regular.flax
+++ b/Content/Editor/Fonts/Inconsolata-Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36995fa880bf47331618b1e96f613c6925e72484fe76e98d6e44c1985ecab017
-size 93015

--- a/Content/Editor/Fonts/NotoSansSC-Regular.flax
+++ b/Content/Editor/Fonts/NotoSansSC-Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19fa43eb7b31ee3936348b1f271c464c79d7020a21d33e3cdbe54f98c3b14304
-size 10560899

--- a/Content/Editor/Fonts/Roboto-Regular.flax
+++ b/Content/Editor/Fonts/Roboto-Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:574b86d8e7439e88c3d7b4265cbc5ad7089c49368c47661b2c6f4c997cb53d86
-size 172093

--- a/Content/Editor/Fonts/SegMDL2.flax
+++ b/Content/Editor/Fonts/SegMDL2.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c4a17c412fce35275af5be883c784b57d192eb188fb3568990b0ae8e0e6d34e
-size 204049

--- a/Content/Editor/Fonts/Segoe Media Center Regular.flax
+++ b/Content/Editor/Fonts/Segoe Media Center Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d277b4abbdc1c91f056dd0d838631135242643abb41ce5751b1be3aaca72401
-size 72697

--- a/Content/Editor/Gizmo/FoliageBrushMaterial.flax
+++ b/Content/Editor/Gizmo/FoliageBrushMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10aff82173474030b7ce41b491c803cc0de265ea0317a3aca87102099d65ca79
-size 37392

--- a/Content/Editor/Gizmo/Material.flax
+++ b/Content/Editor/Gizmo/Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e68032a48b3196f73c614a6302223765485e8fa3e1e278a2395c9d9ae1c5064
-size 32519

--- a/Content/Editor/Gizmo/MaterialAxisFocus.flax
+++ b/Content/Editor/Gizmo/MaterialAxisFocus.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db7018144f8a2774e1188b6f0ef7edfde3f8cb9c7f11f576163512c02f4c5a54
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisLocked.flax
+++ b/Content/Editor/Gizmo/MaterialAxisLocked.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7518765847301a4b13625fb05d542fab4fc924190a7414d39227db817a0e29cb
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisX.flax
+++ b/Content/Editor/Gizmo/MaterialAxisX.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:261382d0e9d30168f325eea14e96ae7abdd2c1fd8bad166f1b134df507e5fda9
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisY.flax
+++ b/Content/Editor/Gizmo/MaterialAxisY.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9160ba4200d01d7dfe6c529bb2f8893ee5106fa644921de51757947a0cb7bea
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisZ.flax
+++ b/Content/Editor/Gizmo/MaterialAxisZ.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d129825361a89fca14f1dbad60a983cfac60d69284be66ca5e84041713e07a6
-size 661

--- a/Content/Editor/Gizmo/MaterialSphere.flax
+++ b/Content/Editor/Gizmo/MaterialSphere.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55fe4f30e87ddda26928901beeef710bc5eaaf7712224bf633c674465cf3b4ac
-size 661

--- a/Content/Editor/Gizmo/MaterialWire.flax
+++ b/Content/Editor/Gizmo/MaterialWire.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbc08de78faa00aab330168dce166867d85dcae142081219d6a7eeb5f285ffd7
-size 31216

--- a/Content/Editor/Gizmo/MaterialWireFocus.flax
+++ b/Content/Editor/Gizmo/MaterialWireFocus.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f49170f829a9b2cb9d9c7680d199f6271e810dd1a181c61e0d83fa62988ba12
-size 535

--- a/Content/Editor/Gizmo/RotationAxis.flax
+++ b/Content/Editor/Gizmo/RotationAxis.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb6446b5931ca57dd35ea37b62cbb8dec2cb0a9861170651c1d00d732a3419e9
-size 41735

--- a/Content/Editor/Gizmo/ScaleAxis.flax
+++ b/Content/Editor/Gizmo/ScaleAxis.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fcfc658f89f41477086540f866263a87b657df152575e618292a3b7af40a470
-size 40804

--- a/Content/Editor/Gizmo/SelectionOutlineMaterial.flax
+++ b/Content/Editor/Gizmo/SelectionOutlineMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de0b19b33a2aac03a0fb7beda935c8a22cbb506f9ca9383bcce3eaac858a54e3
-size 16166

--- a/Content/Editor/Gizmo/TranslationAxis.flax
+++ b/Content/Editor/Gizmo/TranslationAxis.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9eb79cb2acf80e6d30ee4339e7d920518232ae5a9d5518a708b2b351804f08d
-size 8965

--- a/Content/Editor/Gizmo/VertexColorsPreviewMaterial.flax
+++ b/Content/Editor/Gizmo/VertexColorsPreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a32d40e1f13606fea29e45cb0df1a45dbcc51eb329963d8db18ff64fa66bd4e
-size 30293

--- a/Content/Editor/Gizmo/WireBox.flax
+++ b/Content/Editor/Gizmo/WireBox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b5cd7a5eb1d50d8c600d74e2a96024930716e50c9d26b33bab5f85dc5c3d1fe
-size 8024

--- a/Content/Editor/Highlight Material.flax
+++ b/Content/Editor/Highlight Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1ec249ecd34cc66f9236431705adfaccff3e9ac5825ea72eb8b18449a96ccb7
-size 29910

--- a/Content/Editor/Icons/AudioListener.flax
+++ b/Content/Editor/Icons/AudioListener.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d9f3b36a78d558c8430f2b14420711d708d0633874a183b9eaab5f3963de8d5
-size 567

--- a/Content/Editor/Icons/AudioSource.flax
+++ b/Content/Editor/Icons/AudioSource.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc6c177b3537b1aae695cbaf256adf07b2891c91ae3e48286e547e851c6cd0bc
-size 567

--- a/Content/Editor/Icons/Decal.flax
+++ b/Content/Editor/Icons/Decal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2dd18babe45190ee2820995e7282e8a365e0e74cf275f2da2ee8c91bdb348a97
-size 567

--- a/Content/Editor/Icons/DirectionalLight.flax
+++ b/Content/Editor/Icons/DirectionalLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:920bccc12a9bb65eefa1f1fe6acc1c87c949acb81a2ec19f45a0770e9c38c1a8
-size 567

--- a/Content/Editor/Icons/EnvironmentProbe.flax
+++ b/Content/Editor/Icons/EnvironmentProbe.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:245ec4045f64984aaf58d2442e949ae7ad6500f3631216bf67b0142d5fb7df66
-size 567

--- a/Content/Editor/Icons/IconsMaterial.flax
+++ b/Content/Editor/Icons/IconsMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:652de424a7e366c1dcafd42cfe552f2d4f1327cd9ef033fb554d961e0a29ae2b
-size 29827

--- a/Content/Editor/Icons/ParticleEffect.flax
+++ b/Content/Editor/Icons/ParticleEffect.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b830f15153d9c86dc0bfc9c982f41a95e360727423716d6ea3b5c57e8739a8d
-size 567

--- a/Content/Editor/Icons/PointLight.flax
+++ b/Content/Editor/Icons/PointLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c98e9d6fba236f325f6979803b6c6d37ba5d21b92f5639338423cf13c17be0db
-size 567

--- a/Content/Editor/Icons/SceneAnimationPlayer.flax
+++ b/Content/Editor/Icons/SceneAnimationPlayer.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96cb14e43719a7645084f322edcb47aaea0a0044be6b9300c8761fb34d33417d
-size 567

--- a/Content/Editor/Icons/SkyLight.flax
+++ b/Content/Editor/Icons/SkyLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8ef3f16cb2482196da99ac5ee14dbc2ebe477f0bdc636e62f8f4577bc417a48
-size 567

--- a/Content/Editor/Icons/Skybox.flax
+++ b/Content/Editor/Icons/Skybox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7cf0288c069f20e48b553515e10417994aedc924dd47469634b61615021c8bc
-size 567

--- a/Content/Editor/Icons/Textures/AudioListner.flax
+++ b/Content/Editor/Icons/Textures/AudioListner.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71244c864e5f1ca5232a5800ecb36379fad9bc75d3e0fb735a6105accf274fb0
-size 88362

--- a/Content/Editor/Icons/Textures/AudioSource.flax
+++ b/Content/Editor/Icons/Textures/AudioSource.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ba27db325a9d3c33f7b030b61730d03cca1727ed2477122a1a60de5578c1d22
-size 88361

--- a/Content/Editor/Icons/Textures/Decal.flax
+++ b/Content/Editor/Icons/Textures/Decal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6d258e04be1835c8164e93289bd496dd9b9bdb2cc9f7633db6b9929f08575ed
-size 88355

--- a/Content/Editor/Icons/Textures/DirectionalLight.flax
+++ b/Content/Editor/Icons/Textures/DirectionalLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:742bd2c5755db7672e8a1fe27f1db013ebe885f495956b4406226f25c0c49536
-size 88366

--- a/Content/Editor/Icons/Textures/EnvironmentProbe.flax
+++ b/Content/Editor/Icons/Textures/EnvironmentProbe.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9c4e7a93cb5548253270063226452cedc6648edd95b0227a4146cee5013eae2
-size 88366

--- a/Content/Editor/Icons/Textures/ParticleEffect.flax
+++ b/Content/Editor/Icons/Textures/ParticleEffect.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad12b06bd7e64460f43442e8700d5f7862c1dd522e5e7335b21bd8fef1b7f1c1
-size 88364

--- a/Content/Editor/Icons/Textures/PointLight.flax
+++ b/Content/Editor/Icons/Textures/PointLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccf4443326fc4efa30acce040684f620b1ec55b2e22081184b28abb7e4a5a45e
-size 88360

--- a/Content/Editor/Icons/Textures/SceneAnimationPlayer.flax
+++ b/Content/Editor/Icons/Textures/SceneAnimationPlayer.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:419fd82bce8ffbb155ddcb5bd7387279571283555b212b374a18d95be88d5c62
-size 88370

--- a/Content/Editor/Icons/Textures/SkyLight.flax
+++ b/Content/Editor/Icons/Textures/SkyLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c5d5f9ec5a3e9bff677b18b420ac8cc83aeeee778033471aa6677092c1e9f6d
-size 88358

--- a/Content/Editor/Icons/Textures/Skybox.flax
+++ b/Content/Editor/Icons/Textures/Skybox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ebe5c47347d28484a4cbc0eca7f727bc93a3f9e90b781b72bc34bb44046fe75
-size 88356

--- a/Content/Editor/IconsAtlas.flax
+++ b/Content/Editor/IconsAtlas.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f43bf2050d47a1e4d6db35e5da66c2f999236939b9d962cd0fba56dcb171852
-size 5611913

--- a/Content/Editor/IesProfilePreviewMaterial.flax
+++ b/Content/Editor/IesProfilePreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6388c4a40a0de927abdd532d5bfaff5b7c651f8daa434c6f04a0579e33a1015b
-size 20399

--- a/Content/Editor/Particles/Constant Burst.flax
+++ b/Content/Editor/Particles/Constant Burst.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc1e46708152005dc92532e940b3ce19ec527b595fb18365b41ebdcd338ad2c4
-size 2705

--- a/Content/Editor/Particles/Particle Material Color.flax
+++ b/Content/Editor/Particles/Particle Material Color.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c71a6394a3a0668f6d2b18281aaa36d83b1b150fd10a869edace21e1ffa5b07
-size 30361

--- a/Content/Editor/Particles/Particle Material Preview.flax
+++ b/Content/Editor/Particles/Particle Material Preview.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88de448e023b35296531fff817d4b95200bac97fbd5c927ee6a5e5a815323978
-size 2110

--- a/Content/Editor/Particles/Periodic Burst.flax
+++ b/Content/Editor/Particles/Periodic Burst.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94bf88983e3cf9fe555141a867af3c20e5bd58d13a527a9b4e02d4d1be157be9
-size 3664

--- a/Content/Editor/Particles/Ribbon Spiral.flax
+++ b/Content/Editor/Particles/Ribbon Spiral.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9016e074d23649b91b9eb2438c4f48d0dbd5bed0c7d29b58fdaea5a8530e905
-size 2365

--- a/Content/Editor/Particles/Smoke Atlas Normal.flax
+++ b/Content/Editor/Particles/Smoke Atlas Normal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b142885fc327b3a1dccf07446e01f16e0783beaeae9e6bba0bd3adfdf6eb8f29
-size 1398948

--- a/Content/Editor/Particles/Smoke Atlas.flax
+++ b/Content/Editor/Particles/Smoke Atlas.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44705a0f6475390845f3dc1b377ce98b5abaae5c5837eb258eb492b8da1b1218
-size 1398946

--- a/Content/Editor/Particles/Smoke Material.flax
+++ b/Content/Editor/Particles/Smoke Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6097a8ca31dbe7a985b5c512d2049d2d22c73175551965c75d6b360323505491
-size 38427

--- a/Content/Editor/Particles/Smoke.flax
+++ b/Content/Editor/Particles/Smoke.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78b70b627e87f520fccf610a9f20f68e72af68022e5093e6cbbb2fdf6d0d886d
-size 14662

--- a/Content/Editor/Particles/Sparks.flax
+++ b/Content/Editor/Particles/Sparks.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5cd0be41d80f829f23ab67ad0d82f2023b9ee81f0f2119769034c7b57047ad1
-size 13650

--- a/Content/Editor/Primitives/Capsule.flax
+++ b/Content/Editor/Primitives/Capsule.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6fca37ec1a8a9035c590bc645003e20df3eb3a9f65913df68f89d58ef65694a2
-size 31528

--- a/Content/Editor/Primitives/Cone.flax
+++ b/Content/Editor/Primitives/Cone.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca7fadefea06d699af13fc086c6104579c0693e39af3298b9589e00c55293d3a
-size 27251

--- a/Content/Editor/Primitives/Cube.flax
+++ b/Content/Editor/Primitives/Cube.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5a18bf58e0b93c8bba9459fd77a92898f0fae373b58d3acbcb9e36f66c89cd7
-size 23537

--- a/Content/Editor/Primitives/Cylinder.flax
+++ b/Content/Editor/Primitives/Cylinder.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e88868ab5a587b4ca1984a7db6cfec2188080cd6c080cc5a409bd25d409998c0
-size 16321

--- a/Content/Editor/Primitives/Plane.flax
+++ b/Content/Editor/Primitives/Plane.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:835990c21d45238821a42efb02b6b1e92a2497f72ddb1652e1b7ad4e615ea438
-size 3371

--- a/Content/Editor/Primitives/Sphere.flax
+++ b/Content/Editor/Primitives/Sphere.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0bc62448b0e951bad9749ef740e5d292b2ec3281534740bf9af0a66a0b3864d
-size 43177

--- a/Content/Editor/SimplySky.flax
+++ b/Content/Editor/SimplySky.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7df7d1c905dcce01ba93caa39464016d58c9a4a0218d0158139a7e98b4947cb1
-size 524671

--- a/Content/Editor/SpriteMaterial.flax
+++ b/Content/Editor/SpriteMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ed88e5e8b513f7460e94942ad722d8b193c013434586f4382673f7dc3074e98
-size 30376

--- a/Content/Editor/Terrain/Circle Brush Material.flax
+++ b/Content/Editor/Terrain/Circle Brush Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ab7e9c88c9896f37ac5a43efe176e13f98eafacc3117b49cd7173b31376b21d
-size 28003

--- a/Content/Editor/Terrain/Highlight Terrain Material.flax
+++ b/Content/Editor/Terrain/Highlight Terrain Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40e38d672c13c06a84366689b8ce2b346179b4aa0de3cf1fc6035b33ad036e4a
-size 21506

--- a/Content/Editor/TexturePreviewMaterial.flax
+++ b/Content/Editor/TexturePreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93b0220308d2a3051d7e449505ca18dab7a82d46bf6a86e4ecfb9b741909f91b
-size 10698

--- a/Content/Editor/VisjectSurface.flax
+++ b/Content/Editor/VisjectSurface.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce771772f9e14b43a11a617273da7316234870c3b8dca50c25b9fd50be1226d7
-size 5593008

--- a/Content/Editor/Wires Debug Material.flax
+++ b/Content/Editor/Wires Debug Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7e22035ac54615fee78cad71d5e5268ff139811d4390fe9a5025ab4d234ff4e
-size 29910

--- a/Content/Engine/DefaultDeformableMaterial.flax
+++ b/Content/Engine/DefaultDeformableMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:feac2f9ced2d8edf6a43f1c56cdfdc27bbd018a4c23a527a403c30bdb9217e63
-size 18922

--- a/Content/Engine/DefaultMaterial.flax
+++ b/Content/Engine/DefaultMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1db3d343643eec7c6f7c3ac33a205618480ce41b4b196ebfc6b63e00085a555f
-size 31205

--- a/Content/Engine/DefaultRadialMenu.flax
+++ b/Content/Engine/DefaultRadialMenu.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9e9e01ae0222d9dc0db7c51741c3e2c2595bb550fa9dd1665d11ce4fac0afc9
-size 20468

--- a/Content/Engine/DefaultTerrainMaterial.flax
+++ b/Content/Engine/DefaultTerrainMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c890a5b43c0158d1885c3905ab02c8b0ee36a558c4770d79892837960ee07e5
-size 23628

--- a/Content/Engine/Models/Box.flax
+++ b/Content/Engine/Models/Box.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be3e9498a6f55c631f20187d7084158089a265d59c2c8c81748ae41dde81fb96
-size 3171

--- a/Content/Engine/Models/Quad.flax
+++ b/Content/Engine/Models/Quad.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bc157593dd5209616dd17f39ea04e4b2f609a6c6b38da648d7df0b8b15fb28f
-size 1015

--- a/Content/Engine/Models/SimpleBox.flax
+++ b/Content/Engine/Models/SimpleBox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c6269591e15337ff7b0235b3b8d8b641296a33298aa0bf77bd69b3b576af270
-size 2205

--- a/Content/Engine/Models/Sphere.flax
+++ b/Content/Engine/Models/Sphere.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d06d281960b16ebf13cc69e71317e03261225d2992cee45da44b848632d1585e
-size 112019

--- a/Content/Engine/Models/SphereLowPoly.flax
+++ b/Content/Engine/Models/SphereLowPoly.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3da1c828b3d55c08385f6a0b9a9bba36597d8f065a0fc827915dece33be165f9
-size 3807

--- a/Content/Engine/SingleColorMaterial.flax
+++ b/Content/Engine/SingleColorMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27acfeeafdb50abe76a2feee0616ea90ee5d4fd72c678244d80f15ed4a97894a
-size 29381

--- a/Content/Engine/SkyboxMaterial.flax
+++ b/Content/Engine/SkyboxMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e7d0fe3697a0b65eefb8756e0f9aa48bc2d505eb94710b5972097eb61b6b029
-size 30944

--- a/Content/Engine/Textures/BlackTexture.flax
+++ b/Content/Engine/Textures/BlackTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ee43f9b878672be95e2567281f0a75c3bc834955a98f9c199266a39d3c485ae
-size 474

--- a/Content/Engine/Textures/Bokeh/Circle.flax
+++ b/Content/Engine/Textures/Bokeh/Circle.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:407184ea7e4805a52c3e18af58ceb53b2809f15dcd476ea2e645e568e11c8d28
-size 11320

--- a/Content/Engine/Textures/Bokeh/Cross.flax
+++ b/Content/Engine/Textures/Bokeh/Cross.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd37736fc6e0012712d8bbaa7c09239b9162ac7978daa02d574d4b4808c0fa2a
-size 11319

--- a/Content/Engine/Textures/Bokeh/Hexagon.flax
+++ b/Content/Engine/Textures/Bokeh/Hexagon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84b028093344341af783e612aa1c80c143246f5c5cf2558dea58d58f59ef80f0
-size 11317

--- a/Content/Engine/Textures/Bokeh/Octagon.flax
+++ b/Content/Engine/Textures/Bokeh/Octagon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12c2293c5d3f07c8bb1a261005a7487738dfa151025bcd1b1c8836cb6f5027a6
-size 11317

--- a/Content/Engine/Textures/DefaultLensColor.flax
+++ b/Content/Engine/Textures/DefaultLensColor.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a33c432074129df8c96f7d2296bb5c37c07f6ea52b83b5b1d45fab61c79c7dc
-size 2458

--- a/Content/Engine/Textures/DefaultLensDirt.flax
+++ b/Content/Engine/Textures/DefaultLensDirt.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:149b9a2d5d9d5f02e3e1e0a8d58964d53c4432d969ee290dd2be08ce2285d946
-size 8295253

--- a/Content/Engine/Textures/DefaultLensStarburst.flax
+++ b/Content/Engine/Textures/DefaultLensStarburst.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b6d662c3f40e7c03da5854bccc34ccf9b81219e38a05141eabefc9d830ff4c3
-size 1399104

--- a/Content/Engine/Textures/FlaxIcon.flax
+++ b/Content/Engine/Textures/FlaxIcon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:038b7f0df0e45f320a54183dcf6de43372bf3b76a7b07e1bfeb82827578f495e
-size 1398906

--- a/Content/Engine/Textures/FlaxIconBlue.flax
+++ b/Content/Engine/Textures/FlaxIconBlue.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ead561da9a3689613404da036705bb6b128c150322137d408ed193a27ffdbc52
-size 1398910

--- a/Content/Engine/Textures/GrayTexture.flax
+++ b/Content/Engine/Textures/GrayTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afc7ccb71d12256329c888e740e0d6f5154f95774c82092a5128aa8ed3b80c3c
-size 473

--- a/Content/Engine/Textures/Logo.flax
+++ b/Content/Engine/Textures/Logo.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f673152512b6f7840ae25d5dd0b4ab9ee5cfa91a2cabc62f19890b33865ba73c
-size 600623

--- a/Content/Engine/Textures/NormalTexture.flax
+++ b/Content/Engine/Textures/NormalTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:654e87ee866aebf5342159564a31df2b95e318b0cad7b7e3033a4e837192934e
-size 671

--- a/Content/Engine/Textures/PreIntegratedGF.flax
+++ b/Content/Engine/Textures/PreIntegratedGF.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fcaf6ab41c5745842a005284259b9ed8eaec73587d73a9e3d7f39086b78ec0e2
-size 87789

--- a/Content/Engine/Textures/SMAA_AreaTex.flax
+++ b/Content/Engine/Textures/SMAA_AreaTex.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de768189b6aa6fec0c1906ec713d879e91e03a338855f0f92848a31adb1dfe3d
-size 45484

--- a/Content/Engine/Textures/SMAA_SearchTex.flax
+++ b/Content/Engine/Textures/SMAA_SearchTex.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bcc5a34993b7dbd8a7177618f650ee878b444f1fcefdc1165f4d82fca52a9c2
-size 1470

--- a/Content/Engine/Textures/SplashScreenLogo.flax
+++ b/Content/Engine/Textures/SplashScreenLogo.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc0b1fe7596894317bbf7049d4e31794bbb98f224eba098025ae972f988fae59
-size 1266836

--- a/Content/Engine/Textures/Tiles_M.flax
+++ b/Content/Engine/Textures/Tiles_M.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:332359786ae1acc0c2b979981c1aa07f96c46172fc8b0c52da268d0a62cdcf65
-size 2797177

--- a/Content/Engine/Textures/Tiles_N.flax
+++ b/Content/Engine/Textures/Tiles_N.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:beae5ea42642324e9ef9b50793e1746f8fa97f0c3ad5752ddf440484db993d3f
-size 5593393

--- a/Content/Engine/Textures/WhiteTexture.flax
+++ b/Content/Engine/Textures/WhiteTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b6db73909f6ea8b4cf39ebd25cc69c9c9df9e64fc4f138b15b21d29282bb79c
-size 474

--- a/Content/Engine/WhiteMaterial.flax
+++ b/Content/Engine/WhiteMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5778a7c9133d946207e32e07914b79849822fa79f4a213b84667e8ee9a7b16c6
-size 583

--- a/Content/Shaders/AtmospherePreCompute.flax
+++ b/Content/Shaders/AtmospherePreCompute.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8086fe1ee43006a13582e0b1dc7f445f87b6a201357bdc4e079495eb7fe6b7d3
-size 11408

--- a/Content/Shaders/BakeLightmap.flax
+++ b/Content/Shaders/BakeLightmap.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ab9a4d7377684f4d51b01c6cdbb44a80249d39ca3ebb0a443fcc0c6beb84ffc
-size 15755

--- a/Content/Shaders/BitonicSort.flax
+++ b/Content/Shaders/BitonicSort.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:924884da1dfef7a802b7190fd148eebbeece50d6fa4d69295c38238dd96331e6
-size 6538

--- a/Content/Shaders/CAS.flax
+++ b/Content/Shaders/CAS.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe87eb5ca0054e79cded864b912884aee05e8635f71f3088d6a6c0a74d72d9c4
-size 2030

--- a/Content/Shaders/ColorGrading.flax
+++ b/Content/Shaders/ColorGrading.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad1d9597dd930f0b63358dbe8326d131661f9cc2251181eeec0cb44ffc530d7a
-size 12311

--- a/Content/Shaders/DebugDraw.flax
+++ b/Content/Shaders/DebugDraw.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf85b8fb7e3f5c7cf0aab9adb6564e5f31ad0b75fd6d6205f2531ced3b1e9889
-size 1938

--- a/Content/Shaders/DepthOfField.flax
+++ b/Content/Shaders/DepthOfField.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abd45cf24b2b6c728ec603052a2aace6f335d6ccfc8b0d5e3184c48c7c2a35f1
-size 13356

--- a/Content/Shaders/Editor/Grid.flax
+++ b/Content/Shaders/Editor/Grid.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c13729c4ec2ef534271c60fee6fff2e0489bf4445fe91aa8a2bbc3d581715602
-size 4666

--- a/Content/Shaders/Editor/LightmapUVsDensity.flax
+++ b/Content/Shaders/Editor/LightmapUVsDensity.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0845b6475dce10d217aca94e62e4a044c776bb3c4fbe8f1c4650bc4170efe60
-size 4365

--- a/Content/Shaders/Editor/MaterialComplexity.flax
+++ b/Content/Shaders/Editor/MaterialComplexity.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecdd3ddc3aa6542e3dfcae2961aa37cda2dad109ec8a8a5e09b798f901f0bae2
-size 1293

--- a/Content/Shaders/Editor/QuadOverdraw.flax
+++ b/Content/Shaders/Editor/QuadOverdraw.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f550ad83652e9669142a1e973a4cc748c377c135a8c19244f0c8fece1a04b4c3
-size 1404

--- a/Content/Shaders/Editor/VertexColors.flax
+++ b/Content/Shaders/Editor/VertexColors.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8230651fcf998b534db60db1db205c163be2609485b903beed3e508215bc7c30
-size 2043

--- a/Content/Shaders/EyeAdaptation.flax
+++ b/Content/Shaders/EyeAdaptation.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1a34e4fb3d0dc276abba393984b0c8112e1727f1425985949128d92984b89a9
-size 4443

--- a/Content/Shaders/FXAA.flax
+++ b/Content/Shaders/FXAA.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebd4e089c963ba72d8e82a19b288ab2870ec1834abcbd0d783f3b2bcd8163b41
-size 24474

--- a/Content/Shaders/Fog.flax
+++ b/Content/Shaders/Fog.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7735a770a87483d4df5e4e653373067c26469de8088f071ca092ed3e797bf461
-size 2785

--- a/Content/Shaders/Forward.flax
+++ b/Content/Shaders/Forward.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9b0df7f7033fe84464de3e369db8e5f38047520682110462eaa75d29977f127
-size 1187

--- a/Content/Shaders/GBuffer.flax
+++ b/Content/Shaders/GBuffer.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70414c6d184befbec5edbea3d8b377114bb03328df4a972216ae357244b7f8f4
-size 2764

--- a/Content/Shaders/GI/DDGI.flax
+++ b/Content/Shaders/GI/DDGI.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5577ef4ce821b08a38afe17b9e5d11cb0b409eb05dd89b2ca76ea95d88085dc0
-size 32893

--- a/Content/Shaders/GI/GlobalSurfaceAtlas.flax
+++ b/Content/Shaders/GI/GlobalSurfaceAtlas.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64a53e850ac662cb98ce91a8122dece7a43562f55a85c37f830f44324e4d16c5
-size 12925

--- a/Content/Shaders/GPUParticlesSorting.flax
+++ b/Content/Shaders/GPUParticlesSorting.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70db76daf1adae225c5354926b84ab738b0dfba4a66233e291223e81685900c8
-size 2629

--- a/Content/Shaders/GUI.flax
+++ b/Content/Shaders/GUI.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fed6a05104322f61a77f6cf69b64478518b829165a2a3ab7fc151098dcd48be
-size 4526

--- a/Content/Shaders/GlobalSignDistanceField.flax
+++ b/Content/Shaders/GlobalSignDistanceField.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e593e15c500b14f6e49d5e4ca6156135fd84d9cc1072a4597ee8bcea77d9339e
-size 13255

--- a/Content/Shaders/Histogram.flax
+++ b/Content/Shaders/Histogram.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af6e12eef9b70f29ed31bfbd30197e69e14202b9e2b71cf0391d03387e77d84d
-size 2522

--- a/Content/Shaders/Lights.flax
+++ b/Content/Shaders/Lights.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68c138e5d710abb090551019a711eff083c61494a632e79b492a597776b8bf86
-size 5118

--- a/Content/Shaders/MotionBlur.flax
+++ b/Content/Shaders/MotionBlur.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af63c3e954919a968e21f19313af1a704c2afa42c5a02744200e1dbf132dc88f
-size 9418

--- a/Content/Shaders/MultiScaler.flax
+++ b/Content/Shaders/MultiScaler.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12b8b623aaa735f126dbe59f1d41280094d3711365e991b5974d180045dd6c53
-size 6996

--- a/Content/Shaders/PostProcessing.flax
+++ b/Content/Shaders/PostProcessing.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb7baebfb28eb44a18c8947ccc5eb4eed8467c3c669af63b7e1be5fde2514948
-size 22677

--- a/Content/Shaders/ProbesFilter.flax
+++ b/Content/Shaders/ProbesFilter.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0249696b525cd59825ab3c0ce38bd612f93cf4be1f88fb49bfcecaac6e9ab34
-size 2022

--- a/Content/Shaders/Quad.flax
+++ b/Content/Shaders/Quad.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a611024c6cf2e5ea5865fe9a98a9b8f43469cde7597033ccfc9e87e93032837
-size 4075

--- a/Content/Shaders/Reflections.flax
+++ b/Content/Shaders/Reflections.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5c99a81c70ccb7e9b2e1e4bc5f271c2fe7b36630489fbb269adfaa34de2cc80
-size 3183

--- a/Content/Shaders/SDF.flax
+++ b/Content/Shaders/SDF.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1abacca0d63b575f0c88d54839f30ce4ec1bb8912478cb81ada8219d417001f9
-size 7891

--- a/Content/Shaders/SMAA.flax
+++ b/Content/Shaders/SMAA.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:013970c677da74c2eb300ee81d6aa6f996dbfaaa74abe13cc76329d77b4dab48
-size 46439

--- a/Content/Shaders/SSAO.flax
+++ b/Content/Shaders/SSAO.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0a576e8a8b818d06ff258874c8d73b273d05c2b8856ff6c14cf0accb2f23f52
-size 36832

--- a/Content/Shaders/SSR.flax
+++ b/Content/Shaders/SSR.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9602d25ef9300636aa23112b3ba3a4f45bf1c4c99b1484a86074da5a787abfc
-size 11085

--- a/Content/Shaders/Shadows.flax
+++ b/Content/Shaders/Shadows.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10d068572a53529671e7a7fcfe6bea4bc6de0fe4b378b57b434f5d3929e702a9
-size 7378

--- a/Content/Shaders/Sky.flax
+++ b/Content/Shaders/Sky.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28d44ef295d989d49ad4d59d6581eee921bc5fa5237e046d271a433454496388
-size 3463

--- a/Content/Shaders/TAA.flax
+++ b/Content/Shaders/TAA.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ba59e7b56c9cda8b9d19369b998e873f08c634fc87021dc8bbd836f44a5bdc5
-size 4275

--- a/Content/Shaders/VolumetricFog.flax
+++ b/Content/Shaders/VolumetricFog.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a3e331b7d688d4d3a11da6bb50d4608dbc6437978433a83cc79a365f520bc58
-size 13206

--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -14,6 +14,7 @@ namespace FlaxEditor.Content.Create
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     public class PrefabCreateEntry : CreateFileEntry
     {
+        /// <inheritdoc/>
         public override bool CanBeCreated => _options.RootActorType != null;
 
         /// <summary>

--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -754,7 +754,7 @@ namespace FlaxEditor.Content.GUI
                 return true;
             }
 
-            if (InputActions.Process(Editor.Instance, this, key))
+            if (InputActions.Process(Editor.Instance, this))
                 return true;
 
             // Check if sth is selected

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -476,7 +476,7 @@ namespace FlaxEditor.GUI.Docking
                 return true;
 
             // Custom input events
-            return InputActions.Process(Editor.Instance, this, key);
+            return InputActions.Process(Editor.Instance, this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/MainMenu.cs
+++ b/Source/Editor/GUI/MainMenu.cs
@@ -313,7 +313,7 @@ namespace FlaxEditor.GUI
 
             // Fallback to the edit window for shortcuts
             var editor = Editor.Instance;
-            return editor.Windows.EditWin.InputActions.Process(editor, this, key);
+            return editor.Windows.EditWin.InputActions.Process(editor, this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -200,7 +200,7 @@ namespace FlaxEditor.GUI
             var editor = Editor.Instance;
             if (editorWindow == null)
                 editorWindow = editor.Windows.EditWin; // Fallback to main editor window
-            return editorWindow.InputActions.Process(editor, this, key);
+            return editorWindow.InputActions.Process(editor, this);
         }
     }
 }

--- a/Source/Editor/Options/InputBinding.cs
+++ b/Source/Editor/Options/InputBinding.cs
@@ -303,7 +303,7 @@ namespace FlaxEditor.Options
             {
                 if (!IsFocused)
                 {
-                    return false;
+                    return base.OnMouseDown(location, button);
                 }
                 var trigger = new InputTrigger(button.ToString());
                 if (!_binding.InputTriggers.Contains(trigger))
@@ -320,7 +320,7 @@ namespace FlaxEditor.Options
             {
                 if (!IsFocused)
                 {
-                    return false;
+                    return base.OnKeyDown(key);
                 }
                 var trigger = new InputTrigger(key.ToString());
                 if (!_binding.InputTriggers.Contains(trigger))
@@ -336,7 +336,7 @@ namespace FlaxEditor.Options
             {
                 if (!IsFocused)
                 {
-                    return false;
+                    return base.OnMouseWheel(location, delta);
                 }
                 var trigger = new InputTrigger(MouseScrollHelper.GetScrollDirection(delta).ToString());
                 if (!_binding.InputTriggers.Contains(trigger))

--- a/Source/Editor/Options/InputBinding.cs
+++ b/Source/Editor/Options/InputBinding.cs
@@ -80,6 +80,13 @@ namespace FlaxEditor.Options
                     InputTriggers.Add(parsedMouse);
                     continue;
                 }
+                if (
+                    input is MouseScroll
+                    && InputTrigger.TryParseInput(input.ToString(), out var parsedMouseScroll))
+                {
+                    InputTriggers.Add(parsedMouseScroll);
+                    continue;
+                }
                 throw new ArgumentException($"Unsupported input type: {input.GetType().Name}");
             }
         }
@@ -107,17 +114,14 @@ namespace FlaxEditor.Options
             var parts = value.Split('+', StringSplitOptions.RemoveEmptyEntries);
             var triggers = new List<InputTrigger>();
 
-            string parsedString = value + "\n";
             foreach (var part in parts)
             {
                 if (InputTrigger.TryParseInput(part.Trim(), out var trigger))
                 {
                     triggers.Add(trigger);
-                    Debug.Log(parsedString);
                 }
                 else
                 {
-                    Debug.Log(parsedString);
                     result = new InputBinding();
                     return false;
                 }
@@ -242,18 +246,14 @@ namespace FlaxEditor.Options
         {
             if (value is string str)
             {
-                //Debug.Log($"[Converter] Converting '{str}'");
                 if (InputBinding.TryParse(str, out var result))
                 {
-                    //Debug.Log("[Converter] Successs!");
                     return result;
                 }
                 else
                 {
                     throw new NotSupportedException($"InputBindingConverter cannot convert from '{str}' to InputBinding.");
                 }
-
-                //Debug.Log("[Converter] Failed to parse string." + value.ToString());
             }
             return base.ConvertFrom(context, culture, value);
         }
@@ -339,7 +339,6 @@ namespace FlaxEditor.Options
                     return false;
                 }
                 var trigger = new InputTrigger(MouseScrollHelper.GetScrollDirection(delta).ToString());
-                Debug.Log(trigger);
                 if (!_binding.InputTriggers.Contains(trigger))
                 {
                     _binding.InputTriggers.Add(trigger);

--- a/Source/Editor/Options/InputBinding.cs
+++ b/Source/Editor/Options/InputBinding.cs
@@ -26,7 +26,7 @@ namespace FlaxEditor.Options
         /// The <see cref="InputTrigger"/> list to bind.
         /// </summary>
         public List<InputTrigger> InputTriggers;
-        private const int MAX_TRIGGERS = 4;
+        public const int MAX_TRIGGERS = 4;
 
         /// <summary>
         /// Initializes an empty <see cref="InputBinding"/>
@@ -165,6 +165,9 @@ namespace FlaxEditor.Options
         /// <returns>True if all input triggers are currently pressed; otherwise, false.</returns>
         private bool Process(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse, float scrollDelta)
         {
+            if (InputTriggers == null || InputTriggers.Count == 0)
+                return false;
+
             foreach (var trigger in InputTriggers)
             {
                 if (!trigger.IsPressed(getKey, getMouse, scrollDelta))
@@ -305,6 +308,7 @@ namespace FlaxEditor.Options
                 {
                     return base.OnMouseDown(location, button);
                 }
+
                 var trigger = new InputTrigger(button.ToString());
                 if (!_binding.InputTriggers.Contains(trigger))
                 {
@@ -312,6 +316,11 @@ namespace FlaxEditor.Options
                 }
 
                 _text = _binding.ToString();
+                if (_binding.InputTriggers.Count >= InputBinding.MAX_TRIGGERS)
+                {
+                    Defocus();
+                    return true;
+                }
                 return true;
             }
 
@@ -322,6 +331,7 @@ namespace FlaxEditor.Options
                 {
                     return base.OnKeyDown(key);
                 }
+
                 var trigger = new InputTrigger(key.ToString());
                 if (!_binding.InputTriggers.Contains(trigger))
                 {
@@ -329,6 +339,11 @@ namespace FlaxEditor.Options
                 }
 
                 _text = _binding.ToString();
+                if (_binding.InputTriggers.Count >= InputBinding.MAX_TRIGGERS)
+                {
+                    Defocus();
+                    return true;
+                }
                 return true;
             }
 
@@ -345,6 +360,10 @@ namespace FlaxEditor.Options
                 }
 
                 _text = _binding.ToString();
+                if (_binding.InputTriggers.Count >= InputBinding.MAX_TRIGGERS)
+                {
+                    Defocus();
+                }
                 return true;
             }
         }

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -114,23 +114,23 @@ namespace FlaxEditor.Options
 
         #region File
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(300)]
         public InputBinding SaveScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(310)]
         public InputBinding CloseScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(320)]
         public InputBinding OpenScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(330)]
         public InputBinding GenerateScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(340)]
         public InputBinding RecompileScripts = new InputBinding(KeyboardKeys.None);
 
@@ -150,7 +150,7 @@ namespace FlaxEditor.Options
         [EditorDisplay("Scene", "Play/Stop"), EditorOrder(510)]
         public InputBinding Play = new InputBinding(KeyboardKeys.F5);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Play Current Scenes/Stop"), EditorOrder(520)]
         public InputBinding PlayCurrentScenes = new InputBinding(KeyboardKeys.None);
 
@@ -162,27 +162,27 @@ namespace FlaxEditor.Options
         [EditorDisplay("Scene"), EditorOrder(540)]
         public InputBinding StepFrame = new InputBinding(KeyboardKeys.F11);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Cook & Run"), EditorOrder(550)]
         public InputBinding CookAndRun = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Run cooked game"), EditorOrder(560)]
         public InputBinding RunCookedGame = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Move actor to viewport"), EditorOrder(570)]
         public InputBinding MoveActorToViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Align actor with viewport"), EditorOrder(571)]
         public InputBinding AlignActorWithViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Align viewport with actor"), EditorOrder(572)]
         public InputBinding AlignViewportWithActor = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene"), EditorOrder(573)]
         public InputBinding PilotActor = new InputBinding(KeyboardKeys.None);
 
@@ -198,27 +198,27 @@ namespace FlaxEditor.Options
         [EditorDisplay("Tools", "Build scenes data"), EditorOrder(600)]
         public InputBinding BuildScenesData = new InputBinding(KeyboardKeys.F10 + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Bake lightmaps"), EditorOrder(601)]
         public InputBinding BakeLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Clear lightmaps data"), EditorOrder(602)]
         public InputBinding ClearLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Bake all env probes"), EditorOrder(603)]
         public InputBinding BakeEnvProbes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build CSG mesh"), EditorOrder(604)]
         public InputBinding BuildCSG = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build Nav Mesh"), EditorOrder(605)]
         public InputBinding BuildNav = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build all meshes SDF"), EditorOrder(606)]
         public InputBinding BuildSDF = new InputBinding(KeyboardKeys.None);
 
@@ -230,15 +230,15 @@ namespace FlaxEditor.Options
 
         #region Profiler
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Open Profiler Window"), EditorOrder(630)]
         public InputBinding ProfilerWindow = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Start/Stop Profiler"), EditorOrder(631)]
         public InputBinding ProfilerStartStop = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Clear Profiler data"), EditorOrder(632)]
         public InputBinding ProfilerClear = new InputBinding(KeyboardKeys.None);
 
@@ -326,15 +326,15 @@ namespace FlaxEditor.Options
         [EditorDisplay("Viewport"), EditorOrder(1551)]
         public InputBinding Rotate = new InputBinding(MouseButton.Right);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
         public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1570)]
         public InputBinding CameraIncreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1571)]
         public InputBinding CameraDecreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -42,71 +42,71 @@ namespace FlaxEditor.Options
     {
         #region Common
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+S")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.S)]
         [EditorDisplay("Common"), EditorOrder(100)]
-        public InputBinding Save = new InputBinding(KeyboardKeys.S, KeyboardKeys.Control);
+        public InputBinding Save = new InputBinding(KeyboardKeys.S + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "F2")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F2)]
         [EditorDisplay("Common"), EditorOrder(110)]
         public InputBinding Rename = new InputBinding(KeyboardKeys.F2);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+C")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.C)]
         [EditorDisplay("Common"), EditorOrder(120)]
-        public InputBinding Copy = new InputBinding(KeyboardKeys.C, KeyboardKeys.Control);
+        public InputBinding Copy = new InputBinding(KeyboardKeys.C + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+X")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.X)]
         [EditorDisplay("Common"), EditorOrder(130)]
-        public InputBinding Cut = new InputBinding(KeyboardKeys.X, KeyboardKeys.Control);
+        public InputBinding Cut = new InputBinding(KeyboardKeys.X + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+V")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.V)]
         [EditorDisplay("Common"), EditorOrder(140)]
-        public InputBinding Paste = new InputBinding(KeyboardKeys.V, KeyboardKeys.Control);
+        public InputBinding Paste = new InputBinding(KeyboardKeys.V + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+D")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.D)]
         [EditorDisplay("Common"), EditorOrder(150)]
-        public InputBinding Duplicate = new InputBinding(KeyboardKeys.D, KeyboardKeys.Control);
+        public InputBinding Duplicate = new InputBinding(KeyboardKeys.D + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Delete")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Delete)]
         [EditorDisplay("Common"), EditorOrder(160)]
         public InputBinding Delete = new InputBinding(KeyboardKeys.Delete);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Z")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Z)]
         [EditorDisplay("Common"), EditorOrder(170)]
-        public InputBinding Undo = new InputBinding(KeyboardKeys.Z, KeyboardKeys.Control);
+        public InputBinding Undo = new InputBinding(KeyboardKeys.Z + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Y")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Y)]
         [EditorDisplay("Common"), EditorOrder(180)]
-        public InputBinding Redo = new InputBinding(KeyboardKeys.Y, KeyboardKeys.Control);
+        public InputBinding Redo = new InputBinding(KeyboardKeys.Y + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+A")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.A)]
         [EditorDisplay("Common"), EditorOrder(190)]
-        public InputBinding SelectAll = new InputBinding(KeyboardKeys.A, KeyboardKeys.Control);
+        public InputBinding SelectAll = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Shift+A")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Shift + "+" + KeyboardKeysString.A)]
         [EditorDisplay("Common"), EditorOrder(195)]
-        public InputBinding DeselectAll = new InputBinding(KeyboardKeys.A, KeyboardKeys.Shift, KeyboardKeys.Control);
+        public InputBinding DeselectAll = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Shift + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "F")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(200)]
         public InputBinding FocusSelection = new InputBinding(KeyboardKeys.F);
 
-        [DefaultValue(typeof(InputBinding), "Shift+F")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(200)]
-        public InputBinding LockFocusSelection = new InputBinding(KeyboardKeys.F, KeyboardKeys.Shift);
+        public InputBinding LockFocusSelection = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Shift);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+F")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(210)]
-        public InputBinding Search = new InputBinding(KeyboardKeys.F, KeyboardKeys.Control);
+        public InputBinding Search = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+O")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.O)]
         [EditorDisplay("Common"), EditorOrder(220)]
-        public InputBinding ContentFinder = new InputBinding(KeyboardKeys.O, KeyboardKeys.Control);
+        public InputBinding ContentFinder = new InputBinding(KeyboardKeys.O + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "R")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.R)]
         [EditorDisplay("Common"), EditorOrder(230)]
         public InputBinding RotateSelection = new InputBinding(KeyboardKeys.R);
 
-        [DefaultValue(typeof(InputBinding), "F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Common"), EditorOrder(240)]
         public InputBinding ToggleFullscreen = new InputBinding(KeyboardKeys.F11);
 
@@ -114,23 +114,23 @@ namespace FlaxEditor.Options
 
         #region File
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(300)]
         public InputBinding SaveScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(310)]
         public InputBinding CloseScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(320)]
         public InputBinding OpenScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(330)]
         public InputBinding GenerateScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(340)]
         public InputBinding RecompileScripts = new InputBinding(KeyboardKeys.None);
 
@@ -138,91 +138,91 @@ namespace FlaxEditor.Options
 
         #region Scene
 
-        [DefaultValue(typeof(InputBinding), "End")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.End)]
         [EditorDisplay("Scene", "Snap To Ground"), EditorOrder(500)]
         public InputBinding SnapToGround = new InputBinding(KeyboardKeys.End);
 
-        [DefaultValue(typeof(InputBinding), "End")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.V)]
         [EditorDisplay("Scene", "Vertex Snapping"), EditorOrder(550)]
         public InputBinding SnapToVertex = new InputBinding(KeyboardKeys.V);
 
-        [DefaultValue(typeof(InputBinding), "F5")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F5)]
         [EditorDisplay("Scene", "Play/Stop"), EditorOrder(510)]
         public InputBinding Play = new InputBinding(KeyboardKeys.F5);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Play Current Scenes/Stop"), EditorOrder(520)]
         public InputBinding PlayCurrentScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "F6")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F6)]
         [EditorDisplay("Scene"), EditorOrder(530)]
         public InputBinding Pause = new InputBinding(KeyboardKeys.F6);
 
-        [DefaultValue(typeof(InputBinding), "F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Scene"), EditorOrder(540)]
         public InputBinding StepFrame = new InputBinding(KeyboardKeys.F11);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Cook & Run"), EditorOrder(550)]
         public InputBinding CookAndRun = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Run cooked game"), EditorOrder(560)]
         public InputBinding RunCookedGame = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Move actor to viewport"), EditorOrder(570)]
         public InputBinding MoveActorToViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Align actor with viewport"), EditorOrder(571)]
         public InputBinding AlignActorWithViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Align viewport with actor"), EditorOrder(572)]
         public InputBinding AlignViewportWithActor = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene"), EditorOrder(573)]
         public InputBinding PilotActor = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+G")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.G)]
         [EditorDisplay("Scene"), EditorOrder(574)]
-        public InputBinding GroupSelectedActors = new InputBinding(KeyboardKeys.G, KeyboardKeys.Control);
+        public InputBinding GroupSelectedActors = new InputBinding(KeyboardKeys.G + "+" + KeyboardKeys.Control);
 
         #endregion
 
         #region Tools
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+F10")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.F10)]
         [EditorDisplay("Tools", "Build scenes data"), EditorOrder(600)]
-        public InputBinding BuildScenesData = new InputBinding(KeyboardKeys.F10, KeyboardKeys.Control);
+        public InputBinding BuildScenesData = new InputBinding(KeyboardKeys.F10 + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Bake lightmaps"), EditorOrder(601)]
         public InputBinding BakeLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Clear lightmaps data"), EditorOrder(602)]
         public InputBinding ClearLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Bake all env probes"), EditorOrder(603)]
         public InputBinding BakeEnvProbes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Build CSG mesh"), EditorOrder(604)]
         public InputBinding BuildCSG = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Build Nav Mesh"), EditorOrder(605)]
         public InputBinding BuildNav = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Build all meshes SDF"), EditorOrder(606)]
         public InputBinding BuildSDF = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "F12")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F12)]
         [EditorDisplay("Tools", "Take screenshot"), EditorOrder(607)]
         public InputBinding TakeScreenshot = new InputBinding(KeyboardKeys.F12);
 
@@ -230,15 +230,15 @@ namespace FlaxEditor.Options
 
         #region Profiler
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Profiler", "Open Profiler Window"), EditorOrder(630)]
         public InputBinding ProfilerWindow = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Profiler", "Start/Stop Profiler"), EditorOrder(631)]
         public InputBinding ProfilerStartStop = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Profiler", "Clear Profiler data"), EditorOrder(632)]
         public InputBinding ProfilerClear = new InputBinding(KeyboardKeys.None);
 
@@ -246,43 +246,43 @@ namespace FlaxEditor.Options
 
         #region Debugger
 
-        [DefaultValue(typeof(InputBinding), "F5")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F5)]
         [EditorDisplay("Debugger", "Continue"), EditorOrder(810)]
         public InputBinding DebuggerContinue = new InputBinding(KeyboardKeys.F5);
 
-        [DefaultValue(typeof(InputBinding), "Shift+F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Unlock mouse in Play Mode"), EditorOrder(820)]
-        public InputBinding DebuggerUnlockMouse = new InputBinding(KeyboardKeys.F11, KeyboardKeys.Shift);
+        public InputBinding DebuggerUnlockMouse = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
 
-        [DefaultValue(typeof(InputBinding), "F10")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F10)]
         [EditorDisplay("Debugger", "Step Over"), EditorOrder(830)]
         public InputBinding DebuggerStepOver = new InputBinding(KeyboardKeys.F10);
 
-        [DefaultValue(typeof(InputBinding), "F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Step Into"), EditorOrder(840)]
         public InputBinding DebuggerStepInto = new InputBinding(KeyboardKeys.F11);
 
-        [DefaultValue(typeof(InputBinding), "Shift+F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Step Out"), EditorOrder(850)]
-        public InputBinding DebuggerStepOut = new InputBinding(KeyboardKeys.F11, KeyboardKeys.Shift);
+        public InputBinding DebuggerStepOut = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
 
         #endregion
 
         #region Gizmo
 
-        [DefaultValue(typeof(InputBinding), "Alpha1")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha1)]
         [EditorDisplay("Gizmo"), EditorOrder(1000)]
         public InputBinding TranslateMode = new InputBinding(KeyboardKeys.Alpha1);
 
-        [DefaultValue(typeof(InputBinding), "Alpha2")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha2)]
         [EditorDisplay("Gizmo"), EditorOrder(1010)]
         public InputBinding RotateMode = new InputBinding(KeyboardKeys.Alpha2);
 
-        [DefaultValue(typeof(InputBinding), "Alpha3")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha3)]
         [EditorDisplay("Gizmo"), EditorOrder(1020)]
         public InputBinding ScaleMode = new InputBinding(KeyboardKeys.Alpha3);
 
-        [DefaultValue(typeof(InputBinding), "Alpha4")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha4)]
         [EditorDisplay("Gizmo"), EditorOrder(1030)]
         public InputBinding ToggleTransformSpace = new InputBinding(KeyboardKeys.Alpha4);
 
@@ -290,67 +290,79 @@ namespace FlaxEditor.Options
 
         #region Viewport
 
-        [DefaultValue(typeof(InputBinding), "W")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.W)]
         [EditorDisplay("Viewport"), EditorOrder(1500)]
         public InputBinding Forward = new InputBinding(KeyboardKeys.W);
 
-        [DefaultValue(typeof(InputBinding), "S")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.S)]
         [EditorDisplay("Viewport"), EditorOrder(1510)]
         public InputBinding Backward = new InputBinding(KeyboardKeys.S);
 
-        [DefaultValue(typeof(InputBinding), "A")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.A)]
         [EditorDisplay("Viewport"), EditorOrder(1520)]
         public InputBinding Left = new InputBinding(KeyboardKeys.A);
 
-        [DefaultValue(typeof(InputBinding), "D")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.D)]
         [EditorDisplay("Viewport"), EditorOrder(1530)]
         public InputBinding Right = new InputBinding(KeyboardKeys.D);
 
-        [DefaultValue(typeof(InputBinding), "E")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.E)]
         [EditorDisplay("Viewport"), EditorOrder(1540)]
         public InputBinding Up = new InputBinding(KeyboardKeys.E);
 
-        [DefaultValue(typeof(InputBinding), "Q")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Q)]
         [EditorDisplay("Viewport"), EditorOrder(1550)]
         public InputBinding Down = new InputBinding(KeyboardKeys.Q);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alt + "+" + MouseButtonString.Left)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding Orbit = new InputBinding(MouseButton.Middle + "+" + KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), MouseButtonString.Middle)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding Pan = new InputBinding(MouseButton.Middle);
+
+        [DefaultValue(typeof(InputBinding), MouseButtonString.Right)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding Rotate = new InputBinding(MouseButton.Right);
+
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
         public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1570)]
         public InputBinding CameraIncreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1571)]
         public InputBinding CameraDecreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "Numpad0")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad0)]
         [EditorDisplay("Viewport"), EditorOrder(1700)]
         public InputBinding ViewpointFront = new InputBinding(KeyboardKeys.Numpad0);
 
-        [DefaultValue(typeof(InputBinding), "Numpad5")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad5)]
         [EditorDisplay("Viewport"), EditorOrder(1710)]
         public InputBinding ViewpointBack = new InputBinding(KeyboardKeys.Numpad5);
 
-        [DefaultValue(typeof(InputBinding), "Numpad4")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad4)]
         [EditorDisplay("Viewport"), EditorOrder(1720)]
         public InputBinding ViewpointLeft = new InputBinding(KeyboardKeys.Numpad4);
 
-        [DefaultValue(typeof(InputBinding), "Numpad6")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad6)]
         [EditorDisplay("Viewport"), EditorOrder(1730)]
         public InputBinding ViewpointRight = new InputBinding(KeyboardKeys.Numpad6);
 
-        [DefaultValue(typeof(InputBinding), "Numpad8")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad8)]
         [EditorDisplay("Viewport"), EditorOrder(1740)]
         public InputBinding ViewpointTop = new InputBinding(KeyboardKeys.Numpad8);
 
-        [DefaultValue(typeof(InputBinding), "Numpad2")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad2)]
         [EditorDisplay("Viewport"), EditorOrder(1750)]
         public InputBinding ViewpointBottom = new InputBinding(KeyboardKeys.Numpad2);
 
-        [DefaultValue(typeof(InputBinding), "NumpadDecimal")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.NumpadDecimal)]
         [EditorDisplay("Viewport"), EditorOrder(1760)]
         public InputBinding ToggleOrthographic = new InputBinding(KeyboardKeys.NumpadDecimal);
 
@@ -358,17 +370,17 @@ namespace FlaxEditor.Options
 
         #region Interface
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+W")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.W)]
         [EditorDisplay("Interface"), EditorOrder(2000)]
-        public InputBinding CloseTab = new InputBinding(KeyboardKeys.W, KeyboardKeys.Control);
+        public InputBinding CloseTab = new InputBinding(KeyboardKeys.W + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Tab")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Tab)]
         [EditorDisplay("Interface"), EditorOrder(2010)]
-        public InputBinding NextTab = new InputBinding(KeyboardKeys.Tab, KeyboardKeys.Control);
+        public InputBinding NextTab = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Tab")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Shift + "+" + KeyboardKeysString.Tab)]
         [EditorDisplay("Interface"), EditorOrder(2020)]
-        public InputBinding PreviousTab = new InputBinding(KeyboardKeys.Tab, KeyboardKeys.Control, KeyboardKeys.Shift);
+        public InputBinding PreviousTab = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control + "+" + KeyboardKeys.Shift);
 
         [DefaultValue(SceneNodeDoubleClick.Expand)]
         [EditorDisplay("Interface"), EditorOrder(2030)]

--- a/Source/Editor/Options/InputTrigger.cs
+++ b/Source/Editor/Options/InputTrigger.cs
@@ -76,7 +76,6 @@ namespace FlaxEditor.Options
             }
 
             trigger = new InputTrigger();
-            Debug.Log("problem parsing " + token);
             return false;
         }
         /// <summary>

--- a/Source/Editor/Options/InputTrigger.cs
+++ b/Source/Editor/Options/InputTrigger.cs
@@ -1,0 +1,109 @@
+using System;
+using FlaxEngine;
+
+namespace FlaxEditor.Options
+{
+    /// <summary>
+    /// The input trigger, either mouse or keyboard
+    /// </summary>
+    [Serializable]
+    public struct InputTrigger : IEquatable<InputTrigger>
+    {
+        public enum InputType { Mouse, Key, None }
+        public MouseButton Button;
+        public KeyboardKeys Key;
+        public InputType Type;
+        public bool IsKeyboard => Type == InputType.Key;
+        public bool IsMouse => Type == InputType.Mouse;
+        public InputTrigger(string token)
+        {
+            if (!TryParseInput(token, out var parsed))
+                throw new ArgumentException($"Invalid input trigger token: {token}");
+
+            this = parsed;
+        }
+        public override string ToString()
+        {
+            return Type switch
+            {
+                InputType.Key => Key.ToString(),
+                InputType.Mouse => Button.ToString(),
+                _ => string.Empty
+            };
+        }
+        public static bool TryParseInput(string token, out InputTrigger trigger)
+        {
+            token = token.Trim(); // Always trim!
+
+            if (Enum.TryParse<KeyboardKeys>(token, true, out var key))
+            {
+                trigger = new InputTrigger()
+                {
+                    Type = InputType.Key,
+                    Button = MouseButton.None,
+                    Key = key
+                };
+                return true;
+            }
+
+            if (Enum.TryParse<MouseButton>(token, true, out var button))
+            {
+                trigger = new InputTrigger()
+                {
+                    Type = InputType.Mouse,
+                    Button = button,
+                    Key = KeyboardKeys.None
+                };
+                return true;
+            }
+            trigger = new InputTrigger();
+            Debug.Log("problem parsing " + token);
+            return false;
+        }
+        /// <summary>
+        /// Checks whether this individual input trigger is currently active.
+        /// </summary>
+        /// <param name="getKey">Function to check if a specific keyboard key is pressed.</param>
+        /// <param name="getMouse">Function to check if a specific mouse button is pressed.</param>
+        /// <returns>True if the trigger is currently active; otherwise, false.</returns>
+        public bool IsPressed(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse)
+        {
+            return Type switch
+            {
+                InputType.Key => getKey(Key),
+                InputType.Mouse => getMouse(Button),
+                _ => false
+            };
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is InputTrigger other && Equals(other);
+        }
+        public override int GetHashCode()
+        {
+            return Type switch
+            {
+                InputType.Key => HashCode.Combine(Type, (int)Key),
+                InputType.Mouse => HashCode.Combine(Type, (int)Button),
+                _ => Type.GetHashCode()
+            };
+        }
+
+        public bool Equals(InputTrigger other)
+        {
+            return Type == other.Type &&
+                   Key == other.Key &&
+                   Button == other.Button;
+        }
+
+        public static bool operator ==(InputTrigger left, InputTrigger right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(InputTrigger left, InputTrigger right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/Source/Editor/Options/InputTrigger.cs
+++ b/Source/Editor/Options/InputTrigger.cs
@@ -78,6 +78,15 @@ namespace FlaxEditor.Options
             trigger = new InputTrigger();
             return false;
         }
+
+        public InputTrigger()
+        {
+            Type = InputType.None;
+            Button = MouseButton.None;
+            Scroll = MouseScroll.None;
+            Key = KeyboardKeys.None;
+        }
+
         /// <summary>
         /// Checks whether this individual input trigger is currently active.
         /// </summary>

--- a/Source/Editor/Options/MouseScroll.cs
+++ b/Source/Editor/Options/MouseScroll.cs
@@ -1,0 +1,31 @@
+#pragma warning disable 1591
+using System;
+
+namespace FlaxEngine
+{
+    public enum MouseScroll
+    {
+        None = 0,
+        ScrollUp = 1,
+        ScrollDown = -1
+    }
+
+    public static class MouseScrollHelper
+    {
+        public static MouseScroll GetScrollDirection(float delta)
+        {
+            if (delta > 0)
+                return MouseScroll.ScrollUp;
+            if (delta < 0)
+                return MouseScroll.ScrollDown;
+            return MouseScroll.None;
+        }
+    }
+
+    public static class MouseScrollString
+    {
+        public const string None = "None";
+        public const string Up = "ScrollUp";
+        public const string Down = "ScrollDown";
+    }
+}

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -682,7 +682,7 @@ namespace FlaxEditor.Surface
             if (base.OnKeyDown(key))
                 return true;
 
-            if (InputActions.Process(Editor.Instance, this, key))
+            if (InputActions.Process(Editor.Instance, this))
                 return true;
 
             if (HasNodesSelection)

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1649,11 +1649,11 @@ namespace FlaxEditor.Viewport
                     bool rbDown = _input.IsMouseRightDown || _isVirtualMouseRightDown;
                     bool wheelInUse = Math.Abs(_input.MouseWheelDelta) > Mathf.Epsilon;
 
-                    _input.IsPanning = !isAltDown && mbDown && !rbDown;
-                    _input.IsRotating = !isAltDown && !mbDown && rbDown;
+                    _input.IsPanning = options.Input.Pan.Process(window);
+                    _input.IsRotating = options.Input.Rotate.Process(window);
                     _input.IsMoving = !isAltDown && mbDown && rbDown;
                     _input.IsZooming = wheelInUse && !(_input.IsShiftDown || (!ContainsFocus && FlaxEngine.Input.GetKey(KeyboardKeys.Shift)));
-                    _input.IsOrbiting = isAltDown && lbDown && !mbDown && !rbDown;
+                    _input.IsOrbiting = options.Input.Orbit.Process(window);
 
                     // Control move speed with RMB+Wheel
                     rmbWheel = useMovementSpeed && (_input.IsMouseRightDown || _isVirtualMouseRightDown) && wheelInUse;
@@ -1666,31 +1666,30 @@ namespace FlaxEditor.Viewport
 
                 // Get input movement
                 var moveDelta = Vector3.Zero;
-                if (win.GetKey(options.Input.Forward.Key))
+                if (options.Input.Forward.Process(window))
                 {
                     moveDelta += Vector3.Forward;
                 }
-                if (win.GetKey(options.Input.Backward.Key))
+                if (options.Input.Backward.Process(window))
                 {
                     moveDelta += Vector3.Backward;
                 }
-                if (win.GetKey(options.Input.Right.Key))
+                if (options.Input.Right.Process(window))
                 {
                     moveDelta += Vector3.Right;
                 }
-                if (win.GetKey(options.Input.Left.Key))
+                if (options.Input.Left.Process(window))
                 {
                     moveDelta += Vector3.Left;
                 }
-                if (win.GetKey(options.Input.Up.Key))
+                if (options.Input.Up.Process(window))
                 {
                     moveDelta += Vector3.Up;
                 }
-                if (win.GetKey(options.Input.Down.Key))
+                if (options.Input.Down.Process(window))
                 {
                     moveDelta += Vector3.Down;
                 }
-                moveDelta.Normalize(); // normalize direction
                 moveDelta *= _movementSpeed;
 
                 // Speed up or speed down
@@ -1861,7 +1860,7 @@ namespace FlaxEditor.Viewport
                 return true;
 
             // Custom input events
-            return InputActions.Process(Editor.Instance, this, key);
+            return InputActions.Process(Editor.Instance, this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/Previews/AnimationPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimationPreview.cs
@@ -108,12 +108,12 @@ namespace FlaxEditor.Viewport.Previews
         public override bool OnKeyDown(KeyboardKeys key)
         {
             var inputOptions = Editor.Instance.Options.Options.Input;
-            if (inputOptions.Play.Process(this, key))
+            if (inputOptions.Play.Process(this))
             {
                 PlayAnimation = true;
                 return true;
             }
-            if (inputOptions.Pause.Process(this, key))
+            if (inputOptions.Pause.Process(this))
             {
                 PlayAnimation = false;
                 return true;

--- a/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
@@ -278,12 +278,12 @@ namespace FlaxEditor.Viewport.Previews
             }
 
             var inputOptions = Editor.Instance.Options.Options.Input;
-            if (inputOptions.Play.Process(this, key))
+            if (inputOptions.Play.Process(this))
             {
                 PlaySimulation = true;
                 return true;
             }
-            if (inputOptions.Pause.Process(this, key))
+            if (inputOptions.Pause.Process(this))
             {
                 PlaySimulation = false;
                 return true;

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -194,7 +194,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             // Prevent closing the editor window when using RMB + Ctrl + W to slow down the camera flight
-            if (Editor.Options.Options.Input.CloseTab.Process(this, key))
+            if (Editor.Options.Options.Input.CloseTab.Process(this))
             {
                 if (Root.GetMouseButton(MouseButton.Right))
                     return true;

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -1135,7 +1135,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             // Prevent closing the game window tab during a play session
-            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(this, key))
+            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(this))
             {
                 return true;
             }

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -792,7 +792,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             var input = Editor.Options.Options.Input;
-            if (input.Search.Process(this, key))
+            if (input.Search.Process(this))
             {
                 if (!_searchBox.ContainsFocus)
                 {

--- a/Source/Engine/UI/GUI/CanvasRootControl.cs
+++ b/Source/Engine/UI/GUI/CanvasRootControl.cs
@@ -157,6 +157,12 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override float GetMouseScrollDelta()
+        {
+            return Input.MouseScrollDelta;
+        }
+
+        /// <inheritdoc />
         public override Float2 PointToParent(ref Float2 location)
         {
             if (Is2D)

--- a/Source/Engine/UI/GUI/RootControl.cs
+++ b/Source/Engine/UI/GUI/RootControl.cs
@@ -225,8 +225,14 @@ namespace FlaxEngine.GUI
         /// Gets mouse button up state.
         /// </summary>
         /// <param name="button">Mouse button to check.</param>
-        /// <returns>True during the frame the user releases the button.</returns>
+        /// <returns>True during the frame the user scrolls the mouse.</returns>
         public abstract bool GetMouseButtonUp(MouseButton button);
+
+        /// <summary>
+        /// Gets mouse button up state.
+        /// </summary>
+        /// <returns>Mouse delta during the frame the user scrolls.</returns>
+        public abstract float GetMouseScrollDelta();
 
         /// <inheritdoc />
         public override RootControl Root => this;

--- a/Source/Engine/UI/GUI/WindowRootControl.cs
+++ b/Source/Engine/UI/GUI/WindowRootControl.cs
@@ -232,6 +232,12 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override float GetMouseScrollDelta()
+        {
+            return _window.MouseScrollDelta;
+        }
+
+        /// <inheritdoc />
         public override Float2 PointFromScreen(Float2 location)
         {
             return _window.ScreenToClient(location) / _window.DpiScale;

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -133,24 +133,24 @@ namespace Flax.Build.Bindings
             // In-built constants
             switch (value)
             {
-            case "nullptr":
-            case "NULL":
-            case "String::Empty":
-            case "StringAnsi::Empty":
-            case "StringAnsiView::Empty":
-            case "StringView::Empty": return "null";
-            case "MAX_int8": return "sbyte.MaxValue";
-            case "MAX_uint8": return "byte.MaxValue";
-            case "MAX_int16": return "short.MaxValue";
-            case "MAX_uint16": return "ushort.MaxValue";
-            case "MAX_int32": return "int.MaxValue";
-            case "MAX_uint32": return "uint.MaxValue";
-            case "MAX_int64": return "long.MaxValue";
-            case "MAX_uint64": return "ulong.MaxValue";
-            case "MAX_float": return "float.MaxValue";
-            case "MAX_double": return "double.MaxValue";
-            case "true":
-            case "false": return value;
+                case "nullptr":
+                case "NULL":
+                case "String::Empty":
+                case "StringAnsi::Empty":
+                case "StringAnsiView::Empty":
+                case "StringView::Empty": return "null";
+                case "MAX_int8": return "sbyte.MaxValue";
+                case "MAX_uint8": return "byte.MaxValue";
+                case "MAX_int16": return "short.MaxValue";
+                case "MAX_uint16": return "ushort.MaxValue";
+                case "MAX_int32": return "int.MaxValue";
+                case "MAX_uint32": return "uint.MaxValue";
+                case "MAX_int64": return "long.MaxValue";
+                case "MAX_uint64": return "ulong.MaxValue";
+                case "MAX_float": return "float.MaxValue";
+                case "MAX_double": return "double.MaxValue";
+                case "true":
+                case "false": return value;
             }
 
             // Handle float{_} style type of default values
@@ -214,34 +214,34 @@ namespace Flax.Build.Bindings
                     // Support for in-built constants
                     switch (value)
                     {
-                    case "Vector2.Zero": return "typeof(Vector2), \"0,0\"";
-                    case "Vector2.One": return "typeof(Vector2), \"1,1\"";
-                    case "Float2.Zero": return "typeof(Float2), \"0,0\"";
-                    case "Float2.One": return "typeof(Float2), \"1,1\"";
-                    case "Double2.Zero": return "typeof(Double2), \"0,0\"";
-                    case "Double2.One": return "typeof(Double2), \"1,1\"";
-                    case "Int2.Zero": return "typeof(Int2), \"0,0\"";
-                    case "Int2.One": return "typeof(Int2), \"1,1\"";
+                        case "Vector2.Zero": return "typeof(Vector2), \"0,0\"";
+                        case "Vector2.One": return "typeof(Vector2), \"1,1\"";
+                        case "Float2.Zero": return "typeof(Float2), \"0,0\"";
+                        case "Float2.One": return "typeof(Float2), \"1,1\"";
+                        case "Double2.Zero": return "typeof(Double2), \"0,0\"";
+                        case "Double2.One": return "typeof(Double2), \"1,1\"";
+                        case "Int2.Zero": return "typeof(Int2), \"0,0\"";
+                        case "Int2.One": return "typeof(Int2), \"1,1\"";
 
-                    case "Vector3.Zero": return "typeof(Vector3), \"0,0,0\"";
-                    case "Vector3.One": return "typeof(Vector3), \"1,1,1\"";
-                    case "Float3.Zero": return "typeof(Float3), \"0,0,0\"";
-                    case "Float3.One": return "typeof(Float3), \"1,1,1\"";
-                    case "Double3.Zero": return "typeof(Double3), \"0,0,0\"";
-                    case "Double3.One": return "typeof(Double3), \"1,1,1\"";
-                    case "Int3.Zero": return "typeof(Int3), \"0,0,0\"";
-                    case "Int3.One": return "typeof(Int3), \"1,1,1\"";
+                        case "Vector3.Zero": return "typeof(Vector3), \"0,0,0\"";
+                        case "Vector3.One": return "typeof(Vector3), \"1,1,1\"";
+                        case "Float3.Zero": return "typeof(Float3), \"0,0,0\"";
+                        case "Float3.One": return "typeof(Float3), \"1,1,1\"";
+                        case "Double3.Zero": return "typeof(Double3), \"0,0,0\"";
+                        case "Double3.One": return "typeof(Double3), \"1,1,1\"";
+                        case "Int3.Zero": return "typeof(Int3), \"0,0,0\"";
+                        case "Int3.One": return "typeof(Int3), \"1,1,1\"";
 
-                    case "Vector4.Zero": return "typeof(Vector4), \"0,0,0,0\"";
-                    case "Vector4.One": return "typeof(Vector4), \"1,1,1,1\"";
-                    case "Double4.Zero": return "typeof(Double4), \"0,0,0,0\"";
-                    case "Double4.One": return "typeof(Double4), \"1,1,1,1\"";
-                    case "Float4.Zero": return "typeof(Float4), \"0,0,0,0\"";
-                    case "Float4.One": return "typeof(Float4), \"1,1,1,1\"";
-                    case "Int4.Zero": return "typeof(Float4), \"0,0,0,0\"";
-                    case "Int4.One": return "typeof(Float4), \"1,1,1,1\"";
+                        case "Vector4.Zero": return "typeof(Vector4), \"0,0,0,0\"";
+                        case "Vector4.One": return "typeof(Vector4), \"1,1,1,1\"";
+                        case "Double4.Zero": return "typeof(Double4), \"0,0,0,0\"";
+                        case "Double4.One": return "typeof(Double4), \"1,1,1,1\"";
+                        case "Float4.Zero": return "typeof(Float4), \"0,0,0,0\"";
+                        case "Float4.One": return "typeof(Float4), \"1,1,1,1\"";
+                        case "Int4.Zero": return "typeof(Float4), \"0,0,0,0\"";
+                        case "Int4.One": return "typeof(Float4), \"1,1,1,1\"";
 
-                    case "Quaternion.Identity": return "typeof(Quaternion), \"0,0,0,1\"";
+                        case "Quaternion.Identity": return "typeof(Quaternion), \"0,0,0,1\"";
                     }
 
                     // Enums
@@ -529,51 +529,51 @@ namespace Flax.Build.Bindings
 
             switch (typeInfo.Type)
             {
-            case "String":
-            case "StringView":
-            case "StringAnsi":
-            case "StringAnsiView":
-                // String
-                return string.Empty;
-            case "ScriptingObject":
-            case "PersistentScriptingObject":
-            case "ManagedScriptingObject":
-                // object
-                return "FlaxEngine.Object.GetUnmanagedPtr({0})";
-            case "Function":
-                // delegate
-                return "NativeInterop.GetFunctionPointerForDelegate({0})";
-            case "Array":
-            case "Span":
-            case "DataContainer":
-                if (typeInfo.GenericArgs != null)
-                {
-                    // Convert array that uses different type for marshalling
-                    var arrayTypeInfo = typeInfo.GenericArgs[0];
-                    var arrayApiType = FindApiTypeInfo(buildData, arrayTypeInfo, caller);
-                    if (arrayApiType != null && arrayApiType.MarshalAs != null)
-                        return $"{{0}}.ConvertArray(x => ({GenerateCSharpNativeToManaged(buildData, arrayApiType.MarshalAs, caller)})x)";
-                }
-                return string.Empty;
-            default:
-                var apiType = FindApiTypeInfo(buildData, typeInfo, caller);
-                if (apiType != null)
-                {
-                    // Scripting Object
-                    if (apiType.IsScriptingObject)
+                case "String":
+                case "StringView":
+                case "StringAnsi":
+                case "StringAnsiView":
+                    // String
+                    return string.Empty;
+                case "ScriptingObject":
+                case "PersistentScriptingObject":
+                case "ManagedScriptingObject":
+                    // object
+                    return "FlaxEngine.Object.GetUnmanagedPtr({0})";
+                case "Function":
+                    // delegate
+                    return "NativeInterop.GetFunctionPointerForDelegate({0})";
+                case "Array":
+                case "Span":
+                case "DataContainer":
+                    if (typeInfo.GenericArgs != null)
+                    {
+                        // Convert array that uses different type for marshalling
+                        var arrayTypeInfo = typeInfo.GenericArgs[0];
+                        var arrayApiType = FindApiTypeInfo(buildData, arrayTypeInfo, caller);
+                        if (arrayApiType != null && arrayApiType.MarshalAs != null)
+                            return $"{{0}}.ConvertArray(x => ({GenerateCSharpNativeToManaged(buildData, arrayApiType.MarshalAs, caller)})x)";
+                    }
+                    return string.Empty;
+                default:
+                    var apiType = FindApiTypeInfo(buildData, typeInfo, caller);
+                    if (apiType != null)
+                    {
+                        // Scripting Object
+                        if (apiType.IsScriptingObject)
+                            return "FlaxEngine.Object.GetUnmanagedPtr({0})";
+
+                        // interface
+                        if (apiType.IsInterface)
+                            return string.Format("FlaxEngine.Object.GetUnmanagedInterface({{0}}, typeof({0}))", apiType.Name);
+                    }
+
+                    // Object reference property
+                    if (typeInfo.IsObjectRef)
                         return "FlaxEngine.Object.GetUnmanagedPtr({0})";
 
-                    // interface
-                    if (apiType.IsInterface)
-                        return string.Format("FlaxEngine.Object.GetUnmanagedInterface({{0}}, typeof({0}))", apiType.Name);
-                }
-
-                // Object reference property
-                if (typeInfo.IsObjectRef)
-                    return "FlaxEngine.Object.GetUnmanagedPtr({0})";
-
-                // Default
-                return string.Empty;
+                    // Default
+                    return string.Empty;
             }
         }
 
@@ -951,7 +951,7 @@ namespace Flax.Build.Bindings
                 if (defaultValue != null)
                     contents.Append(indent).Append("[DefaultValue(").Append(defaultValue).Append(")]").AppendLine();
             }
-            
+
             // Check if array has fixed allocation and add in MaxCount Collection attribute if a Collection attribute does not already exist.
             if (defaultValueType != null && (string.IsNullOrEmpty(attributes) || !attributes.Contains("Collection", StringComparison.Ordinal)))
             {
@@ -2179,6 +2179,30 @@ namespace Flax.Build.Bindings
             {
                 contents.AppendLine("}");
             }
+
+            // Also emit a matching string constants class for enums like KeyboardKeys
+            if (enumInfo.Name == "KeyboardKeys" || enumInfo.Name == "MouseButton")
+            {
+                contents.AppendLine();
+                contents.AppendLine($"namespace {enumInfo.Namespace}");
+                contents.AppendLine("{");
+                contents.AppendLine($"{indent}/// <summary>");
+                contents.AppendLine($"{indent}/// String constants for {enumInfo.Name}.");
+                contents.AppendLine($"{indent}/// </summary>");
+                contents.AppendLine($"{indent}public static class {enumInfo.Name}String");
+                contents.AppendLine($"{indent}{{");
+
+                foreach (var entry in enumInfo.Entries)
+                {
+                    contents.AppendLine($"{indent}    /// <summary>");
+                    contents.AppendLine($"{indent}    /// String representation of <see cref=\"{enumInfo.Name}.{entry.Name}\"/>.");
+                    contents.AppendLine($"{indent}    /// </summary>");
+                    contents.AppendLine($"{indent}    public const string {entry.Name} = \"{entry.Name}\";");
+                }
+
+                contents.AppendLine($"{indent}}}");
+                contents.AppendLine("}");
+            }
         }
 
         private static void GenerateCSharpInterface(BuildData buildData, StringBuilder contents, string indent, InterfaceInfo interfaceInfo)
@@ -2300,7 +2324,9 @@ namespace Flax.Build.Bindings
                 else if (type is StructureInfo structureInfo)
                     GenerateCSharpStructure(buildData, contents, indent, structureInfo);
                 else if (type is EnumInfo enumInfo)
+                {
                     GenerateCSharpEnum(buildData, contents, indent, enumInfo);
+                }
                 else if (type is InterfaceInfo interfaceInfo)
                     GenerateCSharpInterface(buildData, contents, indent, interfaceInfo);
                 else if (type is InjectCodeInfo injectCodeInfo && string.Equals(injectCodeInfo.Lang, "csharp", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
The 171 files is me gitignoring .flax. 

I did hook into the C++ bindings generator to make the KeyboardKeysString and MouseButtonString classes, which might be the most controversial thing.

I really, really, dislike using strings that are not consts, and especially if they are used for logic. This is my way of getting that in there for now. They are used in the defaults for InputOptions,cs.

The GetMouseScrollDelta abstract method in RootControl.cs, I'm not sure. There is probably some property I'm missing that is in RootControl but I didn't find it.

I refactored all the Process to make them much simpler, they do not take a key/mouse anymore. If a key is required it would be much better, in my opinion, to define it as a member and just check it without passing a key. You can get those with the Window or Control context, as well as by passing any override of GetKey, GetMouseButton, and GetMouseScrollDelta.

I also am new to XML comment standards...