### PR TITLE
Fix scroll to node on selection in prefab editor

### DIFF
--- a/Source/Editor/Windows/Assets/PrefabWindow.Selection.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Selection.cs
@@ -97,10 +97,7 @@ namespace FlaxEditor.Windows.Assets
 
                 // For single node selected scroll view so user can see it
                 if (nodes.Count == 1)
-                {
-                    nodes[0].ExpandAllParents(true);
-                    ScrollViewTo(nodes[0]);
-                }
+                    ScrollToSelectedNode();
             }
 
             // Update properties editor


### PR DESCRIPTION
Fixes auto scrolling on selection in the prefab editor. A step towards #3468.

Before:

https://github.com/user-attachments/assets/a98fa902-380f-4c33-88cd-0d6bb678bfa6



After:

https://github.com/user-attachments/assets/8c0996d4-9efd-41f1-b8e6-87da75078737

