### PR TITLE
Add better keyboard navigation to Content Finder and fix right click clearing search

### DIFF
--- a/Source/Editor/Windows/Search/ContentFinder.cs
+++ b/Source/Editor/Windows/Search/ContentFinder.cs
@@ -42,6 +42,7 @@ namespace FlaxEditor.Windows.Search
                 if (value == _selectedItem || (value != null && !_matchedItems.Contains(value)))
                     return;
 
+                // Restore the previous selected item to the non-selected color
                 if (_selectedItem != null)
                 {
                     _selectedItem.BackgroundColor = Color.Transparent;
@@ -54,6 +55,7 @@ namespace FlaxEditor.Windows.Search
                     _selectedItem.BackgroundColor = Style.Current.BackgroundSelected;
                     if (_matchedItems.Count > VisibleItemCount)
                     {
+                        _selectedItem.Focus();
                         _resultPanel.ScrollViewTo(_selectedItem, true);
                     }
                 }


### PR DESCRIPTION
Applies the changes made to scrollable items list in #3527 to the Content Finder popup.

Closes and fixes #3435 (turns out the selected items needed to be focused).

