### PR TITLE
Add shortcuts for Viewflags and Debug View modes

### DIFF
--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -356,22 +356,206 @@ namespace FlaxEditor.Options
 
         #endregion
 
+        #region Debug Views
+
+        [DefaultValue(typeof(InputBinding), "Alt+Alpha4")]
+        [EditorDisplay("Debug Views"), EditorOrder(2000)]
+        public InputBinding Default = new InputBinding(KeyboardKeys.Alpha4, KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), "Alt+Alpha3")]
+        [EditorDisplay("Debug Views"), EditorOrder(2010)]
+        public InputBinding Unlit = new InputBinding(KeyboardKeys.Alpha3, KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2020)]
+        public InputBinding NoPostFX = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "Alt+Alpha2")]
+        [EditorDisplay("Debug Views"), EditorOrder(2030)]
+        public InputBinding Wireframe = new InputBinding(KeyboardKeys.Alpha2, KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), "Alt+Alpha5")]
+        [EditorDisplay("Debug Views"), EditorOrder(2040)]
+        public InputBinding LightBuffer = new InputBinding(KeyboardKeys.Alpha5, KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2050)]
+        public InputBinding ReflectionsBuffer = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2060)]
+        public InputBinding DepthBuffer = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2070)]
+        public InputBinding MotionVectors = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2080)]
+        public InputBinding LightmapUVDensity = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2090)]
+        public InputBinding VertexColors = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "Alt+Alpha1")]
+        [EditorDisplay("Debug Views"), EditorOrder(2100)]
+        public InputBinding PhysicsColliders = new InputBinding(KeyboardKeys.Alpha1, KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2110)]
+        public InputBinding LODPreview = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2120)]
+        public InputBinding MaterialComplexity = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2130)]
+        public InputBinding QuadOverdraw = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2140)]
+        public InputBinding GloablSDF = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2150)]
+        public InputBinding GlobalSurfaceAtlas = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Debug Views"), EditorOrder(2160)]
+        public InputBinding GlobalIllumination = new InputBinding(KeyboardKeys.None);
+
+        #endregion
+
+        #region View Flags
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3000)]
+        public InputBinding AntiAliasing = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3010)]
+        public InputBinding Shadows = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Alpha7")]
+        [EditorDisplay("View Flags"), EditorOrder(3020)]
+        public InputBinding EditorSprites = new InputBinding(KeyboardKeys.Alpha7, KeyboardKeys.Control, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3030)]
+        public InputBinding Reflections = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3040)]
+        public InputBinding ScreenSpaceReflections = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3050)]
+        public InputBinding AmbientOcclusion = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Alpha6")]
+        [EditorDisplay("View Flags", "Global Illumination"), EditorOrder(3060)]
+        public InputBinding GlobalIlluminationViewFlag = new InputBinding(KeyboardKeys.Alpha6, KeyboardKeys.Control, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3070)]
+        public InputBinding DirectionalLights = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3080)]
+        public InputBinding PointLights = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3090)]
+        public InputBinding SpotLights = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3100)]
+        public InputBinding SkyLights = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3110)]
+        public InputBinding Sky = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3120)]
+        public InputBinding Fog = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3130)]
+        public InputBinding SpecularLight = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3140)]
+        public InputBinding Decals = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Alpha3")]
+        [EditorDisplay("View Flags"), EditorOrder(3150)]
+        public InputBinding CustomPostProcess = new InputBinding(KeyboardKeys.Alpha3, KeyboardKeys.Control, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3160)]
+        public InputBinding Bloom = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3170)]
+        public InputBinding ToneMapping = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Alpha2")]
+        [EditorDisplay("View Flags"), EditorOrder(3180)]
+        public InputBinding EyeAdaptation = new InputBinding(KeyboardKeys.Alpha2, KeyboardKeys.Control, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3190)]
+        public InputBinding CameraArtifacts = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3200)]
+        public InputBinding LensFlares = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3210)]
+        public InputBinding DepthOfField = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3220)]
+        public InputBinding MotionBlur = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("View Flags"), EditorOrder(3230)]
+        public InputBinding ContactShadows = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Alpha1")]
+        [EditorDisplay("View Flags"), EditorOrder(3240)]
+        public InputBinding PhysicsDebug = new InputBinding(KeyboardKeys.Alpha1, KeyboardKeys.Control, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Alpha5")]
+        [EditorDisplay("View Flags"), EditorOrder(3250)]
+        public InputBinding LightsDebug = new InputBinding(KeyboardKeys.Alpha5, KeyboardKeys.Control, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Alpha4")]
+        [EditorDisplay("View Flags"), EditorOrder(3260)]
+        public InputBinding DebugDraw = new InputBinding(KeyboardKeys.Alpha4, KeyboardKeys.Control, KeyboardKeys.Shift);
+
+        #endregion
+
         #region Interface
 
         [DefaultValue(typeof(InputBinding), "Ctrl+W")]
-        [EditorDisplay("Interface"), EditorOrder(2000)]
+        [EditorDisplay("Interface"), EditorOrder(3500)]
         public InputBinding CloseTab = new InputBinding(KeyboardKeys.W, KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), "Ctrl+Tab")]
-        [EditorDisplay("Interface"), EditorOrder(2010)]
+        [EditorDisplay("Interface"), EditorOrder(3510)]
         public InputBinding NextTab = new InputBinding(KeyboardKeys.Tab, KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Tab")]
-        [EditorDisplay("Interface"), EditorOrder(2020)]
+        [EditorDisplay("Interface"), EditorOrder(3520)]
         public InputBinding PreviousTab = new InputBinding(KeyboardKeys.Tab, KeyboardKeys.Control, KeyboardKeys.Shift);
 
         [DefaultValue(SceneNodeDoubleClick.Expand)]
-        [EditorDisplay("Interface"), EditorOrder(2030)]
+        [EditorDisplay("Interface"), EditorOrder(3530)]
         public SceneNodeDoubleClick DoubleClickSceneNode = SceneNodeDoubleClick.Expand;
 
         #endregion

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -910,7 +910,7 @@ namespace FlaxEditor.Viewport
                     for (int i = 0; i < ViewFlagsValues.Length; i++)
                     {
                         var v = ViewFlagsValues[i];
-                        var button = viewFlags.AddButton(v.Name);
+                        var button = viewFlags.AddButton(v.Name, v.InputBinding.ToString());
                         button.CloseMenuOnClick = false;
                         button.Tag = v.Mode;
                     }
@@ -959,7 +959,7 @@ namespace FlaxEditor.Viewport
                         }
                         else
                         {
-                            var button = debugView.AddButton(v.Name);
+                            var button = debugView.AddButton(v.Name, v.InputBinding.ToString());
                             button.CloseMenuOnClick = false;
                             button.Tag = v.Mode;
                         }
@@ -1005,16 +1005,64 @@ namespace FlaxEditor.Viewport
                 #endregion View mode widget
             }
 
+            // Viewpoints
             InputActions.Add(options => options.ViewpointTop, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Top").Orientation)));
             InputActions.Add(options => options.ViewpointBottom, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Bottom").Orientation)));
             InputActions.Add(options => options.ViewpointFront, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Front").Orientation)));
             InputActions.Add(options => options.ViewpointBack, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Back").Orientation)));
             InputActions.Add(options => options.ViewpointRight, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Right").Orientation)));
             InputActions.Add(options => options.ViewpointLeft, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Left").Orientation)));
+            // Editor camera
             InputActions.Add(options => options.CameraToggleRotation, () => _isVirtualMouseRightDown = !_isVirtualMouseRightDown);
             InputActions.Add(options => options.CameraIncreaseMoveSpeed, () => AdjustCameraMoveSpeed(1));
             InputActions.Add(options => options.CameraDecreaseMoveSpeed, () => AdjustCameraMoveSpeed(-1));
             InputActions.Add(options => options.ToggleOrthographic, () => OnOrthographicModeToggled(null));
+            // Debug views
+            InputActions.Add(options => options.Default, () => Task.ViewMode = ViewMode.Default);
+            InputActions.Add(options => options.Unlit, () => Task.ViewMode = ViewMode.Unlit);
+            InputActions.Add(options => options.NoPostFX, () => Task.ViewMode = ViewMode.NoPostFx);
+            InputActions.Add(options => options.Wireframe, () => Task.ViewMode = ViewMode.Wireframe);
+            InputActions.Add(options => options.LightBuffer, () => Task.ViewMode = ViewMode.LightBuffer);
+            InputActions.Add(options => options.ReflectionsBuffer, () => Task.ViewMode = ViewMode.Reflections);
+            InputActions.Add(options => options.DepthBuffer, () => Task.ViewMode = ViewMode.Depth);
+            InputActions.Add(options => options.MotionVectors, () => Task.ViewMode = ViewMode.MotionVectors);
+            InputActions.Add(options => options.LightmapUVDensity, () => Task.ViewMode = ViewMode.LightmapUVsDensity);
+            InputActions.Add(options => options.VertexColors, () => Task.ViewMode = ViewMode.VertexColors);
+            InputActions.Add(options => options.PhysicsColliders, () => Task.ViewMode = ViewMode.PhysicsColliders);
+            InputActions.Add(options => options.LODPreview, () => Task.ViewMode = ViewMode.LODPreview);
+            InputActions.Add(options => options.MaterialComplexity, () => Task.ViewMode = ViewMode.MaterialComplexity);
+            InputActions.Add(options => options.QuadOverdraw, () => Task.ViewMode = ViewMode.QuadOverdraw);
+            InputActions.Add(options => options.GloablSDF, () => Task.ViewMode = ViewMode.GlobalSDF);
+            InputActions.Add(options => options.GlobalSurfaceAtlas, () => Task.ViewMode = ViewMode.GlobalSurfaceAtlas);
+            InputActions.Add(options => options.GlobalIllumination, () => Task.ViewMode = ViewMode.GlobalIllumination);
+            // View flags
+            InputActions.Add(options => options.AntiAliasing, () => Task.ViewFlags ^= ViewFlags.AntiAliasing);
+            InputActions.Add(options => options.Shadows, () => Task.ViewFlags ^= ViewFlags.Shadows);
+            InputActions.Add(options => options.EditorSprites, () => Task.ViewFlags ^= ViewFlags.EditorSprites);
+            InputActions.Add(options => options.Reflections, () => Task.ViewFlags ^= ViewFlags.Reflections);
+            InputActions.Add(options => options.ScreenSpaceReflections, () => Task.ViewFlags ^= ViewFlags.SSR);
+            InputActions.Add(options => options.AmbientOcclusion, () => Task.ViewFlags ^= ViewFlags.AO);
+            InputActions.Add(options => options.GlobalIllumination, () => Task.ViewFlags ^= ViewFlags.GI);
+            InputActions.Add(options => options.DirectionalLights, () => Task.ViewFlags ^= ViewFlags.DirectionalLights);
+            InputActions.Add(options => options.PointLights, () => Task.ViewFlags ^= ViewFlags.PointLights);
+            InputActions.Add(options => options.SpotLights, () => Task.ViewFlags ^= ViewFlags.SpotLights);
+            InputActions.Add(options => options.SkyLights, () => Task.ViewFlags ^= ViewFlags.SkyLights);
+            InputActions.Add(options => options.Sky, () => Task.ViewFlags ^= ViewFlags.Sky);
+            InputActions.Add(options => options.Fog, () => Task.ViewFlags ^= ViewFlags.Fog);
+            InputActions.Add(options => options.SpecularLight, () => Task.ViewFlags ^= ViewFlags.SpecularLight);
+            InputActions.Add(options => options.Decals, () => Task.ViewFlags ^= ViewFlags.Decals);
+            InputActions.Add(options => options.CustomPostProcess, () => Task.ViewFlags ^= ViewFlags.CustomPostProcess);
+            InputActions.Add(options => options.Bloom, () => Task.ViewFlags ^= ViewFlags.Bloom);
+            InputActions.Add(options => options.ToneMapping, () => Task.ViewFlags ^= ViewFlags.ToneMapping);
+            InputActions.Add(options => options.EyeAdaptation, () => Task.ViewFlags ^= ViewFlags.EyeAdaptation);
+            InputActions.Add(options => options.CameraArtifacts, () => Task.ViewFlags ^= ViewFlags.CameraArtifacts);
+            InputActions.Add(options => options.LensFlares, () => Task.ViewFlags ^= ViewFlags.LensFlares);
+            InputActions.Add(options => options.DepthOfField, () => Task.ViewFlags ^= ViewFlags.DepthOfField);
+            InputActions.Add(options => options.MotionBlur, () => Task.ViewFlags ^= ViewFlags.MotionBlur);
+            InputActions.Add(options => options.ContactShadows, () => Task.ViewFlags ^= ViewFlags.ContactShadows);
+            InputActions.Add(options => options.PhysicsDebug, () => Task.ViewFlags ^= ViewFlags.PhysicsDebug);
+            InputActions.Add(options => options.LightsDebug, () => Task.ViewFlags ^= ViewFlags.LightsDebug);
+            InputActions.Add(options => options.DebugDraw, () => Task.ViewFlags ^= ViewFlags.DebugDraw);
 
             // Link for task event
             task.Begin += OnRenderBegin;
@@ -1933,7 +1981,16 @@ namespace FlaxEditor.Viewport
         {
             public readonly string Name;
             public readonly ViewMode Mode;
+            public readonly InputBinding InputBinding;
             public readonly ViewModeOptions[] Options;
+
+            public ViewModeOptions(ViewMode mode, string name, InputBinding inputBinding)
+            {
+                Mode = mode;
+                Name = name;
+                InputBinding = inputBinding;
+                Options = null;
+            }
 
             public ViewModeOptions(ViewMode mode, string name)
             {
@@ -1952,13 +2009,13 @@ namespace FlaxEditor.Viewport
 
         private static readonly ViewModeOptions[] ViewModeValues =
         {
-            new ViewModeOptions(ViewMode.Default, "Default"),
-            new ViewModeOptions(ViewMode.Unlit, "Unlit"),
-            new ViewModeOptions(ViewMode.NoPostFx, "No PostFx"),
-            new ViewModeOptions(ViewMode.Wireframe, "Wireframe"),
-            new ViewModeOptions(ViewMode.LightBuffer, "Light Buffer"),
-            new ViewModeOptions(ViewMode.Reflections, "Reflections Buffer"),
-            new ViewModeOptions(ViewMode.Depth, "Depth Buffer"),
+            new ViewModeOptions(ViewMode.Default, "Default", Editor.Instance.Options.Options.Input.Default),
+            new ViewModeOptions(ViewMode.Unlit, "Unlit", Editor.Instance.Options.Options.Input.Unlit),
+            new ViewModeOptions(ViewMode.NoPostFx, "No PostFx", Editor.Instance.Options.Options.Input.NoPostFX),
+            new ViewModeOptions(ViewMode.Wireframe, "Wireframe", Editor.Instance.Options.Options.Input.Wireframe),
+            new ViewModeOptions(ViewMode.LightBuffer, "Light Buffer", Editor.Instance.Options.Options.Input.LightBuffer),
+            new ViewModeOptions(ViewMode.Reflections, "Reflections Buffer", Editor.Instance.Options.Options.Input.ReflectionsBuffer),
+            new ViewModeOptions(ViewMode.Depth, "Depth Buffer", Editor.Instance.Options.Options.Input.DepthBuffer),
             new ViewModeOptions("GBuffer", new[]
             {
                 new ViewModeOptions(ViewMode.Diffuse, "Diffuse"),
@@ -1972,16 +2029,16 @@ namespace FlaxEditor.Viewport
                 new ViewModeOptions(ViewMode.Normals, "Normals"),
                 new ViewModeOptions(ViewMode.AmbientOcclusion, "Ambient Occlusion"),
             }),
-            new ViewModeOptions(ViewMode.MotionVectors, "Motion Vectors"),
-            new ViewModeOptions(ViewMode.LightmapUVsDensity, "Lightmap UVs Density"),
-            new ViewModeOptions(ViewMode.VertexColors, "Vertex Colors"),
-            new ViewModeOptions(ViewMode.PhysicsColliders, "Physics Colliders"),
-            new ViewModeOptions(ViewMode.LODPreview, "LOD Preview"),
-            new ViewModeOptions(ViewMode.MaterialComplexity, "Material Complexity"),
-            new ViewModeOptions(ViewMode.QuadOverdraw, "Quad Overdraw"),
-            new ViewModeOptions(ViewMode.GlobalSDF, "Global SDF"),
-            new ViewModeOptions(ViewMode.GlobalSurfaceAtlas, "Global Surface Atlas"),
-            new ViewModeOptions(ViewMode.GlobalIllumination, "Global Illumination"),
+            new ViewModeOptions(ViewMode.MotionVectors, "Motion Vectors", Editor.Instance.Options.Options.Input.MotionVectors),
+            new ViewModeOptions(ViewMode.LightmapUVsDensity, "Lightmap UVs Density", Editor.Instance.Options.Options.Input.LightmapUVDensity),
+            new ViewModeOptions(ViewMode.VertexColors, "Vertex Colors", Editor.Instance.Options.Options.Input.VertexColors),
+            new ViewModeOptions(ViewMode.PhysicsColliders, "Physics Colliders", Editor.Instance.Options.Options.Input.PhysicsColliders),
+            new ViewModeOptions(ViewMode.LODPreview, "LOD Preview", Editor.Instance.Options.Options.Input.LODPreview),
+            new ViewModeOptions(ViewMode.MaterialComplexity, "Material Complexity", Editor.Instance.Options.Options.Input.MaterialComplexity),
+            new ViewModeOptions(ViewMode.QuadOverdraw, "Quad Overdraw", Editor.Instance.Options.Options.Input.QuadOverdraw),
+            new ViewModeOptions(ViewMode.GlobalSDF, "Global SDF", Editor.Instance.Options.Options.Input.GloablSDF),
+            new ViewModeOptions(ViewMode.GlobalSurfaceAtlas, "Global Surface Atlas", Editor.Instance.Options.Options.Input.GlobalSurfaceAtlas),
+            new ViewModeOptions(ViewMode.GlobalIllumination, "Global Illumination", Editor.Instance.Options.Options.Input.GlobalIllumination),
         };
 
         private void WidgetViewModeShowHideClicked(ContextMenuButton button)
@@ -2014,43 +2071,45 @@ namespace FlaxEditor.Viewport
         {
             public readonly ViewFlags Mode;
             public readonly string Name;
+            public readonly InputBinding InputBinding;
 
-            public ViewFlagOptions(ViewFlags mode, string name)
+            public ViewFlagOptions(ViewFlags mode, string name, InputBinding inputBinding)
             {
                 Mode = mode;
                 Name = name;
+                InputBinding = inputBinding;
             }
         }
 
         private static readonly ViewFlagOptions[] ViewFlagsValues =
         {
-            new ViewFlagOptions(ViewFlags.AntiAliasing, "Anti Aliasing"),
-            new ViewFlagOptions(ViewFlags.Shadows, "Shadows"),
-            new ViewFlagOptions(ViewFlags.EditorSprites, "Editor Sprites"),
-            new ViewFlagOptions(ViewFlags.Reflections, "Reflections"),
-            new ViewFlagOptions(ViewFlags.SSR, "Screen Space Reflections"),
-            new ViewFlagOptions(ViewFlags.AO, "Ambient Occlusion"),
-            new ViewFlagOptions(ViewFlags.GI, "Global Illumination"),
-            new ViewFlagOptions(ViewFlags.DirectionalLights, "Directional Lights"),
-            new ViewFlagOptions(ViewFlags.PointLights, "Point Lights"),
-            new ViewFlagOptions(ViewFlags.SpotLights, "Spot Lights"),
-            new ViewFlagOptions(ViewFlags.SkyLights, "Sky Lights"),
-            new ViewFlagOptions(ViewFlags.Sky, "Sky"),
-            new ViewFlagOptions(ViewFlags.Fog, "Fog"),
-            new ViewFlagOptions(ViewFlags.SpecularLight, "Specular Light"),
-            new ViewFlagOptions(ViewFlags.Decals, "Decals"),
-            new ViewFlagOptions(ViewFlags.CustomPostProcess, "Custom Post Process"),
-            new ViewFlagOptions(ViewFlags.Bloom, "Bloom"),
-            new ViewFlagOptions(ViewFlags.ToneMapping, "Tone Mapping"),
-            new ViewFlagOptions(ViewFlags.EyeAdaptation, "Eye Adaptation"),
-            new ViewFlagOptions(ViewFlags.CameraArtifacts, "Camera Artifacts"),
-            new ViewFlagOptions(ViewFlags.LensFlares, "Lens Flares"),
-            new ViewFlagOptions(ViewFlags.DepthOfField, "Depth of Field"),
-            new ViewFlagOptions(ViewFlags.MotionBlur, "Motion Blur"),
-            new ViewFlagOptions(ViewFlags.ContactShadows, "Contact Shadows"),
-            new ViewFlagOptions(ViewFlags.PhysicsDebug, "Physics Debug"),
-            new ViewFlagOptions(ViewFlags.LightsDebug, "Lights Debug"),
-            new ViewFlagOptions(ViewFlags.DebugDraw, "Debug Draw"),
+            new ViewFlagOptions(ViewFlags.AntiAliasing, "Anti Aliasing", Editor.Instance.Options.Options.Input.AntiAliasing),
+            new ViewFlagOptions(ViewFlags.Shadows, "Shadows", Editor.Instance.Options.Options.Input.Shadows),
+            new ViewFlagOptions(ViewFlags.EditorSprites, "Editor Sprites", Editor.Instance.Options.Options.Input.EditorSprites),
+            new ViewFlagOptions(ViewFlags.Reflections, "Reflections", Editor.Instance.Options.Options.Input.Reflections),
+            new ViewFlagOptions(ViewFlags.SSR, "Screen Space Reflections", Editor.Instance.Options.Options.Input.ScreenSpaceReflections),
+            new ViewFlagOptions(ViewFlags.AO, "Ambient Occlusion", Editor.Instance.Options.Options.Input.AmbientOcclusion),
+            new ViewFlagOptions(ViewFlags.GI, "Global Illumination", Editor.Instance.Options.Options.Input.GlobalIlluminationViewFlag),
+            new ViewFlagOptions(ViewFlags.DirectionalLights, "Directional Lights", Editor.Instance.Options.Options.Input.DirectionalLights),
+            new ViewFlagOptions(ViewFlags.PointLights, "Point Lights", Editor.Instance.Options.Options.Input.PointLights),
+            new ViewFlagOptions(ViewFlags.SpotLights, "Spot Lights", Editor.Instance.Options.Options.Input.SpotLights),
+            new ViewFlagOptions(ViewFlags.SkyLights, "Sky Lights", Editor.Instance.Options.Options.Input.SkyLights),
+            new ViewFlagOptions(ViewFlags.Sky, "Sky", Editor.Instance.Options.Options.Input.Sky),
+            new ViewFlagOptions(ViewFlags.Fog, "Fog", Editor.Instance.Options.Options.Input.Fog),
+            new ViewFlagOptions(ViewFlags.SpecularLight, "Specular Light", Editor.Instance.Options.Options.Input.SpecularLight),
+            new ViewFlagOptions(ViewFlags.Decals, "Decals", Editor.Instance.Options.Options.Input.Decals),
+            new ViewFlagOptions(ViewFlags.CustomPostProcess, "Custom Post Process", Editor.Instance.Options.Options.Input.CustomPostProcess),
+            new ViewFlagOptions(ViewFlags.Bloom, "Bloom", Editor.Instance.Options.Options.Input.Bloom),
+            new ViewFlagOptions(ViewFlags.ToneMapping, "Tone Mapping", Editor.Instance.Options.Options.Input.ToneMapping),
+            new ViewFlagOptions(ViewFlags.EyeAdaptation, "Eye Adaptation", Editor.Instance.Options.Options.Input.EyeAdaptation),
+            new ViewFlagOptions(ViewFlags.CameraArtifacts, "Camera Artifacts", Editor.Instance.Options.Options.Input.CameraArtifacts),
+            new ViewFlagOptions(ViewFlags.LensFlares, "Lens Flares", Editor.Instance.Options.Options.Input.LensFlares),
+            new ViewFlagOptions(ViewFlags.DepthOfField, "Depth of Field", Editor.Instance.Options.Options.Input.DepthOfField),
+            new ViewFlagOptions(ViewFlags.MotionBlur, "Motion Blur", Editor.Instance.Options.Options.Input.MotionBlur),
+            new ViewFlagOptions(ViewFlags.ContactShadows, "Contact Shadows", Editor.Instance.Options.Options.Input.ContactShadows),
+            new ViewFlagOptions(ViewFlags.PhysicsDebug, "Physics Debug", Editor.Instance.Options.Options.Input.PhysicsDebug),
+            new ViewFlagOptions(ViewFlags.LightsDebug, "Lights Debug", Editor.Instance.Options.Options.Input.LightsDebug),
+            new ViewFlagOptions(ViewFlags.DebugDraw, "Debug Draw", Editor.Instance.Options.Options.Input.DebugDraw),
         };
 
         private void WidgetViewFlagsShowHide(Control cm)


### PR DESCRIPTION
This pr adds shortcuts to the options found in the "View Flags" and "Debug View" sections in the "View" menu of the editor and prefab editor.

Bloats the input options a bit, but imo that is a good tradeoff because the shortcuts make switching viewmodes much easier and also allow former Unreal engine users to keep their muscle memory.

There is no need to refresh the view and flags context menu after a shortcut is pressed, because when those menu are open the editor is not registering any shortcuts anyways.

*Edit:* I just did some collision setup for a few prefabs with this pr merged into my branch and it's been so much faster than usual because I could switch between collision view/ overlay mode and normal mode with the press of two buttons

### Debug View

These shortcuts are the same as Unreal engine, the only difference being Alt + 1 for the collision mode, as I couldn't find an equivalent to Unreals "Detailed Lighting" and the collision view mode is also important.

![image](https://github.com/user-attachments/assets/43b461e3-54f6-44d7-bd24-6835d9992c26)

![image](https://github.com/user-attachments/assets/232ef1c4-a9af-42ed-9cfd-6cec6da82b44)


### View Flags

These shortcuts aren't inspired by anything lol. Pressing a shortcut will toggle the view flag it is assigned to on and off. I tried adding some default shortcuts to the most used view flags:

![image](https://github.com/user-attachments/assets/b877c674-d423-412b-8fec-e24da68e8025)

![image](https://github.com/user-attachments/assets/d9b8d2a8-342b-45bc-aa53-de658af3ff6e)

