### PR TITLE
Add additive (box) and subtractive selection to Visject surfaces

### DIFF
--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -27,6 +27,7 @@ namespace FlaxEditor.Surface
         private Float2 _movingNodesDelta;
         private Float2 _gridRoundingDelta;
         private HashSet<SurfaceNode> _movingNodes;
+        private HashSet<SurfaceNode> _temporarySelectedNodes;
         private readonly Stack<InputBracket> _inputBrackets = new Stack<InputBracket>();
 
         private class InputBracket
@@ -130,13 +131,34 @@ namespace FlaxEditor.Surface
                 if (_rootControl.Children[i] is SurfaceControl control)
                 {
                     var select = control.IsSelectionIntersecting(ref selectionRect);
-                    if (select != control.IsSelected)
+
+                    if (Root.GetKey(KeyboardKeys.Shift))
                     {
-                        control.IsSelected = select;
-                        selectionChanged = true;
+                        if (select == control.IsSelected && _temporarySelectedNodes.Contains(control))
+                        {
+                            control.IsSelected = !select;
+                            selectionChanged = true;
+                        }
+                    }
+                    else if (Root.GetKey(KeyboardKeys.Control))
+                    {
+                        if (select != control.IsSelected && !_temporarySelectedNodes.Contains(control))
+                        {
+                            control.IsSelected = select;
+                            selectionChanged = true;
+                        }
+                    }
+                    else
+                    {
+                        if (select != control.IsSelected)
+                        {
+                            control.IsSelected = select;
+                            selectionChanged = true;
+                        }
                     }
                 }
             }
+
             if (selectionChanged)
                 SelectionChanged?.Invoke();
         }
@@ -461,6 +483,19 @@ namespace FlaxEditor.Surface
             // Cache data
             _isMovingSelection = false;
             _mousePos = location;
+            if(_temporarySelectedNodes == null)
+                _temporarySelectedNodes = new HashSet<SurfaceNode>();
+            else
+                _temporarySelectedNodes.Clear();
+
+            for (int i = 0; i < _rootControl.Children.Count; i++)
+            {
+                if (_rootControl.Children[i] is SurfaceNode node && node.IsSelected)
+                {
+                    _temporarySelectedNodes.Add(node);
+                }
+            }
+
             if (button == MouseButton.Left)
             {
                 _leftMouseDown = true;
@@ -488,9 +523,11 @@ namespace FlaxEditor.Surface
                     // Check if user is pressing control
                     if (Root.GetKey(KeyboardKeys.Control))
                     {
-                        // Add/remove from selection
-                        controlUnderMouse.IsSelected = !controlUnderMouse.IsSelected;
-                        SelectionChanged?.Invoke();
+                        AddToSelection(controlUnderMouse);
+                    }
+                    else if (Root.GetKey(KeyboardKeys.Shift))
+                    {
+                        RemoveFromSelection(controlUnderMouse);
                     }
                     // Check if node isn't selected
                     else if (!controlUnderMouse.IsSelected)
@@ -500,10 +537,14 @@ namespace FlaxEditor.Surface
                     }
 
                     // Start moving selected nodes
-                    StartMouseCapture();
-                    _movingSelectionViewPos = _rootControl.Location;
-                    _movingNodesDelta = Float2.Zero;
-                    OnGetNodesToMove();
+                    if (!Root.GetKey(KeyboardKeys.Shift))
+                    {
+                        StartMouseCapture();
+                        _movingSelectionViewPos = _rootControl.Location;
+                        _movingNodesDelta = Float2.Zero;
+                        OnGetNodesToMove();
+                    }
+
                     Focus();
                     return true;
                 }
@@ -515,7 +556,12 @@ namespace FlaxEditor.Surface
                 {
                     // Start selecting or commenting
                     StartMouseCapture();
-                    ClearSelection();
+
+                    if (!Root.GetKey(KeyboardKeys.Control) && !Root.GetKey(KeyboardKeys.Shift))
+                    {
+                        ClearSelection();
+                    }
+
                     Focus();
                     return true;
                 }

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -711,6 +711,18 @@ namespace FlaxEditor.Surface
         }
 
         /// <summary>
+        /// Removes the specified control from the selection.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        public void RemoveFromSelection(SurfaceControl control)
+        {
+            if (!control.IsSelected)
+                return;
+            control.IsSelected = false;
+            SelectionChanged?.Invoke();
+        }
+
+        /// <summary>
         /// Selects the specified control.
         /// </summary>
         /// <param name="control">The control.</param>


### PR DESCRIPTION
This adds additive and subtractive selection to Visject. 
Previously additive selection was only possible with single selections while holding control, this makes it possible to also do it while using a drag box. Subtractive selection is done by holding shift. During drag boxes it remembers previous selections, so the user can discard the new changes easily.

https://github.com/user-attachments/assets/acf5273f-4e53-4e5c-bb3a-949257c40543

This closes #3520 