### PR TITLE
Visject larger input boxes

### DIFF
--- a/Source/Editor/Surface/Archetypes/Comparisons.cs
+++ b/Source/Editor/Surface/Archetypes/Comparisons.cs
@@ -20,6 +20,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = id,
                 Title = title,
+                Create = (id, context, arch, groupArch) => new ComparisonNode(id, context, arch, groupArch),
                 Description = desc,
                 Flags = NodeFlags.AllGraphs,
                 AlternativeTitles = altTitles,
@@ -42,6 +43,28 @@ namespace FlaxEditor.Surface.Archetypes
                     NodeElementArchetype.Factory.Output(0, title, typeof(bool), 2)
                 }
             };
+        }
+
+        private class ComparisonNode : SurfaceNode
+        {
+            public ComparisonNode(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
+            : base(id, context, nodeArch, groupArch)
+            {
+            }
+
+            public override void OnSurfaceLoaded(SurfaceNodeActions action)
+            {
+                base.OnSurfaceLoaded(action);
+
+                ResizeAuto();
+            }
+
+            public override void ConnectionTick(Box box)
+            {
+                base.ConnectionTick(box);
+
+                ResizeAuto();
+            }
         }
 
         private class SwitchOnEnumNode : SurfaceNode
@@ -181,6 +204,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 7,
                 Title = "Switch On Bool",
+                Create = (id, context, arch, groupArch) => new ComparisonNode(id, context, arch, groupArch),
                 AlternativeTitles = new[] { "if", "switch" },
                 Description = "Returns one of the input values based on the condition value",
                 Flags = NodeFlags.AllGraphs,

--- a/Source/Editor/Surface/Elements/InputBox.cs
+++ b/Source/Editor/Surface/Elements/InputBox.cs
@@ -120,7 +120,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = IntegerValue.Get(box.ParentNode, box.Archetype, box.Value);
-            var width = 40;
+            var width = 50;
             var control = new IntValueBox(value, bounds.X, bounds.Y, width + 12, int.MinValue, int.MaxValue, 0.01f)
             {
                 Height = bounds.Height,
@@ -166,7 +166,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = UnsignedIntegerValue.Get(box.ParentNode, box.Archetype, box.Value);
-            var width = 40;
+            var width = 50;
             var control = new UIntValueBox(value, bounds.X, bounds.Y, width + 12, uint.MinValue, uint.MaxValue, 0.01f)
             {
                 Height = bounds.Height,
@@ -212,7 +212,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = FloatValue.Get(box.ParentNode, box.Archetype, box.Value);
-            var width = 40;
+            var width = 50;
             var control = new FloatValueBox(value, bounds.X, bounds.Y, width + 12, float.MinValue, float.MaxValue, 0.01f)
             {
                 Height = bounds.Height,
@@ -303,7 +303,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 30;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 2 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -377,7 +377,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 30;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 3 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -460,7 +460,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 20;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 4 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -553,7 +553,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 30;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 2 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -627,7 +627,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 30;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 3 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -710,7 +710,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 20;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 4 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -803,7 +803,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 30;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 2 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -877,7 +877,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 30;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 3 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -960,7 +960,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box);
-            var width = 20;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 4 - 2, bounds.Height)
             {
                 ClipChildren = false,
@@ -1053,7 +1053,7 @@ namespace FlaxEditor.Surface.Elements
         public Control Create(InputBox box, ref Rectangle bounds)
         {
             var value = GetValue(box).EulerAngles;
-            var width = 20;
+            var width = 50;
             var control = new ContainerControl(bounds.X, bounds.Y, (width + 2) * 3 - 2, bounds.Height)
             {
                 ClipChildren = false,


### PR DESCRIPTION
This makes Visject inputs uniform size of 50 pixels (instead of float3s being 20 pixels each etc). It also makes comparison nodes automatically expand to contain the input boxes instead of allowing them to overflow and potentially block the output node.

![image](https://github.com/user-attachments/assets/f734b72e-8118-4f2e-a5ec-7dc6a0e15430)
While not perfect, this is a huge improvement and makes using the node graphs less painful.
The only notable issue I could spot is that comparisons don't collapse back to their original size if both inputs are populated, indicating that the `SurfaceNode`'s `ReizeAuto()` for some reason does not ignore invisible children despite having a child visibility check.