### PR TITLE
Fix crammed color grading editor value boxes

### DIFF
--- a/Source/Editor/CustomEditors/Editors/ColorTrackball.cs
+++ b/Source/Editor/CustomEditors/Editors/ColorTrackball.cs
@@ -27,7 +27,7 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
         {
-            float trackBallSize = 80.0f;
+            float trackBallSize = 100f;
             float margin = 4.0f;
 
             // Panel


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/7e4cba3e-7343-427a-b051-001e3d3c12b1)


After:
![image](https://github.com/user-attachments/assets/edf293cf-fccf-43cc-900f-2943ff6425f2)
