### PR TITLE
Add Import/export warning message boxes

### DIFF
--- a/Source/Engine/ContentImporters/ImportAudio.cpp
+++ b/Source/Engine/ContentImporters/ImportAudio.cpp
@@ -18,6 +18,7 @@
 #include "Engine/Tools/AudioTool/OggVorbisDecoder.h"
 #include "Engine/Tools/AudioTool/OggVorbisEncoder.h"
 #include "Engine/Serialization/JsonWriters.h"
+#include "Engine/Platform/MessageBox.h"
 
 bool ImportAudio::TryGetImportOptions(const StringView& path, Options& options)
 {
@@ -118,6 +119,7 @@ CreateAssetResult ImportAudio::Import(CreateAssetContext& context, AudioDecoder&
     }
 #else
 #define HANDLE_VORBIS(chunkIndex, dataPtr, dataSize) \
+    MessageBox::Show(TEXT("Vorbis format is not supported."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
 	LOG(Warning, "Vorbis format is not supported."); \
 	return CreateAssetResult::Error;
 #endif
@@ -140,6 +142,7 @@ CreateAssetResult ImportAudio::Import(CreateAssetContext& context, AudioDecoder&
     break; \
     default: \
     { \
+        MessageBox::Show(TEXT("Unknown audio format."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning); \
         LOG(Warning, "Unknown audio format."); \
         return CreateAssetResult::Error; \
     } \

--- a/Source/Engine/Graphics/Models/ModelData.Tool.cpp
+++ b/Source/Engine/Graphics/Models/ModelData.Tool.cpp
@@ -12,6 +12,7 @@
 #include "Engine/Tools/ModelTool/VertexTriangleAdjacency.h"
 #include "Engine/Profiler/ProfilerCPU.h"
 #include "Engine/Platform/Platform.h"
+#include "Engine/Platform/MessageBox.h"
 #define USE_MIKKTSPACE 1
 #include "ThirdParty/MikkTSpace/mikktspace.h"
 #if USE_ASSIMP
@@ -181,6 +182,7 @@ bool MeshData::GenerateLightmapUVs()
     for (int32 i = 0; i < (int32)vb.size(); i++)
         lightmapChannel.Get()[i] = *(Float2*)&vb[i].uv;
 #else
+    MessageBox::Show(TEXT("Model lightmap UVs generation is not supported on this platform."), TEXT("Import error"), MessageBoxButtons::OK, MessageBoxIcon::Error);
     LOG(Error, "Model lightmap UVs generation is not supported on this platform.");
 #endif
 

--- a/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
+++ b/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
@@ -8,12 +8,12 @@
 #include "Engine/Platform/File.h"
 #include "Engine/Platform/CriticalSection.h"
 #include "Engine/Platform/ConditionVariable.h"
-#include "Engine/Platform/MessageBox.h"
 #include "Engine/Graphics/RenderTools.h"
 #include "Engine/Graphics/Async/GPUTask.h"
 #include "Engine/Graphics/Textures/TextureData.h"
 #include "Engine/Graphics/PixelFormatExtensions.h"
 #if USE_EDITOR
+#include "Engine/Platform/MessageBox.h"
 #include "Engine/Graphics/GPUDevice.h"
 #endif
 #include "Engine/Utilities/AnsiPathTempFile.h"
@@ -359,7 +359,9 @@ HRESULT LoadFromEXRFile(const StringView& path, DirectX::ScratchImage& image)
     free(pixels);
     return result;
 #else
+#if USE_EDITOR
     MessageBox::Show(TEXT("EXR format is not supported."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
+#endif
     LOG(Warning, "EXR format is not supported.");
     return E_FAIL;
 #endif

--- a/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
+++ b/Source/Engine/Tools/TextureTool/TextureTool.DirectXTex.cpp
@@ -8,6 +8,7 @@
 #include "Engine/Platform/File.h"
 #include "Engine/Platform/CriticalSection.h"
 #include "Engine/Platform/ConditionVariable.h"
+#include "Engine/Platform/MessageBox.h"
 #include "Engine/Graphics/RenderTools.h"
 #include "Engine/Graphics/Async/GPUTask.h"
 #include "Engine/Graphics/Textures/TextureData.h"
@@ -358,6 +359,7 @@ HRESULT LoadFromEXRFile(const StringView& path, DirectX::ScratchImage& image)
     free(pixels);
     return result;
 #else
+    MessageBox::Show(TEXT("EXR format is not supported."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
     LOG(Warning, "EXR format is not supported.");
     return E_FAIL;
 #endif

--- a/Source/Engine/Tools/TextureTool/TextureTool.stb.cpp
+++ b/Source/Engine/Tools/TextureTool/TextureTool.stb.cpp
@@ -13,6 +13,7 @@
 #include "Engine/Graphics/PixelFormatExtensions.h"
 #include "Engine/Utilities/AnsiPathTempFile.h"
 #include "Engine/Platform/File.h"
+#include "Engine/Platform/MessageBox.h"
 
 #define STBI_ASSERT(x) ASSERT(x)
 #define STBI_MALLOC(sz) Allocator::Allocate(sz)
@@ -286,21 +287,27 @@ bool TextureTool::ExportTextureStb(ImageType type, const StringView& path, const
         break;
     }
     case ImageType::GIF:
+        MessageBox::Show(TEXT("GIF format is not supported."), TEXT("Export warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "GIF format is not supported.");
         break;
     case ImageType::TIFF:
+        MessageBox::Show(TEXT("TIFF format is not supported."), TEXT("Export warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "GIF format is not supported.");
         break;
     case ImageType::DDS:
+        MessageBox::Show(TEXT("DDS format is not supported."), TEXT("Export warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "DDS format is not supported.");
         break;
     case ImageType::RAW:
+        MessageBox::Show(TEXT("RAW format is not supported."), TEXT("Export warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "RAW format is not supported.");
         break;
     case ImageType::EXR:
+        MessageBox::Show(TEXT("EXR format is not supported."), TEXT("Export warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "EXR format is not supported.");
         break;
     default:
+        MessageBox::Show(TEXT("Unknown format."), TEXT("Export warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "Unknown format.");
         break;
     }
@@ -434,17 +441,21 @@ bool TextureTool::ImportTextureStb(ImageType type, const StringView& path, Textu
 
         free(pixels);
 #else
+        MessageBox::Show(TEXT("EXR format is not supported."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "EXR format is not supported.");
 #endif
         break;
     }
     case ImageType::DDS:
+        MessageBox::Show(TEXT("DDS format is not supported."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "DDS format is not supported.");
         break;
     case ImageType::TIFF:
+        MessageBox::Show(TEXT("TIFF format is not supported."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "TIFF format is not supported.");
         break;
     default:
+        MessageBox::Show(TEXT("Unknown format."), TEXT("Import warning"), MessageBoxButtons::OK, MessageBoxIcon::Warning);
         LOG(Warning, "Unknown format.");
         return true;
     }


### PR DESCRIPTION
Flax editor will now pop message boxes during import/export whenever something unsupported is used instead of just silently failing and logging to console (maybe we need a way to make console focused and flash the borders of it for attention?). Should help lessen confusion like what has happened in #1645 

![image](https://github.com/user-attachments/assets/4bde5a82-ce18-4e6c-9ece-9231225b412c)
