### PR TITLE
Dont scroll to node when play is starting or ending.

### DIFF
--- a/Source/Editor/Windows/SceneTreeWindow.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.cs
@@ -27,6 +27,7 @@ namespace FlaxEditor.Windows
         private Panel _sceneTreePanel;
         private bool _isUpdatingSelection;
         private bool _isMouseDown;
+        private bool _isPlayStateChanging = false;
 
         private DragAssets _dragAssets;
         private DragActorType _dragActorType;
@@ -92,6 +93,11 @@ namespace FlaxEditor.Windows
             _tree.RightClick += OnTreeRightClick;
             _tree.Parent = _sceneTreePanel;
             headerPanel.Parent = this;
+
+            Editor.PlayModeBeginning += () => _isPlayStateChanging = true;
+            Editor.PlayModeBegin += () => _isPlayStateChanging = false;
+            Editor.PlayModeEnding += () => _isPlayStateChanging = true;
+            Editor.PlayModeEnd += () => _isPlayStateChanging = false;
 
             // Setup input actions
             InputActions.Add(options => options.TranslateMode, () => Editor.MainTransformGizmo.ActiveMode = TransformGizmoBase.Mode.Translate);
@@ -250,7 +256,7 @@ namespace FlaxEditor.Windows
                 _tree.Select(nodes);
 
                 // For single node selected scroll view so user can see it
-                if (nodes.Count == 1)
+                if (nodes.Count == 1 && !_isPlayStateChanging)
                 {
                     nodes[0].ExpandAllParents(true);
                     _sceneTreePanel.ScrollViewTo(nodes[0]);


### PR DESCRIPTION
Closes #3512

Seems like when the scene loads/unloads when playing/ending the scene, the selection changes and panel scrolls to the top. This is a bypass for that behavior. There may be a better fix somewhere.