### PR TITLE
Wrap scrolling items list with arrow keys and simplify scrolling logic

### DIFF
--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -563,8 +563,17 @@ namespace FlaxEditor.GUI
             case KeyboardKeys.Escape:
                 Hide();
                 return true;
+            case KeyboardKeys.Backspace:
+                // Alow the user to quickly focus the searchbar
+                if (_searchBox != null && !_searchBox.IsFocused)
+                {
+                    _searchBox.Focus();
+                    _searchBox.SelectAll();
+                    return true;
+                }
+                break;
             case KeyboardKeys.ArrowDown:
-            {
+            case KeyboardKeys.ArrowUp:
                 if (RootWindow.FocusedControl == null)
                 {
                     // Focus search box if nothing is focused
@@ -572,39 +581,17 @@ namespace FlaxEditor.GUI
                     return true;
                 }
 
-                //  Focus the first visible item or then next one
+                // Get the next item
                 var items = GetVisibleItems();
                 var focusedIndex = items.IndexOf(focusedItem);
-                if (focusedIndex == -1)
-                    focusedIndex = -1;
-                if (focusedIndex + 1 < items.Count)
-                {
-                    var item = items[focusedIndex + 1];
-                    item.Focus();
-                    _scrollPanel.ScrollViewTo(item);
-                    return true;
-                }
-                break;
-            }
-            case KeyboardKeys.ArrowUp:
-                if (focusedItem != null)
-                {
-                    //  Focus the previous visible item or the search box
-                    var items = GetVisibleItems();
-                    var focusedIndex = items.IndexOf(focusedItem);
-                    if (focusedIndex == 0)
-                    {
-                        _searchBox?.Focus();
-                    }
-                    else if (focusedIndex > 0)
-                    {
-                        var item = items[focusedIndex - 1];
-                        item.Focus();
-                        _scrollPanel.ScrollViewTo(item);
-                        return true;
-                    }
-                }
-                break;
+                int delta = key == KeyboardKeys.ArrowDown ? -1 : 1;
+                int nextIndex = Mathf.Wrap(focusedIndex - delta, 0, items.Count - 1);
+                var nextItem = items[nextIndex];
+
+                // Focus the next item
+                nextItem.Focus();
+                _scrollPanel.ScrollViewTo(nextItem);
+                return true;
             case KeyboardKeys.Return:
                 if (focusedItem != null)
                 {


### PR DESCRIPTION
This pr:
- Simplifies and unifies the keyboard scrolling (arrow up/ down) code
- Wraps scrolling with arrow keys (if selected item is the last item in the list && arrow down pressed -> select the first one, and vice versa)
- Adds pressing the backspace key to instantly focus the search bar and highlight all text, similar to #3323

This also means that debug command suggestions will be wrapped (horrayy).