### PR TITLE
Apply particle effect parameter overrides when emitter is changed and when activated in the tree.

### DIFF
--- a/Source/Engine/Particles/ParticleEffect.cpp
+++ b/Source/Engine/Particles/ParticleEffect.cpp
@@ -548,6 +548,16 @@ void ParticleEffect::OnParticleSystemModified()
 void ParticleEffect::OnParticleSystemLoaded()
 {
     ApplyModifiedParameters();
+    auto& emitters = ParticleSystem.Get()->Emitters;
+    for (auto& emitter : emitters)
+    {
+        emitter.Loaded.BindUnique<ParticleEffect, &ParticleEffect::OnParticleEmitterLoaded>(this);
+    }
+}
+
+void ParticleEffect::OnParticleEmitterLoaded()
+{
+    ApplyModifiedParameters();
 }
 
 bool ParticleEffect::HasContentLoaded() const
@@ -813,6 +823,10 @@ void ParticleEffect::OnActiveInTreeChanged()
         // Invalidate the simulation
         CacheModifiedParameters();
         Instance.ClearState();
+    }
+    else
+    {
+        ApplyModifiedParameters();
     }
 }
 

--- a/Source/Engine/Particles/ParticleEffect.h
+++ b/Source/Engine/Particles/ParticleEffect.h
@@ -387,6 +387,7 @@ private:
     void ApplyModifiedParameters();
     void OnParticleSystemModified();
     void OnParticleSystemLoaded();
+    void OnParticleEmitterLoaded();
 
 public:
     // [Actor]


### PR DESCRIPTION
Fix #3409 

There is some other issue where the Changed event is not fired when a particle emitter is changed, but the loaded is... so this used loaded instead to catch the changes...