### PR TITLE
Fix close visject surface was_ flags to properly reset to false

### DIFF
--- a/Source/Editor/Surface/VisjectSurface.Draw.cs
+++ b/Source/Editor/Surface/VisjectSurface.Draw.cs
@@ -225,6 +225,10 @@ namespace FlaxEditor.Surface
 
             _rootControl.DrawComments();
 
+            // Reset input flags here because this is the closest to Update we have
+            WasBoxSelecting = IsBoxSelecting;
+            WasMovingSelection = IsMovingSelection;
+
             if (IsBoxSelecting)
             {
                 DrawSelection();

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -590,9 +590,6 @@ namespace FlaxEditor.Surface
             // Cache flags and state
             if (_leftMouseDown && button == MouseButton.Left)
             {
-                WasBoxSelecting = IsBoxSelecting;
-                WasMovingSelection = _isMovingSelection;
-
                 _leftMouseDown = false;
                 EndMouseCapture();
                 Cursor = CursorType.Default;


### PR DESCRIPTION
I may or may not have accidentally broken the visject node delete button in #3547, anyways here is a quick fix to make it work again.

