### PR TITLE
Animated Model Additions

### DIFF
--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -174,9 +174,9 @@ void AnimatedModel::GetNodeTransformation(const StringView& nodeName, Matrix& no
     GetNodeTransformation(SkinnedModel ? SkinnedModel->FindNode(nodeName) : -1, nodeTransformation, worldSpace);
 }
 
-void AnimatedModel::GetNodeTransformation(Array<ModelBoneNode>& modelBoneNodes, bool worldSpace) const
+void AnimatedModel::GetNodeTransformation(Array<NodeTransformation>& nodeTransformations, bool worldSpace) const
 {
-    for (ModelBoneNode& item : modelBoneNodes)
+    for (NodeTransformation& item : nodeTransformations)
     {
         GetNodeTransformation(item.NodeIndex, item.NodeMatrix, worldSpace);
     }
@@ -199,7 +199,7 @@ void AnimatedModel::SetNodeTransformation(int32 nodeIndex, const Matrix& nodeTra
     OnAnimationUpdated();
 }
 
-void AnimatedModel::SetNodeTransformation(Array<ModelBoneNode>& modelBoneNodes, bool worldSpace)
+void AnimatedModel::SetNodeTransformation(const Array<NodeTransformation>& nodeTransformations, bool worldSpace)
 {
     if (GraphInstance.NodesPose.IsEmpty())
         const_cast<AnimatedModel*>(this)->PreInitSkinningData(); // Ensure to have valid nodes pose to return
@@ -213,11 +213,11 @@ void AnimatedModel::SetNodeTransformation(Array<ModelBoneNode>& modelBoneNodes, 
         Matrix::Invert(world, invWorld);
     }
 
-    for (int i = 0; i < modelBoneNodes.Count(); i++)
+    for (int i = 0; i < nodeTransformations.Count(); i++)
     {
-        int nodeIndex = modelBoneNodes[i].NodeIndex;
+        int nodeIndex = nodeTransformations[i].NodeIndex;
         CHECK(nodeIndex >= 0 && nodeIndex < GraphInstance.NodesPose.Count());
-        GraphInstance.NodesPose[nodeIndex] = modelBoneNodes[i].NodeMatrix;
+        GraphInstance.NodesPose[nodeIndex] = nodeTransformations[i].NodeMatrix;
         if (worldSpace)
         {
             GraphInstance.NodesPose[nodeIndex] = GraphInstance.NodesPose[nodeIndex] * invWorld;

--- a/Source/Engine/Level/Actors/AnimatedModel.h
+++ b/Source/Engine/Level/Actors/AnimatedModel.h
@@ -9,14 +9,6 @@
 #include "Engine/Renderer/DrawCall.h"
 #include "Engine/Core/Delegate.h"
 
-API_STRUCT() struct ModelBoneNode
-{
-    DECLARE_SCRIPTING_TYPE_MINIMAL(ModelBoneNode);
-
-    API_FIELD() uint32 NodeIndex;
-    API_FIELD() Matrix NodeMatrix;
-};
-
 /// <summary>
 /// Performs an animation and renders a skinned model.
 /// </summary>
@@ -25,6 +17,24 @@ class FLAXENGINE_API AnimatedModel : public ModelInstanceActor
 {
     DECLARE_SCENE_OBJECT(AnimatedModel);
     friend class AnimationsSystem;
+
+    /// <summary>
+    /// Keeps the data of a Node and its relevant Transform Matrix together when passing it between functions.
+    /// </summary>
+    API_STRUCT() struct NodeTransformation
+    {
+        DECLARE_SCRIPTING_TYPE_MINIMAL(NodeTransformation);
+
+        /// <summary>
+        /// The index of the node in the node hierarchy.
+        /// </summary>
+        API_FIELD() uint32 NodeIndex;
+
+        /// <summary>
+        /// The transformation matrix of the node
+        /// </summary>
+        API_FIELD() Matrix NodeMatrix;
+    };
 
     /// <summary>
     /// Describes the animation graph updates frequency for the animated model.
@@ -247,10 +257,10 @@ public:
     /// <summary>
     /// Gets the node final transformation for a series of nodes.
     /// </summary>
-    /// <param name="modelBoneNodes">The series of nodes that will be returned</param>
+    /// <param name="nodeTransformations">The series of nodes that will be returned</param>
     /// <param name="worldSpace">True if convert matrices into world-space, otherwise returned values will be in local-space of the actor.</param>
     /// <returns></returns>
-    API_FUNCTION() void GetNodeTransformation(API_PARAM(Out) Array<ModelBoneNode>& modelBoneNodes, bool worldSpace = false) const;
+    API_FUNCTION() void GetNodeTransformation(API_PARAM(Ref) Array<NodeTransformation>& nodeTransformations, bool worldSpace = false) const;
 
     /// <summary>
     /// Sets the node final transformation. If multiple nodes are to be set within a frame, do not use set worldSpace to true, and do the conversion yourself to avoid recalculation of inv matrices. 
@@ -271,10 +281,10 @@ public:
     /// <summary>
     /// Sets a group of nodes final transformation.
     /// </summary>
-    /// <param name="modelBoneNodes">Array of the final node transformation matrix.</param>
+    /// <param name="nodeTransformations">Array of the final node transformation matrix.</param>
     /// <param name="worldSpace">True if convert matrices from world-space, otherwise values will be in local-space of the actor.</param>
     /// <returns></returns>
-    API_FUNCTION() void SetNodeTransformation(Array<ModelBoneNode>& modelBoneNodes, bool worldSpace = false);
+    API_FUNCTION() void SetNodeTransformation(const Array<NodeTransformation>& nodeTransformations, bool worldSpace = false);
 
     /// <summary>
     /// Finds the closest node to a given location.


### PR DESCRIPTION
Adds struct `ModelBoneNode` to AnimatedModel with some functions that use it, which is to help with getting and setting a series of model bone nodes. This helps avoid calling `OnAnimationUpdated();` repeatedly when setting a series of bones, which can be rather slow since it causes a full loop through the entire mesh to recalculate the bounds.

I also noticed that `UpdateBounds()` is called far more often than it should be, so I've made it conditional on UpdateWhenOffscreen to mirror the same functionality in other engines. This helps speed up rendering AnimatedModels quite a lot. If users are experiencing flickering they can change the bounds scale of the Actor.

Most of this is to help facilitate a future PR for physics bones I've been working on but figured these specific additions/fixes can be a seperate PR.
 