### PR TITLE
Fix node delete button not checking if the user is performing certain actions on the surface before deleting node

### DIFF
--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -912,7 +912,7 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool OnTestTooltipOverControl(ref Float2 location)
         {
-            return _headerRect.Contains(ref location) && ShowTooltip;
+            return _headerRect.Contains(ref location) && ShowTooltip && !Surface.IsConnecting && !Surface.IsBoxSelecting;
         }
 
         /// <inheritdoc />
@@ -1070,7 +1070,7 @@ namespace FlaxEditor.Surface
 
             // Header
             var headerColor = style.BackgroundHighlighted;
-            if (_headerRect.Contains(ref _mousePosition))
+            if (_headerRect.Contains(ref _mousePosition) && !Surface.IsConnecting && !Surface.IsBoxSelecting)
                 headerColor *= 1.07f;
             Render2D.FillRectangle(_headerRect, headerColor);
             Render2D.DrawText(style.FontLarge, Title, _headerRect, style.Foreground, TextAlignment.Center, TextAlignment.Center);
@@ -1078,7 +1078,8 @@ namespace FlaxEditor.Surface
             // Close button
             if ((Archetype.Flags & NodeFlags.NoCloseButton) == 0 && Surface.CanEdit)
             {
-                Render2D.DrawSprite(style.Cross, _closeButtonRect, _closeButtonRect.Contains(_mousePosition) ? style.Foreground : style.ForegroundGrey);
+                bool highlightClose = _closeButtonRect.Contains(_mousePosition) && !Surface.IsConnecting && !Surface.IsBoxSelecting;
+                Render2D.DrawSprite(style.Cross, _closeButtonRect, highlightClose ? style.Foreground : style.ForegroundGrey);
             }
 
             // Footer
@@ -1123,8 +1124,9 @@ namespace FlaxEditor.Surface
             if (base.OnMouseUp(location, button))
                 return true;
 
-            // Close
-            if (button == MouseButton.Left && (Archetype.Flags & NodeFlags.NoCloseButton) == 0 && _closeButtonRect.Contains(ref location))
+            // Close/ delete
+            bool canDelete = !Surface.IsConnecting && !Surface.WasBoxSelecting && !Surface.WasMovingSelection;
+            if (button == MouseButton.Left && canDelete && (Archetype.Flags & NodeFlags.NoCloseButton) == 0 && _closeButtonRect.Contains(ref location))
             {
                 Surface.Delete(this);
                 return true;

--- a/Source/Editor/Surface/VisjectSurface.Draw.cs
+++ b/Source/Editor/Surface/VisjectSurface.Draw.cs
@@ -225,7 +225,7 @@ namespace FlaxEditor.Surface
 
             _rootControl.DrawComments();
 
-            if (IsSelecting)
+            if (IsBoxSelecting)
             {
                 DrawSelection();
             }

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -544,6 +544,9 @@ namespace FlaxEditor.Surface
             // Cache flags and state
             if (_leftMouseDown && button == MouseButton.Left)
             {
+                WasBoxSelecting = IsBoxSelecting;
+                WasMovingSelection = _isMovingSelection;
+
                 _leftMouseDown = false;
                 EndMouseCapture();
                 Cursor = CursorType.Default;

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -232,14 +232,24 @@ namespace FlaxEditor.Surface
         }
 
         /// <summary>
-        /// Gets a value indicating whether user is selecting nodes.
+        /// Gets a value indicating whether user is box selecting nodes.
         /// </summary>
-        public bool IsSelecting => _leftMouseDown && !_isMovingSelection && _connectionInstigator == null;
+        public bool IsBoxSelecting => _leftMouseDown && !_isMovingSelection && _connectionInstigator == null;
+
+        /// <summary>
+        /// Gets a value indicating whether user was previously box selecting nodes.
+        /// </summary>
+        public bool WasBoxSelecting { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether user is moving selected nodes.
         /// </summary>
         public bool IsMovingSelection => _leftMouseDown && _isMovingSelection && _connectionInstigator == null;
+
+        /// <summary>
+        /// Gets a value indicating whether user was previously moving selected nodes.
+        /// </summary>
+        public bool WasMovingSelection { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether user is connecting nodes.


### PR DESCRIPTION
This pr fixes:
- User being able to delete a node when letting go of the left mouse button (mouse up) when/ after:
  - (starting to) dragging a node pin connection line
  - starting a box select
  - moving a node around
 
I also renamed `IsSelecting` to `IsBoxSelecting`, as that is what the property seems to indicate.