### PR TITLE
Add edit & show asset code options to context menu when possible

### DIFF
--- a/Source/Editor/Windows/ContentWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/ContentWindow.ContextMenu.cs
@@ -10,6 +10,7 @@ using FlaxEngine;
 using FlaxEngine.Assertions;
 using FlaxEngine.GUI;
 using FlaxEngine.Json;
+using FlaxEngine.Utilities;
 
 namespace FlaxEditor.Windows
 {
@@ -119,6 +120,14 @@ namespace FlaxEditor.Windows
                     {
                         if (assetItem.IsLoaded)
                             cm.AddButton("Reload", assetItem.Reload);
+
+                        var scriptItem = TypeUtils.GetType(assetItem.TypeName).ContentItem;
+                        if(scriptItem != null)
+                        {
+                            cm.AddButton("Edit asset code", () => { Editor.Instance.ContentEditing.Open(scriptItem); });
+                            cm.AddButton("Show asset code item in content window", () => { Editor.Instance.Windows.ContentWin.Select(scriptItem); });
+                        }
+                        
                         cm.AddButton("Copy asset ID", () => Clipboard.Text = JsonSerializer.GetStringID(assetItem.ID));
                         cm.AddButton("Select actors using this asset", () => Editor.SceneEditing.SelectActorsUsingAsset(assetItem.ID));
                         cm.AddButton("Show asset references graph", () => Editor.Windows.Open(new AssetReferencesGraphWindow(Editor, assetItem)));

--- a/Source/Editor/Windows/ContentWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/ContentWindow.ContextMenu.cs
@@ -124,8 +124,8 @@ namespace FlaxEditor.Windows
                         var scriptItem = TypeUtils.GetType(assetItem.TypeName).ContentItem;
                         if(scriptItem != null)
                         {
-                            cm.AddButton("Edit asset code", () => { Editor.Instance.ContentEditing.Open(scriptItem); });
-                            cm.AddButton("Show asset code item in content window", () => { Editor.Instance.Windows.ContentWin.Select(scriptItem); });
+                            cm.AddButton("Edit asset type", () => { Editor.Instance.ContentEditing.Open(scriptItem); });
+                            cm.AddButton("Show asset type item in content window", () => { Editor.Instance.Windows.ContentWin.Select(scriptItem); });
                         }
                         
                         cm.AddButton("Copy asset ID", () => Clipboard.Text = JsonSerializer.GetStringID(assetItem.ID));


### PR DESCRIPTION
This adds quick options to show & edit the asset code for any applicable asset whenever it is possible to do so, mirroring the behavior found in places like the JSON settings cog menu.

Example: asset with no associated code file
![image](https://github.com/user-attachments/assets/3796f0bb-b9c0-4e0c-897d-968b07707b28)

Example: asset with associated code file (JSON asset)
![image](https://github.com/user-attachments/assets/494fb1ea-0410-4817-9088-a6193812a547)
