### PR TITLE
Improve/ polish behaviour of visject node cm menu

### DIFF
--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -41,6 +41,11 @@ namespace FlaxEditor.Surface
     public class SurfaceNode : SurfaceControl
     {
         /// <summary>
+        /// The box to draw a highlight around. Drawing will be skipped if null.
+        /// </summary>
+        internal Box highlightBox;
+
+        /// <summary>
         /// Flag used to discard node values setting during event sending for node UI flushing.
         /// </summary>
         protected bool _isDuringValuesEditing;
@@ -1101,6 +1106,9 @@ namespace FlaxEditor.Surface
                 Render2D.DrawSprite(icon, new Rectangle(-7, -7, 16, 16), new Color(0.9f, 0.9f, 0.9f));
                 Render2D.DrawSprite(icon, new Rectangle(-6, -6, 14, 14), new Color(0.894117647f, 0.0784313725f, 0.0f));
             }
+
+            if (highlightBox != null)
+                Render2D.DrawRectangle(highlightBox.Bounds, style.BorderHighlighted, 2f);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -402,7 +402,7 @@ namespace FlaxEditor.Surface
             _cmFormatNodesConnectionButton = menu.AddButton("Format node(s)", () => { FormatGraph(SelectedNodes); });
             _cmFormatNodesConnectionButton.Enabled = CanEdit && HasNodesSelection;
 
-            _cmRemoveNodeConnectionsButton = menu.AddButton("Remove all connections to that node(s)", () =>
+            _cmRemoveNodeConnectionsButton = menu.AddButton("Remove all connections", () =>
             {
                 var nodes = ((List<SurfaceNode>)menu.Tag);
 
@@ -428,8 +428,10 @@ namespace FlaxEditor.Surface
 
                 MarkAsEdited();
             });
-            _cmRemoveNodeConnectionsButton.Enabled = CanEdit;
-            _cmRemoveBoxConnectionsButton = menu.AddButton("Remove all connections to that box", () =>
+            bool anyConnection = SelectedNodes.Any(n => n.GetBoxes().Any(b => b.HasAnyConnection));
+            _cmRemoveNodeConnectionsButton.Enabled = CanEdit && anyConnection;
+
+            _cmRemoveBoxConnectionsButton = menu.AddButton("Remove all socket connections", () =>
             {
                 var boxUnderMouse = (Box)_cmRemoveBoxConnectionsButton.Tag;
                 if (Undo != null)
@@ -450,6 +452,16 @@ namespace FlaxEditor.Surface
                 var boxUnderMouse = GetChildAtRecursive(location) as Box;
                 _cmRemoveBoxConnectionsButton.Enabled = boxUnderMouse != null && boxUnderMouse.HasAnyConnection;
                 _cmRemoveBoxConnectionsButton.Tag = boxUnderMouse;
+
+                if (boxUnderMouse != null)
+                {
+                    boxUnderMouse.ParentNode.highlightBox = boxUnderMouse; 
+                    menu.VisibleChanged += (c) =>
+                    {
+                        if (!c.Visible)
+                            boxUnderMouse.ParentNode.highlightBox = null;
+                    };
+                }
             }
 
             controlUnderMouse?.OnShowSecondaryContextMenu(menu, controlUnderMouse.PointFromParent(location));


### PR DESCRIPTION
This pr:
- Rename "Remove all connections to that node(s)" to "Remove all connections"
- Rename "Remove all connections to that box" to "Remove all socket connections"
- Enables/ disables the "Remove all socket connections" option based on if there are any connections
- Draw a highlight around a box if it was rightclicked to better indicate that a) right clicking a box will show different options and b) the box was rightclicked and not the node

After:
![image](https://github.com/user-attachments/assets/b6ee8b1c-1728-4c91-9977-38fee9706559)

![image](https://github.com/user-attachments/assets/939e7217-bd63-4d24-bb3b-d191d773dfb8)
