### PR TITLE
Implement IComparable for Vector and Integer Structs

### DIFF
--- a/Source/Engine/Core/Math/Double2.cs
+++ b/Source/Engine/Core/Math/Double2.cs
@@ -65,7 +65,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Double2Converter))]
 #endif
-    partial struct Double2 : IEquatable<Double2>, IFormattable
+    partial struct Double2 : IEquatable<Double2>, IFormattable, IComparable, IComparable<Double2>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2}";
 
@@ -1612,6 +1612,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Double2 other && Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Double2 other)
+                throw new ArgumentException("Object is not a Double2.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Double2 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Double3.cs
+++ b/Source/Engine/Core/Math/Double3.cs
@@ -66,7 +66,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Double3Converter))]
 #endif
-    partial struct Double3 : IEquatable<Double3>, IFormattable
+    partial struct Double3 : IEquatable<Double3>, IFormattable, IComparable, IComparable<Double3>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2} Z:{2:F2}";
 
@@ -1902,6 +1902,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Double3 other && Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Double3 other)
+                throw new ArgumentException("Object is not a Double3.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Double3 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Double4.cs
+++ b/Source/Engine/Core/Math/Double4.cs
@@ -66,7 +66,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Double4Converter))]
 #endif
-    partial struct Double4 : IEquatable<Double4>, IFormattable
+    partial struct Double4 : IEquatable<Double4>, IFormattable, IComparable, IComparable<Double4>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2} Z:{2:F2} W:{3:F2}";
 
@@ -1401,6 +1401,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Double4 other && Mathd.NearEqual(other.X, X) && Mathd.NearEqual(other.Y, Y) && Mathd.NearEqual(other.Z, Z) && Mathd.NearEqual(other.W, W);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Double4 other)
+                throw new ArgumentException("Object is not a Double4.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Double4 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Float2.cs
+++ b/Source/Engine/Core/Math/Float2.cs
@@ -60,7 +60,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Float2Converter))]
 #endif
-    partial struct Float2 : IEquatable<Float2>, IFormattable
+    partial struct Float2 : IEquatable<Float2>, IFormattable, IComparable, IComparable<Float2>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2}";
 
@@ -1688,6 +1688,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Float2 other && Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Float2 other)
+                throw new ArgumentException("Object is not a Float2.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Float2 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Float3.cs
+++ b/Source/Engine/Core/Math/Float3.cs
@@ -60,7 +60,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Float3Converter))]
 #endif
-    partial struct Float3 : IEquatable<Float3>, IFormattable
+    partial struct Float3 : IEquatable<Float3>, IFormattable, IComparable, IComparable<Float3>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2} Z:{2:F2}";
 
@@ -1934,6 +1934,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Float3 other && Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Float3 other)
+                throw new ArgumentException("Object is not a Float3.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Float3 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Float3.cs
+++ b/Source/Engine/Core/Math/Float3.cs
@@ -1807,6 +1807,54 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Determines if one <see cref="Float3"/> is greater than another <see cref="Float3"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator >(Float3 left, Float3 right)
+        {
+            return left.LengthSquared > right.LengthSquared;
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="Float3"/> is less than another <see cref="Float3"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator <(Float3 left, Float3 right)
+        {
+            return left.LengthSquared < right.LengthSquared;
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="Float3"/> is greater than or equal to another <see cref="Float3"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator >=(Float3 left, Float3 right)
+        {
+            return left.LengthSquared >= right.LengthSquared;
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="Float3"/> is less than or equal to another <see cref="Float3"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator <=(Float3 left, Float3 right)
+        {
+            return left.LengthSquared <= right.LengthSquared;
+        }
+
+        /// <summary>
         /// Performs an explicit conversion from <see cref="Float3" /> to <see cref="Vector3" />.
         /// </summary>
         /// <param name="value">The value.</param>

--- a/Source/Engine/Core/Math/Float3.cs
+++ b/Source/Engine/Core/Math/Float3.cs
@@ -1807,54 +1807,6 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Determines if one <see cref="Float3"/> is greater than another <see cref="Float3"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(Float3 left, Float3 right)
-        {
-            return left.LengthSquared > right.LengthSquared;
-        }
-
-        /// <summary>
-        /// Determines if one <see cref="Float3"/> is less than another <see cref="Float3"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(Float3 left, Float3 right)
-        {
-            return left.LengthSquared < right.LengthSquared;
-        }
-
-        /// <summary>
-        /// Determines if one <see cref="Float3"/> is greater than or equal to another <see cref="Float3"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(Float3 left, Float3 right)
-        {
-            return left.LengthSquared >= right.LengthSquared;
-        }
-
-        /// <summary>
-        /// Determines if one <see cref="Float3"/> is less than or equal to another <see cref="Float3"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float3"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float3"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(Float3 left, Float3 right)
-        {
-            return left.LengthSquared <= right.LengthSquared;
-        }
-
-        /// <summary>
         /// Performs an explicit conversion from <see cref="Float3" /> to <see cref="Vector3" />.
         /// </summary>
         /// <param name="value">The value.</param>

--- a/Source/Engine/Core/Math/Float4.cs
+++ b/Source/Engine/Core/Math/Float4.cs
@@ -1304,54 +1304,6 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Determines if one <see cref="Float4"/> is greater than another <see cref="Float4"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(Float4 left, Float4 right)
-        {
-            return left.LengthSquared > right.LengthSquared;
-        }
-
-        /// <summary>
-        /// Determines if one <see cref="Float4"/> is less than another <see cref="Float4"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(Float4 left, Float4 right)
-        {
-            return left.LengthSquared < right.LengthSquared;
-        }
-
-        /// <summary>
-        /// Determines if one <see cref="Float4"/> is greater than or equal to another <see cref="Float4"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(Float4 left, Float4 right)
-        {
-            return left.LengthSquared >= right.LengthSquared;
-        }
-
-        /// <summary>
-        /// Determines if one <see cref="Float4"/> is less than or equal to another <see cref="Float4"/>.
-        /// </summary>
-        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
-        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
-        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(Float4 left, Float4 right)
-        {
-            return left.LengthSquared <= right.LengthSquared;
-        }
-
-        /// <summary>
         /// Performs an explicit conversion from <see cref="Float4" /> to <see cref="Vector4" />.
         /// </summary>
         /// <param name="value">The value.</param>

--- a/Source/Engine/Core/Math/Float4.cs
+++ b/Source/Engine/Core/Math/Float4.cs
@@ -60,7 +60,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Float4Converter))]
 #endif
-    partial struct Float4 : IEquatable<Float4>, IFormattable
+    partial struct Float4 : IEquatable<Float4>, IFormattable, IComparable, IComparable<Float4>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2} Z:{2:F2} W:{3:F2}";
 
@@ -1304,6 +1304,54 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Determines if one <see cref="Float4"/> is greater than another <see cref="Float4"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator >(Float4 left, Float4 right)
+        {
+            return left.LengthSquared > right.LengthSquared;
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="Float4"/> is less than another <see cref="Float4"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator <(Float4 left, Float4 right)
+        {
+            return left.LengthSquared < right.LengthSquared;
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="Float4"/> is greater than or equal to another <see cref="Float4"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is greater than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator >=(Float4 left, Float4 right)
+        {
+            return left.LengthSquared >= right.LengthSquared;
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="Float4"/> is less than or equal to another <see cref="Float4"/>.
+        /// </summary>
+        /// <param name="left">The first <see cref="Float4"/> to compare.</param>
+        /// <param name="right">The second <see cref="Float4"/> to compare.</param>
+        /// <returns><c>true</c> if the <see cref="LengthSquared"/> of <paramref name="left"/> is less than or equal to the <see cref="LengthSquared"/> of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator <=(Float4 left, Float4 right)
+        {
+            return left.LengthSquared <= right.LengthSquared;
+        }
+
+        /// <summary>
         /// Performs an explicit conversion from <see cref="Float4" /> to <see cref="Vector4" />.
         /// </summary>
         /// <param name="value">The value.</param>
@@ -1441,6 +1489,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Float4 other && Mathf.NearEqual(other.X, X) && Mathf.NearEqual(other.Y, Y) && Mathf.NearEqual(other.Z, Z) && Mathf.NearEqual(other.W, W);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Float4 other)
+                throw new ArgumentException("Object is not a Float4.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Float4 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Int2.cs
+++ b/Source/Engine/Core/Math/Int2.cs
@@ -14,7 +14,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Int2Converter))]
 #endif
-    partial struct Int2 : IEquatable<Int2>, IFormattable
+    partial struct Int2 : IEquatable<Int2>, IFormattable, IComparable, IComparable<Int2>
     {
         private static readonly string _formatString = "X:{0} Y:{1}";
 
@@ -978,6 +978,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Int2 other && Equals(ref other);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Int2 other)
+                throw new ArgumentException("Object is not a Int2.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Int2 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Int3.cs
+++ b/Source/Engine/Core/Math/Int3.cs
@@ -14,7 +14,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Int3Converter))]
 #endif
-    partial struct Int3 : IEquatable<Int3>, IFormattable
+    partial struct Int3 : IEquatable<Int3>, IFormattable, IComparable, IComparable<Int2>
     {
         private static readonly string _formatString = "X:{0} Y:{1} Z:{2}";
 
@@ -1053,6 +1053,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Int3 other && Equals(ref other);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Int3 other)
+                throw new ArgumentException("Object is not a Int3.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Int2 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Int3.cs
+++ b/Source/Engine/Core/Math/Int3.cs
@@ -14,7 +14,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Int3Converter))]
 #endif
-    partial struct Int3 : IEquatable<Int3>, IFormattable, IComparable, IComparable<Int2>
+    partial struct Int3 : IEquatable<Int3>, IFormattable, IComparable, IComparable<Int3>
     {
         private static readonly string _formatString = "X:{0} Y:{1} Z:{2}";
 
@@ -1069,7 +1069,7 @@ namespace FlaxEngine
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int CompareTo(Int2 other)
+        public int CompareTo(Int3 other)
         {
             return LengthSquared.CompareTo(other.LengthSquared);
         }

--- a/Source/Engine/Core/Math/Vector2.cs
+++ b/Source/Engine/Core/Math/Vector2.cs
@@ -73,7 +73,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Vector2Converter))]
 #endif
-    public unsafe partial struct Vector2 : IEquatable<Vector2>, IFormattable
+    public unsafe partial struct Vector2 : IEquatable<Vector2>, IFormattable, IComparable, IComparable<Vector2>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2}";
 
@@ -1812,6 +1812,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Vector2 other && Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Vector2 other)
+                throw new ArgumentException("Object is not a Vector2.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Vector2 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -73,7 +73,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Vector3Converter))]
 #endif
-    public unsafe partial struct Vector3 : IEquatable<Vector3>, IFormattable
+    public unsafe partial struct Vector3 : IEquatable<Vector3>, IFormattable, IComparable, IComparable<Vector3>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2} Z:{2:F2}";
 
@@ -2163,6 +2163,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Vector3 other && Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Vector3 other)
+                throw new ArgumentException("Object is not a Vector3", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Vector3 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }

--- a/Source/Engine/Core/Math/Vector3.cs
+++ b/Source/Engine/Core/Math/Vector3.cs
@@ -2172,7 +2172,7 @@ namespace FlaxEngine
                 return 1;
 
             if (obj is not Vector3 other)
-                throw new ArgumentException("Object is not a Vector3", nameof(obj));
+                throw new ArgumentException("Object is not a Vector3.", nameof(obj));
 
             return LengthSquared.CompareTo(other.LengthSquared);
         }

--- a/Source/Engine/Core/Math/Vector4.cs
+++ b/Source/Engine/Core/Math/Vector4.cs
@@ -72,7 +72,7 @@ namespace FlaxEngine
 #if FLAX_EDITOR
     [System.ComponentModel.TypeConverter(typeof(TypeConverters.Vector4Converter))]
 #endif
-    public partial struct Vector4 : IEquatable<Vector4>, IFormattable
+    public partial struct Vector4 : IEquatable<Vector4>, IFormattable, IComparable, IComparable<Vector4>
     {
         private static readonly string _formatString = "X:{0:F2} Y:{1:F2} Z:{2:F2} W:{3:F2}";
 
@@ -1515,6 +1515,25 @@ namespace FlaxEngine
         public override bool Equals(object value)
         {
             return value is Vector4 other && Mathr.NearEqual(other.X, X) && Mathr.NearEqual(other.Y, Y) && Mathr.NearEqual(other.Z, Z) && Mathr.NearEqual(other.W, W);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (obj is not Vector4 other)
+                throw new ArgumentException("Object is not a Vector4.", nameof(obj));
+
+            return LengthSquared.CompareTo(other.LengthSquared);
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(Vector4 other)
+        {
+            return LengthSquared.CompareTo(other.LengthSquared);
         }
     }
 }


### PR DESCRIPTION
## Implement IComparable for Vector and Integer Structs

This pull request enhances several vector and integer-based structs within the `FlaxEngine` namespace by implementing the `IComparable` and `IComparable<T>` interfaces. These changes enable standardized sorting and ordering operations based on the `LengthSquared` property of each struct.

### Affected Structs:

The following structs have been updated:

* `Vector2`
* `Vector3`
* `Vector4`
* `Int2`
* `Int3`
* `Double2`
* `Double3`
* `Double4`
* `Float2`
* `Float3`
* `Float4`

---

### Changes Made:

For each of the listed structs, the following additions were made:

1.  **Implemented `IComparable`**:
    * Added the `CompareTo(object obj)` method. This method handles `null` checks and type validation, throwing an `ArgumentException` if the object is not of the expected struct type. Comparison is performed based on the `LengthSquared` property.

2.  **Implemented `IComparable<T>`** (where `T` is the specific struct type, e.g., `IComparable<Vector2>` for `Vector2`):
    * Added the `CompareTo(T other)` method for direct, type-safe comparison with another instance of the same struct.
    * This comparison is also based on the `LengthSquared` property.
    * In most cases (e.g., `Vector2`, `Float3`, `Double3`, `Int3`), this method has been marked with `[MethodImpl(MethodImplOptions.AggressiveInlining)]` for potential performance optimization.

**Example Implementation (similar across all affected structs):**

```csharp
// For a struct like Float2:

/// <inheritdoc/>
public int CompareTo(object obj)
{
    if (obj == null)
        return 1;

    if (obj is not Float2 other) // Or respective struct type
        throw new ArgumentException("Object is not a Float2.", nameof(obj)); // Or respective struct type

    return LengthSquared.CompareTo(other.LengthSquared);
}

/// <inheritdoc/>
[MethodImpl(MethodImplOptions.AggressiveInlining)] // Where applicable
public int CompareTo(Float2 other) // Or respective struct type
{
    return LengthSquared.CompareTo(other.LengthSquared);
}
```

---

### Purpose:

These additions provide a consistent way to compare instances of these fundamental structs, which is beneficial for various tasks such as sorting collections or implementing custom ordering logic. The use of `LengthSquared` avoids the computational overhead of a square root operation when only relative order is needed.