### PR TITLE
Add parameter to check if the output log command box is focused

### DIFF
--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -446,6 +446,11 @@ namespace FlaxEditor.Windows
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the command line box is focused. Useful for blocking input when typing into the command line box. 
+        /// </summary>
+        public bool IsCommandLineBoxFocused => IsDisposing ? false : _commandLineBox.IsFocused;
+
         private InterfaceOptions.TimestampsFormats _timestampsFormats;
         private bool _showLogType;
 


### PR DESCRIPTION
A possible solution for #3483. (for github to recognize it: closes #3483)

Allows the user to do something like:
```cs
public Float2 MovementVec => Editor.Instance.Windows.OutputLogWin.IsCommandLineBoxFocused ? Float2.Zero : CalculateMovementVec();
```

This does not really fix the underlying issue, but it provides a way for the user to work around it. Maybe also good to have api in general.
