### PR TITLE
Add node alignment formatting options to visject

### DIFF
--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -647,5 +647,45 @@ namespace FlaxEditor.Options
         public InputBinding VisualScriptDebuggerWindow = new InputBinding(KeyboardKeys.None);
 
         #endregion
+
+        #region Node editors
+
+        [DefaultValue(typeof(InputBinding), "Shift+W")]
+        [EditorDisplay("Node editors"), EditorOrder(4500)]
+        public InputBinding NodesAlignTop = new InputBinding(KeyboardKeys.W, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "Shift+A")]
+        [EditorDisplay("Node editors"), EditorOrder(4510)]
+        public InputBinding NodesAlignLeft = new InputBinding(KeyboardKeys.A, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "Shift+S")]
+        [EditorDisplay("Node editors"), EditorOrder(4520)]
+        public InputBinding NodesAlignBottom = new InputBinding(KeyboardKeys.S, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "Shift+D")]
+        [EditorDisplay("Node editors"), EditorOrder(4530)]
+        public InputBinding NodesAlignRight = new InputBinding(KeyboardKeys.D, KeyboardKeys.Shift);
+
+        [DefaultValue(typeof(InputBinding), "Alt+Shift+W")]
+        [EditorDisplay("Node editors"), EditorOrder(4540)]
+        public InputBinding NodesAlignMiddle = new InputBinding(KeyboardKeys.W, KeyboardKeys.Shift, KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), "Alt+Shift+S")]
+        [EditorDisplay("Node editors"), EditorOrder(4550)]
+        public InputBinding NodesAlignCenter = new InputBinding(KeyboardKeys.S, KeyboardKeys.Shift, KeyboardKeys.Alt);
+
+        [DefaultValue(typeof(InputBinding), "Q")]
+        [EditorDisplay("Node editors"), EditorOrder(4560)]
+        public InputBinding NodesAutoFormat = new InputBinding(KeyboardKeys.Q);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Node editors"), EditorOrder(4570)]
+        public InputBinding NodesDistributeHorizontal = new InputBinding(KeyboardKeys.None);
+
+        [DefaultValue(typeof(InputBinding), "None")]
+        [EditorDisplay("Node editors"), EditorOrder(4580)]
+        public InputBinding NodesDistributeVertical = new InputBinding(KeyboardKeys.None);
+
+        #endregion
     }
 }

--- a/Source/Editor/Surface/NodeAlignmentType.cs
+++ b/Source/Editor/Surface/NodeAlignmentType.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using FlaxEngine;
+
+namespace FlaxEditor.Surface
+{
+	/// <summary>
+	/// Node Alignment type
+	/// </summary>
+	[HideInEditor]
+	public enum NodeAlignmentType
+	{
+		/// <summary>
+		/// Align nodes vertically to top, matching top-most node
+		/// </summary>
+		Top,
+
+		/// <summary>
+		/// Align nodes vertically to middle, using average of all nodes
+		/// </summary>
+		Middle,
+
+		/// <summary>
+		/// Align nodes vertically to bottom, matching bottom-most node
+		/// </summary>
+		Bottom,
+
+		/// <summary>
+		/// Align nodes horizontally to left, matching left-most node
+		/// </summary>
+		Left,
+
+		/// <summary>
+		/// Align nodes horizontally to center, using average of all nodes
+		/// </summary>
+		Center,
+
+		/// <summary>
+		/// Align nodes horizontally to right, matching right-most node
+		/// </summary>
+		Right,
+	}
+}

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -411,21 +411,21 @@ namespace FlaxEditor.Surface
             _cmFormatNodesMenu = menu.AddChildMenu("Format node(s)");
             _cmFormatNodesMenu.Enabled = CanEdit && HasNodesSelection;
 
-            _cmFormatNodesConnectionButton = _cmFormatNodesMenu.ContextMenu.AddButton("Auto format", () => { FormatGraph(SelectedNodes); });
+            _cmFormatNodesConnectionButton = _cmFormatNodesMenu.ContextMenu.AddButton("Auto format", Editor.Instance.Options.Options.Input.NodesAutoFormat, () => { FormatGraph(SelectedNodes); });
 
             _cmFormatNodesMenu.ContextMenu.AddSeparator();
-            _cmAlignNodesTopButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align top", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Top); });
-            _cmAlignNodesMiddleButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align middle", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Middle); });
-            _cmAlignNodesBottomButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align bottom", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Bottom); });
+            _cmAlignNodesTopButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align top", Editor.Instance.Options.Options.Input.NodesAlignTop, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Top); });
+            _cmAlignNodesMiddleButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align middle", Editor.Instance.Options.Options.Input.NodesAlignMiddle, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Middle); });
+            _cmAlignNodesBottomButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align bottom", Editor.Instance.Options.Options.Input.NodesAlignBottom, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Bottom); });
 
             _cmFormatNodesMenu.ContextMenu.AddSeparator();
-            _cmAlignNodesLeftButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align left", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Left); });
-            _cmAlignNodesCenterButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align center", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Center); });
-            _cmAlignNodesRightButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align right", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Right); });
+            _cmAlignNodesLeftButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align left", Editor.Instance.Options.Options.Input.NodesAlignLeft, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Left); });
+            _cmAlignNodesCenterButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align center", Editor.Instance.Options.Options.Input.NodesAlignCenter, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Center); });
+            _cmAlignNodesRightButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align right", Editor.Instance.Options.Options.Input.NodesAlignRight, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Right); });
 
             _cmFormatNodesMenu.ContextMenu.AddSeparator();
-            _cmDistributeNodesHorizontallyButton = _cmFormatNodesMenu.ContextMenu.AddButton("Distribute horizontally", () => { DistributeNodes(SelectedNodes, false); });
-            _cmDistributeNodesVerticallyButton = _cmFormatNodesMenu.ContextMenu.AddButton("Distribute vertically", () => { DistributeNodes(SelectedNodes, true); });
+            _cmDistributeNodesHorizontallyButton = _cmFormatNodesMenu.ContextMenu.AddButton("Distribute horizontally", Editor.Instance.Options.Options.Input.NodesDistributeHorizontal, () => { DistributeNodes(SelectedNodes, false); });
+            _cmDistributeNodesVerticallyButton = _cmFormatNodesMenu.ContextMenu.AddButton("Distribute vertically", Editor.Instance.Options.Options.Input.NodesDistributeVertical, () => { DistributeNodes(SelectedNodes, true); });
 
             _cmRemoveNodeConnectionsButton = menu.AddButton("Remove all connections to that node(s)", () =>
             {

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -199,6 +199,8 @@ namespace FlaxEditor.Surface
         private ContextMenuButton _cmAlignNodesLeftButton;
         private ContextMenuButton _cmAlignNodesCenterButton;
         private ContextMenuButton _cmAlignNodesRightButton;
+        private ContextMenuButton _cmDistributeNodesHorizontallyButton;
+        private ContextMenuButton _cmDistributeNodesVerticallyButton;
         private ContextMenuButton _cmRemoveNodeConnectionsButton;
         private ContextMenuButton _cmRemoveBoxConnectionsButton;
         private readonly Float2 ContextMenuOffset = new Float2(5);
@@ -420,6 +422,10 @@ namespace FlaxEditor.Surface
             _cmAlignNodesLeftButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align left", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Left); });
             _cmAlignNodesCenterButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align center", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Center); });
             _cmAlignNodesRightButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align right", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Right); });
+
+            _cmFormatNodesMenu.ContextMenu.AddSeparator();
+            _cmDistributeNodesHorizontallyButton = _cmFormatNodesMenu.ContextMenu.AddButton("Distribute horizontally", () => { DistributeNodes(SelectedNodes, false); });
+            _cmDistributeNodesVerticallyButton = _cmFormatNodesMenu.ContextMenu.AddButton("Distribute vertically", () => { DistributeNodes(SelectedNodes, true); });
 
             _cmRemoveNodeConnectionsButton = menu.AddButton("Remove all connections to that node(s)", () =>
             {

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -191,7 +191,14 @@ namespace FlaxEditor.Surface
 
         private ContextMenuButton _cmCopyButton;
         private ContextMenuButton _cmDuplicateButton;
+        private ContextMenuChildMenu _cmFormatNodesMenu;
         private ContextMenuButton _cmFormatNodesConnectionButton;
+        private ContextMenuButton _cmAlignNodesTopButton;
+        private ContextMenuButton _cmAlignNodesMiddleButton;
+        private ContextMenuButton _cmAlignNodesBottomButton;
+        private ContextMenuButton _cmAlignNodesLeftButton;
+        private ContextMenuButton _cmAlignNodesCenterButton;
+        private ContextMenuButton _cmAlignNodesRightButton;
         private ContextMenuButton _cmRemoveNodeConnectionsButton;
         private ContextMenuButton _cmRemoveBoxConnectionsButton;
         private readonly Float2 ContextMenuOffset = new Float2(5);
@@ -399,8 +406,20 @@ namespace FlaxEditor.Surface
             }
             menu.AddSeparator();
 
-            _cmFormatNodesConnectionButton = menu.AddButton("Format node(s)", () => { FormatGraph(SelectedNodes); });
-            _cmFormatNodesConnectionButton.Enabled = CanEdit && HasNodesSelection;
+            _cmFormatNodesMenu = menu.AddChildMenu("Format node(s)");
+            _cmFormatNodesMenu.Enabled = CanEdit && HasNodesSelection;
+
+            _cmFormatNodesConnectionButton = _cmFormatNodesMenu.ContextMenu.AddButton("Auto format", () => { FormatGraph(SelectedNodes); });
+
+            _cmFormatNodesMenu.ContextMenu.AddSeparator();
+            _cmAlignNodesTopButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align top", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Top); });
+            _cmAlignNodesMiddleButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align middle", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Middle); });
+            _cmAlignNodesBottomButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align bottom", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Bottom); });
+
+            _cmFormatNodesMenu.ContextMenu.AddSeparator();
+            _cmAlignNodesLeftButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align left", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Left); });
+            _cmAlignNodesCenterButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align center", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Center); });
+            _cmAlignNodesRightButton = _cmFormatNodesMenu.ContextMenu.AddButton("Align right", () => { AlignNodes(SelectedNodes, NodeAlignmentType.Right); });
 
             _cmRemoveNodeConnectionsButton = menu.AddButton("Remove all connections to that node(s)", () =>
             {

--- a/Source/Editor/Surface/VisjectSurface.Formatting.cs
+++ b/Source/Editor/Surface/VisjectSurface.Formatting.cs
@@ -282,5 +282,47 @@ namespace FlaxEditor.Surface
 
             return maxOffset;
         }
+
+        /// <summary>
+        /// Align given nodes on a graph using the given alignment type.
+        /// Ignores any potential overlap.
+        /// </summary>
+        /// <param name="nodes">List of nodes</param>
+        /// <param name="alignmentType">Alignemnt type</param>
+        public void AlignNodes(List<SurfaceNode> nodes, NodeAlignmentType alignmentType)
+        {
+            if(nodes.Count <= 1)
+                return;
+
+            var undoActions = new List<MoveNodesAction>();
+            var boundingBox = GetNodesBounds(nodes);
+            for(int i = 0; i < nodes.Count; i++)
+            {
+                var centerY = boundingBox.Center.Y - (nodes[i].Height / 2);
+                var centerX = boundingBox.Center.X - (nodes[i].Width / 2);
+                
+                var newLocation = alignmentType switch
+                {
+                    NodeAlignmentType.Top    => new Float2(nodes[i].Location.X, boundingBox.Top),
+                    NodeAlignmentType.Middle => new Float2(nodes[i].Location.X, centerY),
+                    NodeAlignmentType.Bottom => new Float2(nodes[i].Location.X, boundingBox.Bottom - nodes[i].Height),
+
+                    NodeAlignmentType.Left   => new Float2(boundingBox.Left, nodes[i].Location.Y),
+                    NodeAlignmentType.Center => new Float2(centerX, nodes[i].Location.Y),
+                    NodeAlignmentType.Right  => new Float2(boundingBox.Right - nodes[i].Width, nodes[i].Location.Y),
+
+                    _ => throw new NotImplementedException($"Unsupported node alignment type: {alignmentType}"),
+                };
+
+                var locationDelta = newLocation - nodes[i].Location;
+                nodes[i].Location = newLocation;
+
+                if(Undo != null)
+                    undoActions.Add(new MoveNodesAction(Context, new[] { nodes[i].ID }, locationDelta));
+            }
+
+            MarkAsEdited(false);
+            Undo?.AddAction(new MultiUndoAction(undoActions, $"Align nodes ({alignmentType})"));
+        }
     }
 }

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -405,6 +405,15 @@ namespace FlaxEditor.Surface
                 new InputActionsContainer.Binding(options => options.Paste, Paste),
                 new InputActionsContainer.Binding(options => options.Cut, Cut),
                 new InputActionsContainer.Binding(options => options.Duplicate, Duplicate),
+                new InputActionsContainer.Binding(options => options.NodesAutoFormat, () => { FormatGraph(SelectedNodes); }),
+                new InputActionsContainer.Binding(options => options.NodesAlignTop, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Top); }),
+                new InputActionsContainer.Binding(options => options.NodesAlignMiddle, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Middle); }),
+                new InputActionsContainer.Binding(options => options.NodesAlignBottom, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Bottom); }),
+                new InputActionsContainer.Binding(options => options.NodesAlignLeft, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Left); }),
+                new InputActionsContainer.Binding(options => options.NodesAlignCenter, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Center); }),
+                new InputActionsContainer.Binding(options => options.NodesAlignRight, () => { AlignNodes(SelectedNodes, NodeAlignmentType.Right); }),
+                new InputActionsContainer.Binding(options => options.NodesDistributeHorizontal, () => {  DistributeNodes(SelectedNodes, false); }),
+                new InputActionsContainer.Binding(options => options.NodesDistributeVertical, () => {  DistributeNodes(SelectedNodes, true); }),
             });
 
             Context.ControlSpawned += OnSurfaceControlSpawned;


### PR DESCRIPTION
This adds vertical and horizontal alignment options to Visject surfaces. The existing option `format node(s)` has been renamed to `auto format` inside the menu so that the original option could be turned into a submenu instead. The alignment options ignore any potential node overlap.

https://github.com/user-attachments/assets/2fb17a34-a6b8-40df-b247-b47921133477

~~It might be worth adding hotkeys for these actions like in Unreal, however i opted to not add them in case #3457 gets PR'd in.~~ went ahead and added hotkeys similar that of Unreal's.

This closes #3519 