### PR TITLE
Allow the user to unfold folded categories when scrolling with keyboard

### DIFF
--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -522,7 +522,7 @@ namespace FlaxEditor.GUI
                 for (int i = 0; i < _categoryPanels.Count; i++)
                 {
                     var category = _categoryPanels[i];
-                    if (!category.Visible)
+                    if (!category.Visible || (category is DropPanel panel && panel.IsClosed))
                         continue;
                     for (int j = 0; j < category.Children.Count; j++)
                     {

--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -227,9 +227,8 @@ namespace FlaxEditor.GUI
                 {
                     int order = -1 * SortScore.CompareTo(otherItem.SortScore);
                     if (order == 0)
-                    {
                         order = string.Compare(Name, otherItem.Name, StringComparison.Ordinal);
-                    }
+
                     return order;
                 }
                 return base.Compare(other);
@@ -535,6 +534,12 @@ namespace FlaxEditor.GUI
             return result;
         }
 
+        private void ExpandToItem(Item item)
+        {
+            if (item.Parent is DropPanel dropPanel)
+                dropPanel.Open(false);
+        }
+
         /// <inheritdoc />
         protected override void OnShow()
         {
@@ -564,7 +569,7 @@ namespace FlaxEditor.GUI
                 Hide();
                 return true;
             case KeyboardKeys.Backspace:
-                // Alow the user to quickly focus the searchbar
+                // Allow the user to quickly focus the searchbar
                 if (_searchBox != null && !_searchBox.IsFocused)
                 {
                     _searchBox.Focus();
@@ -590,6 +595,11 @@ namespace FlaxEditor.GUI
 
                 // Focus the next item
                 nextItem.Focus();
+            
+                // Allow the user to expand groups while scrolling
+                if (Root.GetKey(KeyboardKeys.Control))
+                    ExpandToItem(nextItem);
+                
                 _scrollPanel.ScrollViewTo(nextItem);
                 return true;
             case KeyboardKeys.Return:


### PR DESCRIPTION
This allows the user to (optionally) unfold folded categories in items lists while scrolling with the arrow keys. To do that, they need to hold down the control key. 

I made this optional because, for example in the scripts editor dropdown, there will always be two scripts (Behaviour and NetworkTransform) which the user would have to skip through every time they navigate the list with the arrow keys.

This also fixes `GetVisibleItems()` to ignore/ not return items of which the category is folded, because those are still not visible. If they would still be considered visible, which would mess up the keyboard navigation (it would seem like the input didn't do anything).