### PR TITLE
Clear content panel search when selecting asset picker asset

### DIFF
--- a/Source/Editor/GUI/AssetPicker.cs
+++ b/Source/Editor/GUI/AssetPicker.cs
@@ -299,6 +299,7 @@ namespace FlaxEditor.GUI
                     {
                         // Select asset
                         Editor.Instance.Windows.ContentWin.Select(Validator.SelectedItem);
+                        Editor.Instance.Windows.ContentWin.ClearItemsSearch();
                     }
                 }
                 else if (Button1Rect.Contains(location))
@@ -312,6 +313,7 @@ namespace FlaxEditor.GUI
                     {
                         // Select asset
                         Editor.Instance.Windows.ContentWin.Select(Validator.SelectedItem);
+                        Editor.Instance.Windows.ContentWin.ClearItemsSearch();
                     }
                     else if (Button3Rect.Contains(location))
                     {


### PR DESCRIPTION
Clears the Content Panel search bar and filters when selecting an asset from an asset reference.

It never happened that I wanted my search to apply *after* I pressed the select asset button, but it happens all the time that then need to manually clear the search bar.

If anyone *needs* the old behavior I can make this an editor setting (or holding shift while clicking the button keeps the search bar).