### PR TITLE
Debug command suggestion improvements

### DIFF
--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -325,12 +325,17 @@ namespace FlaxEditor.Windows
 
                 // Show commands search popup based on current text input
                 var text = Text.Trim();
-                if (text.Length != 0)
+                bool isWhitespaceOnly = string.IsNullOrWhiteSpace(Text) && !string.IsNullOrEmpty(Text);
+                if (text.Length != 0 || isWhitespaceOnly)
                 {
                     DebugCommands.Search(text, out var matches);
-                    if (matches.Length != 0)
+                    if (matches.Length != 0 || isWhitespaceOnly)
                     {
-                        ShowPopup(ref _searchPopup, matches, text);
+                        string[] commands = [];
+                        if (isWhitespaceOnly)
+                            DebugCommands.GetAllCommands(out commands);
+
+                        ShowPopup(ref _searchPopup, isWhitespaceOnly ? commands : matches, isWhitespaceOnly ? commands[0] : text);
                         return;
                     }
                 }

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -233,7 +233,10 @@ namespace FlaxEditor.Windows
                 else
                     cm.ClearItems();
 
+                float longestItemWidth = 0.0f;
+
                 // Add items
+                var font = Style.Current.FontMedium;
                 ItemsListContextMenu.Item lastItem = null;
                 foreach (var command in commands)
                 {
@@ -244,7 +247,7 @@ namespace FlaxEditor.Windows
                     });
                     var flags = DebugCommands.GetCommandFlags(command);
                     if (flags.HasFlag(DebugCommands.CommandFlags.Exec))
-                        lastItem.TintColor = new Color(0.85f, 0.85f, 1.0f, 1.0f);
+                        lastItem.TintColor = new Color(0.75f, 0.75f, 1.0f, 1.0f);
                     else if (flags.HasFlag(DebugCommands.CommandFlags.Read) && !flags.HasFlag(DebugCommands.CommandFlags.Write))
                         lastItem.TintColor = new Color(0.85f, 0.85f, 0.85f, 1.0f);
                     lastItem.Focused += item =>
@@ -252,6 +255,10 @@ namespace FlaxEditor.Windows
                         // Set command
                         Set(item.Name);
                     };
+
+                    float width = font.MeasureText(command).X;
+                    if (width > longestItemWidth)
+                        longestItemWidth = width;
                 }
                 cm.ItemClicked += item =>
                 {
@@ -262,6 +269,10 @@ namespace FlaxEditor.Windows
                 // Setup popup
                 var count = commands.Count();
                 var totalHeight = count * lastItem.Height + cm.ItemsPanel.Margin.Height + cm.ItemsPanel.Spacing * (count - 1);
+
+                // Account for scroll bars taking up a part of the width
+                longestItemWidth += 25f;
+                cm.Width = longestItemWidth;
                 cm.Height = 220;
                 if (cm.Height > totalHeight)
                     cm.Height = totalHeight; // Limit popup height if list is small

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -335,7 +335,15 @@ namespace FlaxEditor.Windows
                         if (isWhitespaceOnly)
                             DebugCommands.GetAllCommands(out commands);
 
-                        ShowPopup(ref _searchPopup, isWhitespaceOnly ? commands : matches, isWhitespaceOnly ? commands[0] : text);
+                        ShowPopup(ref _searchPopup, isWhitespaceOnly ? commands : matches, text);
+                        
+                        if (isWhitespaceOnly)
+                        {
+                            // Scroll to and select first item for consistent behaviour
+                            var firstItem = _searchPopup.ItemsPanel.Children[0] as Item;
+                            _searchPopup.ScrollToAndHighlightItemByName(firstItem.Name);
+                        }
+
                         return;
                     }
                 }

--- a/Source/Engine/Debug/DebugCommands.cpp
+++ b/Source/Engine/Debug/DebugCommands.cpp
@@ -435,6 +435,17 @@ void DebugCommands::InitAsync()
     AsyncTask = Task::StartNew(InitCommands);
 }
 
+void DebugCommands::GetAllCommands(Array<StringView>& commands)
+{
+    EnsureInited();
+    ScopeLock lock(Locker);
+
+    for (auto& command : Commands)
+    {
+        commands.Add(command.Name);
+    }
+}
+
 DebugCommands::CommandFlags DebugCommands::GetCommandFlags(StringView command)
 {
     CommandFlags result = CommandFlags::None;

--- a/Source/Engine/Debug/DebugCommands.h
+++ b/Source/Engine/Debug/DebugCommands.h
@@ -50,7 +50,6 @@ public:
     /// Gets all available commands.
     /// </summary>
     /// <param name="matches">The output list of all commands (unsorted).</param>
-    /// <returns>TODO.</returns>
     API_FUNCTION() static void GetAllCommands(API_PARAM(Out) Array<StringView, HeapAllocation>& commands);
 
     /// <summary>

--- a/Source/Engine/Debug/DebugCommands.h
+++ b/Source/Engine/Debug/DebugCommands.h
@@ -47,6 +47,13 @@ public:
     API_FUNCTION() static void InitAsync();
 
     /// <summary>
+    /// Gets all available commands.
+    /// </summary>
+    /// <param name="matches">The output list of all commands (unsorted).</param>
+    /// <returns>TODO.</returns>
+    API_FUNCTION() static void GetAllCommands(API_PARAM(Out) Array<StringView, HeapAllocation>& commands);
+
+    /// <summary>
     /// Returns flags of the command.
     /// </summary>
     /// <param name="command">The full name of the command.</param>


### PR DESCRIPTION
This pr auto resizes the debug command suggestion popup based on the longest command. I added this because I noticed commands with longer names getting their names cut off.



https://github.com/user-attachments/assets/8890c5dd-6592-47b9-b0e1-b67fcc4a5cb9

There are also some slight tweaks to command tinting based on their attributes, hopefully this differentiates the different command types a bit more.

Also in this pr there is a second commit that adds typing " " (or any amount of whitespaces) into the debug command bar showing all commands.
It is possible that I reached a limit with my C++ skills here (which are basically nonexistent), so if the code is too bad feel free to ignore that commit.

https://github.com/user-attachments/assets/8824adcf-ed3a-40c3-b02b-4314c23fb4d4

