### PR TITLE
Make particle emitter editor's source code button enable/disable itself

### DIFF
--- a/Source/Editor/Windows/Assets/ParticleEmitterWindow.cs
+++ b/Source/Editor/Windows/Assets/ParticleEmitterWindow.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FlaxEditor.Content;
 using FlaxEditor.CustomEditors;
+using FlaxEditor.GUI;
 using FlaxEditor.Scripting;
 using FlaxEditor.Surface;
 using FlaxEditor.Viewport.Previews;
@@ -114,6 +115,7 @@ namespace FlaxEditor.Windows.Assets
 
         private readonly PropertiesProxy _properties;
         private Tab _previewTab;
+        private ToolStripButton _showSourceCodeButton;
 
         /// <inheritdoc />
         public ParticleEmitterWindow(Editor editor, AssetItem item)
@@ -146,7 +148,8 @@ namespace FlaxEditor.Windows.Assets
 
             // Toolstrip
             SurfaceUtils.PerformCommonSetup(this, _toolstrip, _surface, out _saveButton, out _undoButton, out _redoButton);
-            _toolstrip.AddButton(editor.Icons.Code64, ShowSourceCode).LinkTooltip("Show generated shader source code");
+            _showSourceCodeButton = _toolstrip.AddButton(editor.Icons.Code64, ShowSourceCode);
+            _showSourceCodeButton.LinkTooltip("Show generated shader source code");
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/particles/index.html")).LinkTooltip("See documentation to learn more");
         }
@@ -285,5 +288,16 @@ namespace FlaxEditor.Windows.Assets
 
         /// <inheritdoc />
         public SearchAssetTypes AssetType => SearchAssetTypes.ParticleEmitter;
+    
+        /// <inheritdoc />
+        public override void Update(float deltaTime)
+        {
+            base.Update(deltaTime);
+
+            if(_asset == null)
+                return;
+
+            _showSourceCodeButton.Enabled = _asset.HasShaderCode();
+        }
     }
 }

--- a/Source/Engine/Particles/ParticleEmitter.cpp
+++ b/Source/Engine/Particles/ParticleEmitter.cpp
@@ -440,4 +440,21 @@ bool ParticleEmitter::Save(const StringView& path)
     return SaveSurface(data);
 }
 
+bool ParticleEmitter::HasShaderCode()
+{
+    if(SimulationMode != ParticlesSimulationMode::GPU)
+    {
+        return false;
+    }
+
+    #if COMPILE_WITH_PARTICLE_GPU_GRAPH && COMPILE_WITH_SHADER_COMPILER
+    if(_shaderHeader.ParticleEmitter.GraphVersion == PARTICLE_GPU_GRAPH_VERSION
+        && HasChunk(SHADER_FILE_CHUNK_SOURCE)
+        && !HasDependenciesModified())
+        return true;
+    #endif
+
+    return false;
+}
+
 #endif

--- a/Source/Engine/Particles/ParticleEmitter.h
+++ b/Source/Engine/Particles/ParticleEmitter.h
@@ -173,6 +173,12 @@ public:
 #if USE_EDITOR
     void GetReferences(Array<Guid>& assets, Array<String>& files) const override;
     bool Save(const StringView& path = StringView::Empty) override;
+
+    /// <summary>
+    /// Determine if the particle emitter has valid shader code present.
+    /// </summary>
+    /// <returns>True if particle emitter has shader code, otherwise false.</returns>
+    API_FUNCTION() bool HasShaderCode();
 #endif
 
 protected:


### PR DESCRIPTION
This makes the particle emitter editor window's source code button enable or disable itself based on if the particle emitter has valid shader code on GPU or not, providing a clearer user experience instead of giving them an error box (which is still present in code if they somehow do end up triggering the function to try to show the code!).

Please doublecheck the condition in `ParticleEmitter.cpp` line 443 for `bool ParticleEmitter::HasShaderCode()`, as I attempted to inverse the logic from lines 133 to 145 in the same file.

https://github.com/user-attachments/assets/31876800-155f-4a4b-bf1b-1cf6d216441f

