### PR TITLE
Add hotkey to quick focus debug console input

### DIFF
--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -139,6 +139,10 @@ namespace FlaxEditor.Options
         [EditorDisplay("Common"), EditorOrder(240)]
         public InputBinding ToggleFullscreen = new InputBinding(KeyboardKeys.F11);
 
+        [DefaultValue(typeof(InputBinding), "Ctrl+BackQuote")]
+        [EditorDisplay("Common"), EditorOrder(250)]
+        public InputBinding FocusConsoleCommand = new InputBinding(KeyboardKeys.BackQuote, KeyboardKeys.Control);
+
         #endregion
 
         #region File

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -1518,6 +1518,7 @@ namespace FlaxEditor.Utilities
             inputActions.Add(options => options.OpenScriptsProject, () => Editor.Instance.CodeEditing.OpenSolution());
             inputActions.Add(options => options.GenerateScriptsProject, () => Editor.Instance.ProgressReporting.GenerateScriptsProjectFiles.RunAsync());
             inputActions.Add(options => options.RecompileScripts, ScriptsBuilder.Compile);
+            inputActions.Add(options => options.FocusConsoleCommand, () => Editor.Instance.Windows.OutputLogWin.FocusCommand());
         }
 
         internal static string ToPathProject(string path)

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -405,6 +405,7 @@ namespace FlaxEditor.Windows
                     return;
                 Editor.Instance.SceneEditing.Delete();
             });
+            InputActions.Add(options => options.FocusConsoleCommand, () => Editor.Instance.Windows.OutputLogWin.FocusCommand());
         }
 
         private void ChangeViewportRatio(ViewportScaleOptions v)

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -830,6 +830,15 @@ namespace FlaxEditor.Windows
             OnOutputTextChanged();
         }
 
+        /// <summary>
+        /// Focus the debug command line and ensure that the output log window is visible.
+        /// </summary>
+        public void FocusCommand()
+        {
+            FocusOrShow();
+            _commandLineBox.Focus();
+        }
+
         /// <inheritdoc />
         public override void Update(float deltaTime)
         {


### PR DESCRIPTION
Adds hotkey `Ctrl` + `` ` `` (BackQuote) to quickly focus the debug command line, ensuring that the log window is shown and focused.

This closes #3356 