### PR TITLE
Fix search item hover auto focusing item and add accent colors (#3539 followup)

### DIFF
--- a/Source/Editor/Windows/Search/SearchItem.cs
+++ b/Source/Editor/Windows/Search/SearchItem.cs
@@ -235,8 +235,8 @@ namespace FlaxEditor.Windows.Search
             var iconRect = _icon.Bounds;
             _asset.DrawThumbnail(ref iconRect);
 
-            // Draw icon color strip
-            var rect = iconRect with { Width = 2, Height = Height, Location = Float2.Zero };
+            // Draw color strip
+            var rect = iconRect with { Width = 2, Height = Height, Location = new Float2(2, 0) };
             Render2D.FillRectangle(rect, _accentColor);
         }
 


### PR DESCRIPTION
### Fix
Followup that fixes an issue in #3539 where hovering over any search item would remove focus from the search bar.

Change what happens when search items get focused to prevent focus being taken away from search box. Also adds a highlight to mouse hovered search item.

### Accent colors
![image](https://github.com/user-attachments/assets/7d184b95-4475-48b2-8b6f-81c56095edc8)

Colors are the same colors that are used in the Content Panel and should help to differentiate different asset types.

*(Sorry for adding this to this pr but I didn't want to cause merge conflics)*
