### PR TITLE
Focus Actor position if no Actor bounding box.

### DIFF
--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -1031,6 +1031,8 @@ namespace FlaxEditor
             {
                 Internal_GetEditorBoxWithChildren(FlaxEngine.Object.GetUnmanagedPtr(actor), out var box);
                 BoundingSphere.FromBox(ref box, out sphere);
+                if (sphere == BoundingSphere.Empty)
+                    sphere = new BoundingSphere(actor.Position, sphere.Radius);
                 sphere.Radius = Math.Max(sphere.Radius, 15.0f);
             }
             else


### PR DESCRIPTION
Closes #2564 although it would be good to expose at least some bounding box setting to c# for custom actors.