### PR TITLE
Initial work on nuget package support

### DIFF
--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -513,6 +513,7 @@ namespace Flax.Build
                             // Combine build options from this module
                             project.CSharp.SystemReferences.AddRange(moduleBuildOptions.ScriptingAPI.SystemReferences);
                             project.CSharp.FileReferences.AddRange(moduleBuildOptions.ScriptingAPI.FileReferences);
+                            project.CSharp.NugetPackageReferences.AddRange(moduleBuildOptions.NugetPackageReferences);
 
                             // Find references based on the modules dependencies (external or from projects)
                             foreach (var dependencyName in moduleBuildOptions.PublicDependencies.Concat(moduleBuildOptions.PrivateDependencies))

--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -150,7 +150,7 @@ namespace Flax.Build
                         {
                             var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
                             if (!File.Exists(path))
-                                Utilities.AddNugetPackage(graph, target, reference);
+                                Utilities.RestoreNugetPackages(graph, target);
                             var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
                             graph.AddCopyFile(dstFile, path);
                         }

--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -109,6 +109,7 @@ namespace Flax.Build
                         // Merge module into target environment
                         buildData.TargetOptions.LinkEnv.InputFiles.AddRange(moduleOptions.OutputFiles);
                         buildData.TargetOptions.DependencyFiles.AddRange(moduleOptions.DependencyFiles);
+                        buildData.TargetOptions.NugetPackageReferences.AddRange(moduleOptions.NugetPackageReferences);
                         buildData.TargetOptions.OptionalDependencyFiles.AddRange(moduleOptions.OptionalDependencyFiles);
                         buildData.TargetOptions.Libraries.AddRange(moduleOptions.Libraries);
                         buildData.TargetOptions.DelayLoadLibraries.AddRange(moduleOptions.DelayLoadLibraries);
@@ -140,6 +141,14 @@ namespace Flax.Build
                     {
                         var dstFile = Path.Combine(outputPath, Path.GetFileName(srcFile));
                         graph.AddCopyFile(dstFile, srcFile);
+                    }
+
+                    var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+                    foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                    {
+                        var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
+                        var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
+                        graph.AddCopyFile(dstFile, path);
                     }
                 }
             }
@@ -283,6 +292,18 @@ namespace Flax.Build
                 args.Add(string.Format("/reference:\"{0}{1}.dll\"", referenceAssemblies, reference));
             foreach (var reference in fileReferences)
                 args.Add(string.Format("/reference:\"{0}\"", reference));
+
+            // Reference Nuget package
+            if (buildData.TargetOptions.NugetPackageReferences.Any())
+            {
+                var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+                foreach (var reference in buildOptions.NugetPackageReferences)
+                {
+                    var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
+                    args.Add(string.Format("/reference:\"{0}\"", path));
+                }
+            }
+
 #if USE_NETCORE
             foreach (var systemAnalyzer in buildOptions.ScriptingAPI.SystemAnalyzers)
                 args.Add(string.Format("/analyzer:\"{0}{1}.dll\"", referenceAnalyzers, systemAnalyzer));

--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -145,34 +145,12 @@ namespace Flax.Build
 
                     if (targetBuildOptions.NugetPackageReferences.Any())
                     {
-                        var buildPlatform = Platform.BuildTargetPlatform;
-                        var dotnetSdk = DotNetSdk.Instance;
-                        if (!dotnetSdk.IsValid)
-                            throw new DotNetSdk.MissingException();
-                        var dotnetPath = "dotnet";
-                        switch (buildPlatform)
-                        {
-                        case TargetPlatform.Windows:
-                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet.exe");
-                            break;
-                        case TargetPlatform.Linux: break;
-                        case TargetPlatform.Mac:
-                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
-                            break;
-                        default: throw new InvalidPlatformException(buildPlatform);
-                        }
                         var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
                         foreach (var reference in targetBuildOptions.NugetPackageReferences)
                         {
                             var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
                             if (!File.Exists(path))
-                            {
-                                var task = graph.Add<Task>();
-                                task.WorkingDirectory = target.FolderPath;
-                                task.InfoMessage = $"Adding Nuget Package: {reference.Name}, Version {reference.Version}";
-                                task.CommandPath = dotnetPath;
-                                task.CommandArguments = $"add package {reference.Name} --version {reference.Version}";
-                            }
+                                Utilities.AddNugetPackage(graph, target, reference);
                             var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
                             graph.AddCopyFile(dstFile, path);
                         }

--- a/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
+++ b/Source/Tools/Flax.Build/Build/DotNet/Builder.DotNet.cs
@@ -143,12 +143,39 @@ namespace Flax.Build
                         graph.AddCopyFile(dstFile, srcFile);
                     }
 
-                    var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
-                    foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                    if (targetBuildOptions.NugetPackageReferences.Any())
                     {
-                        var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
-                        var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
-                        graph.AddCopyFile(dstFile, path);
+                        var buildPlatform = Platform.BuildTargetPlatform;
+                        var dotnetSdk = DotNetSdk.Instance;
+                        if (!dotnetSdk.IsValid)
+                            throw new DotNetSdk.MissingException();
+                        var dotnetPath = "dotnet";
+                        switch (buildPlatform)
+                        {
+                        case TargetPlatform.Windows:
+                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet.exe");
+                            break;
+                        case TargetPlatform.Linux: break;
+                        case TargetPlatform.Mac:
+                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
+                            break;
+                        default: throw new InvalidPlatformException(buildPlatform);
+                        }
+                        var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+                        foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                        {
+                            var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
+                            if (!File.Exists(path))
+                            {
+                                var task = graph.Add<Task>();
+                                task.WorkingDirectory = target.FolderPath;
+                                task.InfoMessage = $"Adding Nuget Package: {reference.Name}, Version {reference.Version}";
+                                task.CommandPath = dotnetPath;
+                                task.CommandArguments = $"add package {reference.Name} --version {reference.Version}";
+                            }
+                            var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
+                            graph.AddCopyFile(dstFile, path);
+                        }
                     }
                 }
             }

--- a/Source/Tools/Flax.Build/Build/EngineTarget.cs
+++ b/Source/Tools/Flax.Build/Build/EngineTarget.cs
@@ -220,6 +220,7 @@ namespace Flax.Build
             exeBuildOptions.LinkEnv.InputLibraries.Add(Path.Combine(buildOptions.OutputFolder, buildOptions.Platform.GetLinkOutputFileName(LibraryName, engineLibraryType)));
             exeBuildOptions.LinkEnv.InputFiles.AddRange(mainModuleOptions.OutputFiles);
             exeBuildOptions.DependencyFiles.AddRange(mainModuleOptions.DependencyFiles);
+            exeBuildOptions.NugetPackageReferences.AddRange(mainModuleOptions.NugetPackageReferences);
             exeBuildOptions.OptionalDependencyFiles.AddRange(mainModuleOptions.OptionalDependencyFiles);
             exeBuildOptions.Libraries.AddRange(mainModuleOptions.Libraries);
             exeBuildOptions.DelayLoadLibraries.AddRange(mainModuleOptions.DelayLoadLibraries);

--- a/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/BuildOptions.cs
@@ -71,6 +71,40 @@ namespace Flax.Build.NativeCpp
     }
 
     /// <summary>
+    /// Defines a Nuget Package
+    /// </summary>
+    public struct NugetPackage
+    {
+        /// <summary>
+        /// The name of the nuget package.
+        /// </summary>
+        public string Name;
+            
+        /// <summary>
+        /// The version of the nuget package.
+        /// </summary>
+        public string Version;
+            
+        /// <summary>
+        /// The target framework. ex. net8.0, netstandard2.1
+        /// </summary>
+        public string Framework;
+
+        /// <summary>
+        /// Initialize the nuget package.
+        /// </summary>
+        /// <param name="name">The name of the package.</param>
+        /// <param name="version">The version of the package.</param>
+        /// <param name="framework">The target framework. ex. net8.0, netstandard2.1, etc.</param>
+        public NugetPackage(string name, string version, string framework)
+        {
+            Name = name;
+            Version = version;
+            Framework = framework;
+        }
+    }
+
+    /// <summary>
     /// The native C++ module build settings container.
     /// </summary>
     public sealed class BuildOptions
@@ -129,6 +163,11 @@ namespace Flax.Build.NativeCpp
         /// The collection of the modules that are required by this module (for linking).
         /// </summary>
         public List<string> PrivateDependencies = new List<string>();
+        
+        /// <summary>
+        /// The nuget package references.
+        /// </summary>
+        public List<NugetPackage> NugetPackageReferences = new List<NugetPackage>();
 
         /// <summary>
         /// The collection of defines with preprocessing symbol for a source files of this module. Inherited by the modules that include it.

--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -1057,12 +1057,39 @@ namespace Flax.Build
                         var dstFile = Path.Combine(outputPath, Path.GetFileName(srcFile));
                         graph.AddCopyFile(dstFile, srcFile);
                     }
-                    var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
-                    foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                    if (targetBuildOptions.NugetPackageReferences.Any())
                     {
-                        var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
-                        var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
-                        graph.AddCopyFile(dstFile, path);
+                        var buildPlatform = Platform.BuildTargetPlatform;
+                        var dotnetSdk = DotNetSdk.Instance;
+                        if (!dotnetSdk.IsValid)
+                            throw new DotNetSdk.MissingException();
+                        var dotnetPath = "dotnet";
+                        switch (buildPlatform)
+                        {
+                        case TargetPlatform.Windows:
+                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet.exe");
+                            break;
+                        case TargetPlatform.Linux: break;
+                        case TargetPlatform.Mac:
+                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
+                            break;
+                        default: throw new InvalidPlatformException(buildPlatform);
+                        }
+                        var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+                        foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                        {
+                            var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
+                            if (!File.Exists(path))
+                            {
+                                var task = graph.Add<Task>();
+                                task.WorkingDirectory = target.FolderPath;
+                                task.InfoMessage = $"Adding Nuget Package: {reference.Name}, Version {reference.Version}";
+                                task.CommandPath = dotnetPath;
+                                task.CommandArguments = $"add package {reference.Name} --version {reference.Version}";
+                            }
+                            var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
+                            graph.AddCopyFile(dstFile, path);
+                        }
                     }
                 }
             }
@@ -1264,12 +1291,40 @@ namespace Flax.Build
                         var dstFile = Path.Combine(outputPath, Path.GetFileName(srcFile));
                         graph.AddCopyFile(dstFile, srcFile);
                     }
-                    var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
-                    foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                    
+                    if (targetBuildOptions.NugetPackageReferences.Any())
                     {
-                        var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
-                        var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
-                        graph.AddCopyFile(dstFile, path);
+                        var buildPlatform = Platform.BuildTargetPlatform;
+                        var dotnetSdk = DotNetSdk.Instance;
+                        if (!dotnetSdk.IsValid)
+                            throw new DotNetSdk.MissingException();
+                        var dotnetPath = "dotnet";
+                        switch (buildPlatform)
+                        {
+                        case TargetPlatform.Windows:
+                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet.exe");
+                            break;
+                        case TargetPlatform.Linux: break;
+                        case TargetPlatform.Mac:
+                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
+                            break;
+                        default: throw new InvalidPlatformException(buildPlatform);
+                        }
+                        var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+                        foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                        {
+                            var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
+                            if (!File.Exists(path))
+                            {
+                                var task = graph.Add<Task>();
+                                task.WorkingDirectory = target.FolderPath;
+                                task.InfoMessage = $"Adding Nuget Package: {reference.Name}, Version {reference.Version}";
+                                task.CommandPath = dotnetPath;
+                                task.CommandArguments = $"add package {reference.Name} --version {reference.Version}";
+                            }
+                            var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
+                            graph.AddCopyFile(dstFile, path);
+                        }
                     }
                 }
             }

--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -425,6 +425,7 @@ namespace Flax.Build
                     moduleOptions.LinkEnv.InputFiles.AddRange(dependencyOptions.OutputFiles);
                     moduleOptions.DependencyFiles.AddRange(dependencyOptions.DependencyFiles);
                     moduleOptions.OptionalDependencyFiles.AddRange(dependencyOptions.OptionalDependencyFiles);
+                    moduleOptions.NugetPackageReferences.AddRange(dependencyOptions.NugetPackageReferences);
                     moduleOptions.PrivateIncludePaths.AddRange(dependencyOptions.PublicIncludePaths);
                     moduleOptions.Libraries.AddRange(dependencyOptions.Libraries);
                     moduleOptions.DelayLoadLibraries.AddRange(dependencyOptions.DelayLoadLibraries);
@@ -440,6 +441,7 @@ namespace Flax.Build
                     moduleOptions.LinkEnv.InputFiles.AddRange(dependencyOptions.OutputFiles);
                     moduleOptions.DependencyFiles.AddRange(dependencyOptions.DependencyFiles);
                     moduleOptions.OptionalDependencyFiles.AddRange(dependencyOptions.OptionalDependencyFiles);
+                    moduleOptions.NugetPackageReferences.AddRange(dependencyOptions.NugetPackageReferences);
                     moduleOptions.PublicIncludePaths.AddRange(dependencyOptions.PublicIncludePaths);
                     moduleOptions.Libraries.AddRange(dependencyOptions.Libraries);
                     moduleOptions.DelayLoadLibraries.AddRange(dependencyOptions.DelayLoadLibraries);
@@ -934,6 +936,7 @@ namespace Flax.Build
                         buildData.TargetOptions.LinkEnv.InputFiles.AddRange(moduleOptions.OutputFiles);
                         buildData.TargetOptions.DependencyFiles.AddRange(moduleOptions.DependencyFiles);
                         buildData.TargetOptions.OptionalDependencyFiles.AddRange(moduleOptions.OptionalDependencyFiles);
+                        buildData.TargetOptions.NugetPackageReferences.AddRange(moduleOptions.NugetPackageReferences);
                         buildData.TargetOptions.Libraries.AddRange(moduleOptions.Libraries);
                         buildData.TargetOptions.DelayLoadLibraries.AddRange(moduleOptions.DelayLoadLibraries);
                         buildData.TargetOptions.ScriptingAPI.Add(moduleOptions.ScriptingAPI);
@@ -1053,6 +1056,13 @@ namespace Flax.Build
                     {
                         var dstFile = Path.Combine(outputPath, Path.GetFileName(srcFile));
                         graph.AddCopyFile(dstFile, srcFile);
+                    }
+                    var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+                    foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                    {
+                        var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
+                        var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
+                        graph.AddCopyFile(dstFile, path);
                     }
                 }
             }
@@ -1192,6 +1202,7 @@ namespace Flax.Build
                             buildData.TargetOptions.ExternalModules.AddRange(moduleOptions.ExternalModules);
                             buildData.TargetOptions.DependencyFiles.AddRange(moduleOptions.DependencyFiles);
                             buildData.TargetOptions.OptionalDependencyFiles.AddRange(moduleOptions.OptionalDependencyFiles);
+                            buildData.TargetOptions.NugetPackageReferences.AddRange(moduleOptions.NugetPackageReferences);
                         }
                     }
                 }
@@ -1252,6 +1263,13 @@ namespace Flax.Build
                     {
                         var dstFile = Path.Combine(outputPath, Path.GetFileName(srcFile));
                         graph.AddCopyFile(dstFile, srcFile);
+                    }
+                    var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+                    foreach (var reference in targetBuildOptions.NugetPackageReferences)
+                    {
+                        var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
+                        var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
+                        graph.AddCopyFile(dstFile, path);
                     }
                 }
             }

--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -1057,36 +1057,15 @@ namespace Flax.Build
                         var dstFile = Path.Combine(outputPath, Path.GetFileName(srcFile));
                         graph.AddCopyFile(dstFile, srcFile);
                     }
+
                     if (targetBuildOptions.NugetPackageReferences.Any())
                     {
-                        var buildPlatform = Platform.BuildTargetPlatform;
-                        var dotnetSdk = DotNetSdk.Instance;
-                        if (!dotnetSdk.IsValid)
-                            throw new DotNetSdk.MissingException();
-                        var dotnetPath = "dotnet";
-                        switch (buildPlatform)
-                        {
-                        case TargetPlatform.Windows:
-                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet.exe");
-                            break;
-                        case TargetPlatform.Linux: break;
-                        case TargetPlatform.Mac:
-                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
-                            break;
-                        default: throw new InvalidPlatformException(buildPlatform);
-                        }
                         var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
                         foreach (var reference in targetBuildOptions.NugetPackageReferences)
                         {
                             var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
                             if (!File.Exists(path))
-                            {
-                                var task = graph.Add<Task>();
-                                task.WorkingDirectory = target.FolderPath;
-                                task.InfoMessage = $"Adding Nuget Package: {reference.Name}, Version {reference.Version}";
-                                task.CommandPath = dotnetPath;
-                                task.CommandArguments = $"add package {reference.Name} --version {reference.Version}";
-                            }
+                                Utilities.AddNugetPackage(graph, target, reference);
                             var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
                             graph.AddCopyFile(dstFile, path);
                         }
@@ -1291,37 +1270,15 @@ namespace Flax.Build
                         var dstFile = Path.Combine(outputPath, Path.GetFileName(srcFile));
                         graph.AddCopyFile(dstFile, srcFile);
                     }
-                    
+
                     if (targetBuildOptions.NugetPackageReferences.Any())
                     {
-                        var buildPlatform = Platform.BuildTargetPlatform;
-                        var dotnetSdk = DotNetSdk.Instance;
-                        if (!dotnetSdk.IsValid)
-                            throw new DotNetSdk.MissingException();
-                        var dotnetPath = "dotnet";
-                        switch (buildPlatform)
-                        {
-                        case TargetPlatform.Windows:
-                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet.exe");
-                            break;
-                        case TargetPlatform.Linux: break;
-                        case TargetPlatform.Mac:
-                            dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
-                            break;
-                        default: throw new InvalidPlatformException(buildPlatform);
-                        }
                         var nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
                         foreach (var reference in targetBuildOptions.NugetPackageReferences)
                         {
                             var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
                             if (!File.Exists(path))
-                            {
-                                var task = graph.Add<Task>();
-                                task.WorkingDirectory = target.FolderPath;
-                                task.InfoMessage = $"Adding Nuget Package: {reference.Name}, Version {reference.Version}";
-                                task.CommandPath = dotnetPath;
-                                task.CommandArguments = $"add package {reference.Name} --version {reference.Version}";
-                            }
+                                Utilities.AddNugetPackage(graph, target, reference);
                             var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
                             graph.AddCopyFile(dstFile, path);
                         }

--- a/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/Builder.NativeCpp.cs
@@ -1065,7 +1065,7 @@ namespace Flax.Build
                         {
                             var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
                             if (!File.Exists(path))
-                                Utilities.AddNugetPackage(graph, target, reference);
+                                Utilities.RestoreNugetPackages(graph, target);
                             var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
                             graph.AddCopyFile(dstFile, path);
                         }
@@ -1278,7 +1278,7 @@ namespace Flax.Build
                         {
                             var path = Path.Combine(nugetPath, reference.Name, reference.Version, "lib", reference.Framework, $"{reference.Name}.dll");
                             if (!File.Exists(path))
-                                Utilities.AddNugetPackage(graph, target, reference);
+                                Utilities.RestoreNugetPackages(graph, target);
                             var dstFile = Path.Combine(outputPath, Path.GetFileName(path));
                             graph.AddCopyFile(dstFile, path);
                         }

--- a/Source/Tools/Flax.Build/Projects/Project.cs
+++ b/Source/Tools/Flax.Build/Projects/Project.cs
@@ -229,6 +229,11 @@ namespace Flax.Build.Projects
             /// The .Net libraries references (dll or exe files paths).
             /// </summary>
             public HashSet<string> FileReferences;
+            
+            /// <summary>
+            /// The nuget references.
+            /// </summary>
+            public HashSet<NugetPackage> NugetPackageReferences;
 
             /// <summary>
             /// The output folder path (optional).
@@ -248,6 +253,7 @@ namespace Flax.Build.Projects
         {
             SystemReferences = new HashSet<string>(),
             FileReferences = new HashSet<string>(),
+            NugetPackageReferences = new HashSet<NugetPackage>(),
         };
 
         /// <summary>

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSProjectGenerator.cs
@@ -175,6 +175,19 @@ namespace Flax.Build.Projects.VisualStudio
                 csProjectFileContent.AppendLine("  </PropertyGroup>");
             }
 
+            // Nuget
+            if (project.CSharp.NugetPackageReferences.Any())
+            {
+                csProjectFileContent.AppendLine("  <ItemGroup>");
+            
+                foreach (var reference in project.CSharp.NugetPackageReferences)
+                {
+                    csProjectFileContent.AppendLine(string.Format("    <PackageReference Include=\"{0}\" Version=\"{1}\" />", reference.Name, reference.Version));
+                }
+
+                csProjectFileContent.AppendLine("  </ItemGroup>");
+            }
+
             // References
 
             csProjectFileContent.AppendLine("  <ItemGroup>");

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -134,6 +134,20 @@ namespace Flax.Build.Projects.VisualStudio
             }
 
             // References
+            
+            // Nuget
+            if (project.CSharp.NugetPackageReferences.Any())
+            {
+                csProjectFileContent.AppendLine("  <ItemGroup>");
+            
+                foreach (var reference in project.CSharp.NugetPackageReferences)
+                {
+                    csProjectFileContent.AppendLine(string.Format("    <PackageReference Include=\"{0}\" Version=\"{1}\" />", reference.Name, reference.Version));
+                }
+
+                csProjectFileContent.AppendLine("  </ItemGroup>");
+                csProjectFileContent.AppendLine("");
+            }
 
             csProjectFileContent.AppendLine("  <ItemGroup>");
 

--- a/Source/Tools/Flax.Build/Utilities/Utilities.cs
+++ b/Source/Tools/Flax.Build/Utilities/Utilities.cs
@@ -55,7 +55,6 @@ namespace Flax.Build
             task.WorkingDirectory = target.FolderPath;
             task.InfoMessage = $"Add Nuget Package: {package.Name}, Version {package.Version}";
             task.CommandPath = dotNetPath;
-            //task.CommandArguments = $"add package {package.Name} --version {package.Version}";
             task.CommandArguments = $"restore";
         }
         

--- a/Source/Tools/Flax.Build/Utilities/Utilities.cs
+++ b/Source/Tools/Flax.Build/Utilities/Utilities.cs
@@ -17,6 +17,49 @@ namespace Flax.Build
     public static class Utilities
     {
         /// <summary>
+        /// Gets the .Net SDK path.
+        /// </summary>
+        /// <returns>The path.</returns>
+        public static string GetDotNetPath()
+        {
+            var buildPlatform = Platform.BuildTargetPlatform;
+            var dotnetSdk = DotNetSdk.Instance;
+            if (!dotnetSdk.IsValid)
+                throw new DotNetSdk.MissingException();
+            var dotnetPath = "dotnet";
+            switch (buildPlatform)
+            {
+            case TargetPlatform.Windows:
+                dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet.exe");
+                break;
+            case TargetPlatform.Linux: break;
+            case TargetPlatform.Mac:
+                dotnetPath = Path.Combine(dotnetSdk.RootPath, "dotnet");
+                break;
+            default: throw new InvalidPlatformException(buildPlatform);
+            }
+            return dotnetPath;
+        }
+
+        /// <summary>
+        /// Downloads a nuget package.
+        /// </summary>
+        /// <param name="graph">The task graph.</param>
+        /// <param name="target">The target.</param>
+        /// <param name="dotNetPath">The dotnet path.</param>
+        /// <param name="package"></param>
+        public static void AddNugetPackage(Graph.TaskGraph graph, Target target, NativeCpp.NugetPackage package)
+        {
+            var dotNetPath = GetDotNetPath();
+            var task = graph.Add<Graph.Task>();
+            task.WorkingDirectory = target.FolderPath;
+            task.InfoMessage = $"Add Nuget Package: {package.Name}, Version {package.Version}";
+            task.CommandPath = dotNetPath;
+            //task.CommandArguments = $"add package {package.Name} --version {package.Version}";
+            task.CommandArguments = $"restore";
+        }
+        
+        /// <summary>
         /// Gets the hash code for the string (the same for all platforms). Matches Engine algorithm for string hashing.
         /// </summary>
         /// <param name="str">The input string.</param>

--- a/Source/Tools/Flax.Build/Utilities/Utilities.cs
+++ b/Source/Tools/Flax.Build/Utilities/Utilities.cs
@@ -42,18 +42,17 @@ namespace Flax.Build
         }
 
         /// <summary>
-        /// Downloads a nuget package.
+        /// Restores a targets nuget packages.
         /// </summary>
         /// <param name="graph">The task graph.</param>
         /// <param name="target">The target.</param>
         /// <param name="dotNetPath">The dotnet path.</param>
-        /// <param name="package"></param>
-        public static void AddNugetPackage(Graph.TaskGraph graph, Target target, NativeCpp.NugetPackage package)
+        public static void RestoreNugetPackages(Graph.TaskGraph graph, Target target)
         {
             var dotNetPath = GetDotNetPath();
             var task = graph.Add<Graph.Task>();
             task.WorkingDirectory = target.FolderPath;
-            task.InfoMessage = $"Add Nuget Package: {package.Name}, Version {package.Version}";
+            task.InfoMessage = $"Restoring Nuget Packages for {target.Name}";
             task.CommandPath = dotNetPath;
             task.CommandArguments = $"restore";
         }


### PR DESCRIPTION
This allows for adding something like this: `options.NugetPackageReferences.Add(new NugetPackage("YamlDotNet", "16.3.0", "net8.0"));` to a build.cs file and it will add the nuget package to the project. This tries to restore packages if the dll is not found which is good for vscode (rider and visual studio do this automatically).

TODO (dont need to be added for this to be merged, just could be future work):
- This uses the standard path for Nuget. Has only been tested on windows and not linux or mac.
- Auto find package framework version.
- Copy xml files as well if it exists and is not release.

If this is approved, I will write some docs for it.