### PR TITLE
Perform layout two times to fix scroll bar not updaing in context menus on search.

### DIFF
--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -342,6 +342,7 @@ namespace FlaxEditor.GUI
 
             UnlockChildrenRecursive();
             PerformLayout(true);
+            PerformLayout(true);
             _searchBox?.Focus();
             TextChanged?.Invoke(searchText);
         }


### PR DESCRIPTION
Fix #3470 