### PR TITLE
EditorViewport refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Source/*.csproj
 PackageEditor_Cert.command
 PackageEditor_Cert.bat
 PackagePlatforms_Cert.bat
+*.flax
 
 # User-specific files
 *.suo

--- a/Content/Editor/Camera/M_Camera.flax
+++ b/Content/Editor/Camera/M_Camera.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4dc3a7d0a8287c7c2c26b7685b726583677f96e1fe86ccb5f8518cb189b51a92
-size 29407

--- a/Content/Editor/Camera/O_Camera.flax
+++ b/Content/Editor/Camera/O_Camera.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df80cdde1b74c2fc3fb5de2ab68c36118e3441d0b317aedaa54df8b4baac921c
-size 88545

--- a/Content/Editor/Camera/T_Camera.flax
+++ b/Content/Editor/Camera/T_Camera.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbb8bff552a5f261aa2119d52b9f97cd8f16eb28ecbbcd5915ad41aa4b4b5f5f
-size 3105

--- a/Content/Editor/CubeTexturePreviewMaterial.flax
+++ b/Content/Editor/CubeTexturePreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:857edec8daa8bbd5bf16c839f65042df7a921154dcf48c1ac7a06aab4e40eab6
-size 30999

--- a/Content/Editor/DebugMaterials/DDGIDebugProbes.flax
+++ b/Content/Editor/DebugMaterials/DDGIDebugProbes.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb32df5fa9255c8d27f968819ab7f59236640661c83ae33588733542ea635b0f
-size 40232

--- a/Content/Editor/DebugMaterials/SingleColor/Decal.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Decal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fddc7cd2d8732f8eef008d0a2bdc47948b87a14849d9e6fabcfe60ddb218aa42
-size 7617

--- a/Content/Editor/DebugMaterials/SingleColor/Particle.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Particle.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e06851af881852106892b2bd03df0127c84db3a601abd9d7aaac7baf40343369
-size 32040

--- a/Content/Editor/DebugMaterials/SingleColor/Surface.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Surface.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34080fbc40ed62bc5501969640403013291b3104dbb4374d9268994f3902e5a8
-size 29180

--- a/Content/Editor/DebugMaterials/SingleColor/SurfaceAdditive.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/SurfaceAdditive.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71acbd5242dd2d2f02554af0e5a95da9a5bd90d77aef80dc6fcdaefb88251d23
-size 31365

--- a/Content/Editor/DebugMaterials/SingleColor/Terrain.flax
+++ b/Content/Editor/DebugMaterials/SingleColor/Terrain.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcc185a2ec2e02ee9f52c806ba3756827c6d12f586c91a12b44295a95dd093dc
-size 21331

--- a/Content/Editor/DefaultFontMaterial.flax
+++ b/Content/Editor/DefaultFontMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1500a05e700f3b12d7e3984a978773c61f4c9ecc34ec96720fae724a87bab8e
-size 29501

--- a/Content/Editor/EditorIcon.flax
+++ b/Content/Editor/EditorIcon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5ff94d35d9615450a4c3ee32a6d254d4eb1887bf34c1be62a5bd267c7c9f00b
-size 6206

--- a/Content/Editor/Fonts/Inconsolata-Regular.flax
+++ b/Content/Editor/Fonts/Inconsolata-Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36995fa880bf47331618b1e96f613c6925e72484fe76e98d6e44c1985ecab017
-size 93015

--- a/Content/Editor/Fonts/NotoSansSC-Regular.flax
+++ b/Content/Editor/Fonts/NotoSansSC-Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19fa43eb7b31ee3936348b1f271c464c79d7020a21d33e3cdbe54f98c3b14304
-size 10560899

--- a/Content/Editor/Fonts/Roboto-Regular.flax
+++ b/Content/Editor/Fonts/Roboto-Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:574b86d8e7439e88c3d7b4265cbc5ad7089c49368c47661b2c6f4c997cb53d86
-size 172093

--- a/Content/Editor/Fonts/SegMDL2.flax
+++ b/Content/Editor/Fonts/SegMDL2.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c4a17c412fce35275af5be883c784b57d192eb188fb3568990b0ae8e0e6d34e
-size 204049

--- a/Content/Editor/Fonts/Segoe Media Center Regular.flax
+++ b/Content/Editor/Fonts/Segoe Media Center Regular.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d277b4abbdc1c91f056dd0d838631135242643abb41ce5751b1be3aaca72401
-size 72697

--- a/Content/Editor/Gizmo/FoliageBrushMaterial.flax
+++ b/Content/Editor/Gizmo/FoliageBrushMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10aff82173474030b7ce41b491c803cc0de265ea0317a3aca87102099d65ca79
-size 37392

--- a/Content/Editor/Gizmo/Material.flax
+++ b/Content/Editor/Gizmo/Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e68032a48b3196f73c614a6302223765485e8fa3e1e278a2395c9d9ae1c5064
-size 32519

--- a/Content/Editor/Gizmo/MaterialAxisFocus.flax
+++ b/Content/Editor/Gizmo/MaterialAxisFocus.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db7018144f8a2774e1188b6f0ef7edfde3f8cb9c7f11f576163512c02f4c5a54
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisLocked.flax
+++ b/Content/Editor/Gizmo/MaterialAxisLocked.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7518765847301a4b13625fb05d542fab4fc924190a7414d39227db817a0e29cb
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisX.flax
+++ b/Content/Editor/Gizmo/MaterialAxisX.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:261382d0e9d30168f325eea14e96ae7abdd2c1fd8bad166f1b134df507e5fda9
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisY.flax
+++ b/Content/Editor/Gizmo/MaterialAxisY.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9160ba4200d01d7dfe6c529bb2f8893ee5106fa644921de51757947a0cb7bea
-size 661

--- a/Content/Editor/Gizmo/MaterialAxisZ.flax
+++ b/Content/Editor/Gizmo/MaterialAxisZ.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d129825361a89fca14f1dbad60a983cfac60d69284be66ca5e84041713e07a6
-size 661

--- a/Content/Editor/Gizmo/MaterialSphere.flax
+++ b/Content/Editor/Gizmo/MaterialSphere.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55fe4f30e87ddda26928901beeef710bc5eaaf7712224bf633c674465cf3b4ac
-size 661

--- a/Content/Editor/Gizmo/MaterialWire.flax
+++ b/Content/Editor/Gizmo/MaterialWire.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbc08de78faa00aab330168dce166867d85dcae142081219d6a7eeb5f285ffd7
-size 31216

--- a/Content/Editor/Gizmo/MaterialWireFocus.flax
+++ b/Content/Editor/Gizmo/MaterialWireFocus.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f49170f829a9b2cb9d9c7680d199f6271e810dd1a181c61e0d83fa62988ba12
-size 535

--- a/Content/Editor/Gizmo/RotationAxis.flax
+++ b/Content/Editor/Gizmo/RotationAxis.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb6446b5931ca57dd35ea37b62cbb8dec2cb0a9861170651c1d00d732a3419e9
-size 41735

--- a/Content/Editor/Gizmo/ScaleAxis.flax
+++ b/Content/Editor/Gizmo/ScaleAxis.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fcfc658f89f41477086540f866263a87b657df152575e618292a3b7af40a470
-size 40804

--- a/Content/Editor/Gizmo/SelectionOutlineMaterial.flax
+++ b/Content/Editor/Gizmo/SelectionOutlineMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de0b19b33a2aac03a0fb7beda935c8a22cbb506f9ca9383bcce3eaac858a54e3
-size 16166

--- a/Content/Editor/Gizmo/TranslationAxis.flax
+++ b/Content/Editor/Gizmo/TranslationAxis.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9eb79cb2acf80e6d30ee4339e7d920518232ae5a9d5518a708b2b351804f08d
-size 8965

--- a/Content/Editor/Gizmo/VertexColorsPreviewMaterial.flax
+++ b/Content/Editor/Gizmo/VertexColorsPreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a32d40e1f13606fea29e45cb0df1a45dbcc51eb329963d8db18ff64fa66bd4e
-size 30293

--- a/Content/Editor/Gizmo/WireBox.flax
+++ b/Content/Editor/Gizmo/WireBox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b5cd7a5eb1d50d8c600d74e2a96024930716e50c9d26b33bab5f85dc5c3d1fe
-size 8024

--- a/Content/Editor/Highlight Material.flax
+++ b/Content/Editor/Highlight Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1ec249ecd34cc66f9236431705adfaccff3e9ac5825ea72eb8b18449a96ccb7
-size 29910

--- a/Content/Editor/Icons/AudioListener.flax
+++ b/Content/Editor/Icons/AudioListener.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d9f3b36a78d558c8430f2b14420711d708d0633874a183b9eaab5f3963de8d5
-size 567

--- a/Content/Editor/Icons/AudioSource.flax
+++ b/Content/Editor/Icons/AudioSource.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc6c177b3537b1aae695cbaf256adf07b2891c91ae3e48286e547e851c6cd0bc
-size 567

--- a/Content/Editor/Icons/Decal.flax
+++ b/Content/Editor/Icons/Decal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2dd18babe45190ee2820995e7282e8a365e0e74cf275f2da2ee8c91bdb348a97
-size 567

--- a/Content/Editor/Icons/DirectionalLight.flax
+++ b/Content/Editor/Icons/DirectionalLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:920bccc12a9bb65eefa1f1fe6acc1c87c949acb81a2ec19f45a0770e9c38c1a8
-size 567

--- a/Content/Editor/Icons/EnvironmentProbe.flax
+++ b/Content/Editor/Icons/EnvironmentProbe.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:245ec4045f64984aaf58d2442e949ae7ad6500f3631216bf67b0142d5fb7df66
-size 567

--- a/Content/Editor/Icons/IconsMaterial.flax
+++ b/Content/Editor/Icons/IconsMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:652de424a7e366c1dcafd42cfe552f2d4f1327cd9ef033fb554d961e0a29ae2b
-size 29827

--- a/Content/Editor/Icons/ParticleEffect.flax
+++ b/Content/Editor/Icons/ParticleEffect.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b830f15153d9c86dc0bfc9c982f41a95e360727423716d6ea3b5c57e8739a8d
-size 567

--- a/Content/Editor/Icons/PointLight.flax
+++ b/Content/Editor/Icons/PointLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c98e9d6fba236f325f6979803b6c6d37ba5d21b92f5639338423cf13c17be0db
-size 567

--- a/Content/Editor/Icons/SceneAnimationPlayer.flax
+++ b/Content/Editor/Icons/SceneAnimationPlayer.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96cb14e43719a7645084f322edcb47aaea0a0044be6b9300c8761fb34d33417d
-size 567

--- a/Content/Editor/Icons/SkyLight.flax
+++ b/Content/Editor/Icons/SkyLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8ef3f16cb2482196da99ac5ee14dbc2ebe477f0bdc636e62f8f4577bc417a48
-size 567

--- a/Content/Editor/Icons/Skybox.flax
+++ b/Content/Editor/Icons/Skybox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7cf0288c069f20e48b553515e10417994aedc924dd47469634b61615021c8bc
-size 567

--- a/Content/Editor/Icons/Textures/AudioListner.flax
+++ b/Content/Editor/Icons/Textures/AudioListner.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71244c864e5f1ca5232a5800ecb36379fad9bc75d3e0fb735a6105accf274fb0
-size 88362

--- a/Content/Editor/Icons/Textures/AudioSource.flax
+++ b/Content/Editor/Icons/Textures/AudioSource.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ba27db325a9d3c33f7b030b61730d03cca1727ed2477122a1a60de5578c1d22
-size 88361

--- a/Content/Editor/Icons/Textures/Decal.flax
+++ b/Content/Editor/Icons/Textures/Decal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6d258e04be1835c8164e93289bd496dd9b9bdb2cc9f7633db6b9929f08575ed
-size 88355

--- a/Content/Editor/Icons/Textures/DirectionalLight.flax
+++ b/Content/Editor/Icons/Textures/DirectionalLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:742bd2c5755db7672e8a1fe27f1db013ebe885f495956b4406226f25c0c49536
-size 88366

--- a/Content/Editor/Icons/Textures/EnvironmentProbe.flax
+++ b/Content/Editor/Icons/Textures/EnvironmentProbe.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9c4e7a93cb5548253270063226452cedc6648edd95b0227a4146cee5013eae2
-size 88366

--- a/Content/Editor/Icons/Textures/ParticleEffect.flax
+++ b/Content/Editor/Icons/Textures/ParticleEffect.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad12b06bd7e64460f43442e8700d5f7862c1dd522e5e7335b21bd8fef1b7f1c1
-size 88364

--- a/Content/Editor/Icons/Textures/PointLight.flax
+++ b/Content/Editor/Icons/Textures/PointLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccf4443326fc4efa30acce040684f620b1ec55b2e22081184b28abb7e4a5a45e
-size 88360

--- a/Content/Editor/Icons/Textures/SceneAnimationPlayer.flax
+++ b/Content/Editor/Icons/Textures/SceneAnimationPlayer.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:419fd82bce8ffbb155ddcb5bd7387279571283555b212b374a18d95be88d5c62
-size 88370

--- a/Content/Editor/Icons/Textures/SkyLight.flax
+++ b/Content/Editor/Icons/Textures/SkyLight.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c5d5f9ec5a3e9bff677b18b420ac8cc83aeeee778033471aa6677092c1e9f6d
-size 88358

--- a/Content/Editor/Icons/Textures/Skybox.flax
+++ b/Content/Editor/Icons/Textures/Skybox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ebe5c47347d28484a4cbc0eca7f727bc93a3f9e90b781b72bc34bb44046fe75
-size 88356

--- a/Content/Editor/IconsAtlas.flax
+++ b/Content/Editor/IconsAtlas.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f43bf2050d47a1e4d6db35e5da66c2f999236939b9d962cd0fba56dcb171852
-size 5611913

--- a/Content/Editor/IesProfilePreviewMaterial.flax
+++ b/Content/Editor/IesProfilePreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6388c4a40a0de927abdd532d5bfaff5b7c651f8daa434c6f04a0579e33a1015b
-size 20399

--- a/Content/Editor/Particles/Constant Burst.flax
+++ b/Content/Editor/Particles/Constant Burst.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc1e46708152005dc92532e940b3ce19ec527b595fb18365b41ebdcd338ad2c4
-size 2705

--- a/Content/Editor/Particles/Particle Material Color.flax
+++ b/Content/Editor/Particles/Particle Material Color.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c71a6394a3a0668f6d2b18281aaa36d83b1b150fd10a869edace21e1ffa5b07
-size 30361

--- a/Content/Editor/Particles/Particle Material Preview.flax
+++ b/Content/Editor/Particles/Particle Material Preview.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88de448e023b35296531fff817d4b95200bac97fbd5c927ee6a5e5a815323978
-size 2110

--- a/Content/Editor/Particles/Periodic Burst.flax
+++ b/Content/Editor/Particles/Periodic Burst.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94bf88983e3cf9fe555141a867af3c20e5bd58d13a527a9b4e02d4d1be157be9
-size 3664

--- a/Content/Editor/Particles/Ribbon Spiral.flax
+++ b/Content/Editor/Particles/Ribbon Spiral.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9016e074d23649b91b9eb2438c4f48d0dbd5bed0c7d29b58fdaea5a8530e905
-size 2365

--- a/Content/Editor/Particles/Smoke Atlas Normal.flax
+++ b/Content/Editor/Particles/Smoke Atlas Normal.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b142885fc327b3a1dccf07446e01f16e0783beaeae9e6bba0bd3adfdf6eb8f29
-size 1398948

--- a/Content/Editor/Particles/Smoke Atlas.flax
+++ b/Content/Editor/Particles/Smoke Atlas.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44705a0f6475390845f3dc1b377ce98b5abaae5c5837eb258eb492b8da1b1218
-size 1398946

--- a/Content/Editor/Particles/Smoke Material.flax
+++ b/Content/Editor/Particles/Smoke Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6097a8ca31dbe7a985b5c512d2049d2d22c73175551965c75d6b360323505491
-size 38427

--- a/Content/Editor/Particles/Smoke.flax
+++ b/Content/Editor/Particles/Smoke.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78b70b627e87f520fccf610a9f20f68e72af68022e5093e6cbbb2fdf6d0d886d
-size 14662

--- a/Content/Editor/Particles/Sparks.flax
+++ b/Content/Editor/Particles/Sparks.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5cd0be41d80f829f23ab67ad0d82f2023b9ee81f0f2119769034c7b57047ad1
-size 13650

--- a/Content/Editor/Primitives/Capsule.flax
+++ b/Content/Editor/Primitives/Capsule.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6fca37ec1a8a9035c590bc645003e20df3eb3a9f65913df68f89d58ef65694a2
-size 31528

--- a/Content/Editor/Primitives/Cone.flax
+++ b/Content/Editor/Primitives/Cone.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca7fadefea06d699af13fc086c6104579c0693e39af3298b9589e00c55293d3a
-size 27251

--- a/Content/Editor/Primitives/Cube.flax
+++ b/Content/Editor/Primitives/Cube.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5a18bf58e0b93c8bba9459fd77a92898f0fae373b58d3acbcb9e36f66c89cd7
-size 23537

--- a/Content/Editor/Primitives/Cylinder.flax
+++ b/Content/Editor/Primitives/Cylinder.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e88868ab5a587b4ca1984a7db6cfec2188080cd6c080cc5a409bd25d409998c0
-size 16321

--- a/Content/Editor/Primitives/Plane.flax
+++ b/Content/Editor/Primitives/Plane.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:835990c21d45238821a42efb02b6b1e92a2497f72ddb1652e1b7ad4e615ea438
-size 3371

--- a/Content/Editor/Primitives/Sphere.flax
+++ b/Content/Editor/Primitives/Sphere.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0bc62448b0e951bad9749ef740e5d292b2ec3281534740bf9af0a66a0b3864d
-size 43177

--- a/Content/Editor/SimplySky.flax
+++ b/Content/Editor/SimplySky.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7df7d1c905dcce01ba93caa39464016d58c9a4a0218d0158139a7e98b4947cb1
-size 524671

--- a/Content/Editor/SpriteMaterial.flax
+++ b/Content/Editor/SpriteMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ed88e5e8b513f7460e94942ad722d8b193c013434586f4382673f7dc3074e98
-size 30376

--- a/Content/Editor/Terrain/Circle Brush Material.flax
+++ b/Content/Editor/Terrain/Circle Brush Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ab7e9c88c9896f37ac5a43efe176e13f98eafacc3117b49cd7173b31376b21d
-size 28003

--- a/Content/Editor/Terrain/Highlight Terrain Material.flax
+++ b/Content/Editor/Terrain/Highlight Terrain Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40e38d672c13c06a84366689b8ce2b346179b4aa0de3cf1fc6035b33ad036e4a
-size 21506

--- a/Content/Editor/TexturePreviewMaterial.flax
+++ b/Content/Editor/TexturePreviewMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93b0220308d2a3051d7e449505ca18dab7a82d46bf6a86e4ecfb9b741909f91b
-size 10698

--- a/Content/Editor/VisjectSurface.flax
+++ b/Content/Editor/VisjectSurface.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce771772f9e14b43a11a617273da7316234870c3b8dca50c25b9fd50be1226d7
-size 5593008

--- a/Content/Editor/Wires Debug Material.flax
+++ b/Content/Editor/Wires Debug Material.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7e22035ac54615fee78cad71d5e5268ff139811d4390fe9a5025ab4d234ff4e
-size 29910

--- a/Content/Engine/DefaultDeformableMaterial.flax
+++ b/Content/Engine/DefaultDeformableMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:feac2f9ced2d8edf6a43f1c56cdfdc27bbd018a4c23a527a403c30bdb9217e63
-size 18922

--- a/Content/Engine/DefaultMaterial.flax
+++ b/Content/Engine/DefaultMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1db3d343643eec7c6f7c3ac33a205618480ce41b4b196ebfc6b63e00085a555f
-size 31205

--- a/Content/Engine/DefaultRadialMenu.flax
+++ b/Content/Engine/DefaultRadialMenu.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9e9e01ae0222d9dc0db7c51741c3e2c2595bb550fa9dd1665d11ce4fac0afc9
-size 20468

--- a/Content/Engine/DefaultTerrainMaterial.flax
+++ b/Content/Engine/DefaultTerrainMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c890a5b43c0158d1885c3905ab02c8b0ee36a558c4770d79892837960ee07e5
-size 23628

--- a/Content/Engine/Models/Box.flax
+++ b/Content/Engine/Models/Box.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be3e9498a6f55c631f20187d7084158089a265d59c2c8c81748ae41dde81fb96
-size 3171

--- a/Content/Engine/Models/Quad.flax
+++ b/Content/Engine/Models/Quad.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bc157593dd5209616dd17f39ea04e4b2f609a6c6b38da648d7df0b8b15fb28f
-size 1015

--- a/Content/Engine/Models/SimpleBox.flax
+++ b/Content/Engine/Models/SimpleBox.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c6269591e15337ff7b0235b3b8d8b641296a33298aa0bf77bd69b3b576af270
-size 2205

--- a/Content/Engine/Models/Sphere.flax
+++ b/Content/Engine/Models/Sphere.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d06d281960b16ebf13cc69e71317e03261225d2992cee45da44b848632d1585e
-size 112019

--- a/Content/Engine/Models/SphereLowPoly.flax
+++ b/Content/Engine/Models/SphereLowPoly.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3da1c828b3d55c08385f6a0b9a9bba36597d8f065a0fc827915dece33be165f9
-size 3807

--- a/Content/Engine/SingleColorMaterial.flax
+++ b/Content/Engine/SingleColorMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27acfeeafdb50abe76a2feee0616ea90ee5d4fd72c678244d80f15ed4a97894a
-size 29381

--- a/Content/Engine/SkyboxMaterial.flax
+++ b/Content/Engine/SkyboxMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e7d0fe3697a0b65eefb8756e0f9aa48bc2d505eb94710b5972097eb61b6b029
-size 30944

--- a/Content/Engine/Textures/BlackTexture.flax
+++ b/Content/Engine/Textures/BlackTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ee43f9b878672be95e2567281f0a75c3bc834955a98f9c199266a39d3c485ae
-size 474

--- a/Content/Engine/Textures/Bokeh/Circle.flax
+++ b/Content/Engine/Textures/Bokeh/Circle.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:407184ea7e4805a52c3e18af58ceb53b2809f15dcd476ea2e645e568e11c8d28
-size 11320

--- a/Content/Engine/Textures/Bokeh/Cross.flax
+++ b/Content/Engine/Textures/Bokeh/Cross.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd37736fc6e0012712d8bbaa7c09239b9162ac7978daa02d574d4b4808c0fa2a
-size 11319

--- a/Content/Engine/Textures/Bokeh/Hexagon.flax
+++ b/Content/Engine/Textures/Bokeh/Hexagon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84b028093344341af783e612aa1c80c143246f5c5cf2558dea58d58f59ef80f0
-size 11317

--- a/Content/Engine/Textures/Bokeh/Octagon.flax
+++ b/Content/Engine/Textures/Bokeh/Octagon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12c2293c5d3f07c8bb1a261005a7487738dfa151025bcd1b1c8836cb6f5027a6
-size 11317

--- a/Content/Engine/Textures/DefaultLensColor.flax
+++ b/Content/Engine/Textures/DefaultLensColor.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a33c432074129df8c96f7d2296bb5c37c07f6ea52b83b5b1d45fab61c79c7dc
-size 2458

--- a/Content/Engine/Textures/DefaultLensDirt.flax
+++ b/Content/Engine/Textures/DefaultLensDirt.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:149b9a2d5d9d5f02e3e1e0a8d58964d53c4432d969ee290dd2be08ce2285d946
-size 8295253

--- a/Content/Engine/Textures/DefaultLensStarburst.flax
+++ b/Content/Engine/Textures/DefaultLensStarburst.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b6d662c3f40e7c03da5854bccc34ccf9b81219e38a05141eabefc9d830ff4c3
-size 1399104

--- a/Content/Engine/Textures/FlaxIcon.flax
+++ b/Content/Engine/Textures/FlaxIcon.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:038b7f0df0e45f320a54183dcf6de43372bf3b76a7b07e1bfeb82827578f495e
-size 1398906

--- a/Content/Engine/Textures/FlaxIconBlue.flax
+++ b/Content/Engine/Textures/FlaxIconBlue.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ead561da9a3689613404da036705bb6b128c150322137d408ed193a27ffdbc52
-size 1398910

--- a/Content/Engine/Textures/GrayTexture.flax
+++ b/Content/Engine/Textures/GrayTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afc7ccb71d12256329c888e740e0d6f5154f95774c82092a5128aa8ed3b80c3c
-size 473

--- a/Content/Engine/Textures/Logo.flax
+++ b/Content/Engine/Textures/Logo.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f673152512b6f7840ae25d5dd0b4ab9ee5cfa91a2cabc62f19890b33865ba73c
-size 600623

--- a/Content/Engine/Textures/NormalTexture.flax
+++ b/Content/Engine/Textures/NormalTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:654e87ee866aebf5342159564a31df2b95e318b0cad7b7e3033a4e837192934e
-size 671

--- a/Content/Engine/Textures/PreIntegratedGF.flax
+++ b/Content/Engine/Textures/PreIntegratedGF.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fcaf6ab41c5745842a005284259b9ed8eaec73587d73a9e3d7f39086b78ec0e2
-size 87789

--- a/Content/Engine/Textures/SMAA_AreaTex.flax
+++ b/Content/Engine/Textures/SMAA_AreaTex.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de768189b6aa6fec0c1906ec713d879e91e03a338855f0f92848a31adb1dfe3d
-size 45484

--- a/Content/Engine/Textures/SMAA_SearchTex.flax
+++ b/Content/Engine/Textures/SMAA_SearchTex.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bcc5a34993b7dbd8a7177618f650ee878b444f1fcefdc1165f4d82fca52a9c2
-size 1470

--- a/Content/Engine/Textures/SplashScreenLogo.flax
+++ b/Content/Engine/Textures/SplashScreenLogo.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc0b1fe7596894317bbf7049d4e31794bbb98f224eba098025ae972f988fae59
-size 1266836

--- a/Content/Engine/Textures/Tiles_M.flax
+++ b/Content/Engine/Textures/Tiles_M.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:332359786ae1acc0c2b979981c1aa07f96c46172fc8b0c52da268d0a62cdcf65
-size 2797177

--- a/Content/Engine/Textures/Tiles_N.flax
+++ b/Content/Engine/Textures/Tiles_N.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:beae5ea42642324e9ef9b50793e1746f8fa97f0c3ad5752ddf440484db993d3f
-size 5593393

--- a/Content/Engine/Textures/WhiteTexture.flax
+++ b/Content/Engine/Textures/WhiteTexture.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b6db73909f6ea8b4cf39ebd25cc69c9c9df9e64fc4f138b15b21d29282bb79c
-size 474

--- a/Content/Engine/WhiteMaterial.flax
+++ b/Content/Engine/WhiteMaterial.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5778a7c9133d946207e32e07914b79849822fa79f4a213b84667e8ee9a7b16c6
-size 583

--- a/Content/Shaders/AtmospherePreCompute.flax
+++ b/Content/Shaders/AtmospherePreCompute.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8086fe1ee43006a13582e0b1dc7f445f87b6a201357bdc4e079495eb7fe6b7d3
-size 11408

--- a/Content/Shaders/BakeLightmap.flax
+++ b/Content/Shaders/BakeLightmap.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ab9a4d7377684f4d51b01c6cdbb44a80249d39ca3ebb0a443fcc0c6beb84ffc
-size 15755

--- a/Content/Shaders/BitonicSort.flax
+++ b/Content/Shaders/BitonicSort.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:924884da1dfef7a802b7190fd148eebbeece50d6fa4d69295c38238dd96331e6
-size 6538

--- a/Content/Shaders/CAS.flax
+++ b/Content/Shaders/CAS.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe87eb5ca0054e79cded864b912884aee05e8635f71f3088d6a6c0a74d72d9c4
-size 2030

--- a/Content/Shaders/ColorGrading.flax
+++ b/Content/Shaders/ColorGrading.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad1d9597dd930f0b63358dbe8326d131661f9cc2251181eeec0cb44ffc530d7a
-size 12311

--- a/Content/Shaders/DebugDraw.flax
+++ b/Content/Shaders/DebugDraw.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf85b8fb7e3f5c7cf0aab9adb6564e5f31ad0b75fd6d6205f2531ced3b1e9889
-size 1938

--- a/Content/Shaders/DepthOfField.flax
+++ b/Content/Shaders/DepthOfField.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abd45cf24b2b6c728ec603052a2aace6f335d6ccfc8b0d5e3184c48c7c2a35f1
-size 13356

--- a/Content/Shaders/Editor/Grid.flax
+++ b/Content/Shaders/Editor/Grid.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c13729c4ec2ef534271c60fee6fff2e0489bf4445fe91aa8a2bbc3d581715602
-size 4666

--- a/Content/Shaders/Editor/LightmapUVsDensity.flax
+++ b/Content/Shaders/Editor/LightmapUVsDensity.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0845b6475dce10d217aca94e62e4a044c776bb3c4fbe8f1c4650bc4170efe60
-size 4365

--- a/Content/Shaders/Editor/MaterialComplexity.flax
+++ b/Content/Shaders/Editor/MaterialComplexity.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecdd3ddc3aa6542e3dfcae2961aa37cda2dad109ec8a8a5e09b798f901f0bae2
-size 1293

--- a/Content/Shaders/Editor/QuadOverdraw.flax
+++ b/Content/Shaders/Editor/QuadOverdraw.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f550ad83652e9669142a1e973a4cc748c377c135a8c19244f0c8fece1a04b4c3
-size 1404

--- a/Content/Shaders/Editor/VertexColors.flax
+++ b/Content/Shaders/Editor/VertexColors.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8230651fcf998b534db60db1db205c163be2609485b903beed3e508215bc7c30
-size 2043

--- a/Content/Shaders/EyeAdaptation.flax
+++ b/Content/Shaders/EyeAdaptation.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1a34e4fb3d0dc276abba393984b0c8112e1727f1425985949128d92984b89a9
-size 4443

--- a/Content/Shaders/FXAA.flax
+++ b/Content/Shaders/FXAA.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebd4e089c963ba72d8e82a19b288ab2870ec1834abcbd0d783f3b2bcd8163b41
-size 24474

--- a/Content/Shaders/Fog.flax
+++ b/Content/Shaders/Fog.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7735a770a87483d4df5e4e653373067c26469de8088f071ca092ed3e797bf461
-size 2785

--- a/Content/Shaders/Forward.flax
+++ b/Content/Shaders/Forward.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9b0df7f7033fe84464de3e369db8e5f38047520682110462eaa75d29977f127
-size 1187

--- a/Content/Shaders/GBuffer.flax
+++ b/Content/Shaders/GBuffer.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70414c6d184befbec5edbea3d8b377114bb03328df4a972216ae357244b7f8f4
-size 2764

--- a/Content/Shaders/GI/DDGI.flax
+++ b/Content/Shaders/GI/DDGI.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5577ef4ce821b08a38afe17b9e5d11cb0b409eb05dd89b2ca76ea95d88085dc0
-size 32893

--- a/Content/Shaders/GI/GlobalSurfaceAtlas.flax
+++ b/Content/Shaders/GI/GlobalSurfaceAtlas.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64a53e850ac662cb98ce91a8122dece7a43562f55a85c37f830f44324e4d16c5
-size 12925

--- a/Content/Shaders/GPUParticlesSorting.flax
+++ b/Content/Shaders/GPUParticlesSorting.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70db76daf1adae225c5354926b84ab738b0dfba4a66233e291223e81685900c8
-size 2629

--- a/Content/Shaders/GUI.flax
+++ b/Content/Shaders/GUI.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fed6a05104322f61a77f6cf69b64478518b829165a2a3ab7fc151098dcd48be
-size 4526

--- a/Content/Shaders/GlobalSignDistanceField.flax
+++ b/Content/Shaders/GlobalSignDistanceField.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e593e15c500b14f6e49d5e4ca6156135fd84d9cc1072a4597ee8bcea77d9339e
-size 13255

--- a/Content/Shaders/Histogram.flax
+++ b/Content/Shaders/Histogram.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af6e12eef9b70f29ed31bfbd30197e69e14202b9e2b71cf0391d03387e77d84d
-size 2522

--- a/Content/Shaders/Lights.flax
+++ b/Content/Shaders/Lights.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68c138e5d710abb090551019a711eff083c61494a632e79b492a597776b8bf86
-size 5118

--- a/Content/Shaders/MotionBlur.flax
+++ b/Content/Shaders/MotionBlur.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af63c3e954919a968e21f19313af1a704c2afa42c5a02744200e1dbf132dc88f
-size 9418

--- a/Content/Shaders/MultiScaler.flax
+++ b/Content/Shaders/MultiScaler.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12b8b623aaa735f126dbe59f1d41280094d3711365e991b5974d180045dd6c53
-size 6996

--- a/Content/Shaders/PostProcessing.flax
+++ b/Content/Shaders/PostProcessing.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb7baebfb28eb44a18c8947ccc5eb4eed8467c3c669af63b7e1be5fde2514948
-size 22677

--- a/Content/Shaders/ProbesFilter.flax
+++ b/Content/Shaders/ProbesFilter.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0249696b525cd59825ab3c0ce38bd612f93cf4be1f88fb49bfcecaac6e9ab34
-size 2022

--- a/Content/Shaders/Quad.flax
+++ b/Content/Shaders/Quad.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a611024c6cf2e5ea5865fe9a98a9b8f43469cde7597033ccfc9e87e93032837
-size 4075

--- a/Content/Shaders/Reflections.flax
+++ b/Content/Shaders/Reflections.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5c99a81c70ccb7e9b2e1e4bc5f271c2fe7b36630489fbb269adfaa34de2cc80
-size 3183

--- a/Content/Shaders/SDF.flax
+++ b/Content/Shaders/SDF.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1abacca0d63b575f0c88d54839f30ce4ec1bb8912478cb81ada8219d417001f9
-size 7891

--- a/Content/Shaders/SMAA.flax
+++ b/Content/Shaders/SMAA.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:013970c677da74c2eb300ee81d6aa6f996dbfaaa74abe13cc76329d77b4dab48
-size 46439

--- a/Content/Shaders/SSAO.flax
+++ b/Content/Shaders/SSAO.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0a576e8a8b818d06ff258874c8d73b273d05c2b8856ff6c14cf0accb2f23f52
-size 36832

--- a/Content/Shaders/SSR.flax
+++ b/Content/Shaders/SSR.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9602d25ef9300636aa23112b3ba3a4f45bf1c4c99b1484a86074da5a787abfc
-size 11085

--- a/Content/Shaders/Shadows.flax
+++ b/Content/Shaders/Shadows.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10d068572a53529671e7a7fcfe6bea4bc6de0fe4b378b57b434f5d3929e702a9
-size 7378

--- a/Content/Shaders/Sky.flax
+++ b/Content/Shaders/Sky.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28d44ef295d989d49ad4d59d6581eee921bc5fa5237e046d271a433454496388
-size 3463

--- a/Content/Shaders/TAA.flax
+++ b/Content/Shaders/TAA.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ba59e7b56c9cda8b9d19369b998e873f08c634fc87021dc8bbd836f44a5bdc5
-size 4275

--- a/Content/Shaders/VolumetricFog.flax
+++ b/Content/Shaders/VolumetricFog.flax
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a3e331b7d688d4d3a11da6bb50d4608dbc6437978433a83cc79a365f520bc58
-size 13206

--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -14,6 +14,7 @@ namespace FlaxEditor.Content.Create
     /// <seealso cref="FlaxEditor.Content.Create.CreateFileEntry" />
     public class PrefabCreateEntry : CreateFileEntry
     {
+        /// <inheritdoc/>
         public override bool CanBeCreated => _options.RootActorType != null;
 
         /// <summary>

--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -193,7 +193,6 @@ namespace FlaxEditor.Content.GUI
         public ContentView()
         {
             // Setup input actions
-            InputOptions options = Editor.Instance.Options.Options.Input;
             InputBindings = new InputBindingList
             (
                 [

--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -754,7 +754,7 @@ namespace FlaxEditor.Content.GUI
                 return true;
             }
 
-            if (InputActions.Process(Editor.Instance, this, key))
+            if (InputActions.Process(Editor.Instance, this))
                 return true;
 
             // Check if sth is selected

--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -758,7 +758,7 @@ namespace FlaxEditor.Content.GUI
                 return true;
             }
 
-            if (InputBindings.Process(this))
+            if (InputBindings.Process(this) != null)
                 return true;
 
             // Check if sth is selected

--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -194,35 +194,38 @@ namespace FlaxEditor.Content.GUI
         {
             // Setup input actions
             InputOptions options = Editor.Instance.Options.Options.Input;
-            InputBindings = new InputBindingList(
-            (options.Delete, () =>
-                {
-                    if (HasSelection)
-                        OnDelete?.Invoke(_selection);
-                }
-            ),
-            (options.SelectAll, SelectAll),
-            (options.DeselectAll, DeselectAll),
-            (options.Rename, () =>
-                {
-                    if (HasSelection && _selection[0].CanRename)
-                    {
-                        if (_selection.Count > 1)
-                            Select(_selection[0]);
-                        OnRename?.Invoke(_selection[0]);
-                    }
-                }
-            ),
-            (options.Copy, Copy),
-            (options.Paste, Paste),
-            (options.Cut, Cut),
-            (options.Undo, () =>
-                {
-                    if (_isCutting)
-                        UpdateContentItemCut(false);
-                }
-            ),
-            (options.Duplicate, Duplicate)
+            InputBindings = new InputBindingList
+            (
+                [
+                    new(InputOptionName.Delete,
+                        () => {
+                            if (HasSelection)
+                                OnDelete?.Invoke(_selection);
+                        }
+                    ),
+                    new(InputOptionName.SelectAll, SelectAll),
+                    new(InputOptionName.DeselectAll, DeselectAll),
+                    new(InputOptionName.Rename,
+                        () => {
+                            if (HasSelection && _selection[0].CanRename)
+                            {
+                                if (_selection.Count > 1)
+                                    Select(_selection[0]);
+                                OnRename?.Invoke(_selection[0]);
+                            }
+                        }
+                    ),
+                    new(InputOptionName.Copy, Copy),
+                    new(InputOptionName.Paste, Paste),
+                    new(InputOptionName.Cut, Cut),
+                    new(InputOptionName.Undo,
+                        () => {
+                            if (_isCutting)
+                                UpdateContentItemCut(false);
+                        }
+                    ),
+                    new(InputOptionName.Duplicate, Duplicate)
+                ]
             );
         }
 

--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -99,6 +99,11 @@ namespace FlaxEditor
         public WindowsModule Windows;
 
         /// <summary>
+        /// The windows module.
+        /// </summary>
+        public ViewportWidgetsModule ViewportWidgets;
+
+        /// <summary>
         /// The UI module.
         /// </summary>
         public UIModule UI;
@@ -281,6 +286,7 @@ namespace FlaxEditor
             RegisterModule(ProjectCache = new ProjectCacheModule(this));
             RegisterModule(Scene = new SceneModule(this));
             RegisterModule(Windows = new WindowsModule(this));
+            RegisterModule(ViewportWidgets = new ViewportWidgetsModule(this));
             RegisterModule(UI = new UIModule(this));
             RegisterModule(Thumbnails = new ThumbnailsModule(this));
             RegisterModule(Simulation = new SimulationModule(this));
@@ -327,27 +333,27 @@ namespace FlaxEditor
                     startupSceneMode = GeneralOptions.StartupSceneModes.ProjectDefault;
                 switch (startupSceneMode)
                 {
-                case GeneralOptions.StartupSceneModes.ProjectDefault:
-                {
-                    if (string.IsNullOrEmpty(GameProject.DefaultScene))
-                        break;
-                    JsonSerializer.ParseID(GameProject.DefaultScene, out var defaultSceneId);
-                    Internal_LoadAsset(ref defaultSceneId);
-                    break;
-                }
-                case GeneralOptions.StartupSceneModes.LastOpened:
-                {
-                    if (ProjectCache.TryGetCustomData(ProjectDataLastScene, out string lastSceneIdName))
-                    {
-                        var lastScenes = JsonSerializer.Deserialize<Guid[]>(lastSceneIdName);
-                        foreach (var scene in lastScenes)
+                    case GeneralOptions.StartupSceneModes.ProjectDefault:
                         {
-                            var lastScene = scene;
-                            Internal_LoadAsset(ref lastScene);
+                            if (string.IsNullOrEmpty(GameProject.DefaultScene))
+                                break;
+                            JsonSerializer.ParseID(GameProject.DefaultScene, out var defaultSceneId);
+                            Internal_LoadAsset(ref defaultSceneId);
+                            break;
                         }
-                    }
-                    break;
-                }
+                    case GeneralOptions.StartupSceneModes.LastOpened:
+                        {
+                            if (ProjectCache.TryGetCustomData(ProjectDataLastScene, out string lastSceneIdName))
+                            {
+                                var lastScenes = JsonSerializer.Deserialize<Guid[]>(lastSceneIdName);
+                                foreach (var scene in lastScenes)
+                                {
+                                    var lastScene = scene;
+                                    Internal_LoadAsset(ref lastScene);
+                                }
+                            }
+                            break;
+                        }
                 }
             }
             catch (Exception)
@@ -431,46 +437,46 @@ namespace FlaxEditor
                 }
                 switch (startupSceneMode)
                 {
-                case GeneralOptions.StartupSceneModes.ProjectDefault:
-                {
-                    if (string.IsNullOrEmpty(GameProject.DefaultScene))
-                        break;
-                    JsonSerializer.ParseID(GameProject.DefaultScene, out var defaultSceneId);
-                    var defaultScene = ContentDatabase.Find(defaultSceneId);
-                    if (defaultScene is SceneItem)
-                    {
-                        Editor.Log("Loading default project scene");
-                        Scene.OpenScene(defaultSceneId);
-
-                        // Use spawn point
-                        Windows.EditWin.Viewport.ViewRay = GameProject.DefaultSceneSpawn;
-                    }
-                    break;
-                }
-                case GeneralOptions.StartupSceneModes.LastOpened:
-                {
-                    if (ProjectCache.TryGetCustomData(ProjectDataLastScene, out string lastSceneIdName))
-                    {
-                        var lastScenes = JsonSerializer.Deserialize<Guid[]>(lastSceneIdName);
-                        foreach (var sceneId in lastScenes)
+                    case GeneralOptions.StartupSceneModes.ProjectDefault:
                         {
-                            var lastScene = ContentDatabase.Find(sceneId);
-                            if (!(lastScene is SceneItem))
-                                continue;
+                            if (string.IsNullOrEmpty(GameProject.DefaultScene))
+                                break;
+                            JsonSerializer.ParseID(GameProject.DefaultScene, out var defaultSceneId);
+                            var defaultScene = ContentDatabase.Find(defaultSceneId);
+                            if (defaultScene is SceneItem)
+                            {
+                                Editor.Log("Loading default project scene");
+                                Scene.OpenScene(defaultSceneId);
 
-                            Editor.Log($"Loading last opened scene: {lastScene.ShortName}");
-                            if (sceneId == lastScenes[0])
-                                Scene.OpenScene(sceneId);
-                            else
-                                Level.LoadSceneAsync(sceneId);
+                                // Use spawn point
+                                Windows.EditWin.Viewport.ViewRay = GameProject.DefaultSceneSpawn;
+                            }
+                            break;
                         }
+                    case GeneralOptions.StartupSceneModes.LastOpened:
+                        {
+                            if (ProjectCache.TryGetCustomData(ProjectDataLastScene, out string lastSceneIdName))
+                            {
+                                var lastScenes = JsonSerializer.Deserialize<Guid[]>(lastSceneIdName);
+                                foreach (var sceneId in lastScenes)
+                                {
+                                    var lastScene = ContentDatabase.Find(sceneId);
+                                    if (!(lastScene is SceneItem))
+                                        continue;
 
-                        // Restore view
-                        if (ProjectCache.TryGetCustomData(ProjectDataLastSceneSpawn, out string lastSceneSpawnName))
-                            Windows.EditWin.Viewport.ViewRay = JsonSerializer.Deserialize<Ray>(lastSceneSpawnName);
-                    }
-                    break;
-                }
+                                    Editor.Log($"Loading last opened scene: {lastScene.ShortName}");
+                                    if (sceneId == lastScenes[0])
+                                        Scene.OpenScene(sceneId);
+                                    else
+                                        Level.LoadSceneAsync(sceneId);
+                                }
+
+                                // Restore view
+                                if (ProjectCache.TryGetCustomData(ProjectDataLastSceneSpawn, out string lastSceneSpawnName))
+                                    Windows.EditWin.Viewport.ViewRay = JsonSerializer.Deserialize<Ray>(lastSceneSpawnName);
+                            }
+                            break;
+                        }
                 }
             }
             catch (Exception)
@@ -501,7 +507,7 @@ namespace FlaxEditor
                 {
                     StateMachine.CurrentState.UpdateFPS();
                 }
-                
+
                 EditorUpdate?.Invoke();
 
                 // Update modules
@@ -1060,46 +1066,46 @@ namespace FlaxEditor
             string tag;
             switch (type)
             {
-            case NewAssetType.Material:
-                tag = "Material";
-                break;
-            case NewAssetType.MaterialInstance:
-                tag = "MaterialInstance";
-                break;
-            case NewAssetType.CollisionData:
-                tag = "CollisionData";
-                break;
-            case NewAssetType.AnimationGraph:
-                tag = "AnimationGraph";
-                break;
-            case NewAssetType.SkeletonMask:
-                tag = "SkeletonMask";
-                break;
-            case NewAssetType.ParticleEmitter:
-                tag = "ParticleEmitter";
-                break;
-            case NewAssetType.ParticleSystem:
-                tag = "ParticleSystem";
-                break;
-            case NewAssetType.SceneAnimation:
-                tag = "SceneAnimation";
-                break;
-            case NewAssetType.MaterialFunction:
-                tag = "MaterialFunction";
-                break;
-            case NewAssetType.ParticleEmitterFunction:
-                tag = "ParticleEmitterFunction";
-                break;
-            case NewAssetType.AnimationGraphFunction:
-                tag = "AnimationGraphFunction";
-                break;
-            case NewAssetType.Animation:
-                tag = "Animation";
-                break;
-            case NewAssetType.BehaviorTree:
-                tag = "BehaviorTree";
-                break;
-            default: return true;
+                case NewAssetType.Material:
+                    tag = "Material";
+                    break;
+                case NewAssetType.MaterialInstance:
+                    tag = "MaterialInstance";
+                    break;
+                case NewAssetType.CollisionData:
+                    tag = "CollisionData";
+                    break;
+                case NewAssetType.AnimationGraph:
+                    tag = "AnimationGraph";
+                    break;
+                case NewAssetType.SkeletonMask:
+                    tag = "SkeletonMask";
+                    break;
+                case NewAssetType.ParticleEmitter:
+                    tag = "ParticleEmitter";
+                    break;
+                case NewAssetType.ParticleSystem:
+                    tag = "ParticleSystem";
+                    break;
+                case NewAssetType.SceneAnimation:
+                    tag = "SceneAnimation";
+                    break;
+                case NewAssetType.MaterialFunction:
+                    tag = "MaterialFunction";
+                    break;
+                case NewAssetType.ParticleEmitterFunction:
+                    tag = "ParticleEmitterFunction";
+                    break;
+                case NewAssetType.AnimationGraphFunction:
+                    tag = "AnimationGraphFunction";
+                    break;
+                case NewAssetType.Animation:
+                    tag = "Animation";
+                    break;
+                case NewAssetType.BehaviorTree:
+                    tag = "BehaviorTree";
+                    break;
+                default: return true;
             }
             return CreateAsset(tag, outputPath);
         }

--- a/Source/Editor/GUI/ContextMenu/ContextMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenu.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FlaxEditor.InputConfig;
 using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;

--- a/Source/Editor/GUI/CurveEditor.cs
+++ b/Source/Editor/GUI/CurveEditor.cs
@@ -994,35 +994,34 @@ namespace FlaxEditor.GUI
             if (base.OnKeyDown(key))
                 return true;
 
-            InputOptions options = Editor.Instance.Options.Options.Input;
-            if (options.SelectAll.Process(this))
+            if (InputOptions.SelectAll.Process(this))
             {
                 SelectAll();
                 UpdateTangents();
                 return true;
             }
-            else if (options.DeselectAll.Process(this))
+            else if (InputOptions.DeselectAll.Process(this))
             {
                 DeselectAll();
                 UpdateTangents();
                 return true;
             }
-            else if (options.Delete.Process(this))
+            else if (InputOptions.Delete.Process(this))
             {
                 RemoveKeyframes();
                 return true;
             }
-            else if (options.Copy.Process(this))
+            else if (InputOptions.Copy.Process(this))
             {
                 CopyKeyframes();
                 return true;
             }
-            else if (options.Paste.Process(this))
+            else if (InputOptions.Paste.Process(this))
             {
                 KeyframesEditorUtils.Paste(this);
                 return true;
             }
-            else if (options.FocusSelection.Process(this))
+            else if (InputOptions.FocusSelection.Process(this))
             {
                 FocusSelection();
                 return true;

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -124,7 +124,6 @@ namespace FlaxEditor.GUI.Docking
             AnchorPreset = AnchorPresets.StretchAll;
             Offsets = Margin.Zero;
 
-            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
             // Bind navigation shortcuts
             InputActions = new InputBindingList
             (

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -108,7 +108,7 @@ namespace FlaxEditor.GUI.Docking
         /// <summary>
         /// The input actions collection to processed during user input.
         /// </summary>
-        public InputBindingList InputActions = new InputBindingList();
+        public InputBindingList InputActions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DockWindow"/> class.
@@ -126,26 +126,29 @@ namespace FlaxEditor.GUI.Docking
 
             InputOptions inputOptions = Editor.Instance.Options.Options.Input;
             // Bind navigation shortcuts
-            InputActions.Add(
-                (inputOptions.CloseTab, () => Close(ClosingReason.User)),
-                (inputOptions.PreviousTab, () =>
-                {
-                    if (_dockedTo != null)
+            InputActions = new InputBindingList
+            (
+                [
+                    new(InputOptionName.CloseTab, () => Close(ClosingReason.User)),
+                    new(InputOptionName.PreviousTab, () =>
                     {
-                        var index = _dockedTo.SelectedTabIndex;
-                        index = index == 0 ? _dockedTo.TabsCount - 1 : index - 1;
-                        _dockedTo.SelectedTabIndex = index;
-                    }
-                }),
-                (inputOptions.NextTab, () =>
-                {
-                    if (_dockedTo != null)
+                        if (_dockedTo != null)
+                        {
+                            var index = _dockedTo.SelectedTabIndex;
+                            index = index == 0 ? _dockedTo.TabsCount - 1 : index - 1;
+                            _dockedTo.SelectedTabIndex = index;
+                        }
+                    }                    ),
+                    new(InputOptionName.NextTab, () =>
                     {
-                        var index = _dockedTo.SelectedTabIndex;
-                        index = (index + 1) % _dockedTo.TabsCount;
-                        _dockedTo.SelectedTabIndex = index;
-                    }
-                })
+                        if (_dockedTo != null)
+                        {
+                            var index = _dockedTo.SelectedTabIndex;
+                            index = (index + 1) % _dockedTo.TabsCount;
+                            _dockedTo.SelectedTabIndex = index;
+                        }
+                    })
+                ]
             );
 
             // Link to the master panel

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -6,6 +6,7 @@ using FlaxEngine;
 using FlaxEngine.Assertions;
 using FlaxEngine.GUI;
 using FlaxEditor.Options;
+using FlaxEditor.InputConfig;
 
 namespace FlaxEditor.GUI.Docking
 {
@@ -107,7 +108,7 @@ namespace FlaxEditor.GUI.Docking
         /// <summary>
         /// The input actions collection to processed during user input.
         /// </summary>
-        public InputActionsContainer InputActions = new InputActionsContainer();
+        public InputBindingList InputActions = new InputBindingList();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DockWindow"/> class.
@@ -123,26 +124,29 @@ namespace FlaxEditor.GUI.Docking
             AnchorPreset = AnchorPresets.StretchAll;
             Offsets = Margin.Zero;
 
+            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
             // Bind navigation shortcuts
-            InputActions.Add(options => options.CloseTab, () => Close(ClosingReason.User));
-            InputActions.Add(options => options.PreviousTab, () =>
-            {
-                if (_dockedTo != null)
+            InputActions.Add(
+                (inputOptions.CloseTab, () => Close(ClosingReason.User)),
+                (inputOptions.PreviousTab, () =>
                 {
-                    var index = _dockedTo.SelectedTabIndex;
-                    index = index == 0 ? _dockedTo.TabsCount - 1 : index - 1;
-                    _dockedTo.SelectedTabIndex = index;
-                }
-            });
-            InputActions.Add(options => options.NextTab, () =>
-            {
-                if (_dockedTo != null)
+                    if (_dockedTo != null)
+                    {
+                        var index = _dockedTo.SelectedTabIndex;
+                        index = index == 0 ? _dockedTo.TabsCount - 1 : index - 1;
+                        _dockedTo.SelectedTabIndex = index;
+                    }
+                }),
+                (inputOptions.NextTab, () =>
                 {
-                    var index = _dockedTo.SelectedTabIndex;
-                    index = (index + 1) % _dockedTo.TabsCount;
-                    _dockedTo.SelectedTabIndex = index;
-                }
-            });
+                    if (_dockedTo != null)
+                    {
+                        var index = _dockedTo.SelectedTabIndex;
+                        index = (index + 1) % _dockedTo.TabsCount;
+                        _dockedTo.SelectedTabIndex = index;
+                    }
+                })
+            );
 
             // Link to the master panel
             _masterPanel?.LinkWindow(this);
@@ -474,9 +478,9 @@ namespace FlaxEditor.GUI.Docking
             // Base
             if (base.OnKeyDown(key))
                 return true;
-
+            Debug.Log(InputActions.List.ToString());
             // Custom input events
-            return InputActions.Process(Editor.Instance, this);
+            return InputActions.Process(this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -476,7 +476,7 @@ namespace FlaxEditor.GUI.Docking
                 return true;
 
             // Custom input events
-            return InputActions.Process(Editor.Instance, this, key);
+            return InputActions.Process(Editor.Instance, this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -478,9 +478,8 @@ namespace FlaxEditor.GUI.Docking
             // Base
             if (base.OnKeyDown(key))
                 return true;
-            Debug.Log(InputActions.List.ToString());
             // Custom input events
-            return InputActions.Process(this);
+            return InputActions.Process(this) == null ? false : true;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/MainMenu.cs
+++ b/Source/Editor/GUI/MainMenu.cs
@@ -313,7 +313,7 @@ namespace FlaxEditor.GUI
 
             // Fallback to the edit window for shortcuts
             var editor = Editor.Instance;
-            return editor.Windows.EditWin.InputActions.Process(editor, this, key);
+            return editor.Windows.EditWin.InputActions.Process(editor, this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/MainMenu.cs
+++ b/Source/Editor/GUI/MainMenu.cs
@@ -313,7 +313,7 @@ namespace FlaxEditor.GUI
 
             // Fallback to the edit window for shortcuts
             var editor = Editor.Instance;
-            return editor.Windows.EditWin.InputActions.Process(this);
+            return editor.Windows.EditWin.InputActions.Process(this) == null ? false : true;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/MainMenu.cs
+++ b/Source/Editor/GUI/MainMenu.cs
@@ -313,7 +313,7 @@ namespace FlaxEditor.GUI
 
             // Fallback to the edit window for shortcuts
             var editor = Editor.Instance;
-            return editor.Windows.EditWin.InputActions.Process(editor, this);
+            return editor.Windows.EditWin.InputActions.Process(this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
+++ b/Source/Editor/GUI/Timeline/GUI/KeyframesEditor.cs
@@ -1282,28 +1282,27 @@ namespace FlaxEditor.GUI
             if (base.OnKeyDown(key))
                 return true;
 
-            InputOptions options = Editor.Instance.Options.Options.Input;
-            if (options.SelectAll.Process(this))
+            if (InputOptions.SelectAll.Process(this))
             {
                 SelectAll();
                 return true;
             }
-            else if (options.DeselectAll.Process(this))
+            else if (InputOptions.DeselectAll.Process(this))
             {
                 DeselectAll();
                 return true;
             }
-            else if (options.Delete.Process(this))
+            else if (InputOptions.Delete.Process(this))
             {
                 RemoveKeyframes();
                 return true;
             }
-            else if (options.Copy.Process(this))
+            else if (InputOptions.Copy.Process(this))
             {
                 CopyKeyframes();
                 return true;
             }
-            else if (options.Paste.Process(this))
+            else if (InputOptions.Paste.Process(this))
             {
                 KeyframesEditorUtils.Paste(this);
                 return true;

--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -200,7 +200,7 @@ namespace FlaxEditor.GUI
             var editor = Editor.Instance;
             if (editorWindow == null)
                 editorWindow = editor.Windows.EditWin; // Fallback to main editor window
-            return editorWindow.InputActions.Process(this);
+            return editorWindow.InputActions.Process(this) == null ? false : true;
         }
     }
 }

--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -200,7 +200,7 @@ namespace FlaxEditor.GUI
             var editor = Editor.Instance;
             if (editorWindow == null)
                 editorWindow = editor.Windows.EditWin; // Fallback to main editor window
-            return editorWindow.InputActions.Process(editor, this);
+            return editorWindow.InputActions.Process(this);
         }
     }
 }

--- a/Source/Editor/GUI/ToolStrip.cs
+++ b/Source/Editor/GUI/ToolStrip.cs
@@ -200,7 +200,7 @@ namespace FlaxEditor.GUI
             var editor = Editor.Instance;
             if (editorWindow == null)
                 editorWindow = editor.Windows.EditWin; // Fallback to main editor window
-            return editorWindow.InputActions.Process(editor, this, key);
+            return editorWindow.InputActions.Process(editor, this);
         }
     }
 }

--- a/Source/Editor/GUI/ToolStripButton.cs
+++ b/Source/Editor/GUI/ToolStripButton.cs
@@ -114,7 +114,7 @@ namespace FlaxEditor.GUI
         /// <param name="text">The text.</param>
         /// <param name="inputBinding">The input key binding.</param>
         /// <returns>This tooltip.</returns>
-        public ToolStripButton LinkTooltip(string text, ref InputBinding inputBinding)
+        public ToolStripButton LinkTooltip(string text, InputBinding inputBinding)
         {
             var input = inputBinding.ToString();
             if (input.Length != 0)

--- a/Source/Editor/GUI/ToolStripButton.cs
+++ b/Source/Editor/GUI/ToolStripButton.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using System;
+using FlaxEditor.InputConfig;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -113,7 +114,7 @@ namespace FlaxEditor.GUI
         /// <param name="text">The text.</param>
         /// <param name="inputBinding">The input key binding.</param>
         /// <returns>This tooltip.</returns>
-        public ToolStripButton LinkTooltip(string text, ref Options.InputBinding inputBinding)
+        public ToolStripButton LinkTooltip(string text, ref InputBinding inputBinding)
         {
             var input = inputBinding.ToString();
             if (input.Length != 0)

--- a/Source/Editor/GUI/Tree/Tree.cs
+++ b/Source/Editor/GUI/Tree/Tree.cs
@@ -487,15 +487,14 @@ namespace FlaxEditor.GUI.Tree
             // Check if can use multi selection
             if (_supportMultiSelect)
             {
-                InputOptions options = Editor.Instance.Options.Options.Input;
 
                 // Select all expanded nodes
-                if (options.SelectAll.Process(this))
+                if (InputOptions.SelectAll.Process(this))
                 {
                     SelectAllExpanded();
                     return true;
                 }
-                else if (options.DeselectAll.Process(this))
+                else if (InputOptions.DeselectAll.Process(this))
                 {
                     DeselectAll();
                     return true;

--- a/Source/Editor/Gizmo/TransformGizmoBase.cs
+++ b/Source/Editor/Gizmo/TransformGizmoBase.cs
@@ -179,7 +179,7 @@ namespace FlaxEditor.Gizmo
 
             // Scale gizmo to fit on-screen
             Vector3 position = Position;
-            if (Owner.Viewport.UseOrthographicProjection)
+            if (Owner.Viewport.OrthographicProjection)
             {
                 //[hack] this is far form ideal the View Position is in wrong location, any think using the View Position will have problem
                 //the camera system needs rewrite the to be a camera on springarm, similar how the ArcBallCamera is handled

--- a/Source/Editor/InputConfig/InputBinding.cs
+++ b/Source/Editor/InputConfig/InputBinding.cs
@@ -26,6 +26,11 @@ namespace FlaxEditor.InputConfig
         public Action Callback;
 
         /// <summary>
+        /// This is called to clear up the state of the callback when it is no longer triggered
+        /// </summary>
+        public Action? Clear;
+
+        /// <summary>
         /// The <see cref="InputTrigger"/> list to bind.
         /// </summary>
         public List<InputTrigger> InputTriggers;
@@ -37,6 +42,11 @@ namespace FlaxEditor.InputConfig
         public InputBinding()
         {
             InputTriggers = new List<InputTrigger>();
+        }
+
+        public void ClearState()
+        {
+            Clear?.Invoke();
         }
 
         /// <summary>
@@ -171,12 +181,12 @@ namespace FlaxEditor.InputConfig
         /// </summary>
         /// <param name="control">The input providing control.</param>
         /// <returns>True if input has been processed, otherwise false.</returns>
-        public bool Process(Control control)
+        public bool Process(Control control, bool fireCallback = true)
         {
             if (control?.Root == null)
                 return false;
 
-            return Process(control.Root.GetKey, control.Root.GetMouseButton, control.Root.GetMouseScrollDelta());
+            return Process(control.Root.GetKey, control.Root.GetMouseButton, control.Root.GetMouseScrollDelta(), fireCallback);
         }
 
         /// <summary>
@@ -197,19 +207,18 @@ namespace FlaxEditor.InputConfig
         /// <param name="getMouse">Function to check if a mouse button is currently pressed.</param>
         /// <param name="scrollDelta">The mouse scroll delta over the last frame</param>
         /// <returns>True if all input triggers are currently pressed; otherwise, false.</returns>
-        private bool Process(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse, float scrollDelta)
+        private bool Process(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse, float scrollDelta, bool fireCallback = true)
         {
             if (InputTriggers == null || InputTriggers.Count == 0)
                 return false;
 
             foreach (var trigger in InputTriggers)
             {
-                Debug.Log(trigger);
                 if (!trigger.IsPressed(getKey, getMouse, scrollDelta))
                     return false;
             }
-            Debug.Log(this);
-            Callback?.Invoke();
+            if(fireCallback)
+                Callback?.Invoke();
             return true;
         }
 

--- a/Source/Editor/InputConfig/InputBinding.cs
+++ b/Source/Editor/InputConfig/InputBinding.cs
@@ -29,7 +29,7 @@ namespace FlaxEditor.InputConfig
         /// The <see cref="InputTrigger"/> list to bind.
         /// </summary>
         public List<InputTrigger> InputTriggers;
-        private const int MAX_TRIGGERS = 4;
+        public const int MAX_TRIGGERS = 4;
 
         /// <summary>
         /// Initializes an empty <see cref="InputBinding"/>
@@ -343,7 +343,7 @@ namespace FlaxEditor.InputConfig
             {
                 if (!IsFocused)
                 {
-                    return false;
+                    return base.OnMouseDown(location, button);
                 }
                 var trigger = new InputTrigger(button.ToString());
                 if (!_binding.InputTriggers.Contains(trigger))
@@ -352,6 +352,11 @@ namespace FlaxEditor.InputConfig
                 }
 
                 _text = _binding.ToString();
+                if (_binding.InputTriggers.Count >= InputBinding.MAX_TRIGGERS)
+                {
+                    Defocus();
+                    return true;
+                }
                 return true;
             }
 
@@ -360,7 +365,7 @@ namespace FlaxEditor.InputConfig
             {
                 if (!IsFocused)
                 {
-                    return false;
+                    return base.OnKeyDown(key);
                 }
                 var trigger = new InputTrigger(key.ToString());
                 if (!_binding.InputTriggers.Contains(trigger))
@@ -369,6 +374,11 @@ namespace FlaxEditor.InputConfig
                 }
 
                 _text = _binding.ToString();
+                if (_binding.InputTriggers.Count >= InputBinding.MAX_TRIGGERS)
+                {
+                    Defocus();
+                    return true;
+                }
                 return true;
             }
 
@@ -376,7 +386,7 @@ namespace FlaxEditor.InputConfig
             {
                 if (!IsFocused)
                 {
-                    return false;
+                    return base.OnMouseWheel(location, delta);
                 }
                 var trigger = new InputTrigger(MouseScrollHelper.GetScrollDirection(delta).ToString());
                 if (!_binding.InputTriggers.Contains(trigger))
@@ -385,6 +395,11 @@ namespace FlaxEditor.InputConfig
                 }
 
                 _text = _binding.ToString();
+                if (_binding.InputTriggers.Count >= InputBinding.MAX_TRIGGERS)
+                {
+                    Defocus();
+                    return true;
+                }
                 return true;
             }
         }

--- a/Source/Editor/InputConfig/InputBinding.cs
+++ b/Source/Editor/InputConfig/InputBinding.cs
@@ -21,16 +21,6 @@ namespace FlaxEditor.InputConfig
     public struct InputBinding : IEquatable<InputBinding>
     {
         /// <summary>
-        /// The action callback.
-        /// </summary>
-        public Action Callback;
-
-        /// <summary>
-        /// This is called to clear up the state of the callback when it is no longer triggered
-        /// </summary>
-        public Action? Clear;
-
-        /// <summary>
         /// The <see cref="InputTrigger"/> list to bind.
         /// </summary>
         public List<InputTrigger> InputTriggers;
@@ -42,11 +32,6 @@ namespace FlaxEditor.InputConfig
         public InputBinding()
         {
             InputTriggers = new List<InputTrigger>();
-        }
-
-        public void ClearState()
-        {
-            Clear?.Invoke();
         }
 
         /// <summary>
@@ -122,21 +107,6 @@ namespace FlaxEditor.InputConfig
         /// <summary>
         /// Initializes using input <see cref="string"/> separated by +
         /// <para>Example: "Left+Control+R" = MouseButton.Left, KeyboardKeys.Control, KeyboardKeys.R</para>
-        /// <param name="bindingString">The string to parse and set the binding.</param>
-        /// <param name="callback">The callback.</param>
-        /// </summary>
-        public InputBinding(string bindingString, Action callback)
-        {
-            if (!TryParse(bindingString, out var result))
-                throw new ArgumentException($"Invalid binding string: {bindingString}");
-
-            this = result;
-            Callback = callback;
-        }
-
-        /// <summary>
-        /// Initializes using input <see cref="string"/> separated by +
-        /// <para>Example: "Left+Control+R" = MouseButton.Left, KeyboardKeys.Control, KeyboardKeys.R</para>
         /// </summary>
         public InputBinding(string bindingString)
         {
@@ -181,12 +151,12 @@ namespace FlaxEditor.InputConfig
         /// </summary>
         /// <param name="control">The input providing control.</param>
         /// <returns>True if input has been processed, otherwise false.</returns>
-        public bool Process(Control control, bool fireCallback = true)
+        public bool Process(Control control)
         {
             if (control?.Root == null)
                 return false;
 
-            return Process(control.Root.GetKey, control.Root.GetMouseButton, control.Root.GetMouseScrollDelta(), fireCallback);
+            return Process(control.Root.GetKey, control.Root.GetMouseButton, control.Root.GetMouseScrollDelta());
         }
 
         /// <summary>
@@ -207,7 +177,7 @@ namespace FlaxEditor.InputConfig
         /// <param name="getMouse">Function to check if a mouse button is currently pressed.</param>
         /// <param name="scrollDelta">The mouse scroll delta over the last frame</param>
         /// <returns>True if all input triggers are currently pressed; otherwise, false.</returns>
-        private bool Process(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse, float scrollDelta, bool fireCallback = true)
+        private bool Process(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse, float scrollDelta)
         {
             if (InputTriggers == null || InputTriggers.Count == 0)
                 return false;
@@ -217,8 +187,6 @@ namespace FlaxEditor.InputConfig
                 if (!trigger.IsPressed(getKey, getMouse, scrollDelta))
                     return false;
             }
-            if(fireCallback)
-                Callback?.Invoke();
             return true;
         }
 

--- a/Source/Editor/InputConfig/InputBindingList.cs
+++ b/Source/Editor/InputConfig/InputBindingList.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FlaxEngine.GUI;
+
+#pragma warning disable 1591
+namespace FlaxEditor.InputConfig
+{
+    /// <summary>
+    /// The input actions processing helper that handles input bindings configuration layer.
+    /// </summary>
+    public class InputBindingList
+    {
+        public List<InputBinding> List = new List<InputBinding>();
+
+        public void Remove(Action callback)
+        {
+            for (int i = List.Count - 1; i >= 0; i--)
+            {
+                if (List[i].Callback == callback)
+                {
+                    List.RemoveAt(i);
+                }
+            }
+        }
+
+        public void Add(InputBinding binding)
+        {
+            if (!List.Contains(binding))
+            {
+                List.Add(binding);
+            }
+        }
+
+        public void Add(InputBinding binding, Action callback)
+        {
+            if (!List.Contains(binding))
+            {
+                binding.Callback = callback;
+                List.Add(binding);
+                return;
+            }
+
+            var foundBinding = List.FirstOrDefault(b => b == binding);
+            foundBinding.Callback = callback;
+        }
+
+        public void Add(params (InputBinding binding, Action callback)[] bindings)
+        {
+            foreach (var (binding, callback) in bindings)
+            {
+                this.Add(binding, callback);
+            }
+        }
+
+        public InputBindingList(params (InputBinding binding, Action callback)[] bindings)
+        {
+            foreach (var (binding, callback) in bindings)
+            {
+                this.Add(binding, callback);
+            }
+        }
+
+        public void SetCallback(params (InputBinding match, Action callback)[] bindings)
+        {
+            foreach (var (match, callback) in bindings)
+            {
+                var binding = List.FirstOrDefault(b => b == match);
+                if (binding != null)
+                    binding.Callback = callback;
+            }
+        }
+
+
+        /// <summary>
+        /// Processes the specified key input and tries to invoke first matching callback for the current user input state.
+        /// </summary>
+        /// <param name="control">The input providing control.</param>
+        /// <returns>True if event has been handled, otherwise false.</returns>
+        public bool Process(Control control)
+        {
+            for (int i = 0; i < List.Count; i++)
+            {
+                if (List[i].Process(control))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Invokes a specific binding.
+        /// </summary>
+        /// <param name="binding">The binding to execute.</param>
+        /// <returns>True if event has been handled, otherwise false.</returns>
+        public bool Invoke(InputBinding binding)
+        {
+            if (binding == new InputBinding())
+                return false;
+            for (int i = 0; i < List.Count; i++)
+            {
+                if (List[i] == binding)
+                {
+                    List[i].Callback();
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Source/Editor/InputConfig/InputTrigger.cs
+++ b/Source/Editor/InputConfig/InputTrigger.cs
@@ -15,9 +15,9 @@ namespace FlaxEditor.InputConfig
         public KeyboardKeys Key;
         public MouseScroll Scroll;
         public InputType Type;
-        public bool IsKeyboard => Type == InputType.Key;
-        public bool IsMouse => Type == InputType.Mouse;
-        public bool IsScroll => Type == InputType.Scroll;
+        public readonly bool IsKeyboard => Type == InputType.Key;
+        public readonly bool IsMouse => Type == InputType.Mouse;
+        public readonly bool IsScroll => Type == InputType.Scroll;
         public InputTrigger(string token)
         {
             if (!TryParseInput(token, out var parsed))
@@ -96,7 +96,6 @@ namespace FlaxEditor.InputConfig
         /// <returns>True if the trigger is currently active; otherwise, false.</returns>
         public bool IsPressed(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse, float scrollDelta)
         {
-            Debug.Log(Key);
             return Type switch
             {
                 InputType.Key => getKey(Key),

--- a/Source/Editor/InputConfig/InputTrigger.cs
+++ b/Source/Editor/InputConfig/InputTrigger.cs
@@ -2,7 +2,7 @@ using System;
 using FlaxEngine;
 
 #pragma warning disable 1591
-namespace FlaxEditor.Options
+namespace FlaxEditor.InputConfig
 {
     /// <summary>
     /// The input trigger, either mouse or keyboard
@@ -78,6 +78,15 @@ namespace FlaxEditor.Options
             trigger = new InputTrigger();
             return false;
         }
+
+        public InputTrigger()
+        {
+            Type = InputType.None;
+            Button = MouseButton.None;
+            Scroll = MouseScroll.None;
+            Key = KeyboardKeys.None;
+        }
+
         /// <summary>
         /// Checks whether this individual input trigger is currently active.
         /// </summary>
@@ -87,6 +96,7 @@ namespace FlaxEditor.Options
         /// <returns>True if the trigger is currently active; otherwise, false.</returns>
         public bool IsPressed(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse, float scrollDelta)
         {
+            Debug.Log(Key);
             return Type switch
             {
                 InputType.Key => getKey(Key),

--- a/Source/Editor/InputConfig/MouseScroll.cs
+++ b/Source/Editor/InputConfig/MouseScroll.cs
@@ -1,7 +1,7 @@
 #pragma warning disable 1591
 using System;
 
-namespace FlaxEngine
+namespace FlaxEditor.InputConfig
 {
     public enum MouseScroll
     {

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -523,20 +523,18 @@ namespace FlaxEditor.Modules
                 Parent = mainWindow
             };
 
-            var inputOptions = Editor.Options.Options.Input;
-
             // File
             MenuFile = MainMenu.AddButton("File");
             var cm = MenuFile.ContextMenu;
             cm.VisibleChanged += OnMenuFileShowHide;
-            _menuFileSaveAll = cm.AddButton("Save All", inputOptions.Save, Editor.SaveAll);
-            _menuFileSaveScenes = cm.AddButton("Save scenes", inputOptions.SaveScenes, Editor.Scene.SaveScenes);
-            _menuFileCloseScenes = cm.AddButton("Close scenes", inputOptions.CloseScenes, Editor.Scene.CloseAllScenes);
+            _menuFileSaveAll = cm.AddButton("Save All", InputOptions.Save, Editor.SaveAll);
+            _menuFileSaveScenes = cm.AddButton("Save scenes", InputOptions.SaveScenes, Editor.Scene.SaveScenes);
+            _menuFileCloseScenes = cm.AddButton("Close scenes", InputOptions.CloseScenes, Editor.Scene.CloseAllScenes);
             _menuFileReloadScenes = cm.AddButton("Reload scenes", Editor.Scene.ReloadScenes);
             cm.AddSeparator();
-            _menuFileOpenScriptsProject = cm.AddButton("Open scripts project", inputOptions.OpenScriptsProject, Editor.CodeEditing.OpenSolution);
-            _menuFileGenerateScriptsProjectFiles = cm.AddButton("Generate scripts project files", inputOptions.GenerateScriptsProject, Editor.ProgressReporting.GenerateScriptsProjectFiles.RunAsync);
-            _menuFileRecompileScripts = cm.AddButton("Recompile scripts", inputOptions.RecompileScripts, ScriptsBuilder.Compile);
+            _menuFileOpenScriptsProject = cm.AddButton("Open scripts project", InputOptions.OpenScriptsProject, Editor.CodeEditing.OpenSolution);
+            _menuFileGenerateScriptsProjectFiles = cm.AddButton("Generate scripts project files", InputOptions.GenerateScriptsProject, Editor.ProgressReporting.GenerateScriptsProjectFiles.RunAsync);
+            _menuFileRecompileScripts = cm.AddButton("Recompile scripts", InputOptions.RecompileScripts, ScriptsBuilder.Compile);
             cm.AddSeparator();
             cm.AddButton("Open project...", OpenProject);
             cm.AddButton("Reload project", ReloadProject);
@@ -548,19 +546,19 @@ namespace FlaxEditor.Modules
             MenuEdit = MainMenu.AddButton("Edit");
             cm = MenuEdit.ContextMenu;
             cm.VisibleChanged += OnMenuEditShowHide;
-            _menuEditUndo = cm.AddButton(string.Empty, inputOptions.Undo, Editor.PerformUndo);
-            _menuEditRedo = cm.AddButton(string.Empty, inputOptions.Redo, Editor.PerformRedo);
+            _menuEditUndo = cm.AddButton(string.Empty, InputOptions.Undo, Editor.PerformUndo);
+            _menuEditRedo = cm.AddButton(string.Empty, InputOptions.Redo, Editor.PerformRedo);
             cm.AddSeparator();
-            _menuEditCut = cm.AddButton("Cut", inputOptions.Cut, Editor.SceneEditing.Cut);
-            _menuEditCopy = cm.AddButton("Copy", inputOptions.Copy, Editor.SceneEditing.Copy);
-            _menuEditPaste = cm.AddButton("Paste", inputOptions.Paste, Editor.SceneEditing.Paste);
-            _menuEditDelete = cm.AddButton("Delete", inputOptions.Delete, Editor.SceneEditing.Delete);
-            _menuEditDuplicate = cm.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
+            _menuEditCut = cm.AddButton("Cut", InputOptions.Cut, Editor.SceneEditing.Cut);
+            _menuEditCopy = cm.AddButton("Copy", InputOptions.Copy, Editor.SceneEditing.Copy);
+            _menuEditPaste = cm.AddButton("Paste", InputOptions.Paste, Editor.SceneEditing.Paste);
+            _menuEditDelete = cm.AddButton("Delete", InputOptions.Delete, Editor.SceneEditing.Delete);
+            _menuEditDuplicate = cm.AddButton("Duplicate", InputOptions.Duplicate, Editor.SceneEditing.Duplicate);
             cm.AddSeparator();
-            _menuEditSelectAll = cm.AddButton("Select all", inputOptions.SelectAll, Editor.SceneEditing.SelectAllScenes);
-            _menuEditDeselectAll = cm.AddButton("Deselect all", inputOptions.DeselectAll, Editor.SceneEditing.DeselectAllScenes);
-            _menuCreateParentForSelectedActors = cm.AddButton("Parent to new Actor", inputOptions.GroupSelectedActors, Editor.SceneEditing.CreateParentForSelectedActors);
-            _menuEditFind = cm.AddButton("Find", inputOptions.Search, Editor.Windows.SceneWin.Search);
+            _menuEditSelectAll = cm.AddButton("Select all", InputOptions.SelectAll, Editor.SceneEditing.SelectAllScenes);
+            _menuEditDeselectAll = cm.AddButton("Deselect all", InputOptions.DeselectAll, Editor.SceneEditing.DeselectAllScenes);
+            _menuCreateParentForSelectedActors = cm.AddButton("Parent to new Actor", InputOptions.GroupSelectedActors, Editor.SceneEditing.CreateParentForSelectedActors);
+            _menuEditFind = cm.AddButton("Find", InputOptions.Search, Editor.Windows.SceneWin.Search);
             cm.AddSeparator();
             cm.AddButton("Game Settings", () =>
             {
@@ -574,10 +572,10 @@ namespace FlaxEditor.Modules
             MenuScene = MainMenu.AddButton("Scene");
             cm = MenuScene.ContextMenu;
             cm.VisibleChanged += OnMenuSceneShowHide;
-            _menuSceneMoveActorToViewport = cm.AddButton("Move actor to viewport", inputOptions.MoveActorToViewport, MoveActorToViewport);
-            _menuSceneAlignActorWithViewport = cm.AddButton("Align actor with viewport", inputOptions.AlignActorWithViewport, AlignActorWithViewport);
-            _menuSceneAlignViewportWithActor = cm.AddButton("Align viewport with actor", inputOptions.AlignViewportWithActor, AlignViewportWithActor);
-            _menuScenePilotActor = cm.AddButton("Pilot actor", inputOptions.PilotActor, PilotActor);
+            _menuSceneMoveActorToViewport = cm.AddButton("Move actor to viewport", InputOptions.MoveActorToViewport, MoveActorToViewport);
+            _menuSceneAlignActorWithViewport = cm.AddButton("Align actor with viewport", InputOptions.AlignActorWithViewport, AlignActorWithViewport);
+            _menuSceneAlignViewportWithActor = cm.AddButton("Align viewport with actor", InputOptions.AlignViewportWithActor, AlignViewportWithActor);
+            _menuScenePilotActor = cm.AddButton("Pilot actor", InputOptions.PilotActor, PilotActor);
             cm.AddSeparator();
             _menuSceneCreateTerrain = cm.AddButton("Create terrain", CreateTerrain);
 
@@ -586,41 +584,41 @@ namespace FlaxEditor.Modules
             cm = MenuGame.ContextMenu;
             cm.VisibleChanged += OnMenuGameShowHide;
 
-            _menuGamePlayGame = cm.AddButton("Play Game", inputOptions.Play, Editor.Simulation.RequestPlayGameOrStopPlay);
-            _menuGamePlayCurrentScenes = cm.AddButton("Play Current Scenes", inputOptions.PlayCurrentScenes, Editor.Simulation.RequestPlayScenesOrStopPlay);
-            _menuGameStop = cm.AddButton("Stop Game", inputOptions.Play, Editor.Simulation.RequestStopPlay);
-            _menuGamePause = cm.AddButton("Pause", inputOptions.Pause, Editor.Simulation.RequestPausePlay);
+            _menuGamePlayGame = cm.AddButton("Play Game", InputOptions.Play, Editor.Simulation.RequestPlayGameOrStopPlay);
+            _menuGamePlayCurrentScenes = cm.AddButton("Play Current Scenes", InputOptions.PlayCurrentScenes, Editor.Simulation.RequestPlayScenesOrStopPlay);
+            _menuGameStop = cm.AddButton("Stop Game", InputOptions.Play, Editor.Simulation.RequestStopPlay);
+            _menuGamePause = cm.AddButton("Pause", InputOptions.Pause, Editor.Simulation.RequestPausePlay);
 
             cm.AddSeparator();
             var numberOfClientsMenu = cm.AddChildMenu("Number of game clients");
             _numberOfClientsGroup.AddItemsToContextMenu(numberOfClientsMenu.ContextMenu);
 
             cm.AddSeparator();
-            _menuGameCookAndRun = cm.AddButton("Cook & Run", inputOptions.CookAndRun, Editor.Windows.GameCookerWin.BuildAndRun);
+            _menuGameCookAndRun = cm.AddButton("Cook & Run", InputOptions.CookAndRun, Editor.Windows.GameCookerWin.BuildAndRun);
             _menuGameCookAndRun.LinkTooltip("Runs Game Cooker to build the game for this platform and runs the game after.");
-            _menuGameRunCookedGame = cm.AddButton("Run cooked game", inputOptions.RunCookedGame, Editor.Windows.GameCookerWin.RunCooked);
+            _menuGameRunCookedGame = cm.AddButton("Run cooked game", InputOptions.RunCookedGame, Editor.Windows.GameCookerWin.RunCooked);
             _menuGameRunCookedGame.LinkTooltip("Runs the game build from the last cooking output. Use 'Cook & Run' or Game Cooker first.");
 
             // Tools
             MenuTools = MainMenu.AddButton("Tools");
             cm = MenuTools.ContextMenu;
             cm.VisibleChanged += OnMenuToolsShowHide;
-            _menuToolsBuildScenes = cm.AddButton("Build scenes data", inputOptions.BuildScenesData, Editor.BuildScenesOrCancel);
+            _menuToolsBuildScenes = cm.AddButton("Build scenes data", InputOptions.BuildScenesData, Editor.BuildScenesOrCancel);
             cm.AddSeparator();
-            _menuToolsBakeLightmaps = cm.AddButton("Bake lightmaps", inputOptions.BakeLightmaps, Editor.BakeLightmapsOrCancel);
-            _menuToolsClearLightmaps = cm.AddButton("Clear lightmaps data", inputOptions.ClearLightmaps, Editor.ClearLightmaps);
-            _menuToolsBakeAllEnvProbes = cm.AddButton("Bake all env probes", inputOptions.BakeEnvProbes, Editor.BakeAllEnvProbes);
-            _menuToolsBuildCSGMesh = cm.AddButton("Build CSG mesh", inputOptions.BuildCSG, Editor.BuildCSG);
-            _menuToolsBuildNavMesh = cm.AddButton("Build Nav Mesh", inputOptions.BuildNav, Editor.BuildNavMesh);
-            _menuToolsBuildAllMeshesSDF = cm.AddButton("Build all meshes SDF", inputOptions.BuildSDF, Editor.BuildAllMeshesSDF);
+            _menuToolsBakeLightmaps = cm.AddButton("Bake lightmaps", InputOptions.BakeLightmaps, Editor.BakeLightmapsOrCancel);
+            _menuToolsClearLightmaps = cm.AddButton("Clear lightmaps data", InputOptions.ClearLightmaps, Editor.ClearLightmaps);
+            _menuToolsBakeAllEnvProbes = cm.AddButton("Bake all env probes", InputOptions.BakeEnvProbes, Editor.BakeAllEnvProbes);
+            _menuToolsBuildCSGMesh = cm.AddButton("Build CSG mesh", InputOptions.BuildCSG, Editor.BuildCSG);
+            _menuToolsBuildNavMesh = cm.AddButton("Build Nav Mesh", InputOptions.BuildNav, Editor.BuildNavMesh);
+            _menuToolsBuildAllMeshesSDF = cm.AddButton("Build all meshes SDF", InputOptions.BuildSDF, Editor.BuildAllMeshesSDF);
             cm.AddSeparator();
             cm.AddButton("Game Cooker", Editor.Windows.GameCookerWin.FocusOrShow);
             _menuToolsCancelBuilding = cm.AddButton("Cancel building game", () => GameCooker.Cancel());
             cm.AddSeparator();
-            _menuToolsProfilerWindow = cm.AddButton("Profiler", inputOptions.ProfilerWindow, () => Editor.Windows.ProfilerWin.FocusOrShow());
+            _menuToolsProfilerWindow = cm.AddButton("Profiler", InputOptions.ProfilerWindow, () => Editor.Windows.ProfilerWin.FocusOrShow());
             cm.AddSeparator();
             _menuToolsSetTheCurrentSceneViewAsDefault = cm.AddButton("Set current scene view as project default", SetTheCurrentSceneViewAsDefault);
-            _menuToolsTakeScreenshot = cm.AddButton("Take screenshot", inputOptions.TakeScreenshot, Editor.Windows.TakeScreenshot);
+            _menuToolsTakeScreenshot = cm.AddButton("Take screenshot", InputOptions.TakeScreenshot, Editor.Windows.TakeScreenshot);
             cm.AddSeparator();
             cm.AddButton("Plugins", () => Editor.Windows.PluginsWin.Show());
 
@@ -638,7 +636,7 @@ namespace FlaxEditor.Modules
             cm.AddButton("Output Log", Editor.Windows.OutputLogWin.FocusOrShow);
             cm.AddButton("Graphics Quality", Editor.Windows.GraphicsQualityWin.FocusOrShow);
             cm.AddButton("Game Cooker", Editor.Windows.GameCookerWin.FocusOrShow);
-            cm.AddButton("Profiler", inputOptions.ProfilerWindow, Editor.Windows.ProfilerWin.FocusOrShow);
+            cm.AddButton("Profiler", InputOptions.ProfilerWindow, Editor.Windows.ProfilerWin.FocusOrShow);
             cm.AddButton("Content Search", Editor.ContentFinding.ShowSearch);
             cm.AddButton("Visual Script Debugger", Editor.Windows.VisualScriptDebuggerWin.FocusOrShow);
             cm.AddSeparator();
@@ -665,36 +663,36 @@ namespace FlaxEditor.Modules
         {
             var inputOptions = options.Input;
 
-            _menuFileSaveAll.ShortKeys = inputOptions.Save.ToString();
-            _menuFileSaveScenes.ShortKeys = inputOptions.SaveScenes.ToString();
-            _menuFileCloseScenes.ShortKeys = inputOptions.CloseScenes.ToString();
-            _menuFileOpenScriptsProject.ShortKeys = inputOptions.OpenScriptsProject.ToString();
-            _menuFileGenerateScriptsProjectFiles.ShortKeys = inputOptions.GenerateScriptsProject.ToString();
-            _menuFileRecompileScripts.ShortKeys = inputOptions.RecompileScripts.ToString();
-            _menuEditUndo.ShortKeys = inputOptions.Undo.ToString();
-            _menuEditRedo.ShortKeys = inputOptions.Redo.ToString();
-            _menuEditCut.ShortKeys = inputOptions.Cut.ToString();
-            _menuEditCopy.ShortKeys = inputOptions.Copy.ToString();
-            _menuEditDelete.ShortKeys = inputOptions.Delete.ToString();
-            _menuEditDuplicate.ShortKeys = inputOptions.Duplicate.ToString();
-            _menuEditSelectAll.ShortKeys = inputOptions.SelectAll.ToString();
-            _menuEditDeselectAll.ShortKeys = inputOptions.DeselectAll.ToString();
-            _menuEditFind.ShortKeys = inputOptions.Search.ToString();
-            _menuGamePlayGame.ShortKeys = inputOptions.Play.ToString();
-            _menuGamePlayCurrentScenes.ShortKeys = inputOptions.PlayCurrentScenes.ToString();
-            _menuGamePause.ShortKeys = inputOptions.Pause.ToString();
-            _menuGameStop.ShortKeys = inputOptions.Play.ToString();
-            _menuGameCookAndRun.ShortKeys = inputOptions.CookAndRun.ToString();
-            _menuGameRunCookedGame.ShortKeys = inputOptions.RunCookedGame.ToString();
-            _menuToolsBuildScenes.ShortKeys = inputOptions.BuildScenesData.ToString();
-            _menuToolsBakeLightmaps.ShortKeys = inputOptions.BakeLightmaps.ToString();
-            _menuToolsClearLightmaps.ShortKeys = inputOptions.ClearLightmaps.ToString();
-            _menuToolsBakeAllEnvProbes.ShortKeys = inputOptions.BakeEnvProbes.ToString();
-            _menuToolsBuildCSGMesh.ShortKeys = inputOptions.BuildCSG.ToString();
-            _menuToolsBuildNavMesh.ShortKeys = inputOptions.BuildNav.ToString();
-            _menuToolsBuildAllMeshesSDF.ShortKeys = inputOptions.BuildSDF.ToString();
-            _menuToolsProfilerWindow.ShortKeys = inputOptions.ProfilerWindow.ToString();
-            _menuToolsTakeScreenshot.ShortKeys = inputOptions.TakeScreenshot.ToString();
+            _menuFileSaveAll.ShortKeys = InputOptions.Save.ToString();
+            _menuFileSaveScenes.ShortKeys = InputOptions.SaveScenes.ToString();
+            _menuFileCloseScenes.ShortKeys = InputOptions.CloseScenes.ToString();
+            _menuFileOpenScriptsProject.ShortKeys = InputOptions.OpenScriptsProject.ToString();
+            _menuFileGenerateScriptsProjectFiles.ShortKeys = InputOptions.GenerateScriptsProject.ToString();
+            _menuFileRecompileScripts.ShortKeys = InputOptions.RecompileScripts.ToString();
+            _menuEditUndo.ShortKeys = InputOptions.Undo.ToString();
+            _menuEditRedo.ShortKeys = InputOptions.Redo.ToString();
+            _menuEditCut.ShortKeys = InputOptions.Cut.ToString();
+            _menuEditCopy.ShortKeys = InputOptions.Copy.ToString();
+            _menuEditDelete.ShortKeys = InputOptions.Delete.ToString();
+            _menuEditDuplicate.ShortKeys = InputOptions.Duplicate.ToString();
+            _menuEditSelectAll.ShortKeys = InputOptions.SelectAll.ToString();
+            _menuEditDeselectAll.ShortKeys = InputOptions.DeselectAll.ToString();
+            _menuEditFind.ShortKeys = InputOptions.Search.ToString();
+            _menuGamePlayGame.ShortKeys = InputOptions.Play.ToString();
+            _menuGamePlayCurrentScenes.ShortKeys = InputOptions.PlayCurrentScenes.ToString();
+            _menuGamePause.ShortKeys = InputOptions.Pause.ToString();
+            _menuGameStop.ShortKeys = InputOptions.Play.ToString();
+            _menuGameCookAndRun.ShortKeys = InputOptions.CookAndRun.ToString();
+            _menuGameRunCookedGame.ShortKeys = InputOptions.RunCookedGame.ToString();
+            _menuToolsBuildScenes.ShortKeys = InputOptions.BuildScenesData.ToString();
+            _menuToolsBakeLightmaps.ShortKeys = InputOptions.BakeLightmaps.ToString();
+            _menuToolsClearLightmaps.ShortKeys = InputOptions.ClearLightmaps.ToString();
+            _menuToolsBakeAllEnvProbes.ShortKeys = InputOptions.BakeEnvProbes.ToString();
+            _menuToolsBuildCSGMesh.ShortKeys = InputOptions.BuildCSG.ToString();
+            _menuToolsBuildNavMesh.ShortKeys = InputOptions.BuildNav.ToString();
+            _menuToolsBuildAllMeshesSDF.ShortKeys = InputOptions.BuildSDF.ToString();
+            _menuToolsProfilerWindow.ShortKeys = InputOptions.ProfilerWindow.ToString();
+            _menuToolsTakeScreenshot.ShortKeys = InputOptions.TakeScreenshot.ToString();
 
             MainMenuShortcutKeysUpdated?.Invoke();
 
@@ -703,25 +701,23 @@ namespace FlaxEditor.Modules
 
         private void InitToolstrip(RootControl mainWindow)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             ToolStrip = new ToolStrip(34.0f, MainMenu.Bottom)
             {
                 Parent = mainWindow,
             };
 
-            _toolStripSaveAll = ToolStrip.AddButton(Editor.Icons.Save64, Editor.SaveAll).LinkTooltip("Save all", ref inputOptions.Save);
+            _toolStripSaveAll = ToolStrip.AddButton(Editor.Icons.Save64, Editor.SaveAll).LinkTooltip("Save all", InputOptions.Save);
             ToolStrip.AddSeparator();
-            _toolStripUndo = ToolStrip.AddButton(Editor.Icons.Undo64, Editor.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _toolStripRedo = ToolStrip.AddButton(Editor.Icons.Redo64, Editor.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _toolStripUndo = ToolStrip.AddButton(Editor.Icons.Undo64, Editor.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _toolStripRedo = ToolStrip.AddButton(Editor.Icons.Redo64, Editor.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             ToolStrip.AddSeparator();
-            _toolStripTranslate = ToolStrip.AddButton(Editor.Icons.Translate32, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate).LinkTooltip("Change Gizmo tool mode to Translate", ref inputOptions.TranslateMode);
-            _toolStripRotate = ToolStrip.AddButton(Editor.Icons.Rotate32, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate).LinkTooltip("Change Gizmo tool mode to Rotate", ref inputOptions.RotateMode);
-            _toolStripScale = ToolStrip.AddButton(Editor.Icons.Scale32, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale).LinkTooltip("Change Gizmo tool mode to Scale", ref inputOptions.ScaleMode);
+            _toolStripTranslate = ToolStrip.AddButton(Editor.Icons.Translate32, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate).LinkTooltip("Change Gizmo tool mode to Translate", InputOptions.TranslateMode);
+            _toolStripRotate = ToolStrip.AddButton(Editor.Icons.Rotate32, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate).LinkTooltip("Change Gizmo tool mode to Rotate", InputOptions.RotateMode);
+            _toolStripScale = ToolStrip.AddButton(Editor.Icons.Scale32, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale).LinkTooltip("Change Gizmo tool mode to Scale", InputOptions.ScaleMode);
             ToolStrip.AddSeparator();
 
             // Play
-            _toolStripPlay = ToolStrip.AddButton(Editor.Icons.Play64, Editor.Simulation.DelegatePlayOrStopPlayInEditor).LinkTooltip("Play In Editor", ref inputOptions.Play);
+            _toolStripPlay = ToolStrip.AddButton(Editor.Icons.Play64, Editor.Simulation.DelegatePlayOrStopPlayInEditor).LinkTooltip("Play In Editor", InputOptions.Play);
             _toolStripPlay.ContextMenu = new ContextMenu();
             var playSubMenu = _toolStripPlay.ContextMenu.AddChildMenu("Play button action");
             var playActionGroup = new ContextMenuSingleSelectGroup<InterfaceOptions.PlayAction>();
@@ -742,16 +738,16 @@ namespace FlaxEditor.Modules
             windowModesGroup.SelectedChanged = SetGameWindowMode;
             Editor.Options.OptionsChanged += options => { windowModesGroup.Selected = options.Interface.DefaultGameWindowMode; };
 
-            _toolStripPause = ToolStrip.AddButton(Editor.Icons.Pause64, Editor.Simulation.RequestResumeOrPause).LinkTooltip("Pause/Resume game", ref inputOptions.Pause);
-            _toolStripStep = ToolStrip.AddButton(Editor.Icons.Skip64, Editor.Simulation.RequestPlayOneFrame).LinkTooltip("Step one frame in game", ref inputOptions.StepFrame);
+            _toolStripPause = ToolStrip.AddButton(Editor.Icons.Pause64, Editor.Simulation.RequestResumeOrPause).LinkTooltip("Pause/Resume game", InputOptions.Pause);
+            _toolStripStep = ToolStrip.AddButton(Editor.Icons.Skip64, Editor.Simulation.RequestPlayOneFrame).LinkTooltip("Step one frame in game", InputOptions.StepFrame);
 
             ToolStrip.AddSeparator();
 
             // Build scenes
-            _toolStripBuildScenes = ToolStrip.AddButton(Editor.Icons.Build64, Editor.BuildScenesOrCancel).LinkTooltip("Build scenes data - CSG, navmesh, static lighting, env probes - configurable via Build Actions in editor options", ref inputOptions.BuildScenesData);
+            _toolStripBuildScenes = ToolStrip.AddButton(Editor.Icons.Build64, Editor.BuildScenesOrCancel).LinkTooltip("Build scenes data - CSG, navmesh, static lighting, env probes - configurable via Build Actions in editor options", InputOptions.BuildScenesData);
 
             // Cook and run
-            _toolStripCook = ToolStrip.AddButton(Editor.Icons.ShipIt64, Editor.Windows.GameCookerWin.BuildAndRun).LinkTooltip("Cook & Run - build game for the current platform and run it locally", ref inputOptions.CookAndRun);
+            _toolStripCook = ToolStrip.AddButton(Editor.Icons.ShipIt64, Editor.Windows.GameCookerWin.BuildAndRun).LinkTooltip("Cook & Run - build game for the current platform and run it locally", InputOptions.CookAndRun);
             _toolStripCook.ContextMenu = new ContextMenu();
             _toolStripCook.ContextMenu.AddButton("Run cooked game", Editor.Windows.GameCookerWin.RunCooked);
             _toolStripCook.ContextMenu.AddSeparator();

--- a/Source/Editor/Modules/ViewportWidgetsModule.cs
+++ b/Source/Editor/Modules/ViewportWidgetsModule.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using FlaxEditor.Viewport;
+using FlaxEditor.Viewport.Widgets;
+using FlaxEngine;
+
+namespace FlaxEditor.Modules
+{
+    /// <summary>
+    /// Used to store and manage widgets used in viewports.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Modules.EditorModule" />
+    public class ViewportWidgetsModule : EditorModule
+    {
+
+        //holds all widget instances
+        private Dictionary<EditorViewport, Dictionary<WidgetNames, ViewportWidget>> _widgetsByViewport = new();
+
+        //factory
+        private readonly Dictionary<WidgetNames, Func<EditorViewport, ViewportWidget>> _widgetFactories = new()
+        {
+            [WidgetNames.Camera] = vp => new CameraSettingsWidget(0, 0, vp),
+            [WidgetNames.Viewmode] = vp => new ViewmodeWidget(0, 0, vp),
+        };
+
+
+        public enum WidgetNames
+        {
+            Camera,
+            Viewmode
+        }
+
+        internal ViewportWidgetsModule(Editor editor)
+        : base(editor)
+        {
+            InitOrder = -74;
+        }
+
+        public override void OnInit()
+        {
+            InitializeViewportWidgets();
+        }
+
+        public void InitializeViewportWidgets()
+        {
+            //defines which widgets are in a viewport
+            Dictionary<EditorViewport, List<WidgetNames>> _editorViewportWidgets = new()
+            {
+                [Editor.Instance.Windows.EditWin.Viewport] = new List<WidgetNames>
+            {
+                WidgetNames.Camera,
+                WidgetNames.Viewmode
+            },
+            };
+
+            foreach (var pair in _editorViewportWidgets)
+            {
+                var viewport = pair.Key;
+                if (viewport == null)
+                {
+                    Debug.LogWarning("InitializeViewportWidgets: Encountered null EditorViewport.");
+                    continue;
+                }
+
+                var widgetNames = pair.Value;
+                if (widgetNames == null || widgetNames.Count == 0)
+                {
+                    Debug.LogWarning($"InitializeViewportWidgets: No widget names defined for viewport {viewport}.");
+                    continue;
+                }
+
+                // Ensure dictionary entry exists
+                if (!_widgetsByViewport.ContainsKey(viewport))
+                    _widgetsByViewport[viewport] = new Dictionary<WidgetNames, ViewportWidget>();
+
+                foreach (var name in widgetNames)
+                {
+                    AddToViewport(viewport, name);
+                }
+            }
+        }
+
+
+        public void AddToViewport(EditorViewport viewport, WidgetNames name)
+        {
+            if (viewport == null)
+            {
+                Debug.LogWarning("AddToViewport: Provided viewport is null.");
+                return;
+            }
+
+            if (!_widgetFactories.TryGetValue(name, out var factory))
+            {
+                Debug.LogWarning($"AddToViewport: No factory found for widget '{name}'.");
+                return;
+            }
+
+            if (!_widgetsByViewport.TryGetValue(viewport, out var widgetMap))
+            {
+                widgetMap = new Dictionary<WidgetNames, ViewportWidget>();
+                _widgetsByViewport[viewport] = widgetMap;
+            }
+
+            var widget = factory(viewport);
+            if (widget == null)
+            {
+                Debug.LogWarning($"AddToViewport: Factory for widget '{name}' returned null.");
+                return;
+            }
+
+            widgetMap[name] = widget;
+        }
+    }
+}

--- a/Source/Editor/Options/InputBinding.cs
+++ b/Source/Editor/Options/InputBinding.cs
@@ -80,6 +80,13 @@ namespace FlaxEditor.Options
                     InputTriggers.Add(parsedMouse);
                     continue;
                 }
+                if (
+                    input is MouseScroll
+                    && InputTrigger.TryParseInput(input.ToString(), out var parsedMouseScroll))
+                {
+                    InputTriggers.Add(parsedMouseScroll);
+                    continue;
+                }
                 throw new ArgumentException($"Unsupported input type: {input.GetType().Name}");
             }
         }
@@ -107,17 +114,14 @@ namespace FlaxEditor.Options
             var parts = value.Split('+', StringSplitOptions.RemoveEmptyEntries);
             var triggers = new List<InputTrigger>();
 
-            string parsedString = value + "\n";
             foreach (var part in parts)
             {
                 if (InputTrigger.TryParseInput(part.Trim(), out var trigger))
                 {
                     triggers.Add(trigger);
-                    Debug.Log(parsedString);
                 }
                 else
                 {
-                    Debug.Log(parsedString);
                     result = new InputBinding();
                     return false;
                 }
@@ -242,18 +246,14 @@ namespace FlaxEditor.Options
         {
             if (value is string str)
             {
-                //Debug.Log($"[Converter] Converting '{str}'");
                 if (InputBinding.TryParse(str, out var result))
                 {
-                    //Debug.Log("[Converter] Successs!");
                     return result;
                 }
                 else
                 {
                     throw new NotSupportedException($"InputBindingConverter cannot convert from '{str}' to InputBinding.");
                 }
-
-                //Debug.Log("[Converter] Failed to parse string." + value.ToString());
             }
             return base.ConvertFrom(context, culture, value);
         }
@@ -339,7 +339,6 @@ namespace FlaxEditor.Options
                     return false;
                 }
                 var trigger = new InputTrigger(MouseScrollHelper.GetScrollDirection(delta).ToString());
-                Debug.Log(trigger);
                 if (!_binding.InputTriggers.Contains(trigger))
                 {
                     _binding.InputTriggers.Add(trigger);

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -114,23 +114,23 @@ namespace FlaxEditor.Options
 
         #region File
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(300)]
         public InputBinding SaveScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(310)]
         public InputBinding CloseScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(320)]
         public InputBinding OpenScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(330)]
         public InputBinding GenerateScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(340)]
         public InputBinding RecompileScripts = new InputBinding(KeyboardKeys.None);
 
@@ -150,7 +150,7 @@ namespace FlaxEditor.Options
         [EditorDisplay("Scene", "Play/Stop"), EditorOrder(510)]
         public InputBinding Play = new InputBinding(KeyboardKeys.F5);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Play Current Scenes/Stop"), EditorOrder(520)]
         public InputBinding PlayCurrentScenes = new InputBinding(KeyboardKeys.None);
 
@@ -162,27 +162,27 @@ namespace FlaxEditor.Options
         [EditorDisplay("Scene"), EditorOrder(540)]
         public InputBinding StepFrame = new InputBinding(KeyboardKeys.F11);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Cook & Run"), EditorOrder(550)]
         public InputBinding CookAndRun = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Run cooked game"), EditorOrder(560)]
         public InputBinding RunCookedGame = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Move actor to viewport"), EditorOrder(570)]
         public InputBinding MoveActorToViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Align actor with viewport"), EditorOrder(571)]
         public InputBinding AlignActorWithViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Align viewport with actor"), EditorOrder(572)]
         public InputBinding AlignViewportWithActor = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene"), EditorOrder(573)]
         public InputBinding PilotActor = new InputBinding(KeyboardKeys.None);
 
@@ -198,27 +198,27 @@ namespace FlaxEditor.Options
         [EditorDisplay("Tools", "Build scenes data"), EditorOrder(600)]
         public InputBinding BuildScenesData = new InputBinding(KeyboardKeys.F10 + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Bake lightmaps"), EditorOrder(601)]
         public InputBinding BakeLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Clear lightmaps data"), EditorOrder(602)]
         public InputBinding ClearLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Bake all env probes"), EditorOrder(603)]
         public InputBinding BakeEnvProbes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build CSG mesh"), EditorOrder(604)]
         public InputBinding BuildCSG = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build Nav Mesh"), EditorOrder(605)]
         public InputBinding BuildNav = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build all meshes SDF"), EditorOrder(606)]
         public InputBinding BuildSDF = new InputBinding(KeyboardKeys.None);
 
@@ -230,15 +230,15 @@ namespace FlaxEditor.Options
 
         #region Profiler
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Open Profiler Window"), EditorOrder(630)]
         public InputBinding ProfilerWindow = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Start/Stop Profiler"), EditorOrder(631)]
         public InputBinding ProfilerStartStop = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Clear Profiler data"), EditorOrder(632)]
         public InputBinding ProfilerClear = new InputBinding(KeyboardKeys.None);
 
@@ -326,15 +326,15 @@ namespace FlaxEditor.Options
         [EditorDisplay("Viewport"), EditorOrder(1551)]
         public InputBinding Rotate = new InputBinding(MouseButton.Right);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
         public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1570)]
         public InputBinding CameraIncreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
+        [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1571)]
         public InputBinding CameraDecreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using System.ComponentModel;
-using System.Reflection;
 using FlaxEditor.InputConfig;
 using FlaxEngine;
 
@@ -42,34 +41,6 @@ namespace FlaxEditor.Options
     [HideInEditor]
     public sealed class InputOptions
     {
-        [HideInEditor]
-        public InputBindingList List = new InputBindingList();
-
-        #region General
-
-        /// <summary>
-        /// Gets or sets the mouse movement sensitivity scale applied when using the viewport camera.
-        /// </summary>
-        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
-        [EditorDisplay("General"), EditorOrder(10), Tooltip("The mouse movement sensitivity scale applied when using the viewport camera.")]
-        public float MouseSensitivity { get; set; } = 1.0f;
-
-        /// <summary>
-        /// Gets or sets the mouse wheel sensitivity applied to zoom in orthographic mode.
-        /// </summary>
-        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
-        [EditorDisplay("General"), EditorOrder(11), Tooltip("The mouse wheel sensitivity applied to zoom in orthographic mode.")]
-        public float MouseWheelSensitivity { get; set; } = 1.0f;
-
-        /// <summary>
-        /// Gets or sets whether to invert the Y rotation of the mouse in the editor viewport.
-        /// </summary>
-        [DefaultValue(false)]
-        [EditorDisplay("General"), EditorOrder(12), Tooltip("Whether to invert the Y rotation of the mouse in the editor viewport.")]
-        public bool InvertMouseYAxisRotation { get; set; } = false;
-
-        #endregion
-
         #region Common
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.S)]
@@ -343,71 +314,37 @@ namespace FlaxEditor.Options
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Q)]
         [EditorDisplay("Viewport"), EditorOrder(1550)]
         public InputBinding Down = new InputBinding(KeyboardKeys.Q);
-        
-        /// <summary>
-        /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
-        /// </summary>
-        [DefaultValue(1.0f), Limit(0.05f, 32.0f)]
-        [EditorDisplay("Viewport"), EditorOrder(1570), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
-        public float MovementSpeed { get; set; } = 1.0f;
-
-        /// <summary>
-        /// Gets or sets the default minimum camera movement speed.
-        /// </summary>
-        [DefaultValue(0.05f), Limit(0.05f, 32.0f)]
-        [EditorDisplay("Viewport"), EditorOrder(1580), Tooltip("The default minimum movement speed for the viewport camera.")]
-        public float MinMovementSpeed { get; set; } = 0.05f;
-
-        /// <summary>
-        /// Gets or sets the default maximum camera movement speed.
-        /// </summary>
-        [DefaultValue(32.0f), Limit(16.0f, 1000.0f)]
-        [EditorDisplay("Viewport"), EditorOrder(1590), Tooltip("The default maximum movement speed for the viewport camera.")]
-        public float MaxMovementSpeed { get; set; } = 32f;
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alt + "+" + MouseButtonString.Left)]
-        [EditorDisplay("Viewport"), EditorOrder(1600)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
         public InputBinding Orbit = new InputBinding(MouseButton.Middle + "+" + KeyboardKeys.Alt);
 
         [DefaultValue(typeof(InputBinding), MouseButtonString.Middle)]
-        [EditorDisplay("Viewport"), EditorOrder(1610)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
         public InputBinding Pan = new InputBinding(MouseButton.Middle);
 
-        /// <summary>
-        /// Gets or sets the default panning direction for the viewport camera.
-        /// </summary>
-        [DefaultValue(false)]
-        [EditorDisplay("Viewport"), EditorOrder(1620), Tooltip("The default panning direction for the viewport camera.")]
-        public bool InvertPanning { get; set; } = false;
-
-        /// <summary>
-        /// Gets or sets the default relative panning mode.
-        /// </summary>
-        [DefaultValue(true)]
-        [EditorDisplay("Viewport"), EditorOrder(1630), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
-        public bool UseRelativePanning { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).
-        /// </summary>
-        [DefaultValue(0.8f), Limit(0.01f, 128.0f, 0.1f)]
-        [EditorDisplay("Viewport"), EditorOrder(1640), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
-        public float PanningSpeed { get; set; } = 0.8f;
-
         [DefaultValue(typeof(InputBinding), MouseButtonString.Right)]
-        [EditorDisplay("Viewport"), EditorOrder(1650)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
         public InputBinding Rotate = new InputBinding(MouseButton.Right);
 
+        [DefaultValue(typeof(InputBinding), MouseScrollString.Up)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding ZoomIn = new InputBinding(MouseScroll.ScrollUp);
+
+        [DefaultValue(typeof(InputBinding), MouseScrollString.Down)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding ZoomOut = new InputBinding(MouseScroll.ScrollDown);
+
         [DefaultValue(typeof(InputBinding), "")]
-        [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1660)]
+        [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
         public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
-        [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1670)]
+        [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1570)]
         public InputBinding CameraIncreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
-        [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1671)]
+        [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1571)]
         public InputBinding CameraDecreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad0)]
@@ -459,17 +396,5 @@ namespace FlaxEditor.Options
         public SceneNodeDoubleClick DoubleClickSceneNode = SceneNodeDoubleClick.Expand;
 
         #endregion
-
-        public InputOptions()
-        {
-            foreach (var field in GetType().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
-            {
-                if (field.FieldType == typeof(InputBinding))
-                {
-                    var binding = (InputBinding)field.GetValue(this);
-                    List.Add(binding);
-                }
-            }
-        }
     }
 }

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Security.Cryptography.X509Certificates;
 using FlaxEditor.InputConfig;
 using FlaxEngine;
 
@@ -145,75 +146,76 @@ namespace FlaxEditor.Options
     [HideInEditor]
     public sealed class InputOptions
     {
-        public static Dictionary<InputOptionName, InputBinding> Dictionary = new();
+        public static Dictionary<InputOptionName, InputBinding> Dictionary = [];
+
         #region Common
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.S)]
         [EditorDisplay("Common"), EditorOrder(100)]
-        public InputBinding Save = new InputBinding(KeyboardKeys.S + "+" + KeyboardKeys.Control);
+        public static InputBinding Save { get; set; } = new InputBinding(KeyboardKeys.S + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F2)]
         [EditorDisplay("Common"), EditorOrder(110)]
-        public InputBinding Rename = new InputBinding(KeyboardKeys.F2);
+        public static InputBinding Rename { get; set; } = new InputBinding(KeyboardKeys.F2);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.C)]
         [EditorDisplay("Common"), EditorOrder(120)]
-        public InputBinding Copy = new InputBinding(KeyboardKeys.C + "+" + KeyboardKeys.Control);
+        public static InputBinding Copy { get; set; } = new InputBinding(KeyboardKeys.C + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.X)]
         [EditorDisplay("Common"), EditorOrder(130)]
-        public InputBinding Cut = new InputBinding(KeyboardKeys.X + "+" + KeyboardKeys.Control);
+        public static InputBinding Cut { get; set; } = new InputBinding(KeyboardKeys.X + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.V)]
         [EditorDisplay("Common"), EditorOrder(140)]
-        public InputBinding Paste = new InputBinding(KeyboardKeys.V + "+" + KeyboardKeys.Control);
+        public static InputBinding Paste { get; set; } = new InputBinding(KeyboardKeys.V + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.D)]
         [EditorDisplay("Common"), EditorOrder(150)]
-        public InputBinding Duplicate = new InputBinding(KeyboardKeys.D + "+" + KeyboardKeys.Control);
+        public static InputBinding Duplicate { get; set; } = new InputBinding(KeyboardKeys.D + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Delete)]
         [EditorDisplay("Common"), EditorOrder(160)]
-        public InputBinding Delete = new InputBinding(KeyboardKeys.Delete);
+        public static InputBinding Delete { get; set; } = new InputBinding(KeyboardKeys.Delete);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Z)]
         [EditorDisplay("Common"), EditorOrder(170)]
-        public InputBinding Undo = new InputBinding(KeyboardKeys.Z + "+" + KeyboardKeys.Control);
+        public static InputBinding Undo { get; set; } = new InputBinding(KeyboardKeys.Z + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Y)]
         [EditorDisplay("Common"), EditorOrder(180)]
-        public InputBinding Redo = new InputBinding(KeyboardKeys.Y + "+" + KeyboardKeys.Control);
+        public static InputBinding Redo { get; set; } = new InputBinding(KeyboardKeys.Y + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.A)]
         [EditorDisplay("Common"), EditorOrder(190)]
-        public InputBinding SelectAll = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Control);
+        public static InputBinding SelectAll { get; set; } = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Shift + "+" + KeyboardKeysString.A)]
         [EditorDisplay("Common"), EditorOrder(195)]
-        public InputBinding DeselectAll = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Shift + "+" + KeyboardKeys.Control);
+        public static InputBinding DeselectAll { get; set; } = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Shift + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(200)]
-        public InputBinding FocusSelection = new InputBinding(KeyboardKeys.F);
+        public static InputBinding FocusSelection { get; set; } = new InputBinding(KeyboardKeys.F);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(200)]
-        public InputBinding LockFocusSelection = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Shift);
+        public static InputBinding LockFocusSelection { get; set; } = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Shift);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(210)]
-        public InputBinding Search = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Control);
+        public static InputBinding Search { get; set; } = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.O)]
         [EditorDisplay("Common"), EditorOrder(220)]
-        public InputBinding ContentFinder = new InputBinding(KeyboardKeys.O + "+" + KeyboardKeys.Control);
+        public static InputBinding ContentFinder { get; set; } = new InputBinding(KeyboardKeys.O + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.R)]
         [EditorDisplay("Common"), EditorOrder(230)]
-        public InputBinding RotateSelection = new InputBinding(KeyboardKeys.R);
+        public static InputBinding RotateSelection { get; set; } = new InputBinding(KeyboardKeys.R);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Common"), EditorOrder(240)]
-        public InputBinding ToggleFullscreen = new InputBinding(KeyboardKeys.F11);
+        public static InputBinding ToggleFullscreen { get; set; } = new InputBinding(KeyboardKeys.F11);
 
         #endregion
 
@@ -221,23 +223,23 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(300)]
-        public InputBinding SaveScenes = new InputBinding(KeyboardKeys.None);
+        public static InputBinding SaveScenes { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(310)]
-        public InputBinding CloseScenes = new InputBinding(KeyboardKeys.None);
+        public static InputBinding CloseScenes { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(320)]
-        public InputBinding OpenScriptsProject = new InputBinding(KeyboardKeys.None);
+        public static InputBinding OpenScriptsProject { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(330)]
-        public InputBinding GenerateScriptsProject = new InputBinding(KeyboardKeys.None);
+        public static InputBinding GenerateScriptsProject { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("File"), EditorOrder(340)]
-        public InputBinding RecompileScripts = new InputBinding(KeyboardKeys.None);
+        public static InputBinding RecompileScripts { get; set; } = new InputBinding(KeyboardKeys.None);
 
         #endregion
 
@@ -245,55 +247,55 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.End)]
         [EditorDisplay("Scene", "Snap To Ground"), EditorOrder(500)]
-        public InputBinding SnapToGround = new InputBinding(KeyboardKeys.End);
+        public static InputBinding SnapToGround { get; set; } = new InputBinding(KeyboardKeys.End);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.V)]
         [EditorDisplay("Scene", "Vertex Snapping"), EditorOrder(550)]
-        public InputBinding SnapToVertex = new InputBinding(KeyboardKeys.V);
+        public static InputBinding SnapToVertex { get; set; } = new InputBinding(KeyboardKeys.V);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F5)]
         [EditorDisplay("Scene", "Play/Stop"), EditorOrder(510)]
-        public InputBinding Play = new InputBinding(KeyboardKeys.F5);
+        public static InputBinding Play { get; set; } = new InputBinding(KeyboardKeys.F5);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Play Current Scenes/Stop"), EditorOrder(520)]
-        public InputBinding PlayCurrentScenes = new InputBinding(KeyboardKeys.None);
+        public static InputBinding PlayCurrentScenes { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F6)]
         [EditorDisplay("Scene"), EditorOrder(530)]
-        public InputBinding Pause = new InputBinding(KeyboardKeys.F6);
+        public static InputBinding Pause { get; set; } = new InputBinding(KeyboardKeys.F6);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Scene"), EditorOrder(540)]
-        public InputBinding StepFrame = new InputBinding(KeyboardKeys.F11);
+        public static InputBinding StepFrame { get; set; } = new InputBinding(KeyboardKeys.F11);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Cook & Run"), EditorOrder(550)]
-        public InputBinding CookAndRun = new InputBinding(KeyboardKeys.None);
+        public static InputBinding CookAndRun { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Run cooked game"), EditorOrder(560)]
-        public InputBinding RunCookedGame = new InputBinding(KeyboardKeys.None);
+        public static InputBinding RunCookedGame { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Move actor to viewport"), EditorOrder(570)]
-        public InputBinding MoveActorToViewport = new InputBinding(KeyboardKeys.None);
+        public static InputBinding MoveActorToViewport { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Align actor with viewport"), EditorOrder(571)]
-        public InputBinding AlignActorWithViewport = new InputBinding(KeyboardKeys.None);
+        public static InputBinding AlignActorWithViewport { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene", "Align viewport with actor"), EditorOrder(572)]
-        public InputBinding AlignViewportWithActor = new InputBinding(KeyboardKeys.None);
+        public static InputBinding AlignViewportWithActor { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Scene"), EditorOrder(573)]
-        public InputBinding PilotActor = new InputBinding(KeyboardKeys.None);
+        public static InputBinding PilotActor { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.G)]
         [EditorDisplay("Scene"), EditorOrder(574)]
-        public InputBinding GroupSelectedActors = new InputBinding(KeyboardKeys.G + "+" + KeyboardKeys.Control);
+        public static InputBinding GroupSelectedActors { get; set; } = new InputBinding(KeyboardKeys.G + "+" + KeyboardKeys.Control);
 
         #endregion
 
@@ -301,35 +303,35 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.F10)]
         [EditorDisplay("Tools", "Build scenes data"), EditorOrder(600)]
-        public InputBinding BuildScenesData = new InputBinding(KeyboardKeys.F10 + "+" + KeyboardKeys.Control);
+        public static InputBinding BuildScenesData { get; set; } = new InputBinding(KeyboardKeys.F10 + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Bake lightmaps"), EditorOrder(601)]
-        public InputBinding BakeLightmaps = new InputBinding(KeyboardKeys.None);
+        public static InputBinding BakeLightmaps { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Clear lightmaps data"), EditorOrder(602)]
-        public InputBinding ClearLightmaps = new InputBinding(KeyboardKeys.None);
+        public static InputBinding ClearLightmaps { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Bake all env probes"), EditorOrder(603)]
-        public InputBinding BakeEnvProbes = new InputBinding(KeyboardKeys.None);
+        public static InputBinding BakeEnvProbes { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build CSG mesh"), EditorOrder(604)]
-        public InputBinding BuildCSG = new InputBinding(KeyboardKeys.None);
+        public static InputBinding BuildCSG { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build Nav Mesh"), EditorOrder(605)]
-        public InputBinding BuildNav = new InputBinding(KeyboardKeys.None);
+        public static InputBinding BuildNav { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Tools", "Build all meshes SDF"), EditorOrder(606)]
-        public InputBinding BuildSDF = new InputBinding(KeyboardKeys.None);
+        public static InputBinding BuildSDF { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F12)]
         [EditorDisplay("Tools", "Take screenshot"), EditorOrder(607)]
-        public InputBinding TakeScreenshot = new InputBinding(KeyboardKeys.F12);
+        public static InputBinding TakeScreenshot { get; set; } = new InputBinding(KeyboardKeys.F12);
 
         #endregion
 
@@ -337,15 +339,15 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Open Profiler Window"), EditorOrder(630)]
-        public InputBinding ProfilerWindow = new InputBinding(KeyboardKeys.None);
+        public static InputBinding ProfilerWindow { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Start/Stop Profiler"), EditorOrder(631)]
-        public InputBinding ProfilerStartStop = new InputBinding(KeyboardKeys.None);
+        public static InputBinding ProfilerStartStop { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Profiler", "Clear Profiler data"), EditorOrder(632)]
-        public InputBinding ProfilerClear = new InputBinding(KeyboardKeys.None);
+        public static InputBinding ProfilerClear { get; set; } = new InputBinding(KeyboardKeys.None);
 
         #endregion
 
@@ -353,23 +355,23 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F5)]
         [EditorDisplay("Debugger", "Continue"), EditorOrder(810)]
-        public InputBinding DebuggerContinue = new InputBinding(KeyboardKeys.F5);
+        public static InputBinding DebuggerContinue { get; set; } = new InputBinding(KeyboardKeys.F5);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Unlock mouse in Play Mode"), EditorOrder(820)]
-        public InputBinding DebuggerUnlockMouse = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
+        public static InputBinding DebuggerUnlockMouse { get; set; } = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F10)]
         [EditorDisplay("Debugger", "Step Over"), EditorOrder(830)]
-        public InputBinding DebuggerStepOver = new InputBinding(KeyboardKeys.F10);
+        public static InputBinding DebuggerStepOver { get; set; } = new InputBinding(KeyboardKeys.F10);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Step Into"), EditorOrder(840)]
-        public InputBinding DebuggerStepInto = new InputBinding(KeyboardKeys.F11);
+        public static InputBinding DebuggerStepInto { get; set; } = new InputBinding(KeyboardKeys.F11);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Step Out"), EditorOrder(850)]
-        public InputBinding DebuggerStepOut = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
+        public static InputBinding DebuggerStepOut { get; set; } = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
 
         #endregion
 
@@ -377,19 +379,19 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha1)]
         [EditorDisplay("Gizmo"), EditorOrder(1000)]
-        public InputBinding TranslateMode = new InputBinding(KeyboardKeys.Alpha1);
+        public static InputBinding TranslateMode { get; set; } = new InputBinding(KeyboardKeys.Alpha1);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha2)]
         [EditorDisplay("Gizmo"), EditorOrder(1010)]
-        public InputBinding RotateMode = new InputBinding(KeyboardKeys.Alpha2);
+        public static InputBinding RotateMode { get; set; } = new InputBinding(KeyboardKeys.Alpha2);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha3)]
         [EditorDisplay("Gizmo"), EditorOrder(1020)]
-        public InputBinding ScaleMode = new InputBinding(KeyboardKeys.Alpha3);
+        public static InputBinding ScaleMode { get; set; } = new InputBinding(KeyboardKeys.Alpha3);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha4)]
         [EditorDisplay("Gizmo"), EditorOrder(1030)]
-        public InputBinding ToggleTransformSpace = new InputBinding(KeyboardKeys.Alpha4);
+        public static InputBinding ToggleTransformSpace { get; set; } = new InputBinding(KeyboardKeys.Alpha4);
 
         #endregion
 
@@ -397,87 +399,87 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.W)]
         [EditorDisplay("Viewport"), EditorOrder(1500)]
-        public InputBinding Forward = new InputBinding(KeyboardKeys.W);
+        public static InputBinding Forward { get; set; } = new InputBinding(KeyboardKeys.W);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.S)]
         [EditorDisplay("Viewport"), EditorOrder(1510)]
-        public InputBinding Backward = new InputBinding(KeyboardKeys.S);
+        public static InputBinding Backward { get; set; } = new InputBinding(KeyboardKeys.S);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.A)]
         [EditorDisplay("Viewport"), EditorOrder(1520)]
-        public InputBinding Left = new InputBinding(KeyboardKeys.A);
+        public static InputBinding Left { get; set; } = new InputBinding(KeyboardKeys.A);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.D)]
         [EditorDisplay("Viewport"), EditorOrder(1530)]
-        public InputBinding Right = new InputBinding(KeyboardKeys.D);
+        public static InputBinding Right { get; set; } = new InputBinding(KeyboardKeys.D);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.E)]
         [EditorDisplay("Viewport"), EditorOrder(1540)]
-        public InputBinding Up = new InputBinding(KeyboardKeys.E);
+        public static InputBinding Up { get; set; } = new InputBinding(KeyboardKeys.E);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Q)]
         [EditorDisplay("Viewport"), EditorOrder(1550)]
-        public InputBinding Down = new InputBinding(KeyboardKeys.Q);
+        public static InputBinding Down { get; set; } = new InputBinding(KeyboardKeys.Q);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alt + "+" + MouseButtonString.Left)]
         [EditorDisplay("Viewport"), EditorOrder(1551)]
-        public InputBinding Orbit = new InputBinding(MouseButton.Middle + "+" + KeyboardKeys.Alt);
+        public static InputBinding Orbit { get; set; } = new InputBinding(MouseButton.Middle + "+" + KeyboardKeys.Alt);
 
         [DefaultValue(typeof(InputBinding), MouseButtonString.Middle)]
         [EditorDisplay("Viewport"), EditorOrder(1551)]
-        public InputBinding Pan = new InputBinding(MouseButton.Middle);
+        public static InputBinding Pan { get; set; } = new InputBinding(MouseButton.Middle);
 
         [DefaultValue(typeof(InputBinding), MouseButtonString.Right)]
         [EditorDisplay("Viewport"), EditorOrder(1551)]
-        public InputBinding Rotate = new InputBinding(MouseButton.Right);
+        public static InputBinding Rotate { get; set; } = new InputBinding(MouseButton.Right);
 
         [DefaultValue(typeof(InputBinding), MouseScrollString.Up)]
         [EditorDisplay("Viewport"), EditorOrder(1551)]
-        public InputBinding ZoomIn = new InputBinding(MouseScroll.ScrollUp);
+        public static InputBinding ZoomIn { get; set; } = new InputBinding(MouseScroll.ScrollUp);
 
         [DefaultValue(typeof(InputBinding), MouseScrollString.Down)]
         [EditorDisplay("Viewport"), EditorOrder(1551)]
-        public InputBinding ZoomOut = new InputBinding(MouseScroll.ScrollDown);
+        public static InputBinding ZoomOut { get; set; } = new InputBinding(MouseScroll.ScrollDown);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
-        public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);
+        public static InputBinding CameraToggleRotation { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1570)]
-        public InputBinding CameraIncreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
+        public static InputBinding CameraIncreaseMoveSpeed { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
         [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1571)]
-        public InputBinding CameraDecreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
+        public static InputBinding CameraDecreaseMoveSpeed { get; set; } = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad0)]
         [EditorDisplay("Viewport"), EditorOrder(1700)]
-        public InputBinding ViewpointFront = new InputBinding(KeyboardKeys.Numpad0);
+        public static InputBinding ViewpointFront { get; set; } = new InputBinding(KeyboardKeys.Numpad0);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad5)]
         [EditorDisplay("Viewport"), EditorOrder(1710)]
-        public InputBinding ViewpointBack = new InputBinding(KeyboardKeys.Numpad5);
+        public static InputBinding ViewpointBack { get; set; } = new InputBinding(KeyboardKeys.Numpad5);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad4)]
         [EditorDisplay("Viewport"), EditorOrder(1720)]
-        public InputBinding ViewpointLeft = new InputBinding(KeyboardKeys.Numpad4);
+        public static InputBinding ViewpointLeft { get; set; } = new InputBinding(KeyboardKeys.Numpad4);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad6)]
         [EditorDisplay("Viewport"), EditorOrder(1730)]
-        public InputBinding ViewpointRight = new InputBinding(KeyboardKeys.Numpad6);
+        public static InputBinding ViewpointRight { get; set; } = new InputBinding(KeyboardKeys.Numpad6);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad8)]
         [EditorDisplay("Viewport"), EditorOrder(1740)]
-        public InputBinding ViewpointTop = new InputBinding(KeyboardKeys.Numpad8);
+        public static InputBinding ViewpointTop { get; set; } = new InputBinding(KeyboardKeys.Numpad8);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad2)]
         [EditorDisplay("Viewport"), EditorOrder(1750)]
-        public InputBinding ViewpointBottom = new InputBinding(KeyboardKeys.Numpad2);
+        public static InputBinding ViewpointBottom { get; set; } = new InputBinding(KeyboardKeys.Numpad2);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.NumpadDecimal)]
         [EditorDisplay("Viewport"), EditorOrder(1760)]
-        public InputBinding ToggleOrthographic = new InputBinding(KeyboardKeys.NumpadDecimal);
+        public static InputBinding ToggleOrthographic { get; set; } = new InputBinding(KeyboardKeys.NumpadDecimal);
 
         #endregion
 
@@ -485,15 +487,15 @@ namespace FlaxEditor.Options
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.W)]
         [EditorDisplay("Interface"), EditorOrder(2000)]
-        public InputBinding CloseTab = new InputBinding(KeyboardKeys.W + "+" + KeyboardKeys.Control);
+        public static InputBinding CloseTab { get; set; } = new InputBinding(KeyboardKeys.W + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Tab)]
         [EditorDisplay("Interface"), EditorOrder(2010)]
-        public InputBinding NextTab = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control);
+        public static InputBinding NextTab { get; set; } = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Shift + "+" + KeyboardKeysString.Tab)]
         [EditorDisplay("Interface"), EditorOrder(2020)]
-        public InputBinding PreviousTab = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control + "+" + KeyboardKeys.Shift);
+        public static InputBinding PreviousTab { get; set; } = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control + "+" + KeyboardKeys.Shift);
 
         [DefaultValue(SceneNodeDoubleClick.Expand)]
         [EditorDisplay("Interface"), EditorOrder(2030)]

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using FlaxEditor.InputConfig;
 using FlaxEngine;
@@ -509,15 +510,15 @@ namespace FlaxEditor.Options
             var type = typeof(InputOptions);
             foreach (InputOptionName name in Enum.GetValues(typeof(InputOptionName)))
             {
-                var field = type.GetField(name.ToString());
-                if (field != null && field.FieldType == typeof(InputBinding))
+                var field = type.GetProperty(name.ToString(), BindingFlags.Public | BindingFlags.Static);
+                if (field != null && field.PropertyType == typeof(InputBinding))
                 {
-                    var binding = (InputBinding)field.GetValue(this);
+                    var binding = (InputBinding)field.GetValue(null); // null for static
                     Dictionary[name] = binding;
                 }
                 else
                 {
-                    Debug.LogWarning($"InputOptionName '{name}' does not match any InputBinding field.");
+                    Debug.LogWarning($"InputOptionName '{name}' does not match any static InputBinding property.");
                 }
             }
         }

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -42,71 +42,71 @@ namespace FlaxEditor.Options
     {
         #region Common
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+S")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.S)]
         [EditorDisplay("Common"), EditorOrder(100)]
-        public InputBinding Save = new InputBinding(KeyboardKeys.S, KeyboardKeys.Control);
+        public InputBinding Save = new InputBinding(KeyboardKeys.S + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "F2")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F2)]
         [EditorDisplay("Common"), EditorOrder(110)]
         public InputBinding Rename = new InputBinding(KeyboardKeys.F2);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+C")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.C)]
         [EditorDisplay("Common"), EditorOrder(120)]
-        public InputBinding Copy = new InputBinding(KeyboardKeys.C, KeyboardKeys.Control);
+        public InputBinding Copy = new InputBinding(KeyboardKeys.C + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+X")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.X)]
         [EditorDisplay("Common"), EditorOrder(130)]
-        public InputBinding Cut = new InputBinding(KeyboardKeys.X, KeyboardKeys.Control);
+        public InputBinding Cut = new InputBinding(KeyboardKeys.X + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+V")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.V)]
         [EditorDisplay("Common"), EditorOrder(140)]
-        public InputBinding Paste = new InputBinding(KeyboardKeys.V, KeyboardKeys.Control);
+        public InputBinding Paste = new InputBinding(KeyboardKeys.V + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+D")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.D)]
         [EditorDisplay("Common"), EditorOrder(150)]
-        public InputBinding Duplicate = new InputBinding(KeyboardKeys.D, KeyboardKeys.Control);
+        public InputBinding Duplicate = new InputBinding(KeyboardKeys.D + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Delete")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Delete)]
         [EditorDisplay("Common"), EditorOrder(160)]
         public InputBinding Delete = new InputBinding(KeyboardKeys.Delete);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Z")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Z)]
         [EditorDisplay("Common"), EditorOrder(170)]
-        public InputBinding Undo = new InputBinding(KeyboardKeys.Z, KeyboardKeys.Control);
+        public InputBinding Undo = new InputBinding(KeyboardKeys.Z + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Y")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Y)]
         [EditorDisplay("Common"), EditorOrder(180)]
-        public InputBinding Redo = new InputBinding(KeyboardKeys.Y, KeyboardKeys.Control);
+        public InputBinding Redo = new InputBinding(KeyboardKeys.Y + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+A")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.A)]
         [EditorDisplay("Common"), EditorOrder(190)]
-        public InputBinding SelectAll = new InputBinding(KeyboardKeys.A, KeyboardKeys.Control);
+        public InputBinding SelectAll = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Shift+A")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Shift + "+" + KeyboardKeysString.A)]
         [EditorDisplay("Common"), EditorOrder(195)]
-        public InputBinding DeselectAll = new InputBinding(KeyboardKeys.A, KeyboardKeys.Shift, KeyboardKeys.Control);
+        public InputBinding DeselectAll = new InputBinding(KeyboardKeys.A + "+" + KeyboardKeys.Shift + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "F")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(200)]
         public InputBinding FocusSelection = new InputBinding(KeyboardKeys.F);
 
-        [DefaultValue(typeof(InputBinding), "Shift+F")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(200)]
-        public InputBinding LockFocusSelection = new InputBinding(KeyboardKeys.F, KeyboardKeys.Shift);
+        public InputBinding LockFocusSelection = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Shift);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+F")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.F)]
         [EditorDisplay("Common"), EditorOrder(210)]
-        public InputBinding Search = new InputBinding(KeyboardKeys.F, KeyboardKeys.Control);
+        public InputBinding Search = new InputBinding(KeyboardKeys.F + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+O")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.O)]
         [EditorDisplay("Common"), EditorOrder(220)]
-        public InputBinding ContentFinder = new InputBinding(KeyboardKeys.O, KeyboardKeys.Control);
+        public InputBinding ContentFinder = new InputBinding(KeyboardKeys.O + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "R")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.R)]
         [EditorDisplay("Common"), EditorOrder(230)]
         public InputBinding RotateSelection = new InputBinding(KeyboardKeys.R);
 
-        [DefaultValue(typeof(InputBinding), "F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Common"), EditorOrder(240)]
         public InputBinding ToggleFullscreen = new InputBinding(KeyboardKeys.F11);
 
@@ -114,23 +114,23 @@ namespace FlaxEditor.Options
 
         #region File
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(300)]
         public InputBinding SaveScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(310)]
         public InputBinding CloseScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(320)]
         public InputBinding OpenScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(330)]
         public InputBinding GenerateScriptsProject = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("File"), EditorOrder(340)]
         public InputBinding RecompileScripts = new InputBinding(KeyboardKeys.None);
 
@@ -138,91 +138,91 @@ namespace FlaxEditor.Options
 
         #region Scene
 
-        [DefaultValue(typeof(InputBinding), "End")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.End)]
         [EditorDisplay("Scene", "Snap To Ground"), EditorOrder(500)]
         public InputBinding SnapToGround = new InputBinding(KeyboardKeys.End);
 
-        [DefaultValue(typeof(InputBinding), "End")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.V)]
         [EditorDisplay("Scene", "Vertex Snapping"), EditorOrder(550)]
         public InputBinding SnapToVertex = new InputBinding(KeyboardKeys.V);
 
-        [DefaultValue(typeof(InputBinding), "F5")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F5)]
         [EditorDisplay("Scene", "Play/Stop"), EditorOrder(510)]
         public InputBinding Play = new InputBinding(KeyboardKeys.F5);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Play Current Scenes/Stop"), EditorOrder(520)]
         public InputBinding PlayCurrentScenes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "F6")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F6)]
         [EditorDisplay("Scene"), EditorOrder(530)]
         public InputBinding Pause = new InputBinding(KeyboardKeys.F6);
 
-        [DefaultValue(typeof(InputBinding), "F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Scene"), EditorOrder(540)]
         public InputBinding StepFrame = new InputBinding(KeyboardKeys.F11);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Cook & Run"), EditorOrder(550)]
         public InputBinding CookAndRun = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Run cooked game"), EditorOrder(560)]
         public InputBinding RunCookedGame = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Move actor to viewport"), EditorOrder(570)]
         public InputBinding MoveActorToViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Align actor with viewport"), EditorOrder(571)]
         public InputBinding AlignActorWithViewport = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene", "Align viewport with actor"), EditorOrder(572)]
         public InputBinding AlignViewportWithActor = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Scene"), EditorOrder(573)]
         public InputBinding PilotActor = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+G")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.G)]
         [EditorDisplay("Scene"), EditorOrder(574)]
-        public InputBinding GroupSelectedActors = new InputBinding(KeyboardKeys.G, KeyboardKeys.Control);
+        public InputBinding GroupSelectedActors = new InputBinding(KeyboardKeys.G + "+" + KeyboardKeys.Control);
 
         #endregion
 
         #region Tools
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+F10")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.F10)]
         [EditorDisplay("Tools", "Build scenes data"), EditorOrder(600)]
-        public InputBinding BuildScenesData = new InputBinding(KeyboardKeys.F10, KeyboardKeys.Control);
+        public InputBinding BuildScenesData = new InputBinding(KeyboardKeys.F10 + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Bake lightmaps"), EditorOrder(601)]
         public InputBinding BakeLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Clear lightmaps data"), EditorOrder(602)]
         public InputBinding ClearLightmaps = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Bake all env probes"), EditorOrder(603)]
         public InputBinding BakeEnvProbes = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Build CSG mesh"), EditorOrder(604)]
         public InputBinding BuildCSG = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Build Nav Mesh"), EditorOrder(605)]
         public InputBinding BuildNav = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Tools", "Build all meshes SDF"), EditorOrder(606)]
         public InputBinding BuildSDF = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "F12")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F12)]
         [EditorDisplay("Tools", "Take screenshot"), EditorOrder(607)]
         public InputBinding TakeScreenshot = new InputBinding(KeyboardKeys.F12);
 
@@ -230,15 +230,15 @@ namespace FlaxEditor.Options
 
         #region Profiler
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Profiler", "Open Profiler Window"), EditorOrder(630)]
         public InputBinding ProfilerWindow = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Profiler", "Start/Stop Profiler"), EditorOrder(631)]
         public InputBinding ProfilerStartStop = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Profiler", "Clear Profiler data"), EditorOrder(632)]
         public InputBinding ProfilerClear = new InputBinding(KeyboardKeys.None);
 
@@ -246,43 +246,43 @@ namespace FlaxEditor.Options
 
         #region Debugger
 
-        [DefaultValue(typeof(InputBinding), "F5")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F5)]
         [EditorDisplay("Debugger", "Continue"), EditorOrder(810)]
         public InputBinding DebuggerContinue = new InputBinding(KeyboardKeys.F5);
 
-        [DefaultValue(typeof(InputBinding), "Shift+F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Unlock mouse in Play Mode"), EditorOrder(820)]
-        public InputBinding DebuggerUnlockMouse = new InputBinding(KeyboardKeys.F11, KeyboardKeys.Shift);
+        public InputBinding DebuggerUnlockMouse = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
 
-        [DefaultValue(typeof(InputBinding), "F10")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F10)]
         [EditorDisplay("Debugger", "Step Over"), EditorOrder(830)]
         public InputBinding DebuggerStepOver = new InputBinding(KeyboardKeys.F10);
 
-        [DefaultValue(typeof(InputBinding), "F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Step Into"), EditorOrder(840)]
         public InputBinding DebuggerStepInto = new InputBinding(KeyboardKeys.F11);
 
-        [DefaultValue(typeof(InputBinding), "Shift+F11")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Shift + "+" + KeyboardKeysString.F11)]
         [EditorDisplay("Debugger", "Step Out"), EditorOrder(850)]
-        public InputBinding DebuggerStepOut = new InputBinding(KeyboardKeys.F11, KeyboardKeys.Shift);
+        public InputBinding DebuggerStepOut = new InputBinding(KeyboardKeys.F11 + "+" + KeyboardKeys.Shift);
 
         #endregion
 
         #region Gizmo
 
-        [DefaultValue(typeof(InputBinding), "Alpha1")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha1)]
         [EditorDisplay("Gizmo"), EditorOrder(1000)]
         public InputBinding TranslateMode = new InputBinding(KeyboardKeys.Alpha1);
 
-        [DefaultValue(typeof(InputBinding), "Alpha2")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha2)]
         [EditorDisplay("Gizmo"), EditorOrder(1010)]
         public InputBinding RotateMode = new InputBinding(KeyboardKeys.Alpha2);
 
-        [DefaultValue(typeof(InputBinding), "Alpha3")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha3)]
         [EditorDisplay("Gizmo"), EditorOrder(1020)]
         public InputBinding ScaleMode = new InputBinding(KeyboardKeys.Alpha3);
 
-        [DefaultValue(typeof(InputBinding), "Alpha4")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alpha4)]
         [EditorDisplay("Gizmo"), EditorOrder(1030)]
         public InputBinding ToggleTransformSpace = new InputBinding(KeyboardKeys.Alpha4);
 
@@ -290,67 +290,79 @@ namespace FlaxEditor.Options
 
         #region Viewport
 
-        [DefaultValue(typeof(InputBinding), "W")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.W)]
         [EditorDisplay("Viewport"), EditorOrder(1500)]
         public InputBinding Forward = new InputBinding(KeyboardKeys.W);
 
-        [DefaultValue(typeof(InputBinding), "S")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.S)]
         [EditorDisplay("Viewport"), EditorOrder(1510)]
         public InputBinding Backward = new InputBinding(KeyboardKeys.S);
 
-        [DefaultValue(typeof(InputBinding), "A")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.A)]
         [EditorDisplay("Viewport"), EditorOrder(1520)]
         public InputBinding Left = new InputBinding(KeyboardKeys.A);
 
-        [DefaultValue(typeof(InputBinding), "D")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.D)]
         [EditorDisplay("Viewport"), EditorOrder(1530)]
         public InputBinding Right = new InputBinding(KeyboardKeys.D);
 
-        [DefaultValue(typeof(InputBinding), "E")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.E)]
         [EditorDisplay("Viewport"), EditorOrder(1540)]
         public InputBinding Up = new InputBinding(KeyboardKeys.E);
 
-        [DefaultValue(typeof(InputBinding), "Q")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Q)]
         [EditorDisplay("Viewport"), EditorOrder(1550)]
         public InputBinding Down = new InputBinding(KeyboardKeys.Q);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alt + "+" + MouseButtonString.Left)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding Orbit = new InputBinding(MouseButton.Middle + "+" + KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), MouseButtonString.Middle)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding Pan = new InputBinding(MouseButton.Middle);
+
+        [DefaultValue(typeof(InputBinding), MouseButtonString.Right)]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding Rotate = new InputBinding(MouseButton.Right);
+
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
         public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1570)]
         public InputBinding CameraIncreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "None")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.None)]
         [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1571)]
         public InputBinding CameraDecreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
-        [DefaultValue(typeof(InputBinding), "Numpad0")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad0)]
         [EditorDisplay("Viewport"), EditorOrder(1700)]
         public InputBinding ViewpointFront = new InputBinding(KeyboardKeys.Numpad0);
 
-        [DefaultValue(typeof(InputBinding), "Numpad5")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad5)]
         [EditorDisplay("Viewport"), EditorOrder(1710)]
         public InputBinding ViewpointBack = new InputBinding(KeyboardKeys.Numpad5);
 
-        [DefaultValue(typeof(InputBinding), "Numpad4")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad4)]
         [EditorDisplay("Viewport"), EditorOrder(1720)]
         public InputBinding ViewpointLeft = new InputBinding(KeyboardKeys.Numpad4);
 
-        [DefaultValue(typeof(InputBinding), "Numpad6")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad6)]
         [EditorDisplay("Viewport"), EditorOrder(1730)]
         public InputBinding ViewpointRight = new InputBinding(KeyboardKeys.Numpad6);
 
-        [DefaultValue(typeof(InputBinding), "Numpad8")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad8)]
         [EditorDisplay("Viewport"), EditorOrder(1740)]
         public InputBinding ViewpointTop = new InputBinding(KeyboardKeys.Numpad8);
 
-        [DefaultValue(typeof(InputBinding), "Numpad2")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad2)]
         [EditorDisplay("Viewport"), EditorOrder(1750)]
         public InputBinding ViewpointBottom = new InputBinding(KeyboardKeys.Numpad2);
 
-        [DefaultValue(typeof(InputBinding), "NumpadDecimal")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.NumpadDecimal)]
         [EditorDisplay("Viewport"), EditorOrder(1760)]
         public InputBinding ToggleOrthographic = new InputBinding(KeyboardKeys.NumpadDecimal);
 
@@ -358,17 +370,17 @@ namespace FlaxEditor.Options
 
         #region Interface
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+W")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.W)]
         [EditorDisplay("Interface"), EditorOrder(2000)]
-        public InputBinding CloseTab = new InputBinding(KeyboardKeys.W, KeyboardKeys.Control);
+        public InputBinding CloseTab = new InputBinding(KeyboardKeys.W + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Ctrl+Tab")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Tab)]
         [EditorDisplay("Interface"), EditorOrder(2010)]
-        public InputBinding NextTab = new InputBinding(KeyboardKeys.Tab, KeyboardKeys.Control);
+        public InputBinding NextTab = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control);
 
-        [DefaultValue(typeof(InputBinding), "Shift+Ctrl+Tab")]
+        [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.Shift + "+" + KeyboardKeysString.Tab)]
         [EditorDisplay("Interface"), EditorOrder(2020)]
-        public InputBinding PreviousTab = new InputBinding(KeyboardKeys.Tab, KeyboardKeys.Control, KeyboardKeys.Shift);
+        public InputBinding PreviousTab = new InputBinding(KeyboardKeys.Tab + "+" + KeyboardKeys.Control + "+" + KeyboardKeys.Shift);
 
         [DefaultValue(SceneNodeDoubleClick.Expand)]
         [EditorDisplay("Interface"), EditorOrder(2030)]

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using FlaxEditor.InputConfig;
 using FlaxEngine;
@@ -8,6 +10,108 @@ using FlaxEngine;
 
 namespace FlaxEditor.Options
 {
+    public enum InputOptionName
+    {
+        None,
+        // Common
+        Save,
+        Rename,
+        Copy,
+        Cut,
+        Paste,
+        Duplicate,
+        Delete,
+        Undo,
+        Redo,
+        SelectAll,
+        DeselectAll,
+        FocusSelection,
+        LockFocusSelection,
+        Search,
+        ContentFinder,
+        RotateSelection,
+        ToggleFullscreen,
+
+        // File
+        SaveScenes,
+        CloseScenes,
+        OpenScriptsProject,
+        GenerateScriptsProject,
+        RecompileScripts,
+
+        // Scene
+        SnapToGround,
+        SnapToVertex,
+        Play,
+        PlayCurrentScenes,
+        Pause,
+        StepFrame,
+        CookAndRun,
+        RunCookedGame,
+        MoveActorToViewport,
+        AlignActorWithViewport,
+        AlignViewportWithActor,
+        PilotActor,
+        GroupSelectedActors,
+
+        // Tools
+        BuildScenesData,
+        BakeLightmaps,
+        ClearLightmaps,
+        BakeEnvProbes,
+        BuildCSG,
+        BuildNav,
+        BuildSDF,
+        TakeScreenshot,
+
+        // Profiler
+        ProfilerWindow,
+        ProfilerStartStop,
+        ProfilerClear,
+
+        // Debugger
+        DebuggerContinue,
+        DebuggerUnlockMouse,
+        DebuggerStepOver,
+        DebuggerStepInto,
+        DebuggerStepOut,
+
+        // Gizmo
+        TranslateMode,
+        RotateMode,
+        ScaleMode,
+        ToggleTransformSpace,
+
+        // Viewport
+        Forward,
+        Backward,
+        Left,
+        Right,
+        Up,
+        Down,
+        Orbit,
+        Pan,
+        Rotate,
+        ZoomIn,
+        ZoomOut,
+        CameraToggleRotation,
+        CameraIncreaseMoveSpeed,
+        CameraDecreaseMoveSpeed,
+        ViewpointFront,
+        ViewpointBack,
+        ViewpointLeft,
+        ViewpointRight,
+        ViewpointTop,
+        ViewpointBottom,
+        ToggleOrthographic,
+
+        // Interface
+        CloseTab,
+        NextTab,
+        PreviousTab,
+        DoubleClickSceneNode
+    }
+
     /// <summary>
     /// Action to perform when a Scene Node receive a double mouse left click.
     /// </summary>
@@ -41,8 +145,8 @@ namespace FlaxEditor.Options
     [HideInEditor]
     public sealed class InputOptions
     {
+        public static Dictionary<InputOptionName, InputBinding> Dictionary = new();
         #region Common
-
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.S)]
         [EditorDisplay("Common"), EditorOrder(100)]
         public InputBinding Save = new InputBinding(KeyboardKeys.S + "+" + KeyboardKeys.Control);
@@ -396,5 +500,24 @@ namespace FlaxEditor.Options
         public SceneNodeDoubleClick DoubleClickSceneNode = SceneNodeDoubleClick.Expand;
 
         #endregion
+
+        //populate the dictionary for our ground truth inputs
+        public InputOptions()
+        {
+            var type = typeof(InputOptions);
+            foreach (InputOptionName name in Enum.GetValues(typeof(InputOptionName)))
+            {
+                var field = type.GetField(name.ToString());
+                if (field != null && field.FieldType == typeof(InputBinding))
+                {
+                    var binding = (InputBinding)field.GetValue(this);
+                    Dictionary[name] = binding;
+                }
+                else
+                {
+                    Debug.LogWarning($"InputOptionName '{name}' does not match any InputBinding field.");
+                }
+            }
+        }
     }
 }

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -42,7 +42,34 @@ namespace FlaxEditor.Options
     [HideInEditor]
     public sealed class InputOptions
     {
+        [HideInEditor]
         public InputBindingList List = new InputBindingList();
+
+        #region General
+
+        /// <summary>
+        /// Gets or sets the mouse movement sensitivity scale applied when using the viewport camera.
+        /// </summary>
+        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
+        [EditorDisplay("General"), EditorOrder(10), Tooltip("The mouse movement sensitivity scale applied when using the viewport camera.")]
+        public float MouseSensitivity { get; set; } = 1.0f;
+
+        /// <summary>
+        /// Gets or sets the mouse wheel sensitivity applied to zoom in orthographic mode.
+        /// </summary>
+        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
+        [EditorDisplay("General"), EditorOrder(11), Tooltip("The mouse wheel sensitivity applied to zoom in orthographic mode.")]
+        public float MouseWheelSensitivity { get; set; } = 1.0f;
+
+        /// <summary>
+        /// Gets or sets whether to invert the Y rotation of the mouse in the editor viewport.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("General"), EditorOrder(12), Tooltip("Whether to invert the Y rotation of the mouse in the editor viewport.")]
+        public bool InvertMouseYAxisRotation { get; set; } = false;
+
+        #endregion
+
         #region Common
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.S)]
@@ -316,29 +343,71 @@ namespace FlaxEditor.Options
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Q)]
         [EditorDisplay("Viewport"), EditorOrder(1550)]
         public InputBinding Down = new InputBinding(KeyboardKeys.Q);
+        
+        /// <summary>
+        /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
+        /// </summary>
+        [DefaultValue(1.0f), Limit(0.05f, 32.0f)]
+        [EditorDisplay("Viewport"), EditorOrder(1570), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
+        public float MovementSpeed { get; set; } = 1.0f;
+
+        /// <summary>
+        /// Gets or sets the default minimum camera movement speed.
+        /// </summary>
+        [DefaultValue(0.05f), Limit(0.05f, 32.0f)]
+        [EditorDisplay("Viewport"), EditorOrder(1580), Tooltip("The default minimum movement speed for the viewport camera.")]
+        public float MinMovementSpeed { get; set; } = 0.05f;
+
+        /// <summary>
+        /// Gets or sets the default maximum camera movement speed.
+        /// </summary>
+        [DefaultValue(32.0f), Limit(16.0f, 1000.0f)]
+        [EditorDisplay("Viewport"), EditorOrder(1590), Tooltip("The default maximum movement speed for the viewport camera.")]
+        public float MaxMovementSpeed { get; set; } = 32f;
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Alt + "+" + MouseButtonString.Left)]
-        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        [EditorDisplay("Viewport"), EditorOrder(1600)]
         public InputBinding Orbit = new InputBinding(MouseButton.Middle + "+" + KeyboardKeys.Alt);
 
         [DefaultValue(typeof(InputBinding), MouseButtonString.Middle)]
-        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        [EditorDisplay("Viewport"), EditorOrder(1610)]
         public InputBinding Pan = new InputBinding(MouseButton.Middle);
 
+        /// <summary>
+        /// Gets or sets the default panning direction for the viewport camera.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Viewport"), EditorOrder(1620), Tooltip("The default panning direction for the viewport camera.")]
+        public bool InvertPanning { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the default relative panning mode.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Viewport"), EditorOrder(1630), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
+        public bool UseRelativePanning { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).
+        /// </summary>
+        [DefaultValue(0.8f), Limit(0.01f, 128.0f, 0.1f)]
+        [EditorDisplay("Viewport"), EditorOrder(1640), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
+        public float PanningSpeed { get; set; } = 0.8f;
+
         [DefaultValue(typeof(InputBinding), MouseButtonString.Right)]
-        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        [EditorDisplay("Viewport"), EditorOrder(1650)]
         public InputBinding Rotate = new InputBinding(MouseButton.Right);
 
         [DefaultValue(typeof(InputBinding), "")]
-        [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
+        [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1660)]
         public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
-        [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1570)]
+        [EditorDisplay("Viewport", "Increase Camera Move Speed"), EditorOrder(1670)]
         public InputBinding CameraIncreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), "")]
-        [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1571)]
+        [EditorDisplay("Viewport", "Decrease Camera Move Speed"), EditorOrder(1671)]
         public InputBinding CameraDecreaseMoveSpeed = new InputBinding(KeyboardKeys.None);
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Numpad0)]

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using System.ComponentModel;
+using System.Reflection;
+using FlaxEditor.InputConfig;
 using FlaxEngine;
 
 #pragma warning disable 1591
@@ -40,6 +42,7 @@ namespace FlaxEditor.Options
     [HideInEditor]
     public sealed class InputOptions
     {
+        public InputBindingList List = new InputBindingList();
         #region Common
 
         [DefaultValue(typeof(InputBinding), KeyboardKeysString.Control + "+" + KeyboardKeysString.S)]
@@ -387,5 +390,17 @@ namespace FlaxEditor.Options
         public SceneNodeDoubleClick DoubleClickSceneNode = SceneNodeDoubleClick.Expand;
 
         #endregion
+
+        public InputOptions()
+        {
+            foreach (var field in GetType().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                if (field.FieldType == typeof(InputBinding))
+                {
+                    var binding = (InputBinding)field.GetValue(this);
+                    List.Add(binding);
+                }
+            }
+        }
     }
 }

--- a/Source/Editor/Options/InputTrigger.cs
+++ b/Source/Editor/Options/InputTrigger.cs
@@ -76,7 +76,6 @@ namespace FlaxEditor.Options
             }
 
             trigger = new InputTrigger();
-            Debug.Log("problem parsing " + token);
             return false;
         }
         /// <summary>

--- a/Source/Editor/Options/InputTrigger.cs
+++ b/Source/Editor/Options/InputTrigger.cs
@@ -1,0 +1,109 @@
+using System;
+using FlaxEngine;
+
+namespace FlaxEditor.Options
+{
+    /// <summary>
+    /// The input trigger, either mouse or keyboard
+    /// </summary>
+    [Serializable]
+    public struct InputTrigger : IEquatable<InputTrigger>
+    {
+        public enum InputType { Mouse, Key, None }
+        public MouseButton Button;
+        public KeyboardKeys Key;
+        public InputType Type;
+        public bool IsKeyboard => Type == InputType.Key;
+        public bool IsMouse => Type == InputType.Mouse;
+        public InputTrigger(string token)
+        {
+            if (!TryParseInput(token, out var parsed))
+                throw new ArgumentException($"Invalid input trigger token: {token}");
+
+            this = parsed;
+        }
+        public override string ToString()
+        {
+            return Type switch
+            {
+                InputType.Key => Key.ToString(),
+                InputType.Mouse => Button.ToString(),
+                _ => string.Empty
+            };
+        }
+        public static bool TryParseInput(string token, out InputTrigger trigger)
+        {
+            token = token.Trim(); // Always trim!
+
+            if (Enum.TryParse<KeyboardKeys>(token, true, out var key))
+            {
+                trigger = new InputTrigger()
+                {
+                    Type = InputType.Key,
+                    Button = MouseButton.None,
+                    Key = key
+                };
+                return true;
+            }
+
+            if (Enum.TryParse<MouseButton>(token, true, out var button))
+            {
+                trigger = new InputTrigger()
+                {
+                    Type = InputType.Mouse,
+                    Button = button,
+                    Key = KeyboardKeys.None
+                };
+                return true;
+            }
+            trigger = new InputTrigger();
+            Debug.Log("problem parsing " + token);
+            return false;
+        }
+        /// <summary>
+        /// Checks whether this individual input trigger is currently active.
+        /// </summary>
+        /// <param name="getKey">Function to check if a specific keyboard key is pressed.</param>
+        /// <param name="getMouse">Function to check if a specific mouse button is pressed.</param>
+        /// <returns>True if the trigger is currently active; otherwise, false.</returns>
+        public bool IsPressed(Func<KeyboardKeys, bool> getKey, Func<MouseButton, bool> getMouse)
+        {
+            return Type switch
+            {
+                InputType.Key => getKey(Key),
+                InputType.Mouse => getMouse(Button),
+                _ => false
+            };
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is InputTrigger other && Equals(other);
+        }
+        public override int GetHashCode()
+        {
+            return Type switch
+            {
+                InputType.Key => HashCode.Combine(Type, (int)Key),
+                InputType.Mouse => HashCode.Combine(Type, (int)Button),
+                _ => Type.GetHashCode()
+            };
+        }
+
+        public bool Equals(InputTrigger other)
+        {
+            return Type == other.Type &&
+                   Key == other.Key &&
+                   Button == other.Button;
+        }
+
+        public static bool operator ==(InputTrigger left, InputTrigger right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(InputTrigger left, InputTrigger right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/Source/Editor/Options/MouseScroll.cs
+++ b/Source/Editor/Options/MouseScroll.cs
@@ -1,0 +1,31 @@
+#pragma warning disable 1591
+using System;
+
+namespace FlaxEngine
+{
+    public enum MouseScroll
+    {
+        None = 0,
+        ScrollUp = 1,
+        ScrollDown = -1
+    }
+
+    public static class MouseScrollHelper
+    {
+        public static MouseScroll GetScrollDirection(float delta)
+        {
+            if (delta > 0)
+                return MouseScroll.ScrollUp;
+            if (delta < 0)
+                return MouseScroll.ScrollDown;
+            return MouseScroll.None;
+        }
+    }
+
+    public static class MouseScrollString
+    {
+        public const string None = "None";
+        public const string Up = "ScrollUp";
+        public const string Down = "ScrollDown";
+    }
+}

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -11,26 +11,6 @@ namespace FlaxEditor.Options
     [CustomEditor(typeof(Editor<ViewportOptions>))]
     public class ViewportOptions
     {
-        /// <summary>
-        /// Gets or sets the mouse movement sensitivity scale applied when using the viewport camera.
-        /// </summary>
-        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
-        [EditorDisplay("General"), EditorOrder(100), Tooltip("The mouse movement sensitivity scale applied when using the viewport camera.")]
-        public float MouseSensitivity { get; set; } = 1.0f;
-
-        /// <summary>
-        /// Gets or sets the mouse wheel sensitivity applied to zoom in orthographic mode.
-        /// </summary>
-        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
-        [EditorDisplay("General"), EditorOrder(101), Tooltip("The mouse wheel sensitivity applied to zoom in orthographic mode.")]
-        public float MouseWheelSensitivity { get; set; } = 1.0f;
-        
-        /// <summary>
-        /// Gets or sets whether to invert the Y rotation of the mouse in the editor viewport.
-        /// </summary>
-        [DefaultValue(false)]
-        [EditorDisplay("General"), EditorOrder(102), Tooltip("Whether to invert the Y rotation of the mouse in the editor viewport.")]
-        public bool InvertMouseYAxisRotation { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the total amount of steps the camera needs to go from minimum to maximum speed.
@@ -47,94 +27,54 @@ namespace FlaxEditor.Options
         public float CameraEasingDegree { get; set; } = 3.0f;
 
         /// <summary>
-        /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
-        /// </summary>
-        [DefaultValue(1.0f), Limit(0.05f, 32.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
-        public float MovementSpeed { get; set; } = 1.0f;
-
-        /// <summary>
-        /// Gets or sets the default minimum camera movement speed.
-        /// </summary>
-        [DefaultValue(0.05f), Limit(0.05f, 32.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(121), Tooltip("The default minimum movement speed for the viewport camera.")]
-        public float MinMovementSpeed { get; set; } = 0.05f;
-
-        /// <summary>
-        /// Gets or sets the default maximum camera movement speed.
-        /// </summary>
-        [DefaultValue(32.0f), Limit(16.0f, 1000.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(122), Tooltip("The default maximum movement speed for the viewport camera.")]
-        public float MaxMovementSpeed { get; set; } = 32f;
-
-        /// <summary>
         /// Gets or sets the default camera easing mode.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Defaults"), EditorOrder(130), Tooltip("The default camera easing mode.")]
+        [EditorDisplay("Camera"), EditorOrder(130), Tooltip("The default camera easing mode.")]
         public bool UseCameraEasing { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default near clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(10.0f), Limit(0.001f, 1000.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(140), Tooltip("The default near clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Camera"), EditorOrder(140), Tooltip("The default near clipping plane distance for the viewport camera.")]
         public float NearPlane { get; set; } = 10.0f;
 
         /// <summary>
         /// Gets or sets the default far clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(40000.0f), Limit(10.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(150), Tooltip("The default far clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Camera"), EditorOrder(150), Tooltip("The default far clipping plane distance for the viewport camera.")]
         public float FarPlane { get; set; } = 40000.0f;
 
         /// <summary>
         /// Gets or sets the default field of view angle (in degrees) for the viewport camera.
         /// </summary>
         [DefaultValue(60.0f), Limit(35.0f, 160.0f, 0.1f)]
-        [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
+        [EditorDisplay("Camera"), EditorOrder(160), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
         public float FieldOfView { get; set; } = 60.0f;
 
         /// <summary>
         /// Gets or sets the default camera orthographic mode.
         /// </summary>
         [DefaultValue(false)]
-        [EditorDisplay("Defaults"), EditorOrder(170), Tooltip("The default camera orthographic mode.")]
+        [EditorDisplay("Camera"), EditorOrder(170), Tooltip("The default camera orthographic mode.")]
         public bool UseOrthographicProjection { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the default camera orthographic scale (if camera uses orthographic mode).
         /// </summary>
         [DefaultValue(5.0f), Limit(0.001f, 100000.0f, 0.1f)]
-        [EditorDisplay("Defaults"), EditorOrder(180), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
+        [EditorDisplay("Camera"), EditorOrder(180), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
         public float OrthographicScale { get; set; } = 5.0f;
 
-        /// <summary>
-        /// Gets or sets the default panning direction for the viewport camera.
-        /// </summary>
-        [DefaultValue(false)]
-        [EditorDisplay("Defaults"), EditorOrder(190), Tooltip("The default panning direction for the viewport camera.")]
-        public bool InvertPanning { get; set; } = false;
 
-        /// <summary>
-        /// Gets or sets the default relative panning mode.
-        /// </summary>
-        [DefaultValue(true)]
-        [EditorDisplay("Defaults"), EditorOrder(200), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
-        public bool UseRelativePanning { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).
-        /// </summary>
-        [DefaultValue(0.8f), Limit(0.01f, 128.0f, 0.1f)]
-        [EditorDisplay("Defaults"), EditorOrder(210), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
-        public float PanningSpeed { get; set; } = 0.8f;
 
         /// <summary>
         /// Gets or sets the default editor viewport grid scale.
         /// </summary>
         [DefaultValue(50.0f), Limit(25.0f, 500.0f, 5.0f)]
-        [EditorDisplay("Defaults"), EditorOrder(220), Tooltip("The default editor viewport grid scale.")]
+        [EditorDisplay("Grid"), EditorOrder(220), Tooltip("The default editor viewport grid scale.")]
         public float ViewportGridScale { get; set; } = 50.0f;
 
         /// <summary>

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -11,13 +11,61 @@ namespace FlaxEditor.Options
     [CustomEditor(typeof(Editor<ViewportOptions>))]
     public class ViewportOptions
     {
+        /// <summary>
+        /// Gets or sets the mouse movement sensitivity scale applied when using the viewport camera.
+        /// </summary>
+        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
+        [EditorDisplay("General"), EditorOrder(100), Tooltip("The mouse movement sensitivity scale applied when using the viewport camera.")]
+        public float MouseSensitivity { get; set; } = 1.0f;
 
         /// <summary>
-        /// Gets or sets the total amount of steps the camera needs to go from minimum to maximum speed.
+        /// Gets or sets the mouse movement speed applied when using the viewport camera.
         /// </summary>
-        [DefaultValue(64), Limit(1, 128)]
-        [EditorDisplay("Camera"), EditorOrder(110), Tooltip("The total amount of steps the camera needs to go from minimum to maximum speed.")]
-        public int TotalCameraSpeedSteps { get; set; } = 64;
+        [DefaultValue(1.0f), Limit(0.01f, 5.0f)]
+        [EditorDisplay("General"), EditorOrder(100), Tooltip("The mouse movement speed applied when using the viewport camera.")]
+        public float MouseSpeed { get; set; } = 1.0f;
+
+        /// <summary>
+        /// Gets or sets the mouse wheel sensitivity applied to zoom in orthographic mode.
+        /// </summary>
+        [DefaultValue(1.0f), Limit(0.01f, 100.0f)]
+        [EditorDisplay("General"), EditorOrder(101), Tooltip("The mouse wheel sensitivity applied to zoom in orthographic mode.")]
+        public float MouseWheelSensitivity { get; set; } = 1.0f;
+
+        /// <summary>
+        /// Gets or sets the mouse acceleration.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("General"), EditorOrder(101), Tooltip("Use mouse acceleration?")]
+        public bool MouseAcceleration { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the mouse acceleration scale.
+        /// </summary>
+        [DefaultValue(0.1f), Limit(0.01f, 1.0f)]
+        [EditorDisplay("General"), EditorOrder(101), Tooltip("The mouse acceleration factor.")]
+        public float MouseAccelerationScale { get; set; } = 0.1f;
+
+        /// <summary>
+        /// Gets or sets the mouse smoothing, uses frame-averaged delta filtering.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("General"), EditorOrder(101), Tooltip("The mouse filtering/smoothing.")]
+        public bool MouseFiltering { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the mouse smoothing frame window.
+        /// </summary>
+        [DefaultValue(3), Limit(1, 10)]
+        [EditorDisplay("General"), EditorOrder(101), Tooltip("The number of frames over which to filter.")]
+        public int MouseFilteringFrames { get; set; } = 3;
+
+        /// <summary>
+        /// Gets or sets whether to invert the Y rotation of the mouse in the editor viewport.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("General"), EditorOrder(102), Tooltip("Whether to invert the Y rotation of the mouse in the editor viewport.")]
+        public bool InvertMouseYAxisRotation { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the degree to which the camera will be eased when using camera flight in the editor window.
@@ -27,54 +75,94 @@ namespace FlaxEditor.Options
         public float CameraEasingDegree { get; set; } = 3.0f;
 
         /// <summary>
+        /// Gets or sets the default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).
+        /// </summary>
+        [DefaultValue(1.0f), Limit(0.05f, 32.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(120), Tooltip("The default movement speed for the viewport camera (must be in range between minimum and maximum movement speed values).")]
+        public float MovementSpeed { get; set; } = 1.0f;
+
+        /// <summary>
+        /// Gets or sets the default minimum camera movement speed.
+        /// </summary>
+        [DefaultValue(0.05f), Limit(0.05f, 32.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(121), Tooltip("The default minimum movement speed for the viewport camera.")]
+        public float MinMovementSpeed { get; set; } = 0.05f;
+
+        /// <summary>
+        /// Gets or sets the default maximum camera movement speed.
+        /// </summary>
+        [DefaultValue(32.0f), Limit(16.0f, 1000.0f)]
+        [EditorDisplay("Defaults"), EditorOrder(122), Tooltip("The default maximum movement speed for the viewport camera.")]
+        public float MaxMovementSpeed { get; set; } = 32f;
+
+        /// <summary>
         /// Gets or sets the default camera easing mode.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Camera"), EditorOrder(130), Tooltip("The default camera easing mode.")]
+        [EditorDisplay("Defaults"), EditorOrder(130), Tooltip("The default camera easing mode.")]
         public bool UseCameraEasing { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default near clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(10.0f), Limit(0.001f, 1000.0f)]
-        [EditorDisplay("Camera"), EditorOrder(140), Tooltip("The default near clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(140), Tooltip("The default near clipping plane distance for the viewport camera.")]
         public float NearPlane { get; set; } = 10.0f;
 
         /// <summary>
         /// Gets or sets the default far clipping plane distance for the viewport camera.
         /// </summary>
         [DefaultValue(40000.0f), Limit(10.0f)]
-        [EditorDisplay("Camera"), EditorOrder(150), Tooltip("The default far clipping plane distance for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(150), Tooltip("The default far clipping plane distance for the viewport camera.")]
         public float FarPlane { get; set; } = 40000.0f;
 
         /// <summary>
         /// Gets or sets the default field of view angle (in degrees) for the viewport camera.
         /// </summary>
         [DefaultValue(60.0f), Limit(35.0f, 160.0f, 0.1f)]
-        [EditorDisplay("Camera"), EditorOrder(160), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
+        [EditorDisplay("Defaults"), EditorOrder(160), Tooltip("The default field of view angle (in degrees) for the viewport camera.")]
         public float FieldOfView { get; set; } = 60.0f;
 
         /// <summary>
         /// Gets or sets the default camera orthographic mode.
         /// </summary>
         [DefaultValue(false)]
-        [EditorDisplay("Camera"), EditorOrder(170), Tooltip("The default camera orthographic mode.")]
-        public bool UseOrthographicProjection { get; set; } = false;
+        [EditorDisplay("Defaults"), EditorOrder(170), Tooltip("The default camera orthographic mode.")]
+        public bool OrthographicProjection { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the default camera orthographic scale (if camera uses orthographic mode).
         /// </summary>
         [DefaultValue(5.0f), Limit(0.001f, 100000.0f, 0.1f)]
-        [EditorDisplay("Camera"), EditorOrder(180), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
+        [EditorDisplay("Defaults"), EditorOrder(180), Tooltip("The default camera orthographic scale (if camera uses orthographic mode).")]
         public float OrthographicScale { get; set; } = 5.0f;
 
+        /// <summary>
+        /// Gets or sets the default panning direction for the viewport camera.
+        /// </summary>
+        [DefaultValue(false)]
+        [EditorDisplay("Defaults"), EditorOrder(190), Tooltip("The default panning direction for the viewport camera.")]
+        public bool InvertPanning { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets the default relative panning mode.
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Defaults"), EditorOrder(200), Tooltip("The default relative panning mode. Uses distance between camera and target to determine panning speed.")]
+        public bool RelativePanning { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the default panning speed (ignored if relative panning is speed enabled).
+        /// </summary>
+        [DefaultValue(0.8f), Limit(0.01f, 128.0f, 0.1f)]
+        [EditorDisplay("Defaults"), EditorOrder(210), Tooltip("The default camera panning speed (ignored if relative panning is enabled).")]
+        public float PanningSpeed { get; set; } = 0.8f;
 
         /// <summary>
         /// Gets or sets the default editor viewport grid scale.
         /// </summary>
         [DefaultValue(50.0f), Limit(25.0f, 500.0f, 5.0f)]
-        [EditorDisplay("Grid"), EditorOrder(220), Tooltip("The default editor viewport grid scale.")]
+        [EditorDisplay("Defaults"), EditorOrder(220), Tooltip("The default editor viewport grid scale.")]
         public float ViewportGridScale { get; set; } = 50.0f;
 
         /// <summary>

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -3,6 +3,7 @@
 using System;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Input;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Utilities;
@@ -184,7 +185,7 @@ namespace FlaxEditor.Surface
             else
             {
                 // Rename on F2
-                if (IsSelected && Editor.Instance.Options.Options.Input.Rename.Process(this))
+                if (IsSelected && InputOptions.Rename.Process(this))
                 {
                     StartRenaming();
                 }

--- a/Source/Editor/Surface/SurfaceUtils.cs
+++ b/Source/Editor/Surface/SurfaceUtils.cs
@@ -587,9 +587,14 @@ namespace FlaxEditor.Surface
             surface.GridSnappingSize = interfaceOptions.SurfaceGridSnappingSize;
 
             // Setup input actions
-            window.InputActions.Add(inputOptions.Undo, undo.PerformUndo);
-            window.InputActions.Add(inputOptions.Redo, undo.PerformRedo);
-            window.InputActions.Add(inputOptions.Search, showSearch);
+            window.InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, undo.PerformUndo),
+                    new(InputOptionName.Redo, undo.PerformRedo),
+                    new(InputOptionName.Search, showSearch)
+                ]
+            );
         }
     }
 }

--- a/Source/Editor/Surface/SurfaceUtils.cs
+++ b/Source/Editor/Surface/SurfaceUtils.cs
@@ -587,9 +587,9 @@ namespace FlaxEditor.Surface
             surface.GridSnappingSize = interfaceOptions.SurfaceGridSnappingSize;
 
             // Setup input actions
-            window.InputActions.Add(options => options.Undo, undo.PerformUndo);
-            window.InputActions.Add(options => options.Redo, undo.PerformRedo);
-            window.InputActions.Add(options => options.Search, showSearch);
+            window.InputActions.Add(inputOptions.Undo, undo.PerformUndo);
+            window.InputActions.Add(inputOptions.Redo, undo.PerformRedo);
+            window.InputActions.Add(inputOptions.Search, showSearch);
         }
     }
 }

--- a/Source/Editor/Surface/SurfaceUtils.cs
+++ b/Source/Editor/Surface/SurfaceUtils.cs
@@ -568,17 +568,16 @@ namespace FlaxEditor.Surface
         {
             var editor = window.Editor;
             var interfaceOptions = editor.Options.Options.Interface;
-            var inputOptions = editor.Options.Options.Input;
             var undo = surface.Undo;
             var showSearch = () => editor.ContentFinding.ShowSearch(window);
 
             // Toolstrip
-            saveButton = toolStrip.AddButton(editor.Icons.Save64, window.Save).LinkTooltip("Save", ref inputOptions.Save);
+            saveButton = toolStrip.AddButton(editor.Icons.Save64, window.Save).LinkTooltip("Save", InputOptions.Save);
             toolStrip.AddSeparator();
-            undoButton = toolStrip.AddButton(editor.Icons.Undo64, undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            redoButton = toolStrip.AddButton(editor.Icons.Redo64, undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            undoButton = toolStrip.AddButton(editor.Icons.Undo64, undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            redoButton = toolStrip.AddButton(editor.Icons.Redo64, undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             toolStrip.AddSeparator();
-            toolStrip.AddButton(editor.Icons.Search64, showSearch).LinkTooltip("Open content search tool",  ref inputOptions.Search);
+            toolStrip.AddButton(editor.Icons.Search64, showSearch).LinkTooltip("Open content search tool",  InputOptions.Search);
             toolStrip.AddButton(editor.Icons.CenterView64, surface.ShowWholeGraph).LinkTooltip("Show whole graph");
             var gridSnapButton = toolStrip.AddButton(editor.Icons.Grid32, surface.ToggleGridSnapping);
             gridSnapButton.LinkTooltip("Toggle grid snapping for nodes.");

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -683,7 +683,7 @@ namespace FlaxEditor.Surface
             if (base.OnKeyDown(key))
                 return true;
 
-            if (InputActions.Process(this))
+            if (InputActions.Process(this) != null)
                 return true;
 
             if (HasNodesSelection)

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -682,7 +682,7 @@ namespace FlaxEditor.Surface
             if (base.OnKeyDown(key))
                 return true;
 
-            if (InputActions.Process(Editor.Instance, this, key))
+            if (InputActions.Process(Editor.Instance, this))
                 return true;
 
             if (HasNodesSelection)

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FlaxEditor.InputConfig;
 using FlaxEditor.Options;
 using FlaxEditor.Surface.Elements;
 using FlaxEditor.Surface.Undo;
@@ -16,7 +17,7 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// The input actions collection to processed during user input.
         /// </summary>
-        public readonly InputActionsContainer InputActions;
+        public readonly InputBindingList InputActions;
 
         /// <summary>
         /// Optional feature.
@@ -682,7 +683,7 @@ namespace FlaxEditor.Surface
             if (base.OnKeyDown(key))
                 return true;
 
-            if (InputActions.Process(Editor.Instance, this))
+            if (InputActions.Process(this))
                 return true;
 
             if (HasNodesSelection)

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -398,14 +398,17 @@ namespace FlaxEditor.Surface
 
             // Setup input actions
             var inputOptions = Editor.Instance.Options.Options.Input;
-            InputActions = new InputBindingList(
-                (inputOptions.Delete, Delete),
-                (inputOptions.SelectAll, SelectAll),
-                (inputOptions.DeselectAll, DeselectAll),
-                (inputOptions.Copy, Copy),
-                (inputOptions.Paste, Paste),
-                (inputOptions.Cut, Cut),
-                (inputOptions.Duplicate, Duplicate)
+            InputActions = new InputBindingList
+            (
+                [
+                    new(InputOptionName.Delete, Delete),
+                    new(InputOptionName.SelectAll, SelectAll),
+                    new(InputOptionName.DeselectAll, DeselectAll),
+                    new(InputOptionName.Copy, Copy),
+                    new(InputOptionName.Paste, Paste),
+                    new(InputOptionName.Cut, Cut),
+                    new(InputOptionName.Duplicate, Duplicate)
+                ]
             );
 
             Context.ControlSpawned += OnSurfaceControlSpawned;

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -397,7 +397,6 @@ namespace FlaxEditor.Surface
             RootContext.Modified += OnRootContextModified;
 
             // Setup input actions
-            var inputOptions = Editor.Instance.Options.Options.Input;
             InputActions = new InputBindingList
             (
                 [

--- a/Source/Editor/Surface/VisjectSurfaceWindow.cs
+++ b/Source/Editor/Surface/VisjectSurfaceWindow.cs
@@ -453,7 +453,7 @@ namespace FlaxEditor.Surface
         {
             var child = _editor.ChildrenEditors[0];
             var container = child.Layout.ContainerControl;
-            var mousePosition = container.PointFromScreen(Input.MouseScreenPosition);
+            var mousePosition = container.PointFromScreen(FlaxEngine.Input.MouseScreenPosition);
             var barSidesExtend = 20.0f;
             var barHeight = 5.0f;
             var barCheckAreaHeight = 40.0f;

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -652,128 +652,128 @@ namespace FlaxEditor.Utilities
 
             switch (type)
             {
-            case 0: // CommonType::Bool:
-                value = stream.ReadByte() != 0;
-                break;
-            case 1: // CommonType::Integer:
-            {
-                value = stream.ReadInt32();
-            }
-                break;
-            case 2: // CommonType::Float:
-            {
-                value = stream.ReadSingle();
-            }
-                break;
-            case 3: // CommonType::Vector2:
-            {
-                value = stream.ReadFloat2();
-            }
-                break;
-            case 4: // CommonType::Vector3:
-            {
-                value = stream.ReadFloat3();
-            }
-                break;
-            case 5: // CommonType::Vector4:
-            {
-                value = stream.ReadFloat4();
-            }
-                break;
-            case 6: // CommonType::Color:
-            {
-                value = stream.ReadColor();
-            }
-                break;
-            case 7: // CommonType::Guid:
-            {
-                value = stream.ReadGuid();
-            }
-                break;
-            case 8: // CommonType::String:
-            {
-                int length = stream.ReadInt32();
-                if (length <= 0)
-                {
-                    value = string.Empty;
-                }
-                else
-                {
-                    var data = new char[length];
-                    for (int i = 0; i < length; i++)
+                case 0: // CommonType::Bool:
+                    value = stream.ReadByte() != 0;
+                    break;
+                case 1: // CommonType::Integer:
                     {
-                        var c = stream.ReadUInt16();
-                        data[i] = (char)(c ^ 953);
+                        value = stream.ReadInt32();
                     }
-                    value = new string(data);
-                }
-                break;
-            }
-            case 9: // CommonType::Box:
-            {
-                value = new BoundingBox(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
+                    break;
+                case 2: // CommonType::Float:
+                    {
+                        value = stream.ReadSingle();
+                    }
+                    break;
+                case 3: // CommonType::Vector2:
+                    {
+                        value = stream.ReadFloat2();
+                    }
+                    break;
+                case 4: // CommonType::Vector3:
+                    {
+                        value = stream.ReadFloat3();
+                    }
+                    break;
+                case 5: // CommonType::Vector4:
+                    {
+                        value = stream.ReadFloat4();
+                    }
+                    break;
+                case 6: // CommonType::Color:
+                    {
+                        value = stream.ReadColor();
+                    }
+                    break;
+                case 7: // CommonType::Guid:
+                    {
+                        value = stream.ReadGuid();
+                    }
+                    break;
+                case 8: // CommonType::String:
+                    {
+                        int length = stream.ReadInt32();
+                        if (length <= 0)
+                        {
+                            value = string.Empty;
+                        }
+                        else
+                        {
+                            var data = new char[length];
+                            for (int i = 0; i < length; i++)
+                            {
+                                var c = stream.ReadUInt16();
+                                data[i] = (char)(c ^ 953);
+                            }
+                            value = new string(data);
+                        }
+                        break;
+                    }
+                case 9: // CommonType::Box:
+                    {
+                        value = new BoundingBox(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
+                                                new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()));
+                    }
+                    break;
+                case 10: // CommonType::Rotation:
+                    {
+                        value = stream.ReadQuaternion();
+                    }
+                    break;
+                case 11: // CommonType::Transform:
+                    {
+                        value = new Transform(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
+                                              new Quaternion(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
+                                              new Float3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()));
+                    }
+                    break;
+                case 12: // CommonType::Sphere:
+                    {
+                        value = new BoundingSphere(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
+                                                   stream.ReadSingle());
+                    }
+                    break;
+                case 13: // CommonType::Rect:
+                    {
+                        value = new Rectangle(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
+                    }
+                    break;
+                case 15: // CommonType::Matrix
+                    {
+                        value = new Matrix(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
+                                           stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
+                                           stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
+                                           stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
+                        break;
+                    }
+                case 16: // CommonType::Blob
+                    {
+                        int length = stream.ReadInt32();
+                        value = stream.ReadBytes(length);
+                        break;
+                    }
+                case 18: // CommonType::Ray
+                    {
+                        value = new Ray(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
                                         new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()));
-            }
-                break;
-            case 10: // CommonType::Rotation:
-            {
-                value = stream.ReadQuaternion();
-            }
-                break;
-            case 11: // CommonType::Transform:
-            {
-                value = new Transform(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
-                                      new Quaternion(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
-                                      new Float3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()));
-            }
-                break;
-            case 12: // CommonType::Sphere:
-            {
-                value = new BoundingSphere(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
-                                           stream.ReadSingle());
-            }
-                break;
-            case 13: // CommonType::Rect:
-            {
-                value = new Rectangle(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
-            }
-                break;
-            case 15: // CommonType::Matrix
-            {
-                value = new Matrix(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
-                                   stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
-                                   stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
-                                   stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
-                break;
-            }
-            case 16: // CommonType::Blob
-            {
-                int length = stream.ReadInt32();
-                value = stream.ReadBytes(length);
-                break;
-            }
-            case 18: // CommonType::Ray
-            {
-                value = new Ray(new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()),
-                                new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle()));
-                break;
-            }
-            case 19: // CommonType::Int2
-            {
-                value = stream.ReadInt2();
-                break;
-            }
-            case 20: // CommonType::Int3
-            {
-                value = stream.ReadInt3();
-                break;
-            }
-            case 21: // CommonType::Int4
-            {
-                value = stream.ReadInt4();
-                break;
-            }
-            default: throw new SystemException();
+                        break;
+                    }
+                case 19: // CommonType::Int2
+                    {
+                        value = stream.ReadInt2();
+                        break;
+                    }
+                case 20: // CommonType::Int3
+                    {
+                        value = stream.ReadInt3();
+                        break;
+                    }
+                case 21: // CommonType::Int4
+                    {
+                        value = stream.ReadInt4();
+                        break;
+                    }
+                default: throw new SystemException();
             }
         }
 
@@ -1302,28 +1302,28 @@ namespace FlaxEditor.Utilities
         {
             switch (category)
             {
-            case FlaxEngine.Utils.ValueCategory.Distance:
-                if (!Units.AutomaticUnitsFormatting)
-                    return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m");
-                var absValue = Mathf.Abs(value);
-                // in case a unit != cm this would be (value / Meters2Units * 100)
-                if (absValue < Units.Meters2Units)
-                    return value.ToString(format, CultureInfo.InvariantCulture) + Units.Unit("cm");
-                if (absValue < Units.Meters2Units * 1000)
-                    return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m");
-                return (value / 1000 / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("km");
-            case FlaxEngine.Utils.ValueCategory.Angle: return value.ToString(format, CultureInfo.InvariantCulture) + "°";
-            case FlaxEngine.Utils.ValueCategory.Time: return value.ToString(format, CultureInfo.InvariantCulture) + Units.Unit("s");
-            // some fonts have a symbol for that: "\u33A7"
-            case FlaxEngine.Utils.ValueCategory.Speed: return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m/s");
-            case FlaxEngine.Utils.ValueCategory.Acceleration: return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m/s²");
-            case FlaxEngine.Utils.ValueCategory.Area: return (value / Units.Meters2Units / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m²");
-            case FlaxEngine.Utils.ValueCategory.Volume: return (value / Units.Meters2Units / Units.Meters2Units / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m³");
-            case FlaxEngine.Utils.ValueCategory.Mass: return value.ToString(format, CultureInfo.InvariantCulture) + Units.Unit("kg");
-            case FlaxEngine.Utils.ValueCategory.Force: return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("N");
-            case FlaxEngine.Utils.ValueCategory.Torque: return (value / Units.Meters2Units / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("Nm");
-            case FlaxEngine.Utils.ValueCategory.None:
-            default: return FormatFloat(value);
+                case FlaxEngine.Utils.ValueCategory.Distance:
+                    if (!Units.AutomaticUnitsFormatting)
+                        return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m");
+                    var absValue = Mathf.Abs(value);
+                    // in case a unit != cm this would be (value / Meters2Units * 100)
+                    if (absValue < Units.Meters2Units)
+                        return value.ToString(format, CultureInfo.InvariantCulture) + Units.Unit("cm");
+                    if (absValue < Units.Meters2Units * 1000)
+                        return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m");
+                    return (value / 1000 / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("km");
+                case FlaxEngine.Utils.ValueCategory.Angle: return value.ToString(format, CultureInfo.InvariantCulture) + "°";
+                case FlaxEngine.Utils.ValueCategory.Time: return value.ToString(format, CultureInfo.InvariantCulture) + Units.Unit("s");
+                // some fonts have a symbol for that: "\u33A7"
+                case FlaxEngine.Utils.ValueCategory.Speed: return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m/s");
+                case FlaxEngine.Utils.ValueCategory.Acceleration: return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m/s²");
+                case FlaxEngine.Utils.ValueCategory.Area: return (value / Units.Meters2Units / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m²");
+                case FlaxEngine.Utils.ValueCategory.Volume: return (value / Units.Meters2Units / Units.Meters2Units / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("m³");
+                case FlaxEngine.Utils.ValueCategory.Mass: return value.ToString(format, CultureInfo.InvariantCulture) + Units.Unit("kg");
+                case FlaxEngine.Utils.ValueCategory.Force: return (value / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("N");
+                case FlaxEngine.Utils.ValueCategory.Torque: return (value / Units.Meters2Units / Units.Meters2Units).ToString(format, CultureInfo.InvariantCulture) + Units.Unit("Nm");
+                case FlaxEngine.Utils.ValueCategory.None:
+                default: return FormatFloat(value);
             }
         }
 
@@ -1463,65 +1463,71 @@ namespace FlaxEditor.Utilities
         public static void SetupCommonInputActions(EditorWindow window)
         {
             var inputActions = window.InputActions;
-
+            var inputOptions = Editor.Instance.Options.Options.Input;
             // Setup input actions
-            inputActions.Add(options => options.Save, Editor.Instance.SaveAll);
-            inputActions.Add(options => options.Undo, () =>
+            inputActions.Add(
+                (inputOptions.Save, Editor.Instance.SaveAll),
+            (inputOptions.Undo, () =>
             {
                 Editor.Instance.PerformUndo();
                 window.Focus();
-            });
-            inputActions.Add(options => options.Redo, () =>
+            }
+            ),
+            (inputOptions.Redo, () =>
             {
                 Editor.Instance.PerformRedo();
                 window.Focus();
-            });
-            inputActions.Add(options => options.Cut, Editor.Instance.SceneEditing.Cut);
-            inputActions.Add(options => options.Copy, Editor.Instance.SceneEditing.Copy);
-            inputActions.Add(options => options.Paste, Editor.Instance.SceneEditing.Paste);
-            inputActions.Add(options => options.Duplicate, Editor.Instance.SceneEditing.Duplicate);
-            inputActions.Add(options => options.SelectAll, Editor.Instance.SceneEditing.SelectAllScenes);
-            inputActions.Add(options => options.DeselectAll, Editor.Instance.SceneEditing.DeselectAllScenes);
-            inputActions.Add(options => options.Delete, Editor.Instance.SceneEditing.Delete);
-            inputActions.Add(options => options.GroupSelectedActors, Editor.Instance.SceneEditing.CreateParentForSelectedActors);
-            inputActions.Add(options => options.Search, () => Editor.Instance.Windows.SceneWin.Search());
-            inputActions.Add(options => options.MoveActorToViewport, Editor.Instance.UI.MoveActorToViewport);
-            inputActions.Add(options => options.AlignActorWithViewport, Editor.Instance.UI.AlignActorWithViewport);
-            inputActions.Add(options => options.AlignViewportWithActor, Editor.Instance.UI.AlignViewportWithActor);
-            inputActions.Add(options => options.PilotActor, Editor.Instance.UI.PilotActor);
-            inputActions.Add(options => options.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor);
-            inputActions.Add(options => options.PlayCurrentScenes, Editor.Instance.Simulation.RequestPlayScenesOrStopPlay);
-            inputActions.Add(options => options.Pause, Editor.Instance.Simulation.RequestResumeOrPause);
-            inputActions.Add(options => options.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame);
-            inputActions.Add(options => options.CookAndRun, () => Editor.Instance.Windows.GameCookerWin.BuildAndRun());
-            inputActions.Add(options => options.RunCookedGame, () => Editor.Instance.Windows.GameCookerWin.RunCooked());
-            inputActions.Add(options => options.BuildScenesData, Editor.Instance.BuildScenesOrCancel);
-            inputActions.Add(options => options.BakeLightmaps, Editor.Instance.BakeLightmapsOrCancel);
-            inputActions.Add(options => options.ClearLightmaps, Editor.Instance.ClearLightmaps);
-            inputActions.Add(options => options.BakeEnvProbes, Editor.Instance.BakeAllEnvProbes);
-            inputActions.Add(options => options.BuildCSG, Editor.Instance.BuildCSG);
-            inputActions.Add(options => options.BuildNav, Editor.Instance.BuildNavMesh);
-            inputActions.Add(options => options.BuildSDF, Editor.Instance.BuildAllMeshesSDF);
-            inputActions.Add(options => options.TakeScreenshot, Editor.Instance.Windows.TakeScreenshot);
-            inputActions.Add(options => options.ProfilerWindow, () => Editor.Instance.Windows.ProfilerWin.FocusOrShow());
+            }
+            ),
+            (inputOptions.Cut, Editor.Instance.SceneEditing.Cut),
+            (inputOptions.Copy, Editor.Instance.SceneEditing.Copy),
+            (inputOptions.Paste, Editor.Instance.SceneEditing.Paste),
+            (inputOptions.Duplicate, Editor.Instance.SceneEditing.Duplicate),
+            (inputOptions.SelectAll, Editor.Instance.SceneEditing.SelectAllScenes),
+            (inputOptions.DeselectAll, Editor.Instance.SceneEditing.DeselectAllScenes),
+            (inputOptions.Delete, Editor.Instance.SceneEditing.Delete),
+            (inputOptions.GroupSelectedActors, Editor.Instance.SceneEditing.CreateParentForSelectedActors),
+            (inputOptions.Search, () => Editor.Instance.Windows.SceneWin.Search()),
+            (inputOptions.MoveActorToViewport, Editor.Instance.UI.MoveActorToViewport),
+            (inputOptions.AlignActorWithViewport, Editor.Instance.UI.AlignActorWithViewport),
+            (inputOptions.AlignViewportWithActor, Editor.Instance.UI.AlignViewportWithActor),
+            (inputOptions.PilotActor, Editor.Instance.UI.PilotActor),
+            (inputOptions.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor),
+            (inputOptions.PlayCurrentScenes, Editor.Instance.Simulation.RequestPlayScenesOrStopPlay),
+            (inputOptions.Pause, Editor.Instance.Simulation.RequestResumeOrPause),
+            (inputOptions.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame),
+            (inputOptions.CookAndRun, () => Editor.Instance.Windows.GameCookerWin.BuildAndRun()),
+            (inputOptions.RunCookedGame, () => Editor.Instance.Windows.GameCookerWin.RunCooked()),
+            (inputOptions.BuildScenesData, Editor.Instance.BuildScenesOrCancel),
+            (inputOptions.BakeLightmaps, Editor.Instance.BakeLightmapsOrCancel),
+            (inputOptions.ClearLightmaps, Editor.Instance.ClearLightmaps),
+            (inputOptions.BakeEnvProbes, Editor.Instance.BakeAllEnvProbes),
+            (inputOptions.BuildCSG, Editor.Instance.BuildCSG),
+            (inputOptions.BuildNav, Editor.Instance.BuildNavMesh),
+            (inputOptions.BuildSDF, Editor.Instance.BuildAllMeshesSDF),
+            (inputOptions.TakeScreenshot, Editor.Instance.Windows.TakeScreenshot),
+            (inputOptions.ProfilerWindow, () => Editor.Instance.Windows.ProfilerWin.FocusOrShow()),
 #if USE_PROFILER
-            inputActions.Add(options => options.ProfilerStartStop, () =>
+            (inputOptions.ProfilerStartStop, () =>
             {
                 bool recording = !Editor.Instance.Windows.ProfilerWin.LiveRecording;
                 Editor.Instance.Windows.ProfilerWin.LiveRecording = recording;
                 Editor.Instance.UI.AddStatusMessage($"Profiling {(recording ? "started" : "stopped")}.");
-            });
-            inputActions.Add(options => options.ProfilerClear, () =>
+            }
+            ),
+            (inputOptions.ProfilerClear, () =>
             {
                 Editor.Instance.Windows.ProfilerWin.Clear();
                 Editor.Instance.UI.AddStatusMessage("Profiling results cleared.");
-            });
+            }
+            ),
 #endif
-            inputActions.Add(options => options.SaveScenes, () => Editor.Instance.Scene.SaveScenes());
-            inputActions.Add(options => options.CloseScenes, () => Editor.Instance.Scene.CloseAllScenes());
-            inputActions.Add(options => options.OpenScriptsProject, () => Editor.Instance.CodeEditing.OpenSolution());
-            inputActions.Add(options => options.GenerateScriptsProject, () => Editor.Instance.ProgressReporting.GenerateScriptsProjectFiles.RunAsync());
-            inputActions.Add(options => options.RecompileScripts, ScriptsBuilder.Compile);
+            (inputOptions.SaveScenes, () => Editor.Instance.Scene.SaveScenes()),
+            (inputOptions.CloseScenes, () => Editor.Instance.Scene.CloseAllScenes()),
+            (inputOptions.OpenScriptsProject, () => Editor.Instance.CodeEditing.OpenSolution()),
+            (inputOptions.GenerateScriptsProject, () => Editor.Instance.ProgressReporting.GenerateScriptsProjectFiles.RunAsync()),
+            (inputOptions.RecompileScripts, ScriptsBuilder.Compile)
+            );
         }
 
         internal static string ToPathProject(string path)

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -1464,7 +1464,6 @@ namespace FlaxEditor.Utilities
         public static void SetupCommonInputActions(EditorWindow window)
         {
             var inputActions = window.InputActions;
-            var inputOptions = Editor.Instance.Options.Options.Input;
             // Setup input actions
             inputActions.Add
             (

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -23,6 +23,7 @@ using FlaxEngine.Json;
 using FlaxEngine.GUI;
 using FlaxEngine.Utilities;
 using FlaxEditor.Windows;
+using FlaxEditor.Options;
 
 namespace FlaxEngine
 {
@@ -1465,68 +1466,71 @@ namespace FlaxEditor.Utilities
             var inputActions = window.InputActions;
             var inputOptions = Editor.Instance.Options.Options.Input;
             // Setup input actions
-            inputActions.Add(
-                (inputOptions.Save, Editor.Instance.SaveAll),
-            (inputOptions.Undo, () =>
-            {
-                Editor.Instance.PerformUndo();
-                window.Focus();
-            }
-            ),
-            (inputOptions.Redo, () =>
-            {
-                Editor.Instance.PerformRedo();
-                window.Focus();
-            }
-            ),
-            (inputOptions.Cut, Editor.Instance.SceneEditing.Cut),
-            (inputOptions.Copy, Editor.Instance.SceneEditing.Copy),
-            (inputOptions.Paste, Editor.Instance.SceneEditing.Paste),
-            (inputOptions.Duplicate, Editor.Instance.SceneEditing.Duplicate),
-            (inputOptions.SelectAll, Editor.Instance.SceneEditing.SelectAllScenes),
-            (inputOptions.DeselectAll, Editor.Instance.SceneEditing.DeselectAllScenes),
-            (inputOptions.Delete, Editor.Instance.SceneEditing.Delete),
-            (inputOptions.GroupSelectedActors, Editor.Instance.SceneEditing.CreateParentForSelectedActors),
-            (inputOptions.Search, () => Editor.Instance.Windows.SceneWin.Search()),
-            (inputOptions.MoveActorToViewport, Editor.Instance.UI.MoveActorToViewport),
-            (inputOptions.AlignActorWithViewport, Editor.Instance.UI.AlignActorWithViewport),
-            (inputOptions.AlignViewportWithActor, Editor.Instance.UI.AlignViewportWithActor),
-            (inputOptions.PilotActor, Editor.Instance.UI.PilotActor),
-            (inputOptions.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor),
-            (inputOptions.PlayCurrentScenes, Editor.Instance.Simulation.RequestPlayScenesOrStopPlay),
-            (inputOptions.Pause, Editor.Instance.Simulation.RequestResumeOrPause),
-            (inputOptions.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame),
-            (inputOptions.CookAndRun, () => Editor.Instance.Windows.GameCookerWin.BuildAndRun()),
-            (inputOptions.RunCookedGame, () => Editor.Instance.Windows.GameCookerWin.RunCooked()),
-            (inputOptions.BuildScenesData, Editor.Instance.BuildScenesOrCancel),
-            (inputOptions.BakeLightmaps, Editor.Instance.BakeLightmapsOrCancel),
-            (inputOptions.ClearLightmaps, Editor.Instance.ClearLightmaps),
-            (inputOptions.BakeEnvProbes, Editor.Instance.BakeAllEnvProbes),
-            (inputOptions.BuildCSG, Editor.Instance.BuildCSG),
-            (inputOptions.BuildNav, Editor.Instance.BuildNavMesh),
-            (inputOptions.BuildSDF, Editor.Instance.BuildAllMeshesSDF),
-            (inputOptions.TakeScreenshot, Editor.Instance.Windows.TakeScreenshot),
-            (inputOptions.ProfilerWindow, () => Editor.Instance.Windows.ProfilerWin.FocusOrShow()),
+            inputActions.Add
+            (
+                [
+                    new(InputOptionName.Save, Editor.Instance.SaveAll),
+                    new(InputOptionName.Undo,
+                        () => {
+                            Editor.Instance.PerformUndo();
+                            window.Focus();
+                        }
+                    ),
+                    new(InputOptionName.Redo,
+                        () => {
+                            Editor.Instance.PerformRedo();
+                            window.Focus();
+                        }
+                    ),
+                    new(InputOptionName.Cut, Editor.Instance.SceneEditing.Cut),
+                    new(InputOptionName.Copy, Editor.Instance.SceneEditing.Copy),
+                    new(InputOptionName.Paste, Editor.Instance.SceneEditing.Paste),
+                    new(InputOptionName.Duplicate, Editor.Instance.SceneEditing.Duplicate),
+                    new(InputOptionName.SelectAll, Editor.Instance.SceneEditing.SelectAllScenes),
+                    new(InputOptionName.DeselectAll, Editor.Instance.SceneEditing.DeselectAllScenes),
+                    new(InputOptionName.Delete, Editor.Instance.SceneEditing.Delete),
+                    new(InputOptionName.GroupSelectedActors, Editor.Instance.SceneEditing.CreateParentForSelectedActors),
+                    new(InputOptionName.Search, () => Editor.Instance.Windows.SceneWin.Search()),
+                    new(InputOptionName.MoveActorToViewport, Editor.Instance.UI.MoveActorToViewport),
+                    new(InputOptionName.AlignActorWithViewport, Editor.Instance.UI.AlignActorWithViewport),
+                    new(InputOptionName.AlignViewportWithActor, Editor.Instance.UI.AlignViewportWithActor),
+                    new(InputOptionName.PilotActor, Editor.Instance.UI.PilotActor),
+                    new(InputOptionName.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor),
+                    new(InputOptionName.PlayCurrentScenes, Editor.Instance.Simulation.RequestPlayScenesOrStopPlay),
+                    new(InputOptionName.Pause, Editor.Instance.Simulation.RequestResumeOrPause),
+                    new(InputOptionName.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame),
+                    new(InputOptionName.CookAndRun, () => Editor.Instance.Windows.GameCookerWin.BuildAndRun()),
+                    new(InputOptionName.RunCookedGame, () => Editor.Instance.Windows.GameCookerWin.RunCooked()),
+                    new(InputOptionName.BuildScenesData, Editor.Instance.BuildScenesOrCancel),
+                    new(InputOptionName.BakeLightmaps, Editor.Instance.BakeLightmapsOrCancel),
+                    new(InputOptionName.ClearLightmaps, Editor.Instance.ClearLightmaps),
+                    new(InputOptionName.BakeEnvProbes, Editor.Instance.BakeAllEnvProbes),
+                    new(InputOptionName.BuildCSG, Editor.Instance.BuildCSG),
+                    new(InputOptionName.BuildNav, Editor.Instance.BuildNavMesh),
+                    new(InputOptionName.BuildSDF, Editor.Instance.BuildAllMeshesSDF),
+                    new(InputOptionName.TakeScreenshot, Editor.Instance.Windows.TakeScreenshot),
+                    new(InputOptionName.ProfilerWindow, () => Editor.Instance.Windows.ProfilerWin.FocusOrShow()),
 #if USE_PROFILER
-            (inputOptions.ProfilerStartStop, () =>
-            {
-                bool recording = !Editor.Instance.Windows.ProfilerWin.LiveRecording;
-                Editor.Instance.Windows.ProfilerWin.LiveRecording = recording;
-                Editor.Instance.UI.AddStatusMessage($"Profiling {(recording ? "started" : "stopped")}.");
-            }
-            ),
-            (inputOptions.ProfilerClear, () =>
-            {
-                Editor.Instance.Windows.ProfilerWin.Clear();
-                Editor.Instance.UI.AddStatusMessage("Profiling results cleared.");
-            }
-            ),
+                    new(InputOptionName.ProfilerStartStop,
+                        () => {
+                            bool recording = !Editor.Instance.Windows.ProfilerWin.LiveRecording;
+                            Editor.Instance.Windows.ProfilerWin.LiveRecording = recording;
+                            Editor.Instance.UI.AddStatusMessage($"Profiling {(recording ? "started" : "stopped")}.");
+                        }
+                    ),
+                    new(InputOptionName.ProfilerClear,
+                        () => {
+                            Editor.Instance.Windows.ProfilerWin.Clear();
+                            Editor.Instance.UI.AddStatusMessage("Profiling results cleared.");
+                        }
+                    ),
 #endif
-            (inputOptions.SaveScenes, () => Editor.Instance.Scene.SaveScenes()),
-            (inputOptions.CloseScenes, () => Editor.Instance.Scene.CloseAllScenes()),
-            (inputOptions.OpenScriptsProject, () => Editor.Instance.CodeEditing.OpenSolution()),
-            (inputOptions.GenerateScriptsProject, () => Editor.Instance.ProgressReporting.GenerateScriptsProjectFiles.RunAsync()),
-            (inputOptions.RecompileScripts, ScriptsBuilder.Compile)
+                    new(InputOptionName.SaveScenes, () => Editor.Instance.Scene.SaveScenes()),
+                    new(InputOptionName.CloseScenes, () => Editor.Instance.Scene.CloseAllScenes()),
+                    new(InputOptionName.OpenScriptsProject, () => Editor.Instance.CodeEditing.OpenSolution()),
+                    new(InputOptionName.GenerateScriptsProject, () => Editor.Instance.ProgressReporting.GenerateScriptsProjectFiles.RunAsync()),
+                    new(InputOptionName.RecompileScripts, ScriptsBuilder.Compile)
+                ]
             );
         }
 

--- a/Source/Editor/Viewport/Cameras/ArcBallCamera.cs
+++ b/Source/Editor/Viewport/Cameras/ArcBallCamera.cs
@@ -120,9 +120,9 @@ namespace FlaxEditor.Viewport.Cameras
             Viewport.YawPitch += mouseDelta;
 
             // Zoom
-            if (input.IsZooming)
+            if (Viewport.Zoom)
             {
-                _orbitRadius = Mathf.Clamp(_orbitRadius - (Viewport.MouseWheelZoomSpeedFactor * input.MouseWheelDelta * 25.0f), 0.001f, 10000.0f);
+                _orbitRadius = Mathf.Clamp(_orbitRadius - (Viewport.MouseWheelSensitivity * Viewport.MouseWheelDelta * 25.0f), 0.001f, 10000.0f);
             }
 
             // Update view position

--- a/Source/Editor/Viewport/Cameras/ArcBallCamera.cs
+++ b/Source/Editor/Viewport/Cameras/ArcBallCamera.cs
@@ -114,8 +114,6 @@ namespace FlaxEditor.Viewport.Cameras
         {
             centerMouse = true;
 
-            Viewport.GetInput(out EditorViewport.Input input);
-
             // Rotate
             Viewport.YawPitch += mouseDelta;
 

--- a/Source/Editor/Viewport/Cameras/FPSCamera.cs
+++ b/Source/Editor/Viewport/Cameras/FPSCamera.cs
@@ -158,8 +158,6 @@ namespace FlaxEditor.Viewport.Cameras
             if (IsAnimatingMove)
                 return;
 
-            Viewport.GetInput(out var input);
-            Viewport.GetPrevInput(out var prevInput);
             var transformGizmo = (Viewport as EditorGizmoViewport)?.Gizmos.Active as TransformGizmoBase;
             var isUsingGizmo = transformGizmo != null && transformGizmo.ActiveAxis != TransformGizmoBase.Axis.None;
 
@@ -220,10 +218,7 @@ namespace FlaxEditor.Viewport.Cameras
             if (Viewport.Zoom && !Viewport.Rotate)
             {
                 position += forward * (Viewport.MouseWheelSensitivity * Viewport.MouseWheelDelta * 25.0f);
-                if (input.IsAltDown)
-                {
-                    position += forward * (Viewport.MouseSpeed * 40 * Viewport.MousePositionDelta.ValuesSum);
-                }
+                //todo speed increase? for alt held
             }
 
             // Move camera with the gizmo

--- a/Source/Editor/Viewport/Cameras/FPSCamera.cs
+++ b/Source/Editor/Viewport/Cameras/FPSCamera.cs
@@ -87,7 +87,7 @@ namespace FlaxEditor.Viewport.Cameras
         public override void ShowSphere(ref BoundingSphere sphere, ref Quaternion orientation)
         {
             Vector3 position;
-            if (Viewport.UseOrthographicProjection)
+            if (Viewport.OrthographicProjection)
             {
                 position = sphere.Center + Vector3.Backward * orientation * (sphere.Radius * 5.0f);
                 Viewport.OrthographicScale = (float)Vector3.Distance(position, sphere.Center) / 1000;
@@ -175,14 +175,14 @@ namespace FlaxEditor.Viewport.Cameras
             var right = Vector3.Cross(forward, up);
 
             // Dolly
-            if (input.IsPanning || input.IsMoving || input.IsRotating)
+            if (Viewport.Pan || Viewport.Move || Viewport.Rotate)
             {
                 Vector3.Transform(ref moveDelta, ref rotation, out Vector3 move);
                 position += move;
             }
 
             // Pan
-            if (input.IsPanning)
+            if (Viewport.Pan)
             {
                 var panningSpeed = (Viewport.RelativePanning)
                     ? Mathf.Abs((position - TargetPoint).Length) * 0.005f
@@ -201,7 +201,7 @@ namespace FlaxEditor.Viewport.Cameras
             }
 
             // Move
-            if (input.IsMoving)
+            if (Viewport.Move)
             {
                 // Move camera over XZ plane
                 var projectedForward = Vector3.Normalize(new Vector3(forward.X, 0, forward.Z));
@@ -210,16 +210,16 @@ namespace FlaxEditor.Viewport.Cameras
             }
 
             // Rotate or orbit
-            if (input.IsRotating || (input.IsOrbiting && !isUsingGizmo && prevInput.IsOrbiting))
+            if (Viewport.Rotate || (Viewport.Orbit && !isUsingGizmo))
             {
                 yaw += mouseDelta.X;
                 pitch += mouseDelta.Y;
             }
 
             // Zoom in/out
-            if (input.IsZooming && !input.IsRotating)
+            if (Viewport.Zoom && !Viewport.Rotate)
             {
-                position += forward * (Viewport.MouseWheelZoomSpeedFactor * input.MouseWheelDelta * 25.0f);
+                position += forward * (Viewport.MouseWheelSensitivity * Viewport.MouseWheelDelta * 25.0f);
                 if (input.IsAltDown)
                 {
                     position += forward * (Viewport.MouseSpeed * 40 * Viewport.MousePositionDelta.ValuesSum);
@@ -227,7 +227,7 @@ namespace FlaxEditor.Viewport.Cameras
             }
 
             // Move camera with the gizmo
-            if (input.IsOrbiting && isUsingGizmo)
+            if (Viewport.Orbit && isUsingGizmo)
             {
                 centerMouse = false;
                 Viewport.ViewPosition += transformGizmo.LastDelta.Translation;
@@ -237,7 +237,7 @@ namespace FlaxEditor.Viewport.Cameras
             // Update view
             Viewport.Yaw = yaw;
             Viewport.Pitch = pitch;
-            if (input.IsOrbiting)
+            if (Viewport.Orbit)
             {
                 float orbitRadius = Mathf.Max((float)Vector3.Distance(ref position, ref TargetPoint), 0.0001f);
                 Vector3 localPosition = Viewport.ViewDirection * (-1 * orbitRadius);

--- a/Source/Editor/Viewport/Cameras/IViewportCamera.cs
+++ b/Source/Editor/Viewport/Cameras/IViewportCamera.cs
@@ -16,6 +16,7 @@ namespace FlaxEditor.Viewport.Cameras
         /// <param name="deltaTime">The delta time (in seconds).</param>
         void Update(float deltaTime);
 
+        //todo i think the centering of the mouse should be predetermined. it depends on what kind of movement is happening and that comes from the controller not the camera being controlled
         /// <summary>
         /// Updates the view.
         /// </summary>

--- a/Source/Editor/Viewport/EditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/EditorGizmoViewport.cs
@@ -101,7 +101,7 @@ namespace FlaxEditor.Viewport
         public abstract void OpenContextMenu();
 
         /// <inheritdoc />
-        protected override bool IsControllingMouse => Gizmos.Active?.IsControllingMouse ?? false;
+        protected override bool WantsMouseCapture => Gizmos.Active?.IsControllingMouse ?? false;
 
         /// <inheritdoc />
         protected override void AddUpdateCallbacks(RootControl root)
@@ -405,6 +405,8 @@ namespace FlaxEditor.Viewport
             };
 
             // Setup input actions
+            //todo
+            /*
             viewport.InputOptions.List.SetCallback(
             (viewport.InputOptions.TranslateMode, () =>
             {
@@ -445,7 +447,7 @@ namespace FlaxEditor.Viewport
                 transformSpaceToggle.Checked = !transformSpaceToggle.Checked;
             }
             )
-            );
+            );*/
         }
 
         internal static readonly float[] TranslateSnapValues =

--- a/Source/Editor/Viewport/EditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/EditorGizmoViewport.cs
@@ -59,16 +59,16 @@ namespace FlaxEditor.Viewport
         public float ViewFarPlane => FarPlane;
 
         /// <inheritdoc />
-        public bool IsLeftMouseButtonDown => _input.IsMouseLeftDown;
+        public bool IsLeftMouseButtonDown => Root?.GetMouseButton(MouseButton.Left) ?? false;
 
         /// <inheritdoc />
-        public bool IsRightMouseButtonDown => _input.IsMouseRightDown;
+        public bool IsRightMouseButtonDown => Root?.GetMouseButton(MouseButton.Right) ?? false;
 
         /// <inheritdoc />
-        public bool IsAltKeyDown => _input.IsAltDown;
+        public bool IsAltKeyDown => Root?.GetKey(KeyboardKeys.Alt) ?? false;
 
         /// <inheritdoc />
-        public bool IsControlDown => _input.IsControlDown;
+        public bool IsControlDown => Root?.GetKey(KeyboardKeys.Control) ?? false;
 
         /// <inheritdoc />
         public bool SnapToGround => ContainsFocus && Editor.Instance.Options.Options.Input.SnapToGround.Process(Root);

--- a/Source/Editor/Viewport/EditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/EditorGizmoViewport.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Input;
+using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.Viewport.Cameras;
 using FlaxEditor.Viewport.Widgets;
@@ -71,10 +72,10 @@ namespace FlaxEditor.Viewport
         public bool IsControlDown => Root?.GetKey(KeyboardKeys.Control) ?? false;
 
         /// <inheritdoc />
-        public bool SnapToGround => ContainsFocus && Editor.Instance.Options.Options.Input.SnapToGround.Process(Root);
+        public bool SnapToGround => ContainsFocus && InputOptions.SnapToGround.Process(Root);
 
         /// <inheritdoc />
-        public bool SnapToVertex => ContainsFocus && Editor.Instance.Options.Options.Input.SnapToVertex.Process(Root);
+        public bool SnapToVertex => ContainsFocus && InputOptions.SnapToVertex.Process(Root);
 
         /// <inheritdoc />
         public Float2 MouseDelta => _mouseDelta;
@@ -133,7 +134,6 @@ namespace FlaxEditor.Viewport
         internal static void AddGizmoViewportWidgets(EditorViewport viewport, TransformGizmo transformGizmo, bool useProjectCache = false)
         {
             var editor = Editor.Instance;
-            var inputOptions = editor.Options.Options.Input;
 
             if (useProjectCache)
             {
@@ -161,7 +161,7 @@ namespace FlaxEditor.Viewport
             var transformSpaceToggle = new ViewportWidgetButton(string.Empty, editor.Icons.Globe32, null, true)
             {
                 Checked = transformGizmo.ActiveTransformSpace == TransformGizmoBase.TransformSpace.World,
-                TooltipText = $"Gizmo transform space (world or local) ({inputOptions.ToggleTransformSpace})",
+                TooltipText = $"Gizmo transform space (world or local) ({InputOptions.ToggleTransformSpace})",
                 Parent = transformSpaceWidget
             };
             transformSpaceWidget.Parent = viewport;
@@ -376,7 +376,7 @@ namespace FlaxEditor.Viewport
             var gizmoModeTranslate = new ViewportWidgetButton(string.Empty, editor.Icons.Translate32, null, true)
             {
                 Tag = TransformGizmoBase.Mode.Translate,
-                TooltipText = $"Translate gizmo mode ({inputOptions.TranslateMode})",
+                TooltipText = $"Translate gizmo mode ({InputOptions.TranslateMode})",
                 Checked = true,
                 Parent = gizmoMode
             };
@@ -384,14 +384,14 @@ namespace FlaxEditor.Viewport
             var gizmoModeRotate = new ViewportWidgetButton(string.Empty, editor.Icons.Rotate32, null, true)
             {
                 Tag = TransformGizmoBase.Mode.Rotate,
-                TooltipText = $"Rotate gizmo mode ({inputOptions.RotateMode})",
+                TooltipText = $"Rotate gizmo mode ({InputOptions.RotateMode})",
                 Parent = gizmoMode
             };
             gizmoModeRotate.Toggled += _ => transformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate;
             var gizmoModeScale = new ViewportWidgetButton(string.Empty, editor.Icons.Scale32, null, true)
             {
                 Tag = TransformGizmoBase.Mode.Scale,
-                TooltipText = $"Scale gizmo mode ({inputOptions.ScaleMode})",
+                TooltipText = $"Scale gizmo mode ({InputOptions.ScaleMode})",
                 Parent = gizmoMode
             };
             gizmoModeScale.Toggled += _ => transformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale;

--- a/Source/Editor/Viewport/EditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/EditorGizmoViewport.cs
@@ -405,31 +405,35 @@ namespace FlaxEditor.Viewport
             };
 
             // Setup input actions
-            viewport.InputActions.Add(options => options.TranslateMode, () =>
+            viewport.InputOptions.List.SetCallback(
+            (viewport.InputOptions.TranslateMode, () =>
             {
                 viewport.GetInput(out var input);
                 if (input.IsMouseRightDown)
                     return;
 
                 transformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate;
-            });
-            viewport.InputActions.Add(options => options.RotateMode, () =>
+            }
+            ),
+            (viewport.InputOptions.RotateMode, () =>
             {
                 viewport.GetInput(out var input);
                 if (input.IsMouseRightDown)
                     return;
 
                 transformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate;
-            });
-            viewport.InputActions.Add(options => options.ScaleMode, () =>
+            }
+            ),
+            (viewport.InputOptions.ScaleMode, () =>
             {
                 viewport.GetInput(out var input);
                 if (input.IsMouseRightDown)
                     return;
 
                 transformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale;
-            });
-            viewport.InputActions.Add(options => options.ToggleTransformSpace, () =>
+            }
+            ),
+            (viewport.InputOptions.ToggleTransformSpace, () =>
             {
                 viewport.GetInput(out var input);
                 if (input.IsMouseRightDown)
@@ -439,7 +443,9 @@ namespace FlaxEditor.Viewport
                 if (useProjectCache)
                     editor.ProjectCache.SetCustomData("TransformSpaceState", transformGizmo.ActiveTransformSpace.ToString());
                 transformSpaceToggle.Checked = !transformSpaceToggle.Checked;
-            });
+            }
+            )
+            );
         }
 
         internal static readonly float[] TranslateSnapValues =

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FlaxEditor.Content.Settings;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Input;
+using FlaxEditor.InputConfig;
 using FlaxEditor.Options;
 using FlaxEditor.Viewport.Cameras;
 using FlaxEditor.Viewport.Widgets;
@@ -131,6 +133,8 @@ namespace FlaxEditor.Viewport
                 IsMouseLeftDown = false;
             }
         }
+
+        public InputOptions InputOptions = Editor.Instance.Options.Options.Input;
 
         /// <summary>
         /// The FPS camera filtering frames count (how much frames we want to keep in the buffer to calculate the avg. delta currently hardcoded).
@@ -506,11 +510,6 @@ namespace FlaxEditor.Viewport
             get => _panningSpeed;
             set => _panningSpeed = value;
         }
-
-        /// <summary>
-        /// The input actions collection to processed during user input.
-        /// </summary>
-        public InputActionsContainer InputActions = new InputActionsContainer();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EditorViewport"/> class.
@@ -1005,16 +1004,18 @@ namespace FlaxEditor.Viewport
                 #endregion View mode widget
             }
 
-            InputActions.Add(options => options.ViewpointTop, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Top").Orientation)));
-            InputActions.Add(options => options.ViewpointBottom, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Bottom").Orientation)));
-            InputActions.Add(options => options.ViewpointFront, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Front").Orientation)));
-            InputActions.Add(options => options.ViewpointBack, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Back").Orientation)));
-            InputActions.Add(options => options.ViewpointRight, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Right").Orientation)));
-            InputActions.Add(options => options.ViewpointLeft, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Left").Orientation)));
-            InputActions.Add(options => options.CameraToggleRotation, () => _isVirtualMouseRightDown = !_isVirtualMouseRightDown);
-            InputActions.Add(options => options.CameraIncreaseMoveSpeed, () => AdjustCameraMoveSpeed(1));
-            InputActions.Add(options => options.CameraDecreaseMoveSpeed, () => AdjustCameraMoveSpeed(-1));
-            InputActions.Add(options => options.ToggleOrthographic, () => OnOrthographicModeToggled(null));
+            InputOptions.List.SetCallback(
+                (InputOptions.ViewpointTop, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Top").Orientation))),
+                (InputOptions.ViewpointBottom, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Bottom").Orientation))),
+                (InputOptions.ViewpointFront, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Front").Orientation))),
+                (InputOptions.ViewpointBack, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Back").Orientation))),
+                (InputOptions.ViewpointRight, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Right").Orientation))),
+                (InputOptions.ViewpointLeft, () => OrientViewport(Quaternion.Euler(CameraViewpointValues.First(vp => vp.Name == "Left").Orientation))),
+                (InputOptions.CameraToggleRotation, () => _isVirtualMouseRightDown = !_isVirtualMouseRightDown),
+                (InputOptions.CameraIncreaseMoveSpeed, () => AdjustCameraMoveSpeed(1)),
+                (InputOptions.CameraDecreaseMoveSpeed, () => AdjustCameraMoveSpeed(-1)),
+                (InputOptions.ToggleOrthographic, () => OnOrthographicModeToggled(null))
+            );
 
             // Link for task event
             task.Begin += OnRenderBegin;
@@ -1860,7 +1861,7 @@ namespace FlaxEditor.Viewport
                 return true;
 
             // Custom input events
-            return InputActions.Process(Editor.Instance, this);
+            return InputOptions.List.Process(this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1649,11 +1649,11 @@ namespace FlaxEditor.Viewport
                     bool rbDown = _input.IsMouseRightDown || _isVirtualMouseRightDown;
                     bool wheelInUse = Math.Abs(_input.MouseWheelDelta) > Mathf.Epsilon;
 
-                    _input.IsPanning = !isAltDown && mbDown && !rbDown;
-                    _input.IsRotating = !isAltDown && !mbDown && rbDown;
+                    _input.IsPanning = options.Input.Pan.Process(window);
+                    _input.IsRotating = options.Input.Rotate.Process(window);
                     _input.IsMoving = !isAltDown && mbDown && rbDown;
                     _input.IsZooming = wheelInUse && !(_input.IsShiftDown || (!ContainsFocus && FlaxEngine.Input.GetKey(KeyboardKeys.Shift)));
-                    _input.IsOrbiting = isAltDown && lbDown && !mbDown && !rbDown;
+                    _input.IsOrbiting = options.Input.Orbit.Process(window);
 
                     // Control move speed with RMB+Wheel
                     rmbWheel = useMovementSpeed && (_input.IsMouseRightDown || _isVirtualMouseRightDown) && wheelInUse;
@@ -1666,31 +1666,30 @@ namespace FlaxEditor.Viewport
 
                 // Get input movement
                 var moveDelta = Vector3.Zero;
-                if (win.GetKey(options.Input.Forward.Key))
+                if (options.Input.Forward.Process(window))
                 {
                     moveDelta += Vector3.Forward;
                 }
-                if (win.GetKey(options.Input.Backward.Key))
+                if (options.Input.Backward.Process(window))
                 {
                     moveDelta += Vector3.Backward;
                 }
-                if (win.GetKey(options.Input.Right.Key))
+                if (options.Input.Right.Process(window))
                 {
                     moveDelta += Vector3.Right;
                 }
-                if (win.GetKey(options.Input.Left.Key))
+                if (options.Input.Left.Process(window))
                 {
                     moveDelta += Vector3.Left;
                 }
-                if (win.GetKey(options.Input.Up.Key))
+                if (options.Input.Up.Process(window))
                 {
                     moveDelta += Vector3.Up;
                 }
-                if (win.GetKey(options.Input.Down.Key))
+                if (options.Input.Down.Process(window))
                 {
                     moveDelta += Vector3.Down;
                 }
-                moveDelta.Normalize(); // normalize direction
                 moveDelta *= _movementSpeed;
 
                 // Speed up or speed down
@@ -1861,7 +1860,7 @@ namespace FlaxEditor.Viewport
                 return true;
 
             // Custom input events
-            return InputActions.Process(Editor.Instance, this, key);
+            return InputActions.Process(Editor.Instance, this);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1027,13 +1027,13 @@ namespace FlaxEditor.Viewport
         private void SetupViewportOptions()
         {
             var options = Editor.Instance.Options.Options;
-            _minMovementSpeed = options.Viewport.MinMovementSpeed;
-            MovementSpeed = options.Viewport.MovementSpeed;
-            _maxMovementSpeed = options.Viewport.MaxMovementSpeed;
+            _minMovementSpeed = options.Input.MinMovementSpeed;
+            MovementSpeed = options.Input.MovementSpeed;
+            _maxMovementSpeed = options.Input.MaxMovementSpeed;
             _useCameraEasing = options.Viewport.UseCameraEasing;
-            _panningSpeed = options.Viewport.PanningSpeed;
-            _invertPanning = options.Viewport.InvertPanning;
-            _relativePanning = options.Viewport.UseRelativePanning;
+            _panningSpeed = options.Input.PanningSpeed;
+            _invertPanning = options.Input.InvertPanning;
+            _relativePanning = options.Input.UseRelativePanning;
 
             _isOrtho = options.Viewport.UseOrthographicProjection;
             _orthoSize = options.Viewport.OrthographicScale;
@@ -1230,7 +1230,7 @@ namespace FlaxEditor.Viewport
 
         private void OnEditorOptionsChanged(EditorOptions options)
         {
-            _mouseSensitivity = options.Viewport.MouseSensitivity;
+            _mouseSensitivity = options.Input.MouseSensitivity;
             _maxSpeedSteps = options.Viewport.TotalCameraSpeedSteps;
             _cameraEasingDegree = options.Viewport.CameraEasingDegree;
             OnCameraMovementProgressChanged();
@@ -1660,7 +1660,7 @@ namespace FlaxEditor.Viewport
                     rmbWheel = useMovementSpeed && (_input.IsMouseRightDown || _isVirtualMouseRightDown) && wheelInUse;
                     if (rmbWheel)
                     {
-                        var step = _input.MouseWheelDelta * options.Viewport.MouseWheelSensitivity;
+                        var step = _input.MouseWheelDelta * options.Input.MouseWheelSensitivity;
                         AdjustCameraMoveSpeed(step > 0.0f ? 1 : -1);
                     }
                 }
@@ -1744,7 +1744,7 @@ namespace FlaxEditor.Viewport
                 // Update
                 moveDelta *= dt * (60.0f * 4.0f);
                 mouseDelta *= 0.1833f * MouseSpeed * _mouseSensitivity;
-                if (options.Viewport.InvertMouseYAxisRotation)
+                if (options.Input.InvertMouseYAxisRotation)
                     mouseDelta *= new Float2(1, -1);
                 UpdateView(dt, ref moveDelta, ref mouseDelta, out var centerMouse);
 
@@ -1760,7 +1760,7 @@ namespace FlaxEditor.Viewport
                 {
                     var scroll = _input.MouseWheelDelta;
                     if (scroll > Mathf.Epsilon || scroll < -Mathf.Epsilon)
-                        _orthoSize -= scroll * options.Viewport.MouseWheelSensitivity * 0.2f * _orthoSize;
+                        _orthoSize -= scroll * options.Input.MouseWheelSensitivity * 0.2f * _orthoSize;
                 }
             }
             else
@@ -1782,12 +1782,6 @@ namespace FlaxEditor.Viewport
 
                 if (ContainsFocus)
                 {
-                    _input.IsPanning = false;
-                    _input.IsRotating = false;
-                    _input.IsMoving = true;
-                    _input.IsZooming = false;
-                    _input.IsOrbiting = false;
-
                     // Get input movement
                     var moveDelta = Vector3.Zero;
                     var mouseDelta = Float2.Zero;
@@ -1797,27 +1791,8 @@ namespace FlaxEditor.Viewport
                         moveDelta += new Vector3(GetGamepadAxis(GamepadAxis.LeftStickX), 0, GetGamepadAxis(GamepadAxis.LeftStickY));
                         mouseDelta += new Float2(GetGamepadAxis(GamepadAxis.RightStickX), -GetGamepadAxis(GamepadAxis.RightStickY));
                         _input.IsRotating |= !mouseDelta.IsZero;
-                    }
-                    if (win.GetKey(KeyboardKeys.ArrowRight))
-                    {
-                        moveDelta += Vector3.Right;
-                    }
-                    if (win.GetKey(KeyboardKeys.ArrowLeft))
-                    {
-                        moveDelta += Vector3.Left;
-                    }
-                    if (win.GetKey(KeyboardKeys.ArrowUp))
-                    {
-                        moveDelta += Vector3.Up;
-                    }
-                    if (win.GetKey(KeyboardKeys.ArrowDown))
-                    {
-                        moveDelta += Vector3.Down;
-                    }
-                    moveDelta.Normalize();
-                    moveDelta *= _movementSpeed;
-                    if (FlaxEngine.Input.GamepadsCount > 0)
                         moveDelta *= Mathf.Remap(GetGamepadAxis(GamepadAxis.RightTrigger), 0, 1, 1, 4.0f);
+                    }
 
                     // Update
                     moveDelta *= dt * (60.0f * 4.0f);

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -201,8 +201,6 @@ namespace FlaxEditor.Viewport
         /// </summary>
         public float MouseWheelSensitivity { get => _mouseWheelSensitivity; set => _mouseWheelSensitivity = value; }
 
-        public InputOptions InputOptions = Editor.Instance.Options.Options.Input;
-
         private readonly Editor _editor;
 
         private float _yaw;
@@ -265,11 +263,9 @@ namespace FlaxEditor.Viewport
 
         private void SetBindings()
         {
-            InputOptions InputOptions = Editor.Instance.Options.Options.Input;
             InputBindingList = new InputBindingList
             (
                 [
-                    //todo fix snapping when using mouse movement while Move=true
                     new(InputOptionName.Forward, () => {Move = true; _moveDelta = Vector3.Forward * MovementSpeed; }, () => {Move = false; _startPos = Vector2.Zero;}),
                     new(InputOptionName.Backward, () => {Move = true; _moveDelta = Vector3.Backward * MovementSpeed; }, () => {Move = false; _moveDelta = Vector3.Zero; }),
                     new(InputOptionName.Left, () => {Move = true; _moveDelta = Vector3.Left * MovementSpeed; }, () => {Move = false; _moveDelta = Vector3.Zero; }),
@@ -279,24 +275,28 @@ namespace FlaxEditor.Viewport
                     new(InputOptionName.Orbit, () => {Orbit = true; CenterMouse = true; }, () => {Orbit = false; CenterMouse = false; }),
                     new(InputOptionName.Pan, () => {Pan = true; CenterMouse = true; }, () => {Pan = false; CenterMouse = false; }),
                     new(InputOptionName.Rotate, () => {Rotate = true; CenterMouse = true; }, () => {Rotate = false; CenterMouse = false; }),
-                    new(InputOptionName.ZoomIn, () =>
-                    {
-                        Zoom = true;
-                        MouseWheelDelta += MouseWheelSensitivity;
-                        if (OrthographicProjection)
-                        {
-                            OrthographicScale -= MouseWheelDelta * MouseWheelSensitivity * 0.2f * OrthographicScale;
-                        }
-                    }, () => Zoom = false),
-                    new(InputOptionName.ZoomOut, () =>
-                    {
-                        Zoom = true;
-                        MouseWheelDelta -= MouseWheelSensitivity;
-                        if (OrthographicProjection)
-                        {
-                            OrthographicScale -= MouseWheelDelta * MouseWheelSensitivity * 0.2f * OrthographicScale;
-                        }
-                    }, () => Zoom = false),
+                    new(InputOptionName.ZoomIn,
+                        () => {
+                            Zoom = true;
+                            MouseWheelDelta += MouseWheelSensitivity;
+                            if (OrthographicProjection)
+                            {
+                                OrthographicScale -= MouseWheelDelta * MouseWheelSensitivity * 0.2f * OrthographicScale;
+                            }
+                        },
+                        () => Zoom = false
+                    ),
+                    new(InputOptionName.ZoomOut, 
+                        () => {
+                            Zoom = true;
+                            MouseWheelDelta -= MouseWheelSensitivity;
+                            if (OrthographicProjection)
+                            {
+                                OrthographicScale -= MouseWheelDelta * MouseWheelSensitivity * 0.2f * OrthographicScale;
+                            }
+                        },
+                        () => Zoom = false
+                    ),
                     new(InputOptionName.CameraIncreaseMoveSpeed, () => MovementSpeed += MouseWheelDelta * MouseWheelSensitivity, null),
                     new(InputOptionName.CameraDecreaseMoveSpeed, () => MovementSpeed += MouseWheelDelta * MouseWheelSensitivity, null),
                     new(InputOptionName.ViewpointTop, () => OrientViewport(CameraViewpoints[Viewpoint.Front]), null),

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -146,10 +146,12 @@ namespace FlaxEditor.Viewport
         /// <summary>
         /// Gets or sets a value indicating whether show navigation mesh.
         /// </summary>
+        //todo
+        private bool DUMMY;
         public bool ShowNavigation
         {
-            get => _showNavigationButton.Checked;
-            set => _showNavigationButton.Checked = value;
+            get => true; //todo _showNavigationButton.Checked;
+            set => DUMMY = value;  //todo _showNavigationButton.Checked = value;
         }
 
         /// <summary>
@@ -227,17 +229,20 @@ namespace FlaxEditor.Viewport
             AddGizmoViewportWidgets(this, TransformGizmo, true);
 
             // Show grid widget
-            _showGridButton = ViewWidgetShowMenu.AddButton("Grid", () => Grid.Enabled = !Grid.Enabled);
-            _showGridButton.Icon = Style.Current.CheckBoxTick;
-            _showGridButton.CloseMenuOnClick = false;
+            //todo
+            //_showGridButton = ViewWidgetShowMenu.AddButton("Grid", () => Grid.Enabled = !Grid.Enabled);
+            //_showGridButton.Icon = Style.Current.CheckBoxTick;
+            //_showGridButton.CloseMenuOnClick = false;
 
             // Show navigation widget
-            _showNavigationButton = ViewWidgetShowMenu.AddButton("Navigation", () => ShowNavigation = !ShowNavigation);
-            _showNavigationButton.CloseMenuOnClick = false;
+            //todo
+            //_showNavigationButton = ViewWidgetShowMenu.AddButton("Navigation", () => ShowNavigation = !ShowNavigation);
+            //_showNavigationButton.CloseMenuOnClick = false;
 
             // Create camera widget
-            ViewWidgetButtonMenu.AddSeparator();
-            ViewWidgetButtonMenu.AddButton("Create camera here", CreateCameraAtView);
+            //todo
+            //ViewWidgetButtonMenu.AddSeparator();
+            //ViewWidgetButtonMenu.AddButton("Create camera here", CreateCameraAtView);
 
             // Init gizmo modes
             {
@@ -255,12 +260,14 @@ namespace FlaxEditor.Viewport
             }
 
             // Setup input actions
+            //todo
+            /*
             Viewport.InputOptions.List.SetCallback(
                 (Viewport.InputOptions.LockFocusSelection, LockFocusSelection),
                 (Viewport.InputOptions.FocusSelection, FocusSelection),
                 (Viewport.InputOptions.RotateSelection, RotateSelection),
                 (Viewport.InputOptions.Delete, _editor.SceneEditing.Delete)
-            );
+            );*/
         }
 
         /// <inheritdoc />
@@ -330,7 +337,7 @@ namespace FlaxEditor.Viewport
                 NearPlane = NearPlane,
                 FarPlane = FarPlane,
                 OrthographicScale = OrthographicScale,
-                UsePerspective = !UseOrthographicProjection,
+                UsePerspective = !OrthographicProjection,
                 FieldOfView = FieldOfView
             };
 
@@ -598,12 +605,12 @@ namespace FlaxEditor.Viewport
         }
 
         /// <inheritdoc />
-        protected override void OrientViewport(ref Quaternion orientation)
+        public override void OrientViewport(Quaternion orientation)
         {
             if (TransformGizmo.SelectedParents.Count != 0)
                 FocusSelection(ref orientation);
             else
-                base.OrientViewport(ref orientation);
+                base.OrientViewport(orientation);
         }
 
         /// <inheritdoc />
@@ -620,8 +627,6 @@ namespace FlaxEditor.Viewport
         /// <inheritdoc />
         protected override void OnLeftMouseButtonDown()
         {
-            base.OnLeftMouseButtonDown();
-
             _rubberBandSelector.TryStartingRubberBandSelection();
         }
 
@@ -641,8 +646,6 @@ namespace FlaxEditor.Viewport
 
             // Keep focus
             Focus();
-
-            base.OnLeftMouseButtonUp();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -634,7 +634,7 @@ namespace FlaxEditor.Viewport
         protected override void OnLeftMouseButtonUp()
         {
             // Skip if was controlling mouse or mouse is not over the area
-            if (_prevInput.IsControllingMouse || !Bounds.Contains(ref _viewMousePos))
+            if (!Bounds.Contains(ref _viewMousePos))
                 return;
 
             // Select rubberbanded rect actor nodes or pick with gizmo

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -255,10 +255,12 @@ namespace FlaxEditor.Viewport
             }
 
             // Setup input actions
-            InputActions.Add(options => options.LockFocusSelection, LockFocusSelection);
-            InputActions.Add(options => options.FocusSelection, FocusSelection);
-            InputActions.Add(options => options.RotateSelection, RotateSelection);
-            InputActions.Add(options => options.Delete, _editor.SceneEditing.Delete);
+            Viewport.InputOptions.List.SetCallback(
+                (Viewport.InputOptions.LockFocusSelection, LockFocusSelection),
+                (Viewport.InputOptions.FocusSelection, FocusSelection),
+                (Viewport.InputOptions.RotateSelection, RotateSelection),
+                (Viewport.InputOptions.Delete, _editor.SceneEditing.Delete)
+            );
         }
 
         /// <inheritdoc />
@@ -391,10 +393,10 @@ namespace FlaxEditor.Viewport
             bool renderPostFx = true;
             switch (renderContext.View.Mode)
             {
-            case ViewMode.Default:
-            case ViewMode.PhysicsColliders:
-                renderPostFx = false;
-                break;
+                case ViewMode.Default:
+                case ViewMode.PhysicsColliders:
+                    renderPostFx = false;
+                    break;
             }
             if (renderPostFx)
             {

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -130,9 +130,10 @@ namespace FlaxEditor.Viewport
                 _spritesRenderer.Enabled = defaultFeatures;
                 SelectionOutline.Enabled = defaultFeatures;
                 _showDefaultSceneButton.Visible = defaultFeatures;
-                _cameraWidget.Visible = defaultFeatures;
-                _cameraButton.Visible = defaultFeatures;
-                _orthographicModeButton.Visible = defaultFeatures;
+                //todo...
+                //_cameraWidget.Visible = defaultFeatures;
+                //_cameraButton.Visible = defaultFeatures;
+                //_orthographicModeButton.Visible = defaultFeatures;
                 Task.Enabled = defaultFeatures;
                 UseAutomaticTaskManagement = defaultFeatures;
                 ShowDefaultSceneActors = defaultFeatures;
@@ -173,7 +174,8 @@ namespace FlaxEditor.Viewport
             Gizmos = new GizmosCollection(this);
 
             _gridGizmo = new GridGizmo(this);
-            var showGridButton = ViewWidgetShowMenu.AddButton("Grid");
+            //todo
+            /*var showGridButton = ViewWidgetShowMenu.AddButton("Grid");
             showGridButton.Clicked += () =>
             {
                 _gridGizmo.Enabled = !_gridGizmo.Enabled;
@@ -181,7 +183,7 @@ namespace FlaxEditor.Viewport
             };
             showGridButton.Checked = true;
             showGridButton.CloseMenuOnClick = false;
-
+*/
             // Prepare rendering task
             Task.ActorsSource = ActorsSources.CustomActors;
             Task.ViewFlags = ViewFlags.DefaultEditor;
@@ -209,8 +211,9 @@ namespace FlaxEditor.Viewport
             _uiRoot.IndexInParent = 0; // Move viewport down below other widgets in the viewport
             _uiParentLink = _uiRoot.UIRoot;
 
-            // UI mode buton
-            _uiModeButton = ViewWidgetShowMenu.AddButton("UI Mode", (button) => ShowUI = button.Checked);
+            // UI mode button
+            //todo
+            //_uiModeButton = ViewWidgetShowMenu.AddButton("UI Mode", (button) => ShowUI = button.Checked);
             _uiModeButton.AutoCheck = true;
             _uiModeButton.VisibleChanged += control => (control as ContextMenuButton).Checked = ShowUI;
 
@@ -366,7 +369,7 @@ namespace FlaxEditor.Viewport
         }
 
         /// <inheritdoc />
-        protected override bool IsControllingMouse => Gizmos.Active?.IsControllingMouse ?? false;
+        protected override bool WantsMouseCapture => Gizmos.Active?.IsControllingMouse ?? false;
 
         /// <inheritdoc />
         protected override void AddUpdateCallbacks(RootControl root)
@@ -511,8 +514,6 @@ namespace FlaxEditor.Viewport
 
             // Keep focus
             Focus();
-
-            base.OnLeftMouseButtonUp();
         }
 
         /// <inheritdoc />
@@ -584,12 +585,12 @@ namespace FlaxEditor.Viewport
         }
 
         /// <inheritdoc />
-        protected override void OrientViewport(ref Quaternion orientation)
+        public override void OrientViewport(Quaternion orientation)
         {
             if (TransformGizmo.SelectedParents.Count != 0)
                 FocusSelection(ref orientation);
             else
-                base.OrientViewport(ref orientation);
+                base.OrientViewport(orientation);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -333,7 +333,7 @@ namespace FlaxEditor.Viewport
         public bool SnapToGround => false;
 
         /// <inheritdoc />
-        public bool SnapToVertex => ContainsFocus && Editor.Instance.Options.Options.Input.SnapToVertex.Process(Root);
+        public bool SnapToVertex => ContainsFocus && InputOptions.SnapToVertex.Process(Root);
 
         /// <inheritdoc />
         public Float2 MouseDelta => _mouseDelta;

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -317,16 +317,16 @@ namespace FlaxEditor.Viewport
         public float ViewFarPlane => FarPlane;
 
         /// <inheritdoc />
-        public bool IsLeftMouseButtonDown => _input.IsMouseLeftDown;
+        public bool IsLeftMouseButtonDown => Root?.GetMouseButton(MouseButton.Left) ?? false;
 
         /// <inheritdoc />
-        public bool IsRightMouseButtonDown => _input.IsMouseRightDown;
+        public bool IsRightMouseButtonDown => Root?.GetMouseButton(MouseButton.Right) ?? false;
 
         /// <inheritdoc />
-        public bool IsAltKeyDown => _input.IsAltDown;
+        public bool IsAltKeyDown => Root?.GetKey(KeyboardKeys.Alt) ?? false;
 
         /// <inheritdoc />
-        public bool IsControlDown => _input.IsControlDown;
+        public bool IsControlDown => Root?.GetKey(KeyboardKeys.Control) ?? false;
 
         /// <inheritdoc />
         public bool SnapToGround => false;
@@ -445,7 +445,7 @@ namespace FlaxEditor.Viewport
         protected override void OnLeftMouseButtonUp()
         {
             // Skip if was controlling mouse or mouse is not over the area
-            if (_prevInput.IsControllingMouse || !Bounds.Contains(ref _viewMousePos))
+            if (!Bounds.Contains(ref _viewMousePos))
                 return;
 
             if (TransformGizmo.IsActive)

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using FlaxEditor.Content;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.Scripting;
 using FlaxEditor.Viewport.Cameras;
@@ -220,7 +221,7 @@ namespace FlaxEditor.Viewport
             EditorGizmoViewport.AddGizmoViewportWidgets(this, TransformGizmo);
 
             // Setup input actions
-            Viewport.InputOptions.FocusSelection.Callback = ShowSelectedActors;
+            Viewport.InputBindingList.Add([new(InputOptionName.FocusSelection, ShowSelectedActors)]);
 
             SetUpdate(ref _update, OnUpdate);
         }

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -217,7 +217,7 @@ namespace FlaxEditor.Viewport
             EditorGizmoViewport.AddGizmoViewportWidgets(this, TransformGizmo);
 
             // Setup input actions
-            InputActions.Add(options => options.FocusSelection, ShowSelectedActors);
+            Viewport.InputOptions.FocusSelection.Callback = ShowSelectedActors;
 
             SetUpdate(ref _update, OnUpdate);
         }

--- a/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
@@ -192,6 +192,8 @@ namespace FlaxEditor.Viewport.Previews
 
             if (useWidgets)
             {
+                //todo
+                /*
                 // Show Bounds
                 _showBoundsButton = ViewWidgetShowMenu.AddButton("Bounds", () => ShowBounds = !ShowBounds);
                 _showBoundsButton.CloseMenuOnClick = false;
@@ -208,6 +210,7 @@ namespace FlaxEditor.Viewport.Previews
                 _showFloorButton = ViewWidgetShowMenu.AddButton("Floor", button => ShowFloor = !ShowFloor);
                 _showFloorButton.IndexInParent = 1;
                 _showFloorButton.CloseMenuOnClick = false;
+                */
             }
 
             // Enable shadows

--- a/Source/Editor/Viewport/Previews/AnimationPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimationPreview.cs
@@ -108,12 +108,12 @@ namespace FlaxEditor.Viewport.Previews
         public override bool OnKeyDown(KeyboardKeys key)
         {
             var inputOptions = Editor.Instance.Options.Options.Input;
-            if (inputOptions.Play.Process(this, key))
+            if (inputOptions.Play.Process(this))
             {
                 PlayAnimation = true;
                 return true;
             }
-            if (inputOptions.Pause.Process(this, key))
+            if (inputOptions.Pause.Process(this))
             {
                 PlayAnimation = false;
                 return true;

--- a/Source/Editor/Viewport/Previews/AnimationPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimationPreview.cs
@@ -5,6 +5,7 @@ using FlaxEditor.GUI.Input;
 using FlaxEngine;
 using FlaxEditor.Viewport.Widgets;
 using FlaxEngine.GUI;
+using FlaxEditor.Options;
 
 namespace FlaxEditor.Viewport.Previews
 {
@@ -110,13 +111,12 @@ namespace FlaxEditor.Viewport.Previews
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {
-            var inputOptions = Editor.Instance.Options.Options.Input;
-            if (inputOptions.Play.Process(this))
+            if (InputOptions.Play.Process(this))
             {
                 PlayAnimation = true;
                 return true;
             }
-            if (inputOptions.Pause.Process(this))
+            if (InputOptions.Pause.Process(this))
             {
                 PlayAnimation = false;
                 return true;

--- a/Source/Editor/Viewport/Previews/AnimationPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimationPreview.cs
@@ -37,6 +37,8 @@ namespace FlaxEditor.Viewport.Previews
         public AnimationPreview(bool useWidgets)
         : base(useWidgets)
         {
+            //todo
+            /*
             PlayAnimation = true;
             PlayAnimationChanged += OnPlayAnimationChanged;
             _snapToOrigin = false;
@@ -80,6 +82,7 @@ namespace FlaxEditor.Viewport.Previews
             PreviewLight.CascadeCount = 2;
             PreviewLight.ShadowsDistance = 1000.0f;
             Task.ViewFlags |= ViewFlags.Shadows;
+            */
         }
 
         private void OnPlayAnimationChanged()

--- a/Source/Editor/Viewport/Previews/AssetPreview.cs
+++ b/Source/Editor/Viewport/Previews/AssetPreview.cs
@@ -168,10 +168,13 @@ namespace FlaxEditor.Viewport.Previews
 
             if (useWidgets)
             {
+                //todo
+                /*
                 // Show Default Scene
                 _showDefaultSceneButton = ViewWidgetShowMenu.AddButton("Default Scene", () => ShowDefaultSceneActors = !ShowDefaultSceneActors);
                 _showDefaultSceneButton.Checked = true;
                 _showDefaultSceneButton.CloseMenuOnClick = false;
+                */
             }
 
             // Setup preview scene

--- a/Source/Editor/Viewport/Previews/ModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/ModelPreview.cs
@@ -198,6 +198,8 @@ namespace FlaxEditor.Viewport.Previews
 
             if (useWidgets)
             {
+                //todo
+                /*
                 _showBoundsButton = ViewWidgetShowMenu.AddButton("Bounds", () => ShowBounds = !ShowBounds);
                 _showBoundsButton.CloseMenuOnClick = false;
                 _showNormalsButton = ViewWidgetShowMenu.AddButton("Normals", () => ShowNormals = !ShowNormals);
@@ -250,7 +252,7 @@ namespace FlaxEditor.Viewport.Previews
                     TooltipText = "Preview LOD properties",
                     Parent = PreviewLODsMode,
                 };
-                PreviewLODsMode.Parent = this;
+                PreviewLODsMode.Parent = this;*/
             }
         }
 

--- a/Source/Editor/Viewport/Previews/ParticleEmitterPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleEmitterPreview.cs
@@ -66,6 +66,8 @@ namespace FlaxEditor.Viewport.Previews
 
             if (useWidgets)
             {
+                //todo
+                /*
                 var playbackDuration = ViewWidgetButtonMenu.AddButton("Duration");
                 playbackDuration.CloseMenuOnClick = false;
                 var playbackDurationValue = new FloatValueBox(_playbackDuration, 90, 2, 70.0f, 0.1f, 1000000.0f, 0.1f)
@@ -74,6 +76,7 @@ namespace FlaxEditor.Viewport.Previews
                 };
                 playbackDurationValue.ValueChanged += () => PlaybackDuration = playbackDurationValue.Value;
                 ViewWidgetButtonMenu.VisibleChanged += control => playbackDurationValue.Value = PlaybackDuration;
+                */
             }
         }
 

--- a/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.Viewport.Cameras;
 using FlaxEditor.Viewport.Widgets;
 using FlaxEngine;
@@ -279,13 +280,12 @@ namespace FlaxEditor.Viewport.Previews
                 return true;
             }
 
-            var inputOptions = Editor.Instance.Options.Options.Input;
-            if (inputOptions.Play.Process(this))
+            if (InputOptions.Play.Process(this))
             {
                 PlaySimulation = true;
                 return true;
             }
-            if (inputOptions.Pause.Process(this))
+            if (InputOptions.Pause.Process(this))
             {
                 PlaySimulation = false;
                 return true;

--- a/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
@@ -185,6 +185,8 @@ namespace FlaxEditor.Viewport.Previews
 
             if (!useWidgets)
                 return;
+            //todo
+            /*
             _showBoundsButton = ViewWidgetShowMenu.AddButton("Bounds", () => ShowBounds = !ShowBounds);
             _showBoundsButton.CloseMenuOnClick = false;
             _showOriginButton = ViewWidgetShowMenu.AddButton("Origin", () => ShowOrigin = !ShowOrigin);
@@ -202,7 +204,7 @@ namespace FlaxEditor.Viewport.Previews
                 };
                 _playPauseButton.Clicked += button => PlaySimulation = !PlaySimulation;
                 playPauseWidget.Parent = this;
-            }
+            }*/
         }
 
         private void UpdateBoundsModel()

--- a/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
+++ b/Source/Editor/Viewport/Previews/ParticleSystemPreview.cs
@@ -278,12 +278,12 @@ namespace FlaxEditor.Viewport.Previews
             }
 
             var inputOptions = Editor.Instance.Options.Options.Input;
-            if (inputOptions.Play.Process(this, key))
+            if (inputOptions.Play.Process(this))
             {
                 PlaySimulation = true;
                 return true;
             }
-            if (inputOptions.Pause.Process(this, key))
+            if (inputOptions.Pause.Process(this))
             {
                 PlaySimulation = false;
                 return true;

--- a/Source/Editor/Viewport/Previews/SkinnedModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/SkinnedModelPreview.cs
@@ -42,6 +42,8 @@ namespace FlaxEditor.Viewport.Previews
         {
             if (useWidgets)
             {
+                //todo
+                /*
                 // Show Current LOD
                 _showCurrentLODButton = ViewWidgetShowMenu.AddButton("Current LOD", button =>
                 {
@@ -80,7 +82,7 @@ namespace FlaxEditor.Viewport.Previews
                     TooltipText = "Preview LOD properties",
                     Parent = PreviewLODSMode,
                 };
-                PreviewLODSMode.Parent = this;
+                PreviewLODSMode.Parent = this;*/
             }
         }
 

--- a/Source/Editor/Viewport/Widgets/BrightnessWidget.cs
+++ b/Source/Editor/Viewport/Widgets/BrightnessWidget.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using FlaxEditor.Content.Settings;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Input;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using JsonSerializer = FlaxEngine.Json.JsonSerializer;
+
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class BrightnessWidget : ViewportWidget
+    {
+        private float _sliderOffset;
+        //todo hack for xLocationForWidgets
+        public BrightnessWidget(float sliderOffset, EditorViewport viewport, ContextMenu contextMenu)
+        : base(0, 0, 64, 32, viewport, contextMenu, true, false)
+        {
+            _sliderOffset = sliderOffset;
+            OnAttach();
+        }
+        protected override void OnAttach()
+        {
+            var brightness = ContextMenu.AddButton("Brightness");
+            brightness.CloseMenuOnClick = false;
+            var brightnessValue = new FloatValueBox(1.0f, _sliderOffset, 2, 70.0f, 0.001f, 10.0f, 0.001f)
+            {
+                Parent = brightness
+            };
+            brightnessValue.ValueChanged += () => Viewport.Brightness = brightnessValue.Value;
+            ContextMenu.VisibleChanged += control => brightnessValue.Value = Viewport.Brightness;
+        }
+    }
+}

--- a/Source/Editor/Viewport/Widgets/CameraSettingsWidget.cs
+++ b/Source/Editor/Viewport/Widgets/CameraSettingsWidget.cs
@@ -1,0 +1,301 @@
+using System.Collections.Generic;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Input;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class CameraSettingsWidget : ViewportWidget
+    {
+        /// <summary>
+        /// The camera settings widget.
+        /// </summary>
+        protected ViewportWidgetsContainer _cameraWidget;
+
+        /// <summary>
+        /// The camera settings widget button.
+        /// </summary>
+        protected ViewportWidgetButton _cameraButton;
+
+        /// <summary>
+        /// The orthographic mode widget button.
+        /// </summary>
+        protected ViewportWidgetButton _orthographicProjectionButton;
+
+        /// <summary>
+        /// Format of the text for the camera move speed.
+        /// </summary>
+        private string MovementSpeedTextFormat
+        {
+            get
+            {
+                if (Mathf.Abs(Viewport.MovementSpeed - Viewport.MaxMovementSpeed) < Mathf.Epsilon || Mathf.Abs(Viewport.MovementSpeed - Viewport.MinMovementSpeed) < Mathf.Epsilon)
+                    return "{0:0.##}";
+                if (Viewport.MovementSpeed < 10.0f)
+                    return "{0:0.00}";
+                if (Viewport.MovementSpeed < 100.0f)
+                    return "{0:0.0}";
+                return "{0:#}";
+            }
+        }
+
+        public CameraSettingsWidget(float x, float y, EditorViewport viewport)
+        : base(x, y, 64, 32, viewport)
+        {
+        }
+
+        protected override void OnAttach()
+        {
+            //todo
+            var largestText = "Relative Panning";
+            var textSize = Style.Current.FontMedium.MeasureText(largestText);
+            var xLocationForExtras = textSize.X + 5;
+            var cameraSpeedTextWidth = Style.Current.FontMedium.MeasureText("0.00").X;
+
+            // Camera Settings Widget
+            _cameraWidget = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperRight);
+
+            // Camera Settings Menu
+            var cameraCM = new ContextMenu();
+            _cameraButton = new ViewportWidgetButton(string.Format(MovementSpeedTextFormat, Viewport.MovementSpeed), Editor.Instance.Icons.Camera64, cameraCM, false, cameraSpeedTextWidth)
+            {
+                Tag = this,
+                TooltipText = "Camera Settings",
+                Parent = _cameraWidget
+            };
+            _cameraWidget.Parent = Viewport;
+
+            // Orthographic/Perspective Mode Widget
+            _orthographicProjectionButton = new ViewportWidgetButton(string.Empty, Editor.Instance.Icons.CamSpeed32, null, true)
+            {
+                Checked = !Viewport.OrthographicProjection,
+                TooltipText = "Toggle Orthographic/Perspective Mode",
+                Parent = _cameraWidget
+            };
+            _orthographicProjectionButton.Toggled += (sender) =>
+                {
+                    Viewport.OrthographicProjection = !Viewport.OrthographicProjection;
+                    _orthographicProjectionButton.Checked = !Viewport.OrthographicProjection;
+                };
+
+            // Camera Speed
+            var camSpeedButton = cameraCM.AddButton("Camera Speed");
+            camSpeedButton.CloseMenuOnClick = false;
+            var camSpeedValue = new FloatValueBox(Viewport.MovementSpeed, xLocationForExtras, 2, 70.0f, Viewport.MinMovementSpeed, Viewport.MaxMovementSpeed, 0.5f)
+            {
+                Parent = camSpeedButton
+            };
+
+            camSpeedValue.ValueChanged += () =>
+                    {
+                        Viewport.MovementSpeed = camSpeedValue.Value;
+                        if (_cameraButton != null)
+                            _cameraButton.Text = string.Format(MovementSpeedTextFormat, Viewport.MovementSpeed);
+                    };
+            cameraCM.VisibleChanged += control => camSpeedValue.Value = Viewport.MovementSpeed;
+
+            // Minimum & Maximum Camera Speed
+            var minCamSpeedButton = cameraCM.AddButton("Min Cam Speed");
+            minCamSpeedButton.CloseMenuOnClick = false;
+            var minCamSpeedValue = new FloatValueBox(Viewport.MinMovementSpeed, xLocationForExtras, 2, 70.0f, 0.05f, Viewport.MaxMovementSpeed, 0.5f)
+            {
+                Parent = minCamSpeedButton
+            };
+            var maxCamSpeedButton = cameraCM.AddButton("Max Cam Speed");
+            maxCamSpeedButton.CloseMenuOnClick = false;
+            var maxCamSpeedValue = new FloatValueBox(Viewport.MaxMovementSpeed, xLocationForExtras, 2, 70.0f, Viewport.MinMovementSpeed, 1000.0f, 0.5f)
+            {
+                Parent = maxCamSpeedButton
+            };
+
+            minCamSpeedValue.ValueChanged += () =>
+            {
+                Viewport.MinMovementSpeed = minCamSpeedValue.Value;
+                minCamSpeedValue.Value = Viewport.MinMovementSpeed;
+            };
+            cameraCM.VisibleChanged += control => minCamSpeedValue.Value = Viewport.MinMovementSpeed;
+
+            maxCamSpeedValue.ValueChanged += () =>
+            {
+                Viewport.MaxMovementSpeed = maxCamSpeedValue.Value;
+                maxCamSpeedValue.Value = Viewport.MaxMovementSpeed;
+            };
+            cameraCM.VisibleChanged += control => maxCamSpeedValue.Value = Viewport.MaxMovementSpeed;
+
+            // Camera Easing
+            {
+                var useCameraEasing = cameraCM.AddButton("Camera Easing");
+                useCameraEasing.CloseMenuOnClick = false;
+                var useCameraEasingValue = new CheckBox(xLocationForExtras, 2, Viewport.UseCameraEasing)
+                {
+                    Parent = useCameraEasing
+                };
+
+                useCameraEasingValue.StateChanged += checkBox => { Viewport.UseCameraEasing = !Viewport.UseCameraEasing; };
+                cameraCM.VisibleChanged += control => useCameraEasingValue.Checked = Viewport.UseCameraEasing;
+            }
+
+            // Panning Speed
+            {
+                var panningSpeed = cameraCM.AddButton("Panning Speed");
+                panningSpeed.CloseMenuOnClick = false;
+                var panningSpeedValue = new FloatValueBox(Viewport.PanningSpeed, xLocationForExtras, 2, 70.0f, 0.01f, 128.0f, 0.1f)
+                {
+                    Parent = panningSpeed
+                };
+
+                panningSpeedValue.ValueChanged += () => { Viewport.PanningSpeed = panningSpeedValue.Value; };//OnPanningSpeedChanged(panningSpeedValue);
+                cameraCM.VisibleChanged += control =>
+                {
+                    panningSpeed.Visible = !Viewport.RelativePanning;
+                    panningSpeedValue.Value = Viewport.PanningSpeed;
+                };
+            }
+
+            // Relative Panning
+            {
+                var relativePanning = cameraCM.AddButton("Relative Panning");
+                relativePanning.CloseMenuOnClick = false;
+                var relativePanningValue = new CheckBox(xLocationForExtras, 2, Viewport.RelativePanning)
+                {
+                    Parent = relativePanning
+                };
+
+                relativePanningValue.StateChanged += checkBox =>
+                {
+                    Viewport.RelativePanning = checkBox.Checked;
+                    cameraCM.Hide();
+                };
+                cameraCM.VisibleChanged += control => relativePanningValue.Checked = Viewport.RelativePanning;
+            }
+
+            // Invert Panning
+            {
+                var invertPanning = cameraCM.AddButton("Invert Panning");
+                invertPanning.CloseMenuOnClick = false;
+                var invertPanningValue = new CheckBox(xLocationForExtras, 2, Viewport.InvertPanning)
+                {
+                    Parent = invertPanning
+                };
+
+                invertPanningValue.StateChanged += checkBox => { Viewport.InvertPanning = !Viewport.InvertPanning; };
+                cameraCM.VisibleChanged += control => invertPanningValue.Checked = Viewport.InvertPanning;
+            }
+
+            cameraCM.AddSeparator();
+
+            // Camera Viewpoints
+            {
+                var cameraView = cameraCM.AddChildMenu("Viewpoints").ContextMenu;
+                foreach (var (key, value) in EditorViewport.CameraViewpoints)
+                {
+                    var button = cameraView.AddButton(key.ToString());
+                    button.Tag = value;
+                }
+
+                cameraView.ButtonClicked += (button) =>
+                {
+                    Viewport.OrientViewport(Quaternion.Euler((Float3)button.Tag));
+                };
+            }
+
+            // Orthographic Mode
+            {
+                var ortho = cameraCM.AddButton("Orthographic");
+                ortho.CloseMenuOnClick = false;
+                var orthoValue = new CheckBox(xLocationForExtras, 2, Viewport.OrthographicProjection)
+                {
+                    Parent = ortho
+                };
+
+                orthoValue.StateChanged += checkBox =>
+                {
+                    Viewport.OrthographicProjection = checkBox.Checked;
+                    cameraCM.Hide();
+                };
+                cameraCM.VisibleChanged += control => orthoValue.Checked = Viewport.OrthographicProjection;
+            }
+
+            // Field of View
+            {
+                var fov = cameraCM.AddButton("Field Of View");
+                fov.CloseMenuOnClick = false;
+                var fovValue = new FloatValueBox(Viewport.FieldOfView, xLocationForExtras, 2, 70.0f, 35.0f, 160.0f, 0.1f)
+                {
+                    Parent = fov
+                };
+
+                fovValue.ValueChanged += () => Viewport.FieldOfView = fovValue.Value;
+                cameraCM.VisibleChanged += control =>
+                {
+                    fov.Visible = !Viewport.OrthographicProjection;
+                    fovValue.Value = Viewport.FieldOfView;
+                };
+            }
+
+            // Orthographic Scale
+            {
+                var orthoSize = cameraCM.AddButton("Ortho Scale");
+                orthoSize.CloseMenuOnClick = false;
+                var orthoSizeValue = new FloatValueBox(Viewport.OrthographicScale, xLocationForExtras, 2, 70.0f, 0.001f, 100000.0f, 0.01f)
+                {
+                    Parent = orthoSize
+                };
+
+                orthoSizeValue.ValueChanged += () => Viewport.OrthographicScale = orthoSizeValue.Value;
+                cameraCM.VisibleChanged += control =>
+                {
+                    orthoSize.Visible = Viewport.OrthographicProjection;
+                    orthoSizeValue.Value = Viewport.OrthographicScale;
+                };
+            }
+
+            // Near Plane
+            {
+                var nearPlane = cameraCM.AddButton("Near Plane");
+                nearPlane.CloseMenuOnClick = false;
+                var nearPlaneValue = new FloatValueBox(Viewport.NearPlane, xLocationForExtras, 2, 70.0f, 0.001f, 1000.0f)
+                {
+                    Parent = nearPlane
+                };
+
+                nearPlaneValue.ValueChanged += () => { Viewport.NearPlane = nearPlaneValue.Value; };
+                cameraCM.VisibleChanged += control => nearPlaneValue.Value = Viewport.NearPlane;
+            }
+
+            // Far Plane
+            {
+                var farPlane = cameraCM.AddButton("Far Plane");
+                farPlane.CloseMenuOnClick = false;
+                var farPlaneValue = new FloatValueBox(Viewport.FarPlane, xLocationForExtras, 2, 70.0f, 10.0f)
+                {
+                    Parent = farPlane
+                };
+
+                farPlaneValue.ValueChanged += () => { Viewport.FarPlane = farPlaneValue.Value; };
+                cameraCM.VisibleChanged += control => farPlaneValue.Value = Viewport.FarPlane;
+            }
+
+            cameraCM.AddSeparator();
+
+            //todo i have no idea why this would be here.
+            // Reset Button
+            {
+                var reset = cameraCM.AddButton("Reset to default");
+                reset.ButtonClicked += button =>
+                {
+                    Viewport.GetViewportOptions();
+
+                    // if the context menu is opened without triggering the value changes beforehand,
+                    // the movement speed will not be correctly reset to its default value in certain cases
+                    // therefore, a UI update needs to be triggered here
+                    minCamSpeedValue.Value = Viewport.MinMovementSpeed;
+                    camSpeedValue.Value = Viewport.MovementSpeed;
+                    maxCamSpeedValue.Value = Viewport.MaxMovementSpeed;
+                };
+            }
+        }
+    }
+}

--- a/Source/Editor/Viewport/Widgets/DebugViewWidget.cs
+++ b/Source/Editor/Viewport/Widgets/DebugViewWidget.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using FlaxEditor.Content.Settings;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Input;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using JsonSerializer = FlaxEngine.Json.JsonSerializer;
+
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class DebugViewWidget : ViewportWidget
+    {
+        private ContextMenu _debugView;
+        public DebugViewWidget(float x, float y, EditorViewport viewport, ContextMenu contextMenu)
+        : base(x, y, 64, 32, viewport, contextMenu)
+        {
+        }
+
+        protected override void OnAttach()
+        {
+            _debugView = ContextMenu.AddChildMenu("Debug View").ContextMenu;
+            _debugView.AddButton("Copy view", () => Clipboard.Text = JsonSerializer.Serialize(Viewport.Task.ViewMode));
+            _debugView.AddButton("Paste view", () =>
+            {
+                try
+                {
+                    Viewport.Task.ViewMode = JsonSerializer.Deserialize<ViewMode>(Clipboard.Text);
+                }
+                catch
+                {
+                }
+            });
+            _debugView.AddSeparator();
+            for (int i = 0; i < ViewModeValues.Length; i++)
+            {
+                ref var v = ref ViewModeValues[i];
+                if (v.Options != null)
+                {
+                    var childMenu = _debugView.AddChildMenu(v.Name).ContextMenu;
+                    childMenu.ButtonClicked += WidgetViewModeShowHideClicked;
+                    childMenu.VisibleChanged += WidgetViewModeShowHide;
+                    for (int j = 0; j < v.Options.Length; j++)
+                    {
+                        ref var vv = ref v.Options[j];
+                        var button = childMenu.AddButton(vv.Name);
+                        button.CloseMenuOnClick = false;
+                        button.Tag = vv.Mode;
+                    }
+                }
+                else
+                {
+                    var button = _debugView.AddButton(v.Name);
+                    button.CloseMenuOnClick = false;
+                    button.Tag = v.Mode;
+                }
+            }
+            _debugView.ButtonClicked += WidgetViewModeShowHideClicked;
+            _debugView.VisibleChanged += WidgetViewModeShowHide;
+        }
+
+        private void WidgetViewModeShowHideClicked(ContextMenuButton button)
+        {
+            if (button.Tag is ViewMode v)
+            {
+                Viewport.Task.ViewMode = v;
+                var cm = button.ParentContextMenu;
+                WidgetViewModeShowHide(cm);
+                if (_debugView != null && cm != _debugView)
+                    WidgetViewModeShowHide(_debugView);
+            }
+        }
+
+        private void WidgetViewModeShowHide(Control cm)
+        {
+            if (cm.Visible == false)
+                return;
+
+            var ccm = (ContextMenu)cm;
+            foreach (var e in ccm.Items)
+            {
+                if (e is ContextMenuButton b && b.Tag is ViewMode v)
+                    b.Icon = Viewport.Task.ViewMode == v ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
+            }
+        }
+        private static readonly ViewModeOptions[] ViewModeValues =
+        {
+            new ViewModeOptions(ViewMode.Default, "Default"),
+            new ViewModeOptions(ViewMode.Unlit, "Unlit"),
+            new ViewModeOptions(ViewMode.NoPostFx, "No PostFx"),
+            new ViewModeOptions(ViewMode.Wireframe, "Wireframe"),
+            new ViewModeOptions(ViewMode.LightBuffer, "Light Buffer"),
+            new ViewModeOptions(ViewMode.Reflections, "Reflections Buffer"),
+            new ViewModeOptions(ViewMode.Depth, "Depth Buffer"),
+            new ViewModeOptions("GBuffer", new[]
+            {
+                new ViewModeOptions(ViewMode.Diffuse, "Diffuse"),
+                new ViewModeOptions(ViewMode.Metalness, "Metalness"),
+                new ViewModeOptions(ViewMode.Roughness, "Roughness"),
+                new ViewModeOptions(ViewMode.Specular, "Specular"),
+                new ViewModeOptions(ViewMode.SpecularColor, "Specular Color"),
+                new ViewModeOptions(ViewMode.SubsurfaceColor, "Subsurface Color"),
+                new ViewModeOptions(ViewMode.ShadingModel, "Shading Model"),
+                new ViewModeOptions(ViewMode.Emissive, "Emissive Light"),
+                new ViewModeOptions(ViewMode.Normals, "Normals"),
+                new ViewModeOptions(ViewMode.AmbientOcclusion, "Ambient Occlusion"),
+            }),
+            new ViewModeOptions(ViewMode.MotionVectors, "Motion Vectors"),
+            new ViewModeOptions(ViewMode.LightmapUVsDensity, "Lightmap UVs Density"),
+            new ViewModeOptions(ViewMode.VertexColors, "Vertex Colors"),
+            new ViewModeOptions(ViewMode.PhysicsColliders, "Physics Colliders"),
+            new ViewModeOptions(ViewMode.LODPreview, "LOD Preview"),
+            new ViewModeOptions(ViewMode.MaterialComplexity, "Material Complexity"),
+            new ViewModeOptions(ViewMode.QuadOverdraw, "Quad Overdraw"),
+            new ViewModeOptions(ViewMode.GlobalSDF, "Global SDF"),
+            new ViewModeOptions(ViewMode.GlobalSurfaceAtlas, "Global Surface Atlas"),
+            new ViewModeOptions(ViewMode.GlobalIllumination, "Global Illumination"),
+        };
+        private struct ViewModeOptions
+        {
+            public readonly string Name;
+            public readonly ViewMode Mode;
+            public readonly ViewModeOptions[] Options;
+
+            public ViewModeOptions(ViewMode mode, string name)
+            {
+                Mode = mode;
+                Name = name;
+                Options = null;
+            }
+
+            public ViewModeOptions(string name, ViewModeOptions[] options)
+            {
+                Name = name;
+                Mode = ViewMode.Default;
+                Options = options;
+            }
+        }
+    }
+}

--- a/Source/Editor/Viewport/Widgets/FpsCounterWidget.cs
+++ b/Source/Editor/Viewport/Widgets/FpsCounterWidget.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class FpsCounterWidget : ViewportWidget
+    {
+        public FpsCounterWidget(float x, float y, EditorViewport viewport, ContextMenu control)
+        : base(x, y, 64, 32, viewport, control)
+        {
+        }
+
+        public override void Draw()
+        {
+            base.Draw();
+
+            int fps = Engine.FramesPerSecond;
+            Color color = Color.Green;
+            if (fps < 13)
+                color = Color.Red;
+            else if (fps < 22)
+                color = Color.Yellow;
+            var text = string.Format("FPS: {0}", fps);
+            var font = Style.Current.FontMedium;
+            Render2D.DrawText(font, text, new Rectangle(Float2.One, Size), Color.Black);
+            Render2D.DrawText(font, text, new Rectangle(Float2.Zero, Size), color);
+        }
+
+        private ContextMenuButton _showFpsButton;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether show or hide FPS counter.
+        /// </summary>
+        public bool ShowFpsCounter
+        {
+            get => Visible;
+            set
+            {
+                Visible = value;
+                Enabled = value;
+                _showFpsButton.Icon = value ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
+            }
+        }
+
+        protected override void OnAttach(){
+                Visible = false;
+                Enabled = false;
+                var fpsMenu = ContextMenu.AddChildMenu("Show").ContextMenu;
+                _showFpsButton = fpsMenu.AddButton("FPS Counter", () => ShowFpsCounter = !ShowFpsCounter);
+                _showFpsButton.CloseMenuOnClick = false;
+            }
+        }
+    }

--- a/Source/Editor/Viewport/Widgets/ResolutionWidget.cs
+++ b/Source/Editor/Viewport/Widgets/ResolutionWidget.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using FlaxEditor.Content.Settings;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Input;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using JsonSerializer = FlaxEngine.Json.JsonSerializer;
+
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class ResolutionWidget : ViewportWidget
+    {
+        private float _sliderOffset;
+        //todo hack for xLocationForWidgets
+        public ResolutionWidget(float sliderOffset, EditorViewport viewport, ContextMenu contextMenu)
+        : base(0, 0, 64, 32, viewport, contextMenu, true, false)
+        {
+            _sliderOffset = sliderOffset;
+            OnAttach();
+        }
+        protected override void OnAttach()
+        {
+            var resolution = ContextMenu.AddButton("Resolution");
+            resolution.CloseMenuOnClick = false;
+            var resolutionValue = new FloatValueBox(1.0f, _sliderOffset, 2, 70.0f, 0.1f, 4.0f, 0.001f)
+            {
+                Parent = resolution
+            };
+            resolutionValue.ValueChanged += () => Viewport.ResolutionScale = resolutionValue.Value;
+            ContextMenu.VisibleChanged += control => resolutionValue.Value = Viewport.ResolutionScale;
+        }
+    }
+}

--- a/Source/Editor/Viewport/Widgets/ViewFlagsWidget.cs
+++ b/Source/Editor/Viewport/Widgets/ViewFlagsWidget.cs
@@ -1,0 +1,110 @@
+using FlaxEditor.Content.Settings;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using JsonSerializer = FlaxEngine.Json.JsonSerializer;
+
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class ViewFlagsWidget : ViewportWidget
+    {
+        public ViewFlagsWidget(float x, float y, EditorViewport viewport, ContextMenu contextMenu)
+        : base(x, y, 64, 32, viewport, contextMenu)
+        {
+        }
+
+        protected override void OnAttach()
+        {
+            var viewFlags = ContextMenu.AddChildMenu("View Flags").ContextMenu;
+            viewFlags.AddButton("Copy flags", () => Clipboard.Text = JsonSerializer.Serialize(Viewport.Task.ViewFlags));
+            viewFlags.AddButton("Paste flags", () =>
+            {
+                try
+                {
+                    Viewport.Task.ViewFlags = JsonSerializer.Deserialize<ViewFlags>(Clipboard.Text);
+                }
+                catch
+                {
+                }
+            });
+            viewFlags.AddButton("Reset flags", () => Viewport.Task.ViewFlags = ViewFlags.DefaultEditor).Icon = Editor.Instance.Icons.Rotate32;
+            viewFlags.AddButton("Disable flags", () => Viewport.Task.ViewFlags = ViewFlags.None).Icon = Editor.Instance.Icons.Rotate32;
+            viewFlags.AddSeparator();
+            for (int i = 0; i < ViewFlagsValues.Length; i++)
+            {
+                var v = ViewFlagsValues[i];
+                var button = viewFlags.AddButton(v.Name);
+                button.CloseMenuOnClick = false;
+                button.Tag = v.Mode;
+            }
+            viewFlags.ButtonClicked += button =>
+            {
+                if (button.Tag != null)
+                {
+                    var v = (ViewFlags)button.Tag;
+                    Viewport.Task.ViewFlags ^= v;
+                    button.Icon = (Viewport.Task.ViewFlags & v) != 0 ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
+                }
+            };
+            viewFlags.VisibleChanged += WidgetViewFlagsShowHide;
+        }
+        private static readonly ViewFlagOptions[] ViewFlagsValues =
+{
+            new ViewFlagOptions(ViewFlags.AntiAliasing, "Anti Aliasing"),
+            new ViewFlagOptions(ViewFlags.Shadows, "Shadows"),
+            new ViewFlagOptions(ViewFlags.EditorSprites, "Editor Sprites"),
+            new ViewFlagOptions(ViewFlags.Reflections, "Reflections"),
+            new ViewFlagOptions(ViewFlags.SSR, "Screen Space Reflections"),
+            new ViewFlagOptions(ViewFlags.AO, "Ambient Occlusion"),
+            new ViewFlagOptions(ViewFlags.GI, "Global Illumination"),
+            new ViewFlagOptions(ViewFlags.DirectionalLights, "Directional Lights"),
+            new ViewFlagOptions(ViewFlags.PointLights, "Point Lights"),
+            new ViewFlagOptions(ViewFlags.SpotLights, "Spot Lights"),
+            new ViewFlagOptions(ViewFlags.SkyLights, "Sky Lights"),
+            new ViewFlagOptions(ViewFlags.Sky, "Sky"),
+            new ViewFlagOptions(ViewFlags.Fog, "Fog"),
+            new ViewFlagOptions(ViewFlags.SpecularLight, "Specular Light"),
+            new ViewFlagOptions(ViewFlags.Decals, "Decals"),
+            new ViewFlagOptions(ViewFlags.CustomPostProcess, "Custom Post Process"),
+            new ViewFlagOptions(ViewFlags.Bloom, "Bloom"),
+            new ViewFlagOptions(ViewFlags.ToneMapping, "Tone Mapping"),
+            new ViewFlagOptions(ViewFlags.EyeAdaptation, "Eye Adaptation"),
+            new ViewFlagOptions(ViewFlags.CameraArtifacts, "Camera Artifacts"),
+            new ViewFlagOptions(ViewFlags.LensFlares, "Lens Flares"),
+            new ViewFlagOptions(ViewFlags.DepthOfField, "Depth of Field"),
+            new ViewFlagOptions(ViewFlags.MotionBlur, "Motion Blur"),
+            new ViewFlagOptions(ViewFlags.ContactShadows, "Contact Shadows"),
+            new ViewFlagOptions(ViewFlags.PhysicsDebug, "Physics Debug"),
+            new ViewFlagOptions(ViewFlags.LightsDebug, "Lights Debug"),
+            new ViewFlagOptions(ViewFlags.DebugDraw, "Debug Draw"),
+        };
+
+        private struct ViewFlagOptions
+        {
+            public readonly ViewFlags Mode;
+            public readonly string Name;
+
+            public ViewFlagOptions(ViewFlags mode, string name)
+            {
+                Mode = mode;
+                Name = name;
+            }
+        }
+
+        private void WidgetViewFlagsShowHide(Control cm)
+        {
+            if (cm.Visible == false)
+                return;
+            var ccm = (ContextMenu)cm;
+            foreach (var e in ccm.Items)
+            {
+                if (e is ContextMenuButton b && b.Tag != null)
+                {
+                    var v = (ViewFlags)b.Tag;
+                    b.Icon = (Viewport.Task.View.Flags & v) != 0 ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
+                }
+            }
+        }
+    }
+}

--- a/Source/Editor/Viewport/Widgets/ViewLayersWidget.cs
+++ b/Source/Editor/Viewport/Widgets/ViewLayersWidget.cs
@@ -1,0 +1,77 @@
+using FlaxEditor.Content.Settings;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using JsonSerializer = FlaxEngine.Json.JsonSerializer;
+
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class ViewLayersWidget : ViewportWidget
+    {
+
+        public ViewLayersWidget(float x, float y, EditorViewport viewport, ContextMenu contextMenu)
+        : base(x, y, 64, 32, viewport, contextMenu)
+        {
+        }
+
+        protected override void OnAttach()
+        {
+            // View Layers
+            var viewLayers = ContextMenu.AddChildMenu("View Layers").ContextMenu;
+            viewLayers.AddButton("Copy layers", () => Clipboard.Text = JsonSerializer.Serialize(Viewport.Task.View.RenderLayersMask));
+            viewLayers.AddButton("Paste layers", () =>
+            {
+                try
+                {
+                    Viewport.Task.ViewLayersMask = JsonSerializer.Deserialize<LayersMask>(Clipboard.Text);
+                }
+                catch
+                {
+                }
+            });
+            viewLayers.AddButton("Reset layers", () => Viewport.Task.ViewLayersMask = LayersMask.Default).Icon = Editor.Instance.Icons.Rotate32;
+            viewLayers.AddButton("Disable layers", () => Viewport.Task.ViewLayersMask = new LayersMask(0)).Icon = Editor.Instance.Icons.Rotate32;
+            viewLayers.AddSeparator();
+            var layers = LayersAndTagsSettings.GetCurrentLayers();
+            if (layers != null && layers.Length > 0)
+            {
+                for (int i = 0; i < layers.Length; i++)
+                {
+                    var layer = layers[i];
+                    var button = viewLayers.AddButton(layer);
+                    button.CloseMenuOnClick = false;
+                    button.Tag = 1 << i;
+                }
+            }
+            viewLayers.ButtonClicked += button =>
+            {
+                if (button.Tag != null)
+                {
+                    int layerIndex = (int)button.Tag;
+                    LayersMask mask = new LayersMask(layerIndex);
+                    Viewport.Task.ViewLayersMask ^= mask;
+                    button.Icon = (Viewport.Task.ViewLayersMask & mask) != 0 ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
+                }
+            };
+            viewLayers.VisibleChanged += WidgetViewLayersShowHide;
+        }
+
+        private void WidgetViewLayersShowHide(Control cm)
+        {
+            if (cm.Visible == false)
+                return;
+            var ccm = (ContextMenu)cm;
+            var layersMask = Viewport.Task.ViewLayersMask;
+            foreach (var e in ccm.Items)
+            {
+                if (e is ContextMenuButton b && b != null && b.Tag != null)
+                {
+                    int layerIndex = (int)b.Tag;
+                    LayersMask mask = new LayersMask(layerIndex);
+                    b.Icon = (layersMask & mask) != 0 ? Style.Current.CheckBoxTick : SpriteHandle.Invalid;
+                }
+            }
+        }
+    }
+}

--- a/Source/Editor/Viewport/Widgets/ViewmodeWidget.cs
+++ b/Source/Editor/Viewport/Widgets/ViewmodeWidget.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Xml;
+using FlaxEditor.Content.Settings;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Input;
+using FlaxEngine;
+using FlaxEngine.GUI;
+namespace FlaxEditor.Viewport.Widgets
+{
+
+    public class ViewmodeWidget : ViewportWidget
+    {
+        /// <summary>
+        /// The 'View' widget button context menu.
+        /// </summary>
+        public ContextMenu widgetMenu;
+
+        /// <summary>
+        /// The 'View' widget 'Show' category context menu.
+        /// </summary>
+        public ContextMenu ViewWidgetShowMenu;
+
+        public ViewmodeWidget(float x, float y, EditorViewport viewport)
+        : base(x, y, 64, 32, viewport)
+        {
+        }
+
+        protected override void OnAttach()
+        {
+            var widgetContainer = new ViewportWidgetsContainer(ViewportWidgetLocation.UpperLeft)
+            {
+                Parent = Viewport
+            };
+            widgetMenu = new ContextMenu();
+            //this needs to hide better
+            var viewModeButton = new ViewportWidgetButton("View", SpriteHandle.Invalid, widgetMenu)
+            {
+                TooltipText = "View properties",
+                Parent = widgetContainer,
+            };
+
+            //Show FPS
+            new FpsCounterWidget(0, 0, Viewport, widgetMenu);
+
+            //View Layers
+            new ViewLayersWidget(0, 0, Viewport, widgetMenu);
+
+            //View Flags
+            new ViewFlagsWidget(0, 0, Viewport, widgetMenu);
+
+            //Debug View
+            new DebugViewWidget(0, 0, Viewport, widgetMenu);
+
+            widgetMenu.AddSeparator();
+
+            var sliderOffset = Style.Current.FontMedium.MeasureText("Brightness").X + 5;
+            //Brightness
+            new BrightnessWidget(sliderOffset, Viewport, widgetMenu);
+
+            //Resolution
+            new ResolutionWidget(sliderOffset, Viewport, widgetMenu);
+
+            widgetMenu.AddSeparator();
+
+            //todo no idea how to test this dont know when it is shown
+            // Clear Debug Draw
+            {
+                var button = widgetMenu.AddButton("Clear Debug Draw");
+                button.CloseMenuOnClick = false;
+                button.Clicked += () => DebugDraw.Clear();
+                widgetMenu.VisibleChanged += (Control cm) => { button.Visible = DebugDraw.CanClear(); };
+            }
+        }
+    }
+}

--- a/Source/Editor/Viewport/Widgets/ViewportWidget.cs
+++ b/Source/Editor/Viewport/Widgets/ViewportWidget.cs
@@ -1,0 +1,51 @@
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Viewport;
+using FlaxEditor.Viewport.Widgets;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using System.Linq;
+using System;
+using System.Xml;
+using System.Reflection;
+
+public abstract class ViewportWidget : Control
+{
+
+    protected ViewportWidget(float x, float y, float width, float height, EditorViewport viewport, ContextMenu contextMenu, bool attachTo = true, bool onAttach = true)
+        : base(x, y, width, height)
+    {
+        if (attachTo)
+            AttachTo(viewport, contextMenu, onAttach);
+    }
+
+    protected ViewportWidget(float x, float y, float width, float height, EditorViewport viewport, bool attachTo = true, bool onAttach = true)
+        : base(x, y, width, height)
+    {
+        if (attachTo)
+            AttachTo(viewport, onAttach);
+    }
+
+    public EditorViewport Viewport { get; private set; }
+    public ContextMenu ContextMenu { get; private set; }
+
+    public virtual void AttachTo(EditorViewport viewport, ContextMenu contextMenu, bool onAttach = true)
+    {
+        Viewport = viewport;
+        Parent = viewport.Parent;
+        ContextMenu = contextMenu;
+        if (onAttach)
+            OnAttach();
+    }
+
+    public virtual void AttachTo(EditorViewport viewport, bool onAttach = true)
+    {
+        Viewport = viewport;
+        Parent = viewport.Parent;
+        if (onAttach)
+            OnAttach();
+    }
+
+    protected virtual void OnAttach()
+    {
+    }
+}

--- a/Source/Editor/Viewport/Widgets/ViewportWidgetButton.cs
+++ b/Source/Editor/Viewport/Widgets/ViewportWidgetButton.cs
@@ -18,7 +18,7 @@ namespace FlaxEditor.Viewport.Widgets
         private ContextMenu _cm;
         private bool _checked;
         private bool _autoCheck;
-        private bool _isMosueDown;
+        private bool _isMouseDown;
         private float _forcedTextWidth;
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace FlaxEditor.Viewport.Widgets
         {
             if (button == MouseButton.Left)
             {
-                _isMosueDown = true;
+                _isMouseDown = true;
             }
             if (_autoCheck)
             {
@@ -148,9 +148,9 @@ namespace FlaxEditor.Viewport.Widgets
         /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
-            if (button == MouseButton.Left && _isMosueDown)
+            if (button == MouseButton.Left && _isMouseDown)
             {
-                _isMosueDown = false;
+                _isMouseDown = false;
                 Clicked?.Invoke(this);
             }
 

--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -271,8 +271,6 @@ namespace FlaxEditor.Windows.Assets
         public AnimationWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;
@@ -306,10 +304,10 @@ namespace FlaxEditor.Windows.Assets
             _propertiesPresenter.Select(_properties);
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/animation/index.html")).LinkTooltip("See documentation to learn more");
 

--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -11,6 +11,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.Timeline;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEditor.Viewport.Cameras;
 using FlaxEditor.Viewport.Previews;
@@ -313,9 +314,12 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/animation/index.html")).LinkTooltip("See documentation to learn more");
 
             // Setup input actions
-            InputActions.Add(
-                (inputOptions.Undo, _undo.PerformUndo),
-                (inputOptions.Redo, _undo.PerformRedo)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo)
+                ]
             );
         }
 

--- a/Source/Editor/Windows/Assets/AnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/AnimationWindow.cs
@@ -313,8 +313,10 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/animation/index.html")).LinkTooltip("See documentation to learn more");
 
             // Setup input actions
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
+            InputActions.Add(
+                (inputOptions.Undo, _undo.PerformUndo),
+                (inputOptions.Redo, _undo.PerformRedo)
+            );
         }
 
         private void OnUndoRedo(IUndoAction action)
@@ -334,8 +336,8 @@ namespace FlaxEditor.Windows.Assets
             _properties.OnLoad(this);
             _propertiesPresenter.BuildLayout();
             ClearEditedFlag();
-            if (!_initialPreviewModel && 
-                Editor.ProjectCache.TryGetCustomData(GetPreviewModelCacheName(), out string str) && 
+            if (!_initialPreviewModel &&
+                Editor.ProjectCache.TryGetCustomData(GetPreviewModelCacheName(), out string str) &&
                 Guid.TryParse(str, out var id))
             {
                 _initialPreviewModel = FlaxEngine.Content.LoadAsync<SkinnedModel>(id);

--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -47,8 +47,6 @@ namespace FlaxEditor.Windows.Assets
         protected AssetEditorWindow(Editor editor, AssetItem item)
         : base(editor, false, ScrollBars.None)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             _item = item ?? throw new ArgumentNullException(nameof(item));
             _item.AddReference(this);
 

--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -4,6 +4,7 @@ using System;
 using FlaxEditor.Content;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -57,7 +58,7 @@ namespace FlaxEditor.Windows.Assets
             };
             _toolstrip.AddButton(editor.Icons.Search64, () => Editor.Windows.ContentWin.Select(_item)).LinkTooltip("Show and select in Content Window");
 
-            InputActions.Add(inputOptions.Save, Save);
+            InputActions.Add([new(InputOptionName.Save, Save)]);
 
             UpdateTitle();
 

--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -46,6 +46,8 @@ namespace FlaxEditor.Windows.Assets
         protected AssetEditorWindow(Editor editor, AssetItem item)
         : base(editor, false, ScrollBars.None)
         {
+            var inputOptions = Editor.Options.Options.Input;
+
             _item = item ?? throw new ArgumentNullException(nameof(item));
             _item.AddReference(this);
 
@@ -55,7 +57,7 @@ namespace FlaxEditor.Windows.Assets
             };
             _toolstrip.AddButton(editor.Icons.Search64, () => Editor.Windows.ContentWin.Select(_item)).LinkTooltip("Show and select in Content Window");
 
-            InputActions.Add(options => options.Save, Save);
+            InputActions.Add(inputOptions.Save, Save);
 
             UpdateTitle();
 

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -213,7 +213,6 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/audio/audio-clip.html")).LinkTooltip("See documentation to learn more");
 
-            var inputOptions = Editor.Options.Options.Input;
             InputActions.Add
             (
                 [

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -212,8 +212,9 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/audio/audio-clip.html")).LinkTooltip("See documentation to learn more");
 
-            InputActions.Add(options => options.Play, OnPlay);
-            InputActions.Add(options => options.Pause, OnPause);
+            var inputOptions = Editor.Options.Options.Input;
+            InputActions.Add(inputOptions.Play, OnPlay);
+            InputActions.Add(inputOptions.Pause, OnPause);
         }
 
         private void OnPlay()

--- a/Source/Editor/Windows/Assets/AudioClipWindow.cs
+++ b/Source/Editor/Windows/Assets/AudioClipWindow.cs
@@ -6,6 +6,7 @@ using FlaxEditor.Content.Import;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.GUI;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
@@ -213,8 +214,13 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/audio/audio-clip.html")).LinkTooltip("See documentation to learn more");
 
             var inputOptions = Editor.Options.Options.Input;
-            InputActions.Add(inputOptions.Play, OnPlay);
-            InputActions.Add(inputOptions.Pause, OnPause);
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Play, OnPlay),
+                    new(InputOptionName.Pause, OnPause)
+                ]
+            );
         }
 
         private void OnPlay()

--- a/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
+++ b/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
@@ -130,8 +130,6 @@ namespace FlaxEditor.Windows.Assets
         public BehaviorTreeWindow(Editor editor, BinaryAssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;

--- a/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
+++ b/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
@@ -429,9 +429,11 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddSeparator();
             _resetButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Rotate32, Reset).LinkTooltip("Resets the variables values to the default values");
 
-            InputActions.Add(options => options.Save, Save);
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
+            InputActions.Add(
+                (inputOptions.Save, Save),
+                (inputOptions.Undo, _undo.PerformUndo),
+                (inputOptions.Redo, _undo.PerformRedo)
+            );
         }
 
         private void OnPropertiesEditorModified()

--- a/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
+++ b/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
@@ -8,6 +8,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.GUI;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -429,10 +430,13 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddSeparator();
             _resetButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Rotate32, Reset).LinkTooltip("Resets the variables values to the default values");
 
-            InputActions.Add(
-                (inputOptions.Save, Save),
-                (inputOptions.Undo, _undo.PerformUndo),
-                (inputOptions.Redo, _undo.PerformRedo)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Save, Save),
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo)
+                ]
             );
         }
 

--- a/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
+++ b/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
@@ -405,8 +405,6 @@ namespace FlaxEditor.Windows.Assets
         public GameplayGlobalsWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             _undo = new Undo();
             _undo.ActionDone += OnUndo;
             _undo.UndoDone += OnUndo;
@@ -423,10 +421,10 @@ namespace FlaxEditor.Windows.Assets
             _proxy = new PropertiesProxy();
             _propertiesEditor.Select(_proxy);
 
-            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             _toolstrip.AddSeparator();
             _resetButton = (ToolStripButton)_toolstrip.AddButton(editor.Icons.Rotate32, Reset).LinkTooltip("Resets the variables values to the default values");
 

--- a/Source/Editor/Windows/Assets/JsonAssetWindow.cs
+++ b/Source/Editor/Windows/Assets/JsonAssetWindow.cs
@@ -5,6 +5,7 @@ using FlaxEditor.Content;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Json;
@@ -114,9 +115,12 @@ namespace FlaxEditor.Windows.Assets
             _presenter.Modified += MarkAsEdited;
 
             // Setup input actions
-            InputActions.Add(
-                (inputOptions.Undo, _undo.PerformUndo),
-                (inputOptions.Redo, _undo.PerformRedo)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo)
+                ]
             );
         }
 

--- a/Source/Editor/Windows/Assets/JsonAssetWindow.cs
+++ b/Source/Editor/Windows/Assets/JsonAssetWindow.cs
@@ -87,8 +87,6 @@ namespace FlaxEditor.Windows.Assets
         public JsonAssetWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;
@@ -96,10 +94,10 @@ namespace FlaxEditor.Windows.Assets
             _undo.ActionDone += OnUndoRedo;
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
 
             // Panel
             var panel = new Panel(ScrollBars.Vertical)

--- a/Source/Editor/Windows/Assets/JsonAssetWindow.cs
+++ b/Source/Editor/Windows/Assets/JsonAssetWindow.cs
@@ -114,8 +114,10 @@ namespace FlaxEditor.Windows.Assets
             _presenter.Modified += MarkAsEdited;
 
             // Setup input actions
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
+            InputActions.Add(
+                (inputOptions.Undo, _undo.PerformUndo),
+                (inputOptions.Redo, _undo.PerformRedo)
+            );
         }
 
         private void OnUndoRedo(IUndoAction action)

--- a/Source/Editor/Windows/Assets/LocalizedStringTableWindow.cs
+++ b/Source/Editor/Windows/Assets/LocalizedStringTableWindow.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using FlaxEditor.Content;
 using FlaxEditor.CustomEditors;
 using FlaxEditor.GUI;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using FlaxEngine.Utilities;
@@ -156,8 +157,13 @@ namespace FlaxEditor.Windows.Assets
             _presenter.Modified += MarkAsEdited;
 
             // Setup input actions
-            InputActions.Add(inputOptions.Undo, _undo.PerformUndo);
-            InputActions.Add(inputOptions.Redo, _undo.PerformRedo);
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo)
+                ]
+            );
         }
 
         private void OnUndoRedo(IUndoAction action)

--- a/Source/Editor/Windows/Assets/LocalizedStringTableWindow.cs
+++ b/Source/Editor/Windows/Assets/LocalizedStringTableWindow.cs
@@ -156,8 +156,8 @@ namespace FlaxEditor.Windows.Assets
             _presenter.Modified += MarkAsEdited;
 
             // Setup input actions
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
+            InputActions.Add(inputOptions.Undo, _undo.PerformUndo);
+            InputActions.Add(inputOptions.Redo, _undo.PerformRedo);
         }
 
         private void OnUndoRedo(IUndoAction action)

--- a/Source/Editor/Windows/Assets/LocalizedStringTableWindow.cs
+++ b/Source/Editor/Windows/Assets/LocalizedStringTableWindow.cs
@@ -127,8 +127,6 @@ namespace FlaxEditor.Windows.Assets
         public LocalizedStringTableWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;
@@ -136,10 +134,10 @@ namespace FlaxEditor.Windows.Assets
             _undo.ActionDone += OnUndoRedo;
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(Editor.Icons.Up64, OnExport).LinkTooltip("Export localization table entries for translation to .pot file");
 

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -10,6 +10,7 @@ using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.CustomEditors.GUI;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.Surface;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
@@ -416,8 +417,13 @@ namespace FlaxEditor.Windows.Assets
             _editor.Modified += OnMaterialPropertyEdited;
 
             // Setup input actions
-            InputActions.Add(inputOptions.Undo, _undo.PerformUndo);
-            InputActions.Add(inputOptions.Redo, _undo.PerformRedo);
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo)
+                ]
+            );
         }
 
         private void OnRevertAllParameters()

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -379,8 +379,6 @@ namespace FlaxEditor.Windows.Assets
         public MaterialInstanceWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;
@@ -388,10 +386,10 @@ namespace FlaxEditor.Windows.Assets
             _undo.ActionDone += OnAction;
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/graphics/materials/instanced-materials/index.html")).LinkTooltip("See documentation to learn more");
 

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -416,8 +416,8 @@ namespace FlaxEditor.Windows.Assets
             _editor.Modified += OnMaterialPropertyEdited;
 
             // Setup input actions
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
+            InputActions.Add(inputOptions.Undo, _undo.PerformUndo);
+            InputActions.Add(inputOptions.Redo, _undo.PerformRedo);
         }
 
         private void OnRevertAllParameters()

--- a/Source/Editor/Windows/Assets/ModelBaseWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelBaseWindow.cs
@@ -10,6 +10,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.Tabs;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -787,10 +788,8 @@ namespace FlaxEditor.Windows.Assets
         protected ModelBaseWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
 
             // Split Panel
             _split = new SplitPanel(Orientation.Horizontal, ScrollBars.None, ScrollBars.None)

--- a/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
+++ b/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
@@ -307,8 +307,6 @@ namespace FlaxEditor.Windows.Assets
         public ParticleSystemWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;
@@ -360,10 +358,10 @@ namespace FlaxEditor.Windows.Assets
             propertiesEditor.Select(new GeneralProxy(this));
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/particles/index.html")).LinkTooltip("See documentation to learn more");
 

--- a/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
+++ b/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
@@ -10,6 +10,7 @@ using FlaxEditor.CustomEditors.GUI;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.Timeline;
 using FlaxEditor.GUI.Timeline.Tracks;
+using FlaxEditor.Options;
 using FlaxEditor.Surface;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
@@ -367,8 +368,13 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/particles/index.html")).LinkTooltip("See documentation to learn more");
 
             // Setup input actions
-            InputActions.Add(inputOptions.Undo, _undo.PerformUndo);
-            InputActions.Add(inputOptions.Redo, _undo.PerformRedo);
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo)
+                ]
+            );
         }
 
         private void OnUndoRedo(IUndoAction action)

--- a/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
+++ b/Source/Editor/Windows/Assets/ParticleSystemWindow.cs
@@ -367,8 +367,8 @@ namespace FlaxEditor.Windows.Assets
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/particles/index.html")).LinkTooltip("See documentation to learn more");
 
             // Setup input actions
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
+            InputActions.Add(inputOptions.Undo, _undo.PerformUndo);
+            InputActions.Add(inputOptions.Redo, _undo.PerformRedo);
         }
 
         private void OnUndoRedo(IUndoAction action)

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -214,23 +214,27 @@ namespace FlaxEditor.Windows.Assets
             ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
 
             // Setup input actions
-            InputActions.Add(options => options.Undo, () =>
+            InputActions.Add(
+                (inputOptions.Undo, () =>
             {
                 _undo.PerformUndo();
                 Focus();
-            });
-            InputActions.Add(options => options.Redo, () =>
+            }
+            ),
+            (inputOptions.Redo, () =>
             {
                 _undo.PerformRedo();
                 Focus();
-            });
-            InputActions.Add(options => options.Cut, Cut);
-            InputActions.Add(options => options.Copy, Copy);
-            InputActions.Add(options => options.Paste, Paste);
-            InputActions.Add(options => options.Duplicate, Duplicate);
-            InputActions.Add(options => options.Delete, Delete);
-            InputActions.Add(options => options.Rename, RenameSelection);
-            InputActions.Add(options => options.FocusSelection, FocusSelection);
+            }
+            ),
+            (inputOptions.Cut, Cut),
+            (inputOptions.Copy, Copy),
+            (inputOptions.Paste, Paste),
+            (inputOptions.Duplicate, Duplicate),
+            (inputOptions.Delete, Delete),
+            (inputOptions.Rename, RenameSelection),
+            (inputOptions.FocusSelection, FocusSelection)
+            );
         }
 
         /// <summary>

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -118,8 +118,6 @@ namespace FlaxEditor.Windows.Assets
         public PrefabWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoEvent;
@@ -200,14 +198,14 @@ namespace FlaxEditor.Windows.Assets
             _propertiesEditor.Modified += MarkAsEdited;
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _toolStripUndo = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _toolStripRedo = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _toolStripUndo = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _toolStripRedo = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             _toolstrip.AddSeparator();
-            _toolStripTranslate = _toolstrip.AddButton(Editor.Icons.Translate32, () => _viewport.TransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate).LinkTooltip("Change Gizmo tool mode to Translate", ref inputOptions.TranslateMode);
-            _toolStripRotate = _toolstrip.AddButton(Editor.Icons.Rotate32, () => _viewport.TransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate).LinkTooltip("Change Gizmo tool mode to Rotate", ref inputOptions.RotateMode);
-            _toolStripScale = _toolstrip.AddButton(Editor.Icons.Scale32, () => _viewport.TransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale).LinkTooltip("Change Gizmo tool mode to Scale", ref inputOptions.ScaleMode);
+            _toolStripTranslate = _toolstrip.AddButton(Editor.Icons.Translate32, () => _viewport.TransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate).LinkTooltip("Change Gizmo tool mode to Translate", InputOptions.TranslateMode);
+            _toolStripRotate = _toolstrip.AddButton(Editor.Icons.Rotate32, () => _viewport.TransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate).LinkTooltip("Change Gizmo tool mode to Rotate", InputOptions.RotateMode);
+            _toolStripScale = _toolstrip.AddButton(Editor.Icons.Scale32, () => _viewport.TransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale).LinkTooltip("Change Gizmo tool mode to Scale", InputOptions.ScaleMode);
             _toolstrip.AddSeparator();
             _toolStripLiveReload = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Refresh64, () => LiveReload = !LiveReload).SetChecked(true).SetAutoCheck(true).LinkTooltip("Live changes preview (applies prefab changes on modification by auto)");
 

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -8,6 +8,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.Input;
+using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.Viewport;
 using FlaxEngine;
@@ -214,26 +215,29 @@ namespace FlaxEditor.Windows.Assets
             ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
 
             // Setup input actions
-            InputActions.Add(
-                (inputOptions.Undo, () =>
-            {
-                _undo.PerformUndo();
-                Focus();
-            }
-            ),
-            (inputOptions.Redo, () =>
-            {
-                _undo.PerformRedo();
-                Focus();
-            }
-            ),
-            (inputOptions.Cut, Cut),
-            (inputOptions.Copy, Copy),
-            (inputOptions.Paste, Paste),
-            (inputOptions.Duplicate, Duplicate),
-            (inputOptions.Delete, Delete),
-            (inputOptions.Rename, RenameSelection),
-            (inputOptions.FocusSelection, FocusSelection)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo,
+                        () => {
+                            _undo.PerformUndo();
+                            Focus();
+                        }
+                    ),
+                    new(InputOptionName.Redo,
+                        () => {
+                            _undo.PerformRedo();
+                            Focus();
+                        }
+                    ),
+                    new(InputOptionName.Cut, Cut),
+                    new(InputOptionName.Copy, Copy),
+                    new(InputOptionName.Paste, Paste),
+                    new(InputOptionName.Duplicate, Duplicate),
+                    new(InputOptionName.Delete, Delete),
+                    new(InputOptionName.Rename, RenameSelection),
+                    new(InputOptionName.FocusSelection, FocusSelection)
+                ]
             );
         }
 

--- a/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
@@ -10,6 +10,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.Timeline;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -699,9 +700,12 @@ namespace FlaxEditor.Windows.Assets
             _previewPlayerPicker.ValueChanged += OnPreviewPlayerPickerChanged;
 
             // Setup input actions
-            InputActions.Add(
-                (inputOptions.Undo, _undo.PerformUndo),
-                (inputOptions.Redo, _undo.PerformRedo)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo)
+                ]
             );
         }
 

--- a/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
@@ -639,8 +639,6 @@ namespace FlaxEditor.Windows.Assets
         public SceneAnimationWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;
@@ -664,10 +662,10 @@ namespace FlaxEditor.Windows.Assets
             _timeline.SetNoTracksText("Loading...");
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
-            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", ref inputOptions.Undo);
-            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
+            _undoButton = _toolstrip.AddButton(Editor.Icons.Undo64, _undo.PerformUndo).LinkTooltip("Undo", InputOptions.Undo);
+            _redoButton = _toolstrip.AddButton(Editor.Icons.Redo64, _undo.PerformRedo).LinkTooltip("Redo", InputOptions.Redo);
             _toolstrip.AddSeparator();
             _previewButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Refresh64, OnPreviewButtonClicked).SetAutoCheck(true).LinkTooltip("If checked, enables live-preview of the animation on a scene while editing");
             _renderButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Build64, OnRenderButtonClicked).LinkTooltip("Open the scene animation rendering utility...");

--- a/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
+++ b/Source/Editor/Windows/Assets/SceneAnimationWindow.cs
@@ -699,8 +699,10 @@ namespace FlaxEditor.Windows.Assets
             _previewPlayerPicker.ValueChanged += OnPreviewPlayerPickerChanged;
 
             // Setup input actions
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
+            InputActions.Add(
+                (inputOptions.Undo, _undo.PerformUndo),
+                (inputOptions.Redo, _undo.PerformRedo)
+            );
         }
 
         private void OnUndoRedo(IUndoAction action)

--- a/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
+++ b/Source/Editor/Windows/Assets/SkeletonMaskWindow.cs
@@ -8,6 +8,7 @@ using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.CustomEditors.Elements;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.Tree;
+using FlaxEditor.Options;
 using FlaxEditor.Viewport.Cameras;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
@@ -192,10 +193,8 @@ namespace FlaxEditor.Windows.Assets
         public SkeletonMaskWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/animation/skeleton-mask.html")).LinkTooltip("See documentation to learn more");
 

--- a/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
+++ b/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
@@ -10,6 +10,7 @@ using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.CustomEditors.Elements;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
@@ -285,8 +286,6 @@ namespace FlaxEditor.Windows.Assets
         public SpriteAtlasWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Split Panel
             _split = new SplitPanel(Orientation.Horizontal, ScrollBars.None, ScrollBars.Vertical)
             {
@@ -310,7 +309,7 @@ namespace FlaxEditor.Windows.Assets
             _propertiesEditor.Modified += MarkAsEdited;
 
             // Toolstrip
-            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = _toolstrip.AddButton(editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddButton(editor.Icons.Import64, () => Editor.ContentImporting.Reimport((BinaryAssetItem)Item)).LinkTooltip("Reimport");
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.AddFile64, () =>

--- a/Source/Editor/Windows/Assets/TextureWindow.cs
+++ b/Source/Editor/Windows/Assets/TextureWindow.cs
@@ -8,6 +8,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Dedicated;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.GUI;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEditor.Viewport.Previews;
 using FlaxEngine;
@@ -225,8 +226,6 @@ namespace FlaxEditor.Windows.Assets
         public TextureWindow(Editor editor, AssetItem item)
         : base(editor, item)
         {
-            var inputOptions = Editor.Options.Options.Input;
-
             // Split Panel
             _split = new SplitPanel(Orientation.Horizontal, ScrollBars.None, ScrollBars.Vertical)
             {
@@ -257,7 +256,7 @@ namespace FlaxEditor.Windows.Assets
             _tabs.AddTab(new ImportTab(this));
 
             // Toolstrip
-            _saveButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
+            _saveButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", InputOptions.Save);
             _toolstrip.AddButton(Editor.Icons.Import64, () => Editor.ContentImporting.Reimport((BinaryAssetItem)Item)).LinkTooltip("Reimport");
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(Editor.Icons.CenterView64, _preview.CenterView).LinkTooltip("Center view");

--- a/Source/Editor/Windows/Assets/VisualScriptWindow.cs
+++ b/Source/Editor/Windows/Assets/VisualScriptWindow.cs
@@ -11,6 +11,7 @@ using FlaxEditor.CustomEditors;
 using FlaxEditor.CustomEditors.Editors;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.Scripting;
 using FlaxEditor.Surface;
 using FlaxEngine;
@@ -637,11 +638,14 @@ namespace FlaxEditor.Windows.Assets
             debugObjectPickerContainer.Parent = _toolstrip;
 
             // Setup input actions
-            InputActions.Add(
-                (inputOptions.DebuggerContinue, OnDebuggerContinue),
-                (inputOptions.DebuggerStepOver, OnDebuggerStepOver),
-                (inputOptions.DebuggerStepOut, OnDebuggerStepOut),
-                (inputOptions.DebuggerStepInto, OnDebuggerStepInto)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.DebuggerContinue, OnDebuggerContinue),
+                    new(InputOptionName.DebuggerStepOver, OnDebuggerStepOver),
+                    new(InputOptionName.DebuggerStepOut, OnDebuggerStepOut),
+                    new(InputOptionName.DebuggerStepInto, OnDebuggerStepInto)
+                ]
             );
 
             SetCanEdit(!isPlayMode);

--- a/Source/Editor/Windows/Assets/VisualScriptWindow.cs
+++ b/Source/Editor/Windows/Assets/VisualScriptWindow.cs
@@ -637,10 +637,12 @@ namespace FlaxEditor.Windows.Assets
             debugObjectPickerContainer.Parent = _toolstrip;
 
             // Setup input actions
-            InputActions.Add(options => options.DebuggerContinue, OnDebuggerContinue);
-            InputActions.Add(options => options.DebuggerStepOver, OnDebuggerStepOver);
-            InputActions.Add(options => options.DebuggerStepOut, OnDebuggerStepOut);
-            InputActions.Add(options => options.DebuggerStepInto, OnDebuggerStepInto);
+            InputActions.Add(
+                (inputOptions.DebuggerContinue, OnDebuggerContinue),
+                (inputOptions.DebuggerStepOver, OnDebuggerStepOver),
+                (inputOptions.DebuggerStepOut, OnDebuggerStepOut),
+                (inputOptions.DebuggerStepInto, OnDebuggerStepInto)
+            );
 
             SetCanEdit(!isPlayMode);
         }

--- a/Source/Editor/Windows/Assets/VisualScriptWindow.cs
+++ b/Source/Editor/Windows/Assets/VisualScriptWindow.cs
@@ -562,7 +562,6 @@ namespace FlaxEditor.Windows.Assets
         : base(editor, item)
         {
             var isPlayMode = Editor.IsPlayMode;
-            var inputOptions = Editor.Options.Options.Input;
 
             // Undo
             _undo = new Undo();
@@ -604,11 +603,11 @@ namespace FlaxEditor.Windows.Assets
             _debugToolstripControls = new[]
             {
                 _toolstrip.AddSeparator(),
-                _toolstrip.AddButton(editor.Icons.Play64, OnDebuggerContinue).LinkTooltip("Continue", ref inputOptions.DebuggerContinue),
+                _toolstrip.AddButton(editor.Icons.Play64, OnDebuggerContinue).LinkTooltip("Continue", InputOptions.DebuggerContinue),
                 _toolstrip.AddButton(editor.Icons.Search64, OnDebuggerNavigateToCurrentNode).LinkTooltip("Navigate to the current stack trace node"),
-                _toolstrip.AddButton(editor.Icons.Right64, OnDebuggerStepOver).LinkTooltip("Step Over", ref inputOptions.DebuggerStepOver),
-                _toolstrip.AddButton(editor.Icons.Down64, OnDebuggerStepInto).LinkTooltip("Step Into", ref inputOptions.DebuggerStepInto),
-                _toolstrip.AddButton(editor.Icons.Up64, OnDebuggerStepOut).LinkTooltip("Step Out", ref inputOptions.DebuggerStepOut),
+                _toolstrip.AddButton(editor.Icons.Right64, OnDebuggerStepOver).LinkTooltip("Step Over", InputOptions.DebuggerStepOver),
+                _toolstrip.AddButton(editor.Icons.Down64, OnDebuggerStepInto).LinkTooltip("Step Into", InputOptions.DebuggerStepInto),
+                _toolstrip.AddButton(editor.Icons.Up64, OnDebuggerStepOut).LinkTooltip("Step Out", InputOptions.DebuggerStepOut),
                 _toolstrip.AddButton(editor.Icons.Stop64, OnDebuggerStop).LinkTooltip("Stop debugging"),
             };
             foreach (var control in _debugToolstripControls)

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -265,8 +265,13 @@ namespace FlaxEditor.Windows
 
             InputOptions inputOptions = Editor.Instance.Options.Options.Input;
 
-            _view.InputBindings.Add(inputOptions.Search, () => _itemsSearchBox.Focus());
-            InputActions.Add(inputOptions.Search, () => _itemsSearchBox.Focus());
+            _view.InputBindings.Add
+            (
+                [
+                    new(InputOptionName.Search, () => _itemsSearchBox.Focus()),
+                    new(InputOptionName.Search, () => _itemsSearchBox.Focus())
+                ]
+            );
         }
 
         private ContextMenu OnViewDropdownPopupCreate(ComboBox comboBox)

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -263,8 +263,10 @@ namespace FlaxEditor.Windows
             _view.OnDuplicate += Duplicate;
             _view.OnPaste += Paste;
 
-            _view.InputActions.Add(options => options.Search, () => _itemsSearchBox.Focus());
-            InputActions.Add(options => options.Search, () => _itemsSearchBox.Focus());
+            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
+
+            _view.InputBindings.Add(inputOptions.Search, () => _itemsSearchBox.Focus());
+            InputActions.Add(inputOptions.Search, () => _itemsSearchBox.Focus());
         }
 
         private ContextMenu OnViewDropdownPopupCreate(ComboBox comboBox)

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -263,8 +263,6 @@ namespace FlaxEditor.Windows
             _view.OnDuplicate += Duplicate;
             _view.OnPaste += Paste;
 
-            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
-
             _view.InputBindings.Add
             (
                 [

--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -177,8 +177,6 @@ namespace FlaxEditor.Windows
             /// <inheritdoc />
             public override bool OnKeyDown(KeyboardKeys key)
             {
-                InputOptions options = FlaxEditor.Editor.Instance.Options.Options.Input;
-
                 // Up
                 if (key == KeyboardKeys.ArrowUp)
                 {
@@ -209,7 +207,7 @@ namespace FlaxEditor.Windows
                     Open();
                 }
                 // Ctrl+C
-                else if (options.Copy.Process(this))
+                else if (InputOptions.Copy.Process(this))
                 {
                     Copy();
                     return true;

--- a/Source/Editor/Windows/EditGameWindow.cs
+++ b/Source/Editor/Windows/EditGameWindow.cs
@@ -422,14 +422,15 @@ namespace FlaxEditor.Windows
         public override void OnLayoutSerialize(XmlWriter writer)
         {
             writer.WriteAttributeString("GridEnabled", Viewport.Grid.Enabled.ToString());
-            writer.WriteAttributeString("ShowFpsCounter", Viewport.ShowFpsCounter.ToString());
+            //todo
+            //writer.WriteAttributeString("ShowFpsCounter", Viewport.FpsCounter.ShowFpsCounter.ToString());
             writer.WriteAttributeString("ShowNavigation", Viewport.ShowNavigation.ToString());
             writer.WriteAttributeString("NearPlane", Viewport.NearPlane.ToString());
             writer.WriteAttributeString("FarPlane", Viewport.FarPlane.ToString());
             writer.WriteAttributeString("FieldOfView", Viewport.FieldOfView.ToString());
             writer.WriteAttributeString("MovementSpeed", Viewport.MovementSpeed.ToString());
             writer.WriteAttributeString("OrthographicScale", Viewport.OrthographicScale.ToString());
-            writer.WriteAttributeString("UseOrthographicProjection", Viewport.UseOrthographicProjection.ToString());
+            writer.WriteAttributeString("UseOrthographicProjection", Viewport.OrthographicProjection.ToString());
             writer.WriteAttributeString("ViewFlags", ((ulong)Viewport.Task.View.Flags).ToString());
         }
 
@@ -439,8 +440,9 @@ namespace FlaxEditor.Windows
             if (bool.TryParse(node.GetAttribute("GridEnabled"), out bool value1))
                 Viewport.Grid.Enabled = value1;
 
-            if (bool.TryParse(node.GetAttribute("ShowFpsCounter"), out value1))
-                Viewport.ShowFpsCounter = value1;
+            //todo
+            //if (bool.TryParse(node.GetAttribute("ShowFpsCounter"), out value1))
+            //Viewport.FpsCounter.ShowFpsCounter = value1;
 
             if (bool.TryParse(node.GetAttribute("ShowNavigation"), out value1))
                 Viewport.ShowNavigation = value1;
@@ -461,7 +463,7 @@ namespace FlaxEditor.Windows
                 Viewport.OrthographicScale = value2;
 
             if (bool.TryParse(node.GetAttribute("UseOrthographicProjection"), out value1))
-                Viewport.UseOrthographicProjection = value1;
+                Viewport.OrthographicProjection = value1;
 
             if (ulong.TryParse(node.GetAttribute("ViewFlags"), out ulong value3))
                 Viewport.Task.ViewFlags = (ViewFlags)value3;
@@ -480,7 +482,7 @@ namespace FlaxEditor.Windows
             Viewport.FieldOfView = 60.0f;
             Viewport.MovementSpeed = 1.0f;
             Viewport.OrthographicScale = 1.0f;
-            Viewport.UseOrthographicProjection = false;
+            Viewport.OrthographicProjection = false;
         }
     }
 }

--- a/Source/Editor/Windows/EditorOptionsWindow.cs
+++ b/Source/Editor/Windows/EditorOptionsWindow.cs
@@ -69,10 +69,13 @@ namespace FlaxEditor.Windows
             CreateTab("Theme", () => _options.Theme);
 
             // Setup input actions
-            InputActions.Add(
-                (inputOptions.Undo, _undo.PerformUndo),
-                (inputOptions.Redo, _undo.PerformRedo),
-                (inputOptions.Save, SaveData)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.Undo, _undo.PerformUndo),
+                    new(InputOptionName.Redo, _undo.PerformRedo),
+                    new(InputOptionName.Save, SaveData)
+                ]
             );
 
             _tabs.SelectedTabIndex = 0;

--- a/Source/Editor/Windows/EditorOptionsWindow.cs
+++ b/Source/Editor/Windows/EditorOptionsWindow.cs
@@ -33,8 +33,10 @@ namespace FlaxEditor.Windows
         public EditorOptionsWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
+            var inputOptions = editor.Options.Options.Input;
+
             Title = "Editor Options";
-            
+
             // Undo
             _undo = new Undo();
             _undo.UndoDone += OnUndoRedo;
@@ -65,15 +67,17 @@ namespace FlaxEditor.Windows
             CreateTab("Visual", () => _options.Visual);
             CreateTab("Source Code", () => _options.SourceCode);
             CreateTab("Theme", () => _options.Theme);
-            
+
             // Setup input actions
-            InputActions.Add(options => options.Undo, _undo.PerformUndo);
-            InputActions.Add(options => options.Redo, _undo.PerformRedo);
-            InputActions.Add(options => options.Save, SaveData);
+            InputActions.Add(
+                (inputOptions.Undo, _undo.PerformUndo),
+                (inputOptions.Redo, _undo.PerformRedo),
+                (inputOptions.Save, SaveData)
+            );
 
             _tabs.SelectedTabIndex = 0;
         }
-        
+
         private void OnUndoRedo(IUndoAction action)
         {
             MarkAsEdited();

--- a/Source/Editor/Windows/EditorOptionsWindow.cs
+++ b/Source/Editor/Windows/EditorOptionsWindow.cs
@@ -33,8 +33,6 @@ namespace FlaxEditor.Windows
         public EditorOptionsWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
-            var inputOptions = editor.Options.Options.Input;
-
             Title = "Editor Options";
 
             // Undo

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -38,10 +38,12 @@ namespace FlaxEditor.Windows
         protected EditorWindow(Editor editor, bool hideOnClose, ScrollBars scrollBars)
         : base(editor.UI.MasterPanel, hideOnClose, scrollBars)
         {
+            var inputOptions = editor.Options.Options.Input;
+
             AutoFocus = true;
             Editor = editor;
 
-            InputActions.Add(options => options.ContentFinder, () =>
+            InputActions.Add(inputOptions.ContentFinder, () =>
             {
                 if (CanOpenContentFinder)
                 {
@@ -205,21 +207,21 @@ namespace FlaxEditor.Windows
 
             switch (key)
             {
-            case KeyboardKeys.Return:
-                if (CanUseNavigation && Root?.FocusedControl != null)
-                {
-                    Root.SubmitFocused();
-                    return true;
-                }
-                break;
-            case KeyboardKeys.Tab:
-                if (CanUseNavigation && Root != null)
-                {
-                    bool shiftDown = Root.GetKey(KeyboardKeys.Shift);
-                    Root.Navigate(shiftDown ? NavDirection.Previous : NavDirection.Next);
-                    return true;
-                }
-                break;
+                case KeyboardKeys.Return:
+                    if (CanUseNavigation && Root?.FocusedControl != null)
+                    {
+                        Root.SubmitFocused();
+                        return true;
+                    }
+                    break;
+                case KeyboardKeys.Tab:
+                    if (CanUseNavigation && Root != null)
+                    {
+                        bool shiftDown = Root.GetKey(KeyboardKeys.Shift);
+                        Root.Navigate(shiftDown ? NavDirection.Previous : NavDirection.Next);
+                        return true;
+                    }
+                    break;
             }
             return false;
         }

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -2,6 +2,7 @@
 
 using System;
 using FlaxEditor.Content;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 using DockWindow = FlaxEditor.GUI.Docking.DockWindow;
@@ -43,13 +44,19 @@ namespace FlaxEditor.Windows
             AutoFocus = true;
             Editor = editor;
 
-            InputActions.Add(inputOptions.ContentFinder, () =>
-            {
-                if (CanOpenContentFinder)
-                {
-                    Editor.ContentFinding.ShowFinder(RootWindow);
-                }
-            });
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.ContentFinder,
+                        () => {
+                            if (CanOpenContentFinder)
+                            {
+                                Editor.ContentFinding.ShowFinder(RootWindow);
+                            }
+                        }
+                    )
+                ]
+            );
 
             // Register
             Editor.Windows.OnWindowAdd(this);

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -194,7 +194,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             // Prevent closing the editor window when using RMB + Ctrl + W to slow down the camera flight
-            if (Editor.Options.Options.Input.CloseTab.Process(this, key))
+            if (Editor.Options.Options.Input.CloseTab.Process(this))
             {
                 if (Root.GetMouseButton(MouseButton.Right))
                     return true;

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -39,8 +39,6 @@ namespace FlaxEditor.Windows
         protected EditorWindow(Editor editor, bool hideOnClose, ScrollBars scrollBars)
         : base(editor.UI.MasterPanel, hideOnClose, scrollBars)
         {
-            var inputOptions = editor.Options.Options.Input;
-
             AutoFocus = true;
             Editor = editor;
 
@@ -203,7 +201,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             // Prevent closing the editor window when using RMB + Ctrl + W to slow down the camera flight
-            if (Editor.Options.Options.Input.CloseTab.Process(this))
+            if (InputOptions.CloseTab.Process(this))
             {
                 if (Root.GetMouseButton(MouseButton.Right))
                     return true;

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -304,8 +304,6 @@ namespace FlaxEditor.Windows
         public GameWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
-            var inputOptions = editor.Options.Options.Input;
-
             Title = "Game";
             AutoFocus = true;
 
@@ -1043,7 +1041,7 @@ namespace FlaxEditor.Windows
                 {
                     var alpha = Mathf.Saturate(-animTime / fadeOutTime);
                     var rect = new Rectangle(new Float2(6), Size - 12);
-                    var text = $"Press {Editor.Options.Options.Input.DebuggerUnlockMouse} to unlock the mouse";
+                    var text = $"Press {InputOptions.DebuggerUnlockMouse} to unlock the mouse";
                     Render2D.DrawText(style.FontSmall, text, rect + new Float2(1.0f), style.Background * alpha, TextAlignment.Near, TextAlignment.Far);
                     Render2D.DrawText(style.FontSmall, text, rect, style.Foreground * alpha, TextAlignment.Near, TextAlignment.Far);
                 }
@@ -1152,7 +1150,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             // Prevent closing the game window tab during a play session
-            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(this))
+            if (Editor.StateMachine.IsPlayMode && InputOptions.CloseTab.Process(this))
             {
                 return true;
             }

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -304,6 +304,8 @@ namespace FlaxEditor.Windows
         public GameWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
+            var inputOptions = editor.Options.Options.Input;
+
             Title = "Game";
             AutoFocus = true;
 
@@ -335,75 +337,87 @@ namespace FlaxEditor.Windows
             Editor.Options.OptionsChanged += OnOptionsChanged;
             OnOptionsChanged(Editor.Options.Options);
 
-            InputActions.Add(options => options.TakeScreenshot, () => Screenshot.Capture(string.Empty));
-            InputActions.Add(options => options.DebuggerUnlockMouse, UnlockMouseInPlay);
-            InputActions.Add(options => options.ToggleFullscreen, () => { if (Editor.IsPlayMode) IsMaximized = !IsMaximized; });
-            InputActions.Add(options => options.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor);
-            InputActions.Add(options => options.Pause, Editor.Instance.Simulation.RequestResumeOrPause);
-            InputActions.Add(options => options.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame);
+            InputActions.Add(
+                (inputOptions.TakeScreenshot, () => Screenshot.Capture(string.Empty)),
+                (inputOptions.DebuggerUnlockMouse, UnlockMouseInPlay),
+                (inputOptions.ToggleFullscreen, () => { if (Editor.IsPlayMode) IsMaximized = !IsMaximized; }),
+                (inputOptions.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor),
+                (inputOptions.Pause, Editor.Instance.Simulation.RequestResumeOrPause),
+                (inputOptions.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame),
 #if USE_PROFILER
-            InputActions.Add(options => options.ProfilerStartStop, () =>
-            {
-                bool recording = !Editor.Instance.Windows.ProfilerWin.LiveRecording;
-                Editor.Instance.Windows.ProfilerWin.LiveRecording = recording;
-                Editor.Instance.UI.AddStatusMessage($"Profiling {(recording ? "started" : "stopped")}.");
-            });
-            InputActions.Add(options => options.ProfilerClear, () =>
-            {
-                Editor.Instance.Windows.ProfilerWin.Clear();
-                Editor.Instance.UI.AddStatusMessage("Profiling results cleared.");
-            });
+                (inputOptions.ProfilerStartStop, () =>
+                {
+                    bool recording = !Editor.Instance.Windows.ProfilerWin.LiveRecording;
+                    Editor.Instance.Windows.ProfilerWin.LiveRecording = recording;
+                    Editor.Instance.UI.AddStatusMessage($"Profiling {(recording ? "started" : "stopped")}.");
+                }
+                ),
+                (inputOptions.ProfilerClear, () =>
+                {
+                    Editor.Instance.Windows.ProfilerWin.Clear();
+                    Editor.Instance.UI.AddStatusMessage("Profiling results cleared.");
+                }
+                ),
 #endif
-            InputActions.Add(options => options.Save, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.SaveAll();
-            });
-            InputActions.Add(options => options.Undo, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.PerformUndo();
-                Focus();
-            });
-            InputActions.Add(options => options.Redo, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.PerformRedo();
-                Focus();
-            });
-            InputActions.Add(options => options.Cut, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.SceneEditing.Cut();
-            });
-            InputActions.Add(options => options.Copy, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.SceneEditing.Copy();
-            });
-            InputActions.Add(options => options.Paste, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.SceneEditing.Paste();
-            });
-            InputActions.Add(options => options.Duplicate, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.SceneEditing.Duplicate();
-            });
-            InputActions.Add(options => options.Delete, () =>
-            {
-                if (Editor.IsPlayMode)
-                    return;
-                Editor.Instance.SceneEditing.Delete();
-            });
+                (inputOptions.Save, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.SaveAll();
+                }
+                ),
+                (inputOptions.Undo, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.PerformUndo();
+                    Focus();
+                }
+                ),
+                (inputOptions.Redo, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.PerformRedo();
+                    Focus();
+                }
+                ),
+                (inputOptions.Cut, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.SceneEditing.Cut();
+                }
+                ),
+                (inputOptions.Copy, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.SceneEditing.Copy();
+                }
+                ),
+                (inputOptions.Paste, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.SceneEditing.Paste();
+                }
+                ),
+                (inputOptions.Duplicate, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.SceneEditing.Duplicate();
+                }
+                ),
+                (inputOptions.Delete, () =>
+                {
+                    if (Editor.IsPlayMode)
+                        return;
+                    Editor.Instance.SceneEditing.Delete();
+                }
+                )
+            );
         }
 
         private void ChangeViewportRatio(ViewportScaleOptions v)
@@ -425,14 +439,14 @@ namespace FlaxEditor.Windows
             {
                 switch (v.ScaleType)
                 {
-                case ViewportScaleType.Aspect:
-                    _useAspect = true;
-                    _freeAspect = false;
-                    break;
-                case ViewportScaleType.Resolution:
-                    _useAspect = false;
-                    _freeAspect = false;
-                    break;
+                    case ViewportScaleType.Aspect:
+                        _useAspect = true;
+                        _freeAspect = false;
+                        break;
+                    case ViewportScaleType.Resolution:
+                        _useAspect = false;
+                        _freeAspect = false;
+                        break;
                 }
             }
 
@@ -1099,18 +1113,18 @@ namespace FlaxEditor.Windows
         {
             switch (mode)
             {
-            case InterfaceOptions.GameWindowMode.Docked:
-                break;
-            case InterfaceOptions.GameWindowMode.PopupWindow:
-                IsFloating = true;
-                break;
-            case InterfaceOptions.GameWindowMode.MaximizedWindow:
-                IsMaximized = true;
-                break;
-            case InterfaceOptions.GameWindowMode.BorderlessWindow:
-                IsBorderless = true;
-                break;
-            default: throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+                case InterfaceOptions.GameWindowMode.Docked:
+                    break;
+                case InterfaceOptions.GameWindowMode.PopupWindow:
+                    IsFloating = true;
+                    break;
+                case InterfaceOptions.GameWindowMode.MaximizedWindow:
+                    IsMaximized = true;
+                    break;
+                case InterfaceOptions.GameWindowMode.BorderlessWindow:
+                    IsBorderless = true;
+                    break;
+                default: throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
             }
         }
 

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -1135,7 +1135,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             // Prevent closing the game window tab during a play session
-            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(this, key))
+            if (Editor.StateMachine.IsPlayMode && Editor.Options.Options.Input.CloseTab.Process(this))
             {
                 return true;
             }

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -337,86 +337,89 @@ namespace FlaxEditor.Windows
             Editor.Options.OptionsChanged += OnOptionsChanged;
             OnOptionsChanged(Editor.Options.Options);
 
-            InputActions.Add(
-                (inputOptions.TakeScreenshot, () => Screenshot.Capture(string.Empty)),
-                (inputOptions.DebuggerUnlockMouse, UnlockMouseInPlay),
-                (inputOptions.ToggleFullscreen, () => { if (Editor.IsPlayMode) IsMaximized = !IsMaximized; }),
-                (inputOptions.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor),
-                (inputOptions.Pause, Editor.Instance.Simulation.RequestResumeOrPause),
-                (inputOptions.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame),
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.TakeScreenshot, () => Screenshot.Capture(string.Empty)),
+                    new(InputOptionName.DebuggerUnlockMouse, UnlockMouseInPlay),
+                    new(InputOptionName.ToggleFullscreen, () => { if (Editor.IsPlayMode) IsMaximized = !IsMaximized; }),
+                    new(InputOptionName.Play, Editor.Instance.Simulation.DelegatePlayOrStopPlayInEditor),
+                    new(InputOptionName.Pause, Editor.Instance.Simulation.RequestResumeOrPause),
+                    new(InputOptionName.StepFrame, Editor.Instance.Simulation.RequestPlayOneFrame),
 #if USE_PROFILER
-                (inputOptions.ProfilerStartStop, () =>
-                {
-                    bool recording = !Editor.Instance.Windows.ProfilerWin.LiveRecording;
-                    Editor.Instance.Windows.ProfilerWin.LiveRecording = recording;
-                    Editor.Instance.UI.AddStatusMessage($"Profiling {(recording ? "started" : "stopped")}.");
-                }
-                ),
-                (inputOptions.ProfilerClear, () =>
-                {
-                    Editor.Instance.Windows.ProfilerWin.Clear();
-                    Editor.Instance.UI.AddStatusMessage("Profiling results cleared.");
-                }
-                ),
+                    new(InputOptionName.ProfilerStartStop,
+                        () => {
+                            bool recording = !Editor.Instance.Windows.ProfilerWin.LiveRecording;
+                            Editor.Instance.Windows.ProfilerWin.LiveRecording = recording;
+                            Editor.Instance.UI.AddStatusMessage($"Profiling {(recording ? "started" : "stopped")}.");
+                        }
+                    ),
+                    new(InputOptionName.ProfilerClear,
+                        () => {
+                            Editor.Instance.Windows.ProfilerWin.Clear();
+                            Editor.Instance.UI.AddStatusMessage("Profiling results cleared.");
+                        }
+                    ),
 #endif
-                (inputOptions.Save, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.SaveAll();
-                }
-                ),
-                (inputOptions.Undo, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.PerformUndo();
-                    Focus();
-                }
-                ),
-                (inputOptions.Redo, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.PerformRedo();
-                    Focus();
-                }
-                ),
-                (inputOptions.Cut, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.SceneEditing.Cut();
-                }
-                ),
-                (inputOptions.Copy, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.SceneEditing.Copy();
-                }
-                ),
-                (inputOptions.Paste, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.SceneEditing.Paste();
-                }
-                ),
-                (inputOptions.Duplicate, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.SceneEditing.Duplicate();
-                }
-                ),
-                (inputOptions.Delete, () =>
-                {
-                    if (Editor.IsPlayMode)
-                        return;
-                    Editor.Instance.SceneEditing.Delete();
-                }
-                )
+                    new(InputOptionName.Save,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.SaveAll();
+                        }
+                    ),
+                    new(InputOptionName.Undo,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.PerformUndo();
+                            Focus();
+                        }
+                    ),
+                    new(InputOptionName.Redo,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.PerformRedo();
+                            Focus();
+                        }
+                    ),
+                    new(InputOptionName.Cut,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.SceneEditing.Cut();
+                        }
+                    ),
+                    new(InputOptionName.Copy,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.SceneEditing.Copy();
+                        }
+                    ),
+                    new(InputOptionName.Paste,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.SceneEditing.Paste();
+                        }
+                    ),
+                    new(InputOptionName.Duplicate,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.SceneEditing.Duplicate();
+                        }
+                    ),
+                    new(InputOptionName.Delete,
+                        () => {
+                            if (Editor.IsPlayMode)
+                                return;
+                            Editor.Instance.SceneEditing.Delete();
+                        }
+                    )
+                ]
             );
         }
 

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -481,8 +481,6 @@ namespace FlaxEditor.Windows
         public OutputLogWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
-            var inputOptions = editor.Options.Options.Input;
-
             Title = "Output Log";
             ClipChildren = false;
             FlaxEditor.Utilities.Utils.SetupCommonInputActions(this);
@@ -793,8 +791,7 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {
-            var input = Editor.Options.Options.Input;
-            if (input.Search.Process(this))
+            if (InputOptions.Search.Process(this))
             {
                 if (!_searchBox.ContainsFocus)
                 {

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -792,7 +792,7 @@ namespace FlaxEditor.Windows
         public override bool OnKeyDown(KeyboardKeys key)
         {
             var input = Editor.Options.Options.Input;
-            if (input.Search.Process(this, key))
+            if (input.Search.Process(this))
             {
                 if (!_searchBox.ContainsFocus)
                 {

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -113,9 +113,9 @@ namespace FlaxEditor.Windows
                     {
                         switch (tag.Type)
                         {
-                        case TextBlockTag.Types.CodeLocation:
-                            Window.Editor.CodeEditing.OpenFile(tag.Url, tag.Line);
-                            return true;
+                            case TextBlockTag.Types.CodeLocation:
+                                Window.Editor.CodeEditing.OpenFile(tag.Url, tag.Line);
+                                return true;
                         }
                     }
                 }
@@ -163,38 +163,38 @@ namespace FlaxEditor.Windows
                 {
                     switch (key)
                     {
-                    case KeyboardKeys.Delete:
-                    case KeyboardKeys.Backspace:
-                        if (Owner != null && (!Owner._searchPopup?.Visible ?? true))
-                        {
-                            // Redirect input into search textbox while typing and using command history
-                            Owner.OnKeyDown(key);
-                            return true;
-                        }
-                        break;
-                    case KeyboardKeys.ArrowLeft:
-                        if (Owner != null && (!Owner._searchPopup?.Visible ?? true))
-                        {
-                            // Focus back the input field as user want to modify command from history
-                            Owner._searchPopup?.Hide();
-                            Owner.RootWindow.Focus();
-                            Owner.Focus();
-                            Owner.OnKeyDown(key);
-                            return true;
-                        }
-                        break;
-                    case KeyboardKeys.ArrowDown:
-                    case KeyboardKeys.ArrowUp:
-                        // UI navigation
-                        return base.OnKeyDown(key);
-                    default:
-                        if (Owner != null && (Owner._searchPopup?.Visible ?? false))
-                        {
-                            // Redirect input into search textbox while typing and using command history
-                            Owner.OnKeyDown(key);
-                            return true;
-                        }
-                        break;
+                        case KeyboardKeys.Delete:
+                        case KeyboardKeys.Backspace:
+                            if (Owner != null && (!Owner._searchPopup?.Visible ?? true))
+                            {
+                                // Redirect input into search textbox while typing and using command history
+                                Owner.OnKeyDown(key);
+                                return true;
+                            }
+                            break;
+                        case KeyboardKeys.ArrowLeft:
+                            if (Owner != null && (!Owner._searchPopup?.Visible ?? true))
+                            {
+                                // Focus back the input field as user want to modify command from history
+                                Owner._searchPopup?.Hide();
+                                Owner.RootWindow.Focus();
+                                Owner.Focus();
+                                Owner.OnKeyDown(key);
+                                return true;
+                            }
+                            break;
+                        case KeyboardKeys.ArrowDown:
+                        case KeyboardKeys.ArrowUp:
+                            // UI navigation
+                            return base.OnKeyDown(key);
+                        default:
+                            if (Owner != null && (Owner._searchPopup?.Visible ?? false))
+                            {
+                                // Redirect input into search textbox while typing and using command history
+                                Owner.OnKeyDown(key);
+                                return true;
+                            }
+                            break;
                     }
 
                     return base.OnKeyDown(key);
@@ -331,106 +331,106 @@ namespace FlaxEditor.Windows
             {
                 switch (key)
                 {
-                case KeyboardKeys.Return:
-                {
-                    // Run command
-                    _searchPopup?.Hide();
-                    var command = Text.Trim();
-                    if (command.Length == 0)
-                        return true;
-                    DebugCommands.Execute(command);
-                    SetText(string.Empty);
-
-                    // Update history buffer
-                    if (_window._commandHistory == null)
-                        _window._commandHistory = new List<string>();
-                    else if (_window._commandHistory.Count != 0 && _window._commandHistory.Last() == command)
-                        _window._commandHistory.RemoveAt(_window._commandHistory.Count - 1);
-                    _window._commandHistory.Add(command);
-                    if (_window._commandHistory.Count > CommandHistoryLimit)
-                        _window._commandHistory.RemoveAt(0);
-                    _window.SaveHistory();
-
-                    return true;
-                }
-                case KeyboardKeys.Tab:
-                {
-                    // Auto-complete
-                    DebugCommands.Search(Text, out var matches, true);
-                    if (matches.Length == 0)
-                    {
-                        // Nothing found
-                    }
-                    else if (matches.Length == 1)
-                    {
-                        // Exact match
-                        Set(matches[0]);
-                    }
-                    else
-                    {
-                        // Find the most common part
-                        Array.Sort(matches);
-                        int minLength = Text.Length;
-                        int maxLength = matches[0].Length;
-                        int sharedLength = minLength + 1;
-                        bool allMatch = true;
-                        for (; allMatch && sharedLength < maxLength; sharedLength++)
+                    case KeyboardKeys.Return:
                         {
-                            var shared = matches[0].Substring(0, sharedLength);
-                            for (int i = 1; i < matches.Length; i++)
+                            // Run command
+                            _searchPopup?.Hide();
+                            var command = Text.Trim();
+                            if (command.Length == 0)
+                                return true;
+                            DebugCommands.Execute(command);
+                            SetText(string.Empty);
+
+                            // Update history buffer
+                            if (_window._commandHistory == null)
+                                _window._commandHistory = new List<string>();
+                            else if (_window._commandHistory.Count != 0 && _window._commandHistory.Last() == command)
+                                _window._commandHistory.RemoveAt(_window._commandHistory.Count - 1);
+                            _window._commandHistory.Add(command);
+                            if (_window._commandHistory.Count > CommandHistoryLimit)
+                                _window._commandHistory.RemoveAt(0);
+                            _window.SaveHistory();
+
+                            return true;
+                        }
+                    case KeyboardKeys.Tab:
+                        {
+                            // Auto-complete
+                            DebugCommands.Search(Text, out var matches, true);
+                            if (matches.Length == 0)
                             {
-                                if (!matches[i].StartsWith(shared, StringComparison.OrdinalIgnoreCase))
+                                // Nothing found
+                            }
+                            else if (matches.Length == 1)
+                            {
+                                // Exact match
+                                Set(matches[0]);
+                            }
+                            else
+                            {
+                                // Find the most common part
+                                Array.Sort(matches);
+                                int minLength = Text.Length;
+                                int maxLength = matches[0].Length;
+                                int sharedLength = minLength + 1;
+                                bool allMatch = true;
+                                for (; allMatch && sharedLength < maxLength; sharedLength++)
                                 {
-                                    sharedLength -= 2;
-                                    allMatch = false;
-                                    break;
+                                    var shared = matches[0].Substring(0, sharedLength);
+                                    for (int i = 1; i < matches.Length; i++)
+                                    {
+                                        if (!matches[i].StartsWith(shared, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            sharedLength -= 2;
+                                            allMatch = false;
+                                            break;
+                                        }
+                                    }
+                                }
+                                if (sharedLength > minLength)
+                                {
+                                    // Use the largest shared part of all matches
+                                    Set(matches[0].Substring(0, sharedLength));
                                 }
                             }
+                            return true;
                         }
-                        if (sharedLength > minLength)
+                    case KeyboardKeys.ArrowUp:
                         {
-                            // Use the largest shared part of all matches
-                            Set(matches[0].Substring(0, sharedLength));
+                            if (_searchPopup != null && _searchPopup.Visible)
+                            {
+                                // Route navigation to active popup
+                                var focusedItem = _searchPopup.RootWindow.FocusedControl as Item;
+                                if (focusedItem == null)
+                                    _searchPopup.SelectItem((Item)_searchPopup.ItemsPanel.Children.Last());
+                                else
+                                    _searchPopup.OnKeyDown(key);
+                            }
+                            else if (TextLength == 0)
+                            {
+                                if (_window._commandHistory != null && _window._commandHistory.Count != 0)
+                                {
+                                    // Show command history popup
+                                    _searchPopup?.Hide();
+                                    ItemsListContextMenu cm = null;
+                                    ShowPopup(ref cm, _window._commandHistory);
+                                }
+                            }
+                            return true;
                         }
-                    }
-                    return true;
-                }
-                case KeyboardKeys.ArrowUp:
-                {
-                    if (_searchPopup != null && _searchPopup.Visible)
-                    {
-                        // Route navigation to active popup
-                        var focusedItem = _searchPopup.RootWindow.FocusedControl as Item;
-                        if (focusedItem == null)
-                            _searchPopup.SelectItem((Item)_searchPopup.ItemsPanel.Children.Last());
-                        else
-                            _searchPopup.OnKeyDown(key);
-                    }
-                    else if (TextLength == 0)
-                    {
-                        if (_window._commandHistory != null && _window._commandHistory.Count != 0)
+                    case KeyboardKeys.ArrowDown:
                         {
-                            // Show command history popup
-                            _searchPopup?.Hide();
-                            ItemsListContextMenu cm = null;
-                            ShowPopup(ref cm, _window._commandHistory);
+                            if (_searchPopup != null && _searchPopup.Visible)
+                            {
+                                // Route navigation to active popup
+                                var focusedItem = _searchPopup.RootWindow.FocusedControl as Item;
+                                if (focusedItem == null)
+                                    _searchPopup.SelectItem((Item)_searchPopup.ItemsPanel.Children.First());
+                                else
+                                    _searchPopup.OnKeyDown(key);
+                            }
+                            return true;
                         }
-                    }
-                    return true;
-                }
-                case KeyboardKeys.ArrowDown:
-                {
-                    if (_searchPopup != null && _searchPopup.Visible)
-                    {
-                        // Route navigation to active popup
-                        var focusedItem = _searchPopup.RootWindow.FocusedControl as Item;
-                        if (focusedItem == null)
-                            _searchPopup.SelectItem((Item)_searchPopup.ItemsPanel.Children.First());
-                        else
-                            _searchPopup.OnKeyDown(key);
-                    }
-                    return true;
-                }
                 }
 
                 return base.OnKeyDown(key);
@@ -481,6 +481,8 @@ namespace FlaxEditor.Windows
         public OutputLogWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
+            var inputOptions = editor.Options.Options.Input;
+
             Title = "Output Log";
             ClipChildren = false;
             FlaxEditor.Utilities.Utils.SetupCommonInputActions(this);
@@ -539,7 +541,7 @@ namespace FlaxEditor.Windows
             Editor.Options.OptionsChanged += OnEditorOptionsChanged;
             OnEditorOptionsChanged(Editor.Options.Options);
 
-            InputActions.Add(options => options.Search, _searchBox.Focus);
+            InputActions.Add(inputOptions.Search, _searchBox.Focus);
 
             GameCooker.Event += OnGameCookerEvent;
             ScriptsBuilder.CompilationFailed += OnScriptsCompilationFailed;
@@ -878,16 +880,16 @@ namespace FlaxEditor.Windows
                     var startIndex = _textBuffer.Length;
                     switch (_timestampsFormats)
                     {
-                    case InterfaceOptions.TimestampsFormats.Utc:
-                        _textBuffer.AppendFormat("[ {0} ]: ", entry.Time.ToUniversalTime());
-                        break;
-                    case InterfaceOptions.TimestampsFormats.LocalTime:
-                        _textBuffer.AppendFormat("[ {0} ]: ", entry.Time);
-                        break;
-                    case InterfaceOptions.TimestampsFormats.TimeSinceStartup:
-                        var diff = entry.Time - _startupTime;
-                        _textBuffer.AppendFormat("[ {0:00}:{1:00}:{2:00}.{3:000} ]: ", diff.Hours, diff.Minutes, diff.Seconds, diff.Milliseconds);
-                        break;
+                        case InterfaceOptions.TimestampsFormats.Utc:
+                            _textBuffer.AppendFormat("[ {0} ]: ", entry.Time.ToUniversalTime());
+                            break;
+                        case InterfaceOptions.TimestampsFormats.LocalTime:
+                            _textBuffer.AppendFormat("[ {0} ]: ", entry.Time);
+                            break;
+                        case InterfaceOptions.TimestampsFormats.TimeSinceStartup:
+                            var diff = entry.Time - _startupTime;
+                            _textBuffer.AppendFormat("[ {0:00}:{1:00}:{2:00}.{3:000} ]: ", diff.Hours, diff.Minutes, diff.Seconds, diff.Milliseconds);
+                            break;
                     }
                     if (_showLogType)
                     {
@@ -912,17 +914,17 @@ namespace FlaxEditor.Windows
 
                     switch (entry.Level)
                     {
-                    case LogType.Info:
-                        textBlock.Style = _output.DefaultStyle;
-                        break;
-                    case LogType.Warning:
-                        textBlock.Style = _output.WarningStyle;
-                        break;
-                    case LogType.Error:
-                    case LogType.Fatal:
-                        textBlock.Style = _output.ErrorStyle;
-                        break;
-                    default: throw new ArgumentOutOfRangeException();
+                        case LogType.Info:
+                            textBlock.Style = _output.DefaultStyle;
+                            break;
+                        case LogType.Warning:
+                            textBlock.Style = _output.WarningStyle;
+                            break;
+                        case LogType.Error:
+                        case LogType.Fatal:
+                            textBlock.Style = _output.ErrorStyle;
+                            break;
+                        default: throw new ArgumentOutOfRangeException();
                     }
                     var prevBlockBottom = _textBlocks.Count == 0 ? 0.0f : _textBlocks[_textBlocks.Count - 1].Bounds.Bottom;
                     var entryText = _textBuffer.ToString(startIndex, endIndex - startIndex);
@@ -952,12 +954,12 @@ namespace FlaxEditor.Windows
                                 {
                                     switch (match.Groups["level"].Value)
                                     {
-                                    case "error":
-                                        textBlock.Style = _output.ErrorStyle;
-                                        break;
-                                    case "warning":
-                                        textBlock.Style = _output.WarningStyle;
-                                        break;
+                                        case "error":
+                                            textBlock.Style = _output.ErrorStyle;
+                                            break;
+                                        case "warning":
+                                            textBlock.Style = _output.WarningStyle;
+                                            break;
                                     }
                                     textBlock.Tag = new TextBlockTag
                                     {

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -541,7 +541,7 @@ namespace FlaxEditor.Windows
             Editor.Options.OptionsChanged += OnEditorOptionsChanged;
             OnEditorOptionsChanged(Editor.Options.Options);
 
-            InputActions.Add(inputOptions.Search, _searchBox.Focus);
+            InputActions.Add([new(InputOptionName.Search, _searchBox.Focus)]);
 
             GameCooker.Event += OnGameCookerEvent;
             ScriptsBuilder.CompilationFailed += OnScriptsCompilationFailed;

--- a/Source/Editor/Windows/Profiler/ProfilerWindow.cs
+++ b/Source/Editor/Windows/Profiler/ProfilerWindow.cs
@@ -3,6 +3,7 @@
 using System;
 using FlaxEditor.GUI;
 using FlaxEditor.GUI.Tabs;
+using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -87,6 +88,8 @@ namespace FlaxEditor.Windows.Profiler
         public ProfilerWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
+            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
+
             Title = "Profiler";
 
 #if USE_PROFILER
@@ -122,8 +125,8 @@ namespace FlaxEditor.Windows.Profiler
             _tabs.SelectedTabChanged += OnSelectedTabChanged;
 
             FlaxEditor.Utilities.Utils.SetupCommonInputActions(this);
-            InputActions.Bindings.RemoveAll(x => x.Callback == this.FocusOrShow);
-            InputActions.Add(options => options.ProfilerWindow, Hide);
+            InputActions.Remove(this.FocusOrShow);
+            InputActions.Add(inputOptions.ProfilerWindow, Hide);
 #endif
         }
 
@@ -293,12 +296,12 @@ namespace FlaxEditor.Windows.Profiler
 
             switch (key)
             {
-            case KeyboardKeys.ArrowLeft:
-                ViewFrameIndex--;
-                return true;
-            case KeyboardKeys.ArrowRight:
-                ViewFrameIndex++;
-                return true;
+                case KeyboardKeys.ArrowLeft:
+                    ViewFrameIndex--;
+                    return true;
+                case KeyboardKeys.ArrowRight:
+                    ViewFrameIndex++;
+                    return true;
             }
 
             return false;

--- a/Source/Editor/Windows/Profiler/ProfilerWindow.cs
+++ b/Source/Editor/Windows/Profiler/ProfilerWindow.cs
@@ -88,8 +88,6 @@ namespace FlaxEditor.Windows.Profiler
         public ProfilerWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
-            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
-
             Title = "Profiler";
 
 #if USE_PROFILER

--- a/Source/Editor/Windows/Profiler/ProfilerWindow.cs
+++ b/Source/Editor/Windows/Profiler/ProfilerWindow.cs
@@ -126,7 +126,7 @@ namespace FlaxEditor.Windows.Profiler
 
             FlaxEditor.Utilities.Utils.SetupCommonInputActions(this);
             InputActions.Remove(this.FocusOrShow);
-            InputActions.Add(inputOptions.ProfilerWindow, Hide);
+            InputActions.Add([new(InputOptionName.ProfilerWindow, Hide)]);
 #endif
         }
 

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -27,7 +28,6 @@ namespace FlaxEditor.Windows
             bool hasSthSelected = Editor.SceneEditing.HasSthSelected;
             bool isSingleActorSelected = Editor.SceneEditing.SelectionCount == 1 && Editor.SceneEditing.Selection[0] is ActorNode;
             bool canEditScene = Editor.StateMachine.CurrentState.CanEditScene && Level.IsAnySceneLoaded;
-            var inputOptions = Editor.Options.Options.Input;
 
             // Create popup
 
@@ -46,16 +46,16 @@ namespace FlaxEditor.Windows
 
             if (hasSthSelected)
             {
-                contextMenu.AddButton(Editor.Windows.EditWin.IsPilotActorActive ? "Stop piloting actor" : "Pilot actor", inputOptions.PilotActor, Editor.UI.PilotActor);
+                contextMenu.AddButton(Editor.Windows.EditWin.IsPilotActorActive ? "Stop piloting actor" : "Pilot actor", InputOptions.PilotActor, Editor.UI.PilotActor);
             }
 
             contextMenu.AddSeparator();
 
             // Basic editing options
             var firstSelection = hasSthSelected ? Editor.SceneEditing.Selection[0] as ActorNode : null;
-            b = contextMenu.AddButton("Rename", inputOptions.Rename, RenameSelection);
+            b = contextMenu.AddButton("Rename", InputOptions.Rename, RenameSelection);
             b.Enabled = hasSthSelected;
-            b = contextMenu.AddButton("Duplicate", inputOptions.Duplicate, Editor.SceneEditing.Duplicate);
+            b = contextMenu.AddButton("Duplicate", InputOptions.Duplicate, Editor.SceneEditing.Duplicate);
             b.Enabled = hasSthSelected && (firstSelection != null ? firstSelection.CanDuplicate : true);
 
             if (isSingleActorSelected && firstSelection?.Actor is not Scene)
@@ -117,24 +117,24 @@ namespace FlaxEditor.Windows
                     }
                 }
             }
-            b = contextMenu.AddButton("Delete", inputOptions.Delete, Editor.SceneEditing.Delete);
+            b = contextMenu.AddButton("Delete", InputOptions.Delete, Editor.SceneEditing.Delete);
             b.Enabled = hasSthSelected && (firstSelection != null ? firstSelection.CanDelete : true);
 
             contextMenu.AddSeparator();
 
-            b = contextMenu.AddButton("Copy", inputOptions.Copy, Editor.SceneEditing.Copy);
+            b = contextMenu.AddButton("Copy", InputOptions.Copy, Editor.SceneEditing.Copy);
             b.Enabled = hasSthSelected && (firstSelection != null ? firstSelection.CanCopyPaste : true);
 
-            contextMenu.AddButton("Paste", inputOptions.Paste, Editor.SceneEditing.Paste);
+            contextMenu.AddButton("Paste", InputOptions.Paste, Editor.SceneEditing.Paste);
 
-            b = contextMenu.AddButton("Cut", inputOptions.Cut, Editor.SceneEditing.Cut);
+            b = contextMenu.AddButton("Cut", InputOptions.Cut, Editor.SceneEditing.Cut);
             b.Enabled = canEditScene && hasSthSelected && (firstSelection != null ? firstSelection.CanCopyPaste : true);
 
             // Create option
 
             contextMenu.AddSeparator();
 
-            b = contextMenu.AddButton("Parent to new Actor", inputOptions.GroupSelectedActors, Editor.SceneEditing.CreateParentForSelectedActors);
+            b = contextMenu.AddButton("Parent to new Actor", InputOptions.GroupSelectedActors, Editor.SceneEditing.CreateParentForSelectedActors);
             b.Enabled = canEditScene && hasSthSelected && firstSelection?.Actor is not Scene;
 
             b = contextMenu.AddButton("Create Prefab", Editor.Prefabs.CreatePrefab);

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -13,6 +13,7 @@ using FlaxEditor.Scripting;
 using FlaxEditor.States;
 using FlaxEngine;
 using FlaxEngine.GUI;
+using FlaxEditor.Options;
 
 namespace FlaxEditor.Windows
 {
@@ -47,6 +48,8 @@ namespace FlaxEditor.Windows
         public SceneTreeWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
+            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
+
             Title = "Scene";
 
             // Scene searching query input box
@@ -92,12 +95,14 @@ namespace FlaxEditor.Windows
             headerPanel.Parent = this;
 
             // Setup input actions
-            InputActions.Add(options => options.TranslateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate);
-            InputActions.Add(options => options.RotateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate);
-            InputActions.Add(options => options.ScaleMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale);
-            InputActions.Add(options => options.FocusSelection, () => Editor.Windows.EditWin.Viewport.FocusSelection());
-            InputActions.Add(options => options.LockFocusSelection, () => Editor.Windows.EditWin.Viewport.LockFocusSelection());
-            InputActions.Add(options => options.Rename, RenameSelection);
+            InputActions.Add(
+                (inputOptions.TranslateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate),
+                (inputOptions.RotateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate),
+                (inputOptions.ScaleMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale),
+                (inputOptions.FocusSelection, () => Editor.Windows.EditWin.Viewport.FocusSelection()),
+                (inputOptions.LockFocusSelection, () => Editor.Windows.EditWin.Viewport.LockFocusSelection()),
+                (inputOptions.Rename, RenameSelection)
+            );
         }
 
         /// <summary>

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -95,13 +95,16 @@ namespace FlaxEditor.Windows
             headerPanel.Parent = this;
 
             // Setup input actions
-            InputActions.Add(
-                (inputOptions.TranslateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate),
-                (inputOptions.RotateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate),
-                (inputOptions.ScaleMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale),
-                (inputOptions.FocusSelection, () => Editor.Windows.EditWin.Viewport.FocusSelection()),
-                (inputOptions.LockFocusSelection, () => Editor.Windows.EditWin.Viewport.LockFocusSelection()),
-                (inputOptions.Rename, RenameSelection)
+            InputActions.Add
+            (
+                [
+                    new(InputOptionName.TranslateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate),
+                    new(InputOptionName.RotateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Rotate),
+                    new(InputOptionName.ScaleMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Scale),
+                    new(InputOptionName.FocusSelection, () => Editor.Windows.EditWin.Viewport.FocusSelection()),
+                    new(InputOptionName.LockFocusSelection, () => Editor.Windows.EditWin.Viewport.LockFocusSelection()),
+                    new(InputOptionName.Rename, RenameSelection)
+                ]
             );
         }
 

--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -48,8 +48,6 @@ namespace FlaxEditor.Windows
         public SceneTreeWindow(Editor editor)
         : base(editor, true, ScrollBars.None)
         {
-            InputOptions inputOptions = Editor.Instance.Options.Options.Input;
-
             Title = "Scene";
 
             // Scene searching query input box

--- a/Source/Editor/Windows/Search/ContentSearchWindow.cs
+++ b/Source/Editor/Windows/Search/ContentSearchWindow.cs
@@ -142,7 +142,6 @@ namespace FlaxEngine.Windows.Search
             /// <inheritdoc />
             public override bool OnKeyDown(KeyboardKeys key)
             {
-                InputOptions options = FlaxEditor.Editor.Instance.Options.Options.Input;
                 if (IsFocused)
                 {
                     if (key == KeyboardKeys.Return && Navigate != null)
@@ -150,7 +149,7 @@ namespace FlaxEngine.Windows.Search
                         Navigate.Invoke(this);
                         return true;
                     }
-                    if (options.Copy.Process(this))
+                    if (InputOptions.Copy.Process(this))
                     {
                         Clipboard.Text = Text;
                         return true;

--- a/Source/Editor/Windows/VisualScriptDebuggerWindow.cs
+++ b/Source/Editor/Windows/VisualScriptDebuggerWindow.cs
@@ -400,8 +400,6 @@ namespace FlaxEditor.Windows
         {
             Title = "Visual Script Debugger";
 
-            var inputOptions = editor.Options.Options.Input;
-
             var toolstrip = new ToolStrip
             {
                 Parent = this
@@ -410,7 +408,7 @@ namespace FlaxEditor.Windows
             _debugToolstripControls = new[]
             {
                 toolstrip.AddSeparator(),
-                toolstrip.AddButton(editor.Icons.Play64, OnDebuggerContinue).LinkTooltip("Continue", ref inputOptions.DebuggerContinue),
+                toolstrip.AddButton(editor.Icons.Play64, OnDebuggerContinue).LinkTooltip("Continue", InputOptions.DebuggerContinue),
                 toolstrip.AddButton(editor.Icons.Search64, OnDebuggerNavigateToCurrentNode).LinkTooltip("Navigate to the current stack trace node"),
                 toolstrip.AddButton(editor.Icons.Stop64, OnDebuggerStop).LinkTooltip("Stop debugging"),
             };

--- a/Source/Editor/Windows/VisualScriptDebuggerWindow.cs
+++ b/Source/Editor/Windows/VisualScriptDebuggerWindow.cs
@@ -7,6 +7,7 @@ using FlaxEditor.GUI;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.GUI.Tabs;
 using FlaxEditor.GUI.Tree;
+using FlaxEditor.Options;
 using FlaxEditor.Surface;
 using FlaxEditor.Windows.Assets;
 using FlaxEngine;
@@ -434,7 +435,7 @@ namespace FlaxEditor.Windows
             foreach (var tab in _tabs)
                 tabs.AddTab(tab);
 
-            InputActions.Add(inputOptions.DebuggerContinue, OnDebuggerContinue);
+            InputActions.Add([new(InputOptionName.DebuggerContinue, OnDebuggerContinue)]);
 
             Editor.Simulation.BreakpointHangBegin += OnBreakpointHangBegin;
             Editor.Simulation.BreakpointHangEnd += OnBreakpointHangEnd;

--- a/Source/Editor/Windows/VisualScriptDebuggerWindow.cs
+++ b/Source/Editor/Windows/VisualScriptDebuggerWindow.cs
@@ -434,7 +434,7 @@ namespace FlaxEditor.Windows
             foreach (var tab in _tabs)
                 tabs.AddTab(tab);
 
-            InputActions.Add(options => options.DebuggerContinue, OnDebuggerContinue);
+            InputActions.Add(inputOptions.DebuggerContinue, OnDebuggerContinue);
 
             Editor.Simulation.BreakpointHangBegin += OnBreakpointHangBegin;
             Editor.Simulation.BreakpointHangEnd += OnBreakpointHangEnd;

--- a/Source/Engine/Scripting/Attributes/Editor/CustomEditorAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/CustomEditorAttribute.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
-
 using System;
-
 namespace FlaxEngine
 {
     /// <summary>
@@ -18,12 +16,51 @@ namespace FlaxEngine
         public readonly Type Type;
 
         /// <summary>
+        /// The type containing the singleton instance.
+        /// </summary>
+        public readonly Type SingletonType;
+
+        /// <summary>
+        /// The name of the static property/field that contains the singleton instance.
+        /// </summary>
+        public readonly string SingletonMemberName;
+
+        /// <summary>
+        /// Indicates whether the editor should be treated as a singleton instance.
+        /// </summary>
+        public bool IsSingleton { get; set; }
+
+        /// <summary>
         /// Overrides default editor provided for the target object.
         /// </summary>
         /// <param name="type">The custom editor class type.</param>
         public CustomEditorAttribute(Type type)
         {
             Type = type;
+            IsSingleton = false;
+        }
+
+        /// <summary>
+        /// Overrides default editor provided for the target object.
+        /// </summary>
+        /// <param name="type">The custom editor class type.</param>
+        /// <param name="isSingleton">True if the editor should be treated as a singleton instance.</param>
+        public CustomEditorAttribute(Type type, bool isSingleton)
+        {
+            Type = type;
+            IsSingleton = isSingleton;
+        }
+
+        /// <summary>
+        /// Overrides default editor provided for the target object using a singleton instance.
+        /// </summary>
+        /// <param name="singletonType">The type containing the singleton instance.</param>
+        /// <param name="memberName">The name of the static property/field containing the singleton.</param>
+        public CustomEditorAttribute(Type singletonType, string memberName)
+        {
+            SingletonType = singletonType;
+            SingletonMemberName = memberName;
+            IsSingleton = true;
         }
     }
 }

--- a/Source/Engine/UI/GUI/CanvasRootControl.cs
+++ b/Source/Engine/UI/GUI/CanvasRootControl.cs
@@ -157,6 +157,12 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override float GetMouseScrollDelta()
+        {
+            return Input.MouseScrollDelta;
+        }
+
+        /// <inheritdoc />
         public override Float2 PointToParent(ref Float2 location)
         {
             if (Is2D)

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1327,33 +1327,32 @@ namespace FlaxEngine.GUI
 
             // Handle controls that have bindings
 #if FLAX_EDITOR
-            InputOptions options = FlaxEditor.Editor.Instance.Options.Options.Input;
-            if (options.Copy.Process(this))
+            if (InputOptions.Copy.Process(this))
             {
                 Copy();
                 return true;
             }
-            else if (options.Paste.Process(this))
+            else if (InputOptions.Paste.Process(this))
             {
                 Paste();
                 return true;
             }
-            else if (options.Duplicate.Process(this))
+            else if (InputOptions.Duplicate.Process(this))
             {
                 Duplicate();
                 return true;
             }
-            else if (options.Cut.Process(this))
+            else if (InputOptions.Cut.Process(this))
             {
                 Cut();
                 return true;
             }
-            else if (options.SelectAll.Process(this))
+            else if (InputOptions.SelectAll.Process(this))
             {
                 SelectAll();
                 return true;
             }
-            else if (options.DeselectAll.Process(this))
+            else if (InputOptions.DeselectAll.Process(this))
             {
                 Deselect();
                 return true;

--- a/Source/Engine/UI/GUI/RootControl.cs
+++ b/Source/Engine/UI/GUI/RootControl.cs
@@ -225,8 +225,14 @@ namespace FlaxEngine.GUI
         /// Gets mouse button up state.
         /// </summary>
         /// <param name="button">Mouse button to check.</param>
-        /// <returns>True during the frame the user releases the button.</returns>
+        /// <returns>True during the frame the user scrolls the mouse.</returns>
         public abstract bool GetMouseButtonUp(MouseButton button);
+
+        /// <summary>
+        /// Gets mouse button up state.
+        /// </summary>
+        /// <returns>Mouse delta during the frame the user scrolls.</returns>
+        public abstract float GetMouseScrollDelta();
 
         /// <inheritdoc />
         public override RootControl Root => this;

--- a/Source/Engine/UI/GUI/WindowRootControl.cs
+++ b/Source/Engine/UI/GUI/WindowRootControl.cs
@@ -232,6 +232,12 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override float GetMouseScrollDelta()
+        {
+            return _window.MouseScrollDelta;
+        }
+
+        /// <inheritdoc />
         public override Float2 PointFromScreen(Float2 location)
         {
             return _window.ScreenToClient(location) / _window.DpiScale;

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -133,24 +133,24 @@ namespace Flax.Build.Bindings
             // In-built constants
             switch (value)
             {
-            case "nullptr":
-            case "NULL":
-            case "String::Empty":
-            case "StringAnsi::Empty":
-            case "StringAnsiView::Empty":
-            case "StringView::Empty": return "null";
-            case "MAX_int8": return "sbyte.MaxValue";
-            case "MAX_uint8": return "byte.MaxValue";
-            case "MAX_int16": return "short.MaxValue";
-            case "MAX_uint16": return "ushort.MaxValue";
-            case "MAX_int32": return "int.MaxValue";
-            case "MAX_uint32": return "uint.MaxValue";
-            case "MAX_int64": return "long.MaxValue";
-            case "MAX_uint64": return "ulong.MaxValue";
-            case "MAX_float": return "float.MaxValue";
-            case "MAX_double": return "double.MaxValue";
-            case "true":
-            case "false": return value;
+                case "nullptr":
+                case "NULL":
+                case "String::Empty":
+                case "StringAnsi::Empty":
+                case "StringAnsiView::Empty":
+                case "StringView::Empty": return "null";
+                case "MAX_int8": return "sbyte.MaxValue";
+                case "MAX_uint8": return "byte.MaxValue";
+                case "MAX_int16": return "short.MaxValue";
+                case "MAX_uint16": return "ushort.MaxValue";
+                case "MAX_int32": return "int.MaxValue";
+                case "MAX_uint32": return "uint.MaxValue";
+                case "MAX_int64": return "long.MaxValue";
+                case "MAX_uint64": return "ulong.MaxValue";
+                case "MAX_float": return "float.MaxValue";
+                case "MAX_double": return "double.MaxValue";
+                case "true":
+                case "false": return value;
             }
 
             // Handle float{_} style type of default values
@@ -214,34 +214,34 @@ namespace Flax.Build.Bindings
                     // Support for in-built constants
                     switch (value)
                     {
-                    case "Vector2.Zero": return "typeof(Vector2), \"0,0\"";
-                    case "Vector2.One": return "typeof(Vector2), \"1,1\"";
-                    case "Float2.Zero": return "typeof(Float2), \"0,0\"";
-                    case "Float2.One": return "typeof(Float2), \"1,1\"";
-                    case "Double2.Zero": return "typeof(Double2), \"0,0\"";
-                    case "Double2.One": return "typeof(Double2), \"1,1\"";
-                    case "Int2.Zero": return "typeof(Int2), \"0,0\"";
-                    case "Int2.One": return "typeof(Int2), \"1,1\"";
+                        case "Vector2.Zero": return "typeof(Vector2), \"0,0\"";
+                        case "Vector2.One": return "typeof(Vector2), \"1,1\"";
+                        case "Float2.Zero": return "typeof(Float2), \"0,0\"";
+                        case "Float2.One": return "typeof(Float2), \"1,1\"";
+                        case "Double2.Zero": return "typeof(Double2), \"0,0\"";
+                        case "Double2.One": return "typeof(Double2), \"1,1\"";
+                        case "Int2.Zero": return "typeof(Int2), \"0,0\"";
+                        case "Int2.One": return "typeof(Int2), \"1,1\"";
 
-                    case "Vector3.Zero": return "typeof(Vector3), \"0,0,0\"";
-                    case "Vector3.One": return "typeof(Vector3), \"1,1,1\"";
-                    case "Float3.Zero": return "typeof(Float3), \"0,0,0\"";
-                    case "Float3.One": return "typeof(Float3), \"1,1,1\"";
-                    case "Double3.Zero": return "typeof(Double3), \"0,0,0\"";
-                    case "Double3.One": return "typeof(Double3), \"1,1,1\"";
-                    case "Int3.Zero": return "typeof(Int3), \"0,0,0\"";
-                    case "Int3.One": return "typeof(Int3), \"1,1,1\"";
+                        case "Vector3.Zero": return "typeof(Vector3), \"0,0,0\"";
+                        case "Vector3.One": return "typeof(Vector3), \"1,1,1\"";
+                        case "Float3.Zero": return "typeof(Float3), \"0,0,0\"";
+                        case "Float3.One": return "typeof(Float3), \"1,1,1\"";
+                        case "Double3.Zero": return "typeof(Double3), \"0,0,0\"";
+                        case "Double3.One": return "typeof(Double3), \"1,1,1\"";
+                        case "Int3.Zero": return "typeof(Int3), \"0,0,0\"";
+                        case "Int3.One": return "typeof(Int3), \"1,1,1\"";
 
-                    case "Vector4.Zero": return "typeof(Vector4), \"0,0,0,0\"";
-                    case "Vector4.One": return "typeof(Vector4), \"1,1,1,1\"";
-                    case "Double4.Zero": return "typeof(Double4), \"0,0,0,0\"";
-                    case "Double4.One": return "typeof(Double4), \"1,1,1,1\"";
-                    case "Float4.Zero": return "typeof(Float4), \"0,0,0,0\"";
-                    case "Float4.One": return "typeof(Float4), \"1,1,1,1\"";
-                    case "Int4.Zero": return "typeof(Float4), \"0,0,0,0\"";
-                    case "Int4.One": return "typeof(Float4), \"1,1,1,1\"";
+                        case "Vector4.Zero": return "typeof(Vector4), \"0,0,0,0\"";
+                        case "Vector4.One": return "typeof(Vector4), \"1,1,1,1\"";
+                        case "Double4.Zero": return "typeof(Double4), \"0,0,0,0\"";
+                        case "Double4.One": return "typeof(Double4), \"1,1,1,1\"";
+                        case "Float4.Zero": return "typeof(Float4), \"0,0,0,0\"";
+                        case "Float4.One": return "typeof(Float4), \"1,1,1,1\"";
+                        case "Int4.Zero": return "typeof(Float4), \"0,0,0,0\"";
+                        case "Int4.One": return "typeof(Float4), \"1,1,1,1\"";
 
-                    case "Quaternion.Identity": return "typeof(Quaternion), \"0,0,0,1\"";
+                        case "Quaternion.Identity": return "typeof(Quaternion), \"0,0,0,1\"";
                     }
 
                     // Enums
@@ -529,51 +529,51 @@ namespace Flax.Build.Bindings
 
             switch (typeInfo.Type)
             {
-            case "String":
-            case "StringView":
-            case "StringAnsi":
-            case "StringAnsiView":
-                // String
-                return string.Empty;
-            case "ScriptingObject":
-            case "PersistentScriptingObject":
-            case "ManagedScriptingObject":
-                // object
-                return "FlaxEngine.Object.GetUnmanagedPtr({0})";
-            case "Function":
-                // delegate
-                return "NativeInterop.GetFunctionPointerForDelegate({0})";
-            case "Array":
-            case "Span":
-            case "DataContainer":
-                if (typeInfo.GenericArgs != null)
-                {
-                    // Convert array that uses different type for marshalling
-                    var arrayTypeInfo = typeInfo.GenericArgs[0];
-                    var arrayApiType = FindApiTypeInfo(buildData, arrayTypeInfo, caller);
-                    if (arrayApiType != null && arrayApiType.MarshalAs != null)
-                        return $"{{0}}.ConvertArray(x => ({GenerateCSharpNativeToManaged(buildData, arrayApiType.MarshalAs, caller)})x)";
-                }
-                return string.Empty;
-            default:
-                var apiType = FindApiTypeInfo(buildData, typeInfo, caller);
-                if (apiType != null)
-                {
-                    // Scripting Object
-                    if (apiType.IsScriptingObject)
+                case "String":
+                case "StringView":
+                case "StringAnsi":
+                case "StringAnsiView":
+                    // String
+                    return string.Empty;
+                case "ScriptingObject":
+                case "PersistentScriptingObject":
+                case "ManagedScriptingObject":
+                    // object
+                    return "FlaxEngine.Object.GetUnmanagedPtr({0})";
+                case "Function":
+                    // delegate
+                    return "NativeInterop.GetFunctionPointerForDelegate({0})";
+                case "Array":
+                case "Span":
+                case "DataContainer":
+                    if (typeInfo.GenericArgs != null)
+                    {
+                        // Convert array that uses different type for marshalling
+                        var arrayTypeInfo = typeInfo.GenericArgs[0];
+                        var arrayApiType = FindApiTypeInfo(buildData, arrayTypeInfo, caller);
+                        if (arrayApiType != null && arrayApiType.MarshalAs != null)
+                            return $"{{0}}.ConvertArray(x => ({GenerateCSharpNativeToManaged(buildData, arrayApiType.MarshalAs, caller)})x)";
+                    }
+                    return string.Empty;
+                default:
+                    var apiType = FindApiTypeInfo(buildData, typeInfo, caller);
+                    if (apiType != null)
+                    {
+                        // Scripting Object
+                        if (apiType.IsScriptingObject)
+                            return "FlaxEngine.Object.GetUnmanagedPtr({0})";
+
+                        // interface
+                        if (apiType.IsInterface)
+                            return string.Format("FlaxEngine.Object.GetUnmanagedInterface({{0}}, typeof({0}))", apiType.Name);
+                    }
+
+                    // Object reference property
+                    if (typeInfo.IsObjectRef)
                         return "FlaxEngine.Object.GetUnmanagedPtr({0})";
 
-                    // interface
-                    if (apiType.IsInterface)
-                        return string.Format("FlaxEngine.Object.GetUnmanagedInterface({{0}}, typeof({0}))", apiType.Name);
-                }
-
-                // Object reference property
-                if (typeInfo.IsObjectRef)
-                    return "FlaxEngine.Object.GetUnmanagedPtr({0})";
-
-                // Default
-                return string.Empty;
+                    // Default
+                    return string.Empty;
             }
         }
 
@@ -951,7 +951,7 @@ namespace Flax.Build.Bindings
                 if (defaultValue != null)
                     contents.Append(indent).Append("[DefaultValue(").Append(defaultValue).Append(")]").AppendLine();
             }
-            
+
             // Check if array has fixed allocation and add in MaxCount Collection attribute if a Collection attribute does not already exist.
             if (defaultValueType != null && (string.IsNullOrEmpty(attributes) || !attributes.Contains("Collection", StringComparison.Ordinal)))
             {
@@ -2179,6 +2179,30 @@ namespace Flax.Build.Bindings
             {
                 contents.AppendLine("}");
             }
+
+            // Also emit a matching string constants class for enums like KeyboardKeys
+            if (enumInfo.Name == "KeyboardKeys" || enumInfo.Name == "MouseButton")
+            {
+                contents.AppendLine();
+                contents.AppendLine($"namespace {enumInfo.Namespace}");
+                contents.AppendLine("{");
+                contents.AppendLine($"{indent}/// <summary>");
+                contents.AppendLine($"{indent}/// String constants for {enumInfo.Name}.");
+                contents.AppendLine($"{indent}/// </summary>");
+                contents.AppendLine($"{indent}public static class {enumInfo.Name}String");
+                contents.AppendLine($"{indent}{{");
+
+                foreach (var entry in enumInfo.Entries)
+                {
+                    contents.AppendLine($"{indent}    /// <summary>");
+                    contents.AppendLine($"{indent}    /// String representation of <see cref=\"{enumInfo.Name}.{entry.Name}\"/>.");
+                    contents.AppendLine($"{indent}    /// </summary>");
+                    contents.AppendLine($"{indent}    public const string {entry.Name} = \"{entry.Name}\";");
+                }
+
+                contents.AppendLine($"{indent}}}");
+                contents.AppendLine("}");
+            }
         }
 
         private static void GenerateCSharpInterface(BuildData buildData, StringBuilder contents, string indent, InterfaceInfo interfaceInfo)
@@ -2300,7 +2324,9 @@ namespace Flax.Build.Bindings
                 else if (type is StructureInfo structureInfo)
                     GenerateCSharpStructure(buildData, contents, indent, structureInfo);
                 else if (type is EnumInfo enumInfo)
+                {
                     GenerateCSharpEnum(buildData, contents, indent, enumInfo);
+                }
                 else if (type is InterfaceInfo interfaceInfo)
                     GenerateCSharpInterface(buildData, contents, indent, interfaceInfo);
                 else if (type is InjectCodeInfo injectCodeInfo && string.Equals(injectCodeInfo.Lang, "csharp", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Depends on #3457 , please review and merge that PR first.
This branch starts at 0af816d647f2fc30faae0ff74d8583f3dfc6ee10 committed on May 19, 2025.
This PR aims to break out discrete pieces of EditorViewport.cs e.g.
FPS counter
Utility methods (ProjectPoint, ConvertMouseToRay, etc...)
CameraWidget
CameraViewpoints
The camera movement persistence (speed, orthographic scale, FOV)
The viewport input (and more complete implementation of gamepad bindings)
Among others...

The initial commit of this PR moves Input to its own namespace, InputConfig (so named to avoid conficts with Flaxengine.Input that is not namespaced. It also removes InputBindingList in favor of a simpler List.
The second commit in this PR has fixes from #3457 and moves some input options in the menus that I believe better reflect their categorization.