### PR TITLE
Tag editor quick expand

### DIFF
--- a/Source/Editor/CustomEditors/Editors/TagEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/TagEditor.cs
@@ -604,6 +604,9 @@ namespace FlaxEditor.CustomEditors.Editors
             root.SortChildrenRecursive();
             root.Expand(true);
 
+            if (Input.GetKey(KeyboardKeys.Shift))
+                root.ExpandAll(true);
+
             return menu;
         }
     }


### PR DESCRIPTION
Very simple addition to make the tag editor expand all nodes if shift is held while the editor is opened. Makes it bit less painful in larger projects :eyes: 