### PR TITLE
Add prefab UI viewport scaling.

### DIFF
--- a/Source/Editor/Gizmo/UIEditorGizmo.cs
+++ b/Source/Editor/Gizmo/UIEditorGizmo.cs
@@ -156,6 +156,16 @@ namespace FlaxEditor
         private Widget _activeWidget;
 
         /// <summary>
+        /// Sets the view size.
+        /// </summary>
+        /// <param name="size">The new size.</param>
+        public void SetViewSize(Float2 size)
+        {
+            _view.Size = size;
+            _view.PerformLayout();
+        }
+
+        /// <summary>
         /// True if enable displaying UI editing background and grid elements.
         /// </summary>
         public virtual bool EnableBackground => false;

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -37,6 +37,53 @@ namespace FlaxEditor.Modules
         private bool _progressFailed;
 
         ContextMenuSingleSelectGroup<int> _numberOfClientsGroup = new ContextMenuSingleSelectGroup<int>();
+        
+        /// <summary>
+        /// Defines a viewport scaling option.
+        /// </summary>
+        public class ViewportScaleOption
+        {
+            /// <summary>
+            /// Defines the viewport scale type.
+            /// </summary>
+            public enum ViewportScaleType
+            {
+                /// <summary>
+                /// Resolution.
+                /// </summary>
+                Resolution = 0,
+
+                /// <summary>
+                /// Aspect Ratio.
+                /// </summary>
+                Aspect = 1,
+            }
+            
+            /// <summary>
+            /// The name.
+            /// </summary>
+            public string Label;
+
+            /// <summary>
+            /// The Type of scaling to do.
+            /// </summary>
+            public ViewportScaleType ScaleType;
+
+            /// <summary>
+            /// The width and height to scale by.
+            /// </summary>
+            public Int2 Size;
+        }
+ 
+        /// <summary>
+        /// The default viewport scaling options.
+        /// </summary>
+        public List<ViewportScaleOption> DefaultViewportScaleOptions = new List<ViewportScaleOption>();
+
+        /// <summary>
+        /// The user defined viewport scaling options.
+        /// </summary>
+        public List<ViewportScaleOption> CustomViewportScaleOptions = new List<ViewportScaleOption>();
 
         private ContextMenuButton _menuFileSaveScenes;
         private ContextMenuButton _menuFileReloadScenes;
@@ -371,6 +418,8 @@ namespace FlaxEditor.Modules
 
             // Update window background
             mainWindow.BackgroundColor = Style.Current.Background;
+            
+            InitViewportScaleOptions();
 
             InitSharedMenus();
             InitMainMenu(mainWindow);
@@ -390,6 +439,57 @@ namespace FlaxEditor.Modules
                     Size = Float2.Zero,
                 });
             }
+        }
+
+        private void InitViewportScaleOptions()
+        {
+            if (DefaultViewportScaleOptions.Count == 0)
+            {
+                DefaultViewportScaleOptions.Add(new ViewportScaleOption
+                {
+                    Label = "Free Aspect",
+                    ScaleType = ViewportScaleOption.ViewportScaleType.Aspect,
+                    Size = new Int2(1, 1),
+                });
+                DefaultViewportScaleOptions.Add(new ViewportScaleOption
+                {
+                    Label = "16:9 Aspect",
+                    ScaleType = ViewportScaleOption.ViewportScaleType.Aspect,
+                    Size = new Int2(16, 9),
+                });
+                DefaultViewportScaleOptions.Add(new ViewportScaleOption
+                {
+                    Label = "16:10 Aspect",
+                    ScaleType = ViewportScaleOption.ViewportScaleType.Aspect,
+                    Size = new Int2(16, 10),
+                });
+                DefaultViewportScaleOptions.Add(new ViewportScaleOption
+                {
+                    Label = "1920x1080 Resolution (Full HD)",
+                    ScaleType = ViewportScaleOption.ViewportScaleType.Resolution,
+                    Size = new Int2(1920, 1080),
+                });
+                DefaultViewportScaleOptions.Add(new ViewportScaleOption
+                {
+                    Label = "2560x1440 Resolution (2K)",
+                    ScaleType = ViewportScaleOption.ViewportScaleType.Resolution,
+                    Size = new Int2(2560, 1440),
+                });
+            }
+            
+            if (Editor.Instance.ProjectCache.TryGetCustomData("CustomViewportScalingOptions", out string data))
+            {
+                CustomViewportScaleOptions = JsonSerializer.Deserialize<List<ViewportScaleOption>>(data);
+            }
+        }
+
+        /// <summary>
+        /// Saves the custom viewport scaling options.
+        /// </summary>
+        public void SaveCustomViewportScalingOptions()
+        {
+            var customOptions = JsonSerializer.Serialize(CustomViewportScaleOptions);
+            Editor.Instance.ProjectCache.SetCustomData("CustomViewportScalingOptions",  customOptions);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using FlaxEditor.Content;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Input;
+using FlaxEditor.Modules;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.Scripting;
 using FlaxEditor.Viewport.Cameras;
@@ -13,6 +15,7 @@ using FlaxEditor.Viewport.Previews;
 using FlaxEditor.Windows.Assets;
 using FlaxEngine;
 using FlaxEngine.GUI;
+using FlaxEngine.Json;
 using Utils = FlaxEditor.Utilities.Utils;
 
 namespace FlaxEditor.Viewport
@@ -71,7 +74,10 @@ namespace FlaxEditor.Viewport
         private PrefabUIEditorRoot _uiRoot;
         private bool _showUI = false;
         
+        private int _defaultScaleActiveIndex = 0;
+        private int _customScaleActiveIndex = -1;
         private ContextMenuButton _uiModeButton;
+        private ContextMenu _uiViewCM;
 
         /// <summary>
         /// Event fired when the UI Mode is toggled.
@@ -213,13 +219,316 @@ namespace FlaxEditor.Viewport
             _uiModeButton = ViewWidgetShowMenu.AddButton("UI Mode", (button) => ShowUI = button.Checked);
             _uiModeButton.AutoCheck = true;
             _uiModeButton.VisibleChanged += control => (control as ContextMenuButton).Checked = ShowUI;
-
+            
             EditorGizmoViewport.AddGizmoViewportWidgets(this, TransformGizmo);
 
             // Setup input actions
             InputActions.Add(options => options.FocusSelection, ShowSelectedActors);
 
             SetUpdate(ref _update, OnUpdate);
+        }
+
+        /// <summary>
+        /// Creates the view scaling options. Needs to be called after a Prefab is valid and loaded.
+        /// </summary>
+        public void CreateViewScalingOptions()
+        {
+            // View Scaling
+            var uiViewCM = ViewWidgetButtonMenu.AddChildMenu("UI View Scaling");
+            LoadCustomUIScalingOption();
+            CreateUIViewScalingContextMenu(uiViewCM.ContextMenu);
+        }
+
+        private void ChangeUIView(UIModule.ViewportScaleOption uiViewScaleOption)
+        {
+            _uiRoot.SetViewSize((Float2)uiViewScaleOption.Size);
+        }
+
+         private void CreateUIViewScalingContextMenu(ContextMenu vsMenu)
+        {
+            // Add default viewport sizing options
+            var defaultOptions = Editor.Instance.UI.DefaultViewportScaleOptions;
+            for (int i = 0; i < defaultOptions.Count; i++)
+            {
+                var viewportScale = defaultOptions[i];
+
+                // Skip aspect ratio types in prefab
+                if (viewportScale.ScaleType == UIModule.ViewportScaleOption.ViewportScaleType.Aspect)
+                    continue;
+
+                var button = vsMenu.AddButton(viewportScale.Label);
+                button.CloseMenuOnClick = false;
+                button.Tag = viewportScale;
+
+                // No default index is active.
+                if (_defaultScaleActiveIndex == -1)
+                {
+                    button.Icon = SpriteHandle.Invalid;
+                }
+                // This is the active index.
+                else if (_defaultScaleActiveIndex == i)
+                {
+                    button.Icon = Style.Current.CheckBoxTick;
+                    ChangeUIView(viewportScale);
+                }
+
+                button.Clicked += () =>
+                {
+                    if (button.Tag == null)
+                        return;
+
+                    // Reset selected icon on all buttons
+                    foreach (var child in vsMenu.Items)
+                    {
+                        if (child is ContextMenuButton cmb && cmb.Tag is UIModule.ViewportScaleOption v)
+                        {
+                            if (cmb == button)
+                            {
+                                var index = defaultOptions.FindIndex(x => x == v);
+                                _defaultScaleActiveIndex = index;
+                                _customScaleActiveIndex = -1; // Reset custom index because default was chosen.
+                                button.Icon = Style.Current.CheckBoxTick;
+                                ChangeUIView(v);
+                            }
+                            else if (cmb.Icon != SpriteHandle.Invalid)
+                            {
+                                cmb.Icon = SpriteHandle.Invalid;
+                            }
+                        }
+                    }
+                };
+            }
+            if (defaultOptions.Count != 0)
+                vsMenu.AddSeparator();
+
+            // Add custom viewport options
+            var customOptions = Editor.Instance.UI.CustomViewportScaleOptions;
+            for (int i = 0; i < customOptions.Count; i++)
+            {
+                var viewportScale = customOptions[i];
+
+                // Skip aspect ratio types for prefabs
+                if (viewportScale.ScaleType == UIModule.ViewportScaleOption.ViewportScaleType.Aspect)
+                    continue;
+
+                var childCM = vsMenu.AddChildMenu(viewportScale.Label);
+                childCM.CloseMenuOnClick = false;
+                childCM.Tag = viewportScale;
+                
+                // No custom index is active.
+                if (_customScaleActiveIndex == -1)
+                {
+                    childCM.Icon = SpriteHandle.Invalid;
+                }
+                // This is the active index.
+                else if (_customScaleActiveIndex == i)
+                {
+                    childCM.Icon = Style.Current.CheckBoxTick;
+                    ChangeUIView(viewportScale);
+                }
+                
+                var applyButton = childCM.ContextMenu.AddButton("Apply");
+                applyButton.Tag = childCM.Tag = viewportScale;
+                applyButton.CloseMenuOnClick = false;
+                applyButton.Clicked += () =>
+                {
+                    if (childCM.Tag == null)
+                        return;
+
+                    // Reset selected icon on all buttons
+                    foreach (var child in vsMenu.Items)
+                    {
+                        if (child is ContextMenuButton cmb && cmb.Tag is UIModule.ViewportScaleOption v)
+                        {
+                            if (child == childCM)
+                            {
+                                var index = customOptions.FindIndex(x => x == v);
+                                _defaultScaleActiveIndex = -1; // Reset default index because custom was chosen.
+                                _customScaleActiveIndex = index;
+                                childCM.Icon = Style.Current.CheckBoxTick;
+                                ChangeUIView(v);
+                            }
+                            else if (cmb.Icon != SpriteHandle.Invalid)
+                            {
+                                cmb.Icon = SpriteHandle.Invalid;
+                            }
+                        }
+                    }
+                };
+
+                var deleteButton = childCM.ContextMenu.AddButton("Delete");
+                deleteButton.CloseMenuOnClick = false;
+                deleteButton.Clicked += () =>
+                {
+                    if (childCM.Tag == null)
+                        return;
+
+                    var v = (UIModule.ViewportScaleOption)childCM.Tag;
+                    if (childCM.Icon != SpriteHandle.Invalid)
+                    {
+                        _customScaleActiveIndex = -1;
+                        _defaultScaleActiveIndex = 0;
+                        ChangeUIView(defaultOptions[0]);
+                    }
+                    customOptions.Remove(v);
+                    Editor.Instance.UI.SaveCustomViewportScalingOptions();
+                    vsMenu.DisposeAllItems();
+                    CreateUIViewScalingContextMenu(vsMenu);
+                    vsMenu.PerformLayout();
+                };
+            }
+            if (customOptions.Count != 0)
+                vsMenu.AddSeparator();
+
+            // Add button
+            var add = vsMenu.AddButton("Add...");
+            add.CloseMenuOnClick = false;
+            add.Clicked += () =>
+            {
+                var popup = new ContextMenuBase
+                {
+                    Size = new Float2(230, 95),
+                    ClipChildren = false,
+                    CullChildren = false,
+                };
+                popup.Show(add, new Float2(add.Width, 0));
+
+                var nameLabel = new Label
+                {
+                    Parent = popup,
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    Text = "Name",
+                    HorizontalAlignment = TextAlignment.Near,
+                };
+                nameLabel.LocalX += 10;
+                nameLabel.LocalY += 10;
+
+                var nameTextBox = new TextBox
+                {
+                    Parent = popup,
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    IsMultiline = false,
+                };
+                nameTextBox.LocalX += 100;
+                nameTextBox.LocalY += 10;
+
+                var whLabel = new Label
+                {
+                    Parent = popup,
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    Text = "Width & Height",
+                    HorizontalAlignment = TextAlignment.Near,
+                };
+                whLabel.LocalX += 10;
+                whLabel.LocalY += 30;
+
+                var wValue = new IntValueBox(1920)
+                {
+                    Parent = popup,
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    MinValue = 1,
+                    Width = 55,
+                };
+                wValue.LocalY += 30;
+                wValue.LocalX += 100;
+
+                var hValue = new IntValueBox(1080)
+                {
+                    Parent = popup,
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    MinValue = 1,
+                    Width = 55,
+                };
+                hValue.LocalY += 30;
+                hValue.LocalX += 165;
+
+                var submitButton = new Button
+                {
+                    Parent = popup,
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    Text = "Submit",
+                    Width = 70,
+                };
+                submitButton.LocalX += 40;
+                submitButton.LocalY += 60;
+
+                submitButton.Clicked += () =>
+                {
+                    var name = nameTextBox.Text + " (" + wValue.Value + "x" + hValue.Value + ")";
+
+                    var newViewportOption = new UIModule.ViewportScaleOption
+                    {
+                        Label = name,
+                        ScaleType = UIModule.ViewportScaleOption.ViewportScaleType.Resolution,
+                        Size = new Int2(wValue.Value, hValue.Value),
+                    };
+
+                    customOptions.Add(newViewportOption);
+                    Editor.Instance.UI.SaveCustomViewportScalingOptions();
+                    vsMenu.DisposeAllItems();
+                    CreateUIViewScalingContextMenu(vsMenu);
+                    vsMenu.PerformLayout();
+                };
+
+                var cancelButton = new Button
+                {
+                    Parent = popup,
+                    AnchorPreset = AnchorPresets.TopLeft,
+                    Text = "Cancel",
+                    Width = 70,
+                };
+                cancelButton.LocalX += 120;
+                cancelButton.LocalY += 60;
+
+                cancelButton.Clicked += () =>
+                {
+                    nameTextBox.Clear();
+                    hValue.Value = 9;
+                    wValue.Value = 16;
+                    popup.Hide();
+                };
+            };
+        }
+
+        /// <summary>
+        /// Saves the active ui scaling option.
+        /// </summary>
+        public void SaveActiveUIScalingOption()
+        {
+            var defaultKey = $"{Prefab.ID}:DefaultViewportScalingIndex";
+            Editor.Instance.ProjectCache.SetCustomData(defaultKey, _defaultScaleActiveIndex.ToString());
+            var customKey = $"{Prefab.ID}:CustomViewportScalingIndex";
+            Editor.Instance.ProjectCache.SetCustomData(customKey, _customScaleActiveIndex.ToString());
+        }
+
+        private void LoadCustomUIScalingOption()
+        {
+            Prefab.WaitForLoaded();
+            var defaultKey = $"{Prefab.ID}:DefaultViewportScalingIndex";
+            if (Editor.Instance.ProjectCache.TryGetCustomData(defaultKey, out string defaultData))
+            {
+                if (int.TryParse(defaultData, out var index))
+                {
+                    _defaultScaleActiveIndex = index;
+                    if (index != -1)
+                    {
+                        ChangeUIView(Editor.Instance.UI.DefaultViewportScaleOptions[index]);
+                    }
+                }
+            }
+            
+            var customKey = $"{Prefab.ID}:CustomViewportScalingIndex";
+            if (Editor.Instance.ProjectCache.TryGetCustomData(customKey, out string data))
+            {
+                if (int.TryParse(data, out var index))
+                {
+                    _customScaleActiveIndex = index;
+                    if (index != -1)
+                    {
+                        ChangeUIView(Editor.Instance.UI.CustomViewportScaleOptions[index]);
+                    }
+                }
+            }
         }
 
         private void OnUpdate(float deltaTime)

--- a/Source/Editor/Windows/Assets/PrefabWindow.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.cs
@@ -368,6 +368,7 @@ namespace FlaxEditor.Windows.Assets
             else
                 _viewport.SetInitialUIMode(_viewport._hasUILinked);
             _viewport.UIModeToggled += OnUIModeToggled;
+            _viewport.CreateViewScalingOptions();
             Graph.MainActor = _viewport.Instance;
             Selection.Clear();
             Select(Graph.Main);
@@ -562,6 +563,15 @@ namespace FlaxEditor.Windows.Assets
 
             _undo.Dispose();
             Graph.Dispose();
+        }
+
+        /// <inheritdoc />
+        protected override void OnClose()
+        {
+            // Save current UI view size state.
+            _viewport.SaveActiveUIScalingOption();
+   
+            base.OnClose();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Adds a drop down in the view widget of the prefab that allows changing the UI viewport scale to adjust the black box that frames the UI in a prefab. This reworks the saving of the game viewport scaling as well to link the options together.