### PR TITLE
Add options for viewport icons

### DIFF
--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -150,5 +150,26 @@ namespace FlaxEditor.Options
         [DefaultValue(typeof(Color), "0.5,0.5,0.5,1.0")]
         [EditorDisplay("Grid"), EditorOrder(310), Tooltip("The color for the viewport grid.")]
         public Color ViewportGridColor { get; set; } = new Color(0.5f, 0.5f, 0.5f, 1.0f);
+
+        /// <summary>
+        /// Gets or sets the minimum size used for viewport icons.
+        /// </summary>
+        [DefaultValue(7.0f), Limit(1.0f, 1000.0f, 5.0f)]
+        [EditorDisplay("Viewport Icons"), EditorOrder(400)]
+        public float IconsMinimumSize { get; set; } = 7.0f;
+
+        /// <summary>
+        /// Gets or sets the maximum size used for viewport icons.
+        /// </summary>
+        [DefaultValue(30.0f), Limit(1.0f, 1000.0f, 5.0f)]
+        [EditorDisplay("Viewport Icons"), EditorOrder(410)]
+        public float IconsMaximumSize { get; set; } = 30.0f;
+
+        /// <summary>
+        /// Gets or sets the distance towards the camera at which the max icon scale will be applied. Set to 0 to disable scaling the icons based on the distance to the camera.
+        /// </summary>
+        [DefaultValue(1000.0f), Limit(0.0f, 20000.0f, 5.0f)]
+        [EditorDisplay("Viewport Icons"), EditorOrder(410)]
+        public float MaxSizeDistance { get; set; } = 1000.0f;
     }
 }

--- a/Source/Editor/Utilities/ViewportIconsRenderer.cpp
+++ b/Source/Editor/Utilities/ViewportIconsRenderer.cpp
@@ -65,13 +65,14 @@ public:
 
 ViewportIconsRendererService ViewportIconsRendererServiceInstance;
 float ViewportIconsRenderer::Scale = 1.0f;
+Real ViewportIconsRenderer::MinSize = 7.0f;
+Real ViewportIconsRenderer::MaxSize = 30.0f;
+Real ViewportIconsRenderer::MaxSizeDistance = 1000.0f;
 
 void ViewportIconsRenderer::GetBounds(const Vector3& position, const Vector3& viewPosition, BoundingSphere& bounds)
 {
-    constexpr Real minSize = 7.0;
-    constexpr Real maxSize = 30.0;
-    Real scale = Math::Square(Vector3::Distance(position, viewPosition) / 1000.0f);
-    Real radius = minSize + Math::Min<Real>(scale, 1.0f) * (maxSize - minSize);
+    Real scale = Math::Square(Vector3::Distance(position, viewPosition) / MaxSizeDistance);
+    Real radius = MinSize + Math::Min<Real>(scale, 1.0f) * (MaxSize - MinSize);
     bounds = BoundingSphere(position, radius * Scale);
 }
 

--- a/Source/Editor/Utilities/ViewportIconsRenderer.h
+++ b/Source/Editor/Utilities/ViewportIconsRenderer.h
@@ -23,6 +23,21 @@ public:
     API_FIELD() static float Scale;
 
     /// <summary>
+    /// The minimum size of the icons.
+    /// </summary>
+    API_FIELD() static Real MinSize;
+
+    /// <summary>
+    /// The maximum size of the icons.
+    /// </summary>
+    API_FIELD() static Real MaxSize;
+
+    /// <summary>
+    /// The distance to the camera at which the icons will be drawn at their maximum size.
+    /// </summary>
+    API_FIELD() static Real MaxSizeDistance;
+
+    /// <summary>
     /// Draws the icons for the actors in the given scene (or actor tree).
     /// </summary>
     /// <param name="position">The icon position.</param>

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -1292,6 +1292,11 @@ namespace FlaxEditor.Viewport
             _mouseSensitivity = options.Viewport.MouseSensitivity;
             _maxSpeedSteps = options.Viewport.TotalCameraSpeedSteps;
             _cameraEasingDegree = options.Viewport.CameraEasingDegree;
+
+            ViewportIconsRenderer.MinSize = options.Viewport.IconsMinimumSize;
+            ViewportIconsRenderer.MaxSize = options.Viewport.IconsMaximumSize;
+            ViewportIconsRenderer.MaxSizeDistance = options.Viewport.MaxSizeDistance;
+
             OnCameraMovementProgressChanged();
         }
 


### PR DESCRIPTION
This adds some customization options for the viewport icons. I think having these is a good idea because people will have different screen sizes and sit at different distances to the screen. Also this improves accessibility because the minimum size can be increased while not making the icons larger in general.

It also allows the user to disable the auto scaling based on the camera distance by setting `Max Size Distance` to `0`.

![image](https://github.com/user-attachments/assets/f0ea4a20-a364-456e-b0d2-a94af5e13810)
