### PR TITLE
Simplify and fix edge case in item list scrolling while holding control (#3555 followup)

### DIFF
--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -514,15 +514,15 @@ namespace FlaxEditor.GUI
             var items = ItemsPanel.Children;
             for (int i = 0; i < items.Count; i++)
             {
-                var item = items[i];
-                if (item is Item item1 && item1.Visible)
-                    result.Add(item1);
-                else if (!ignoreFoldedCategories && item is DropPanel panel && item.Visible)
+                var currentItem = items[i];
+                if (currentItem is Item item && item.Visible)
+                    result.Add(item);
+                else if (currentItem is DropPanel category && (!ignoreFoldedCategories || !category.IsClosed) && currentItem.Visible)
                 {
-                    for (int j = 0; j < panel.Children.Count; j++)
+                    for (int j = 0; j < category.Children.Count; j++)
                     {
-                        if (panel.Children[j] is Item item2 && item2.Visible)
-                            result.Add(item2);
+                        if (category.Children[j] is Item categoryItem && categoryItem.Visible)
+                            result.Add(categoryItem);
                     }
                 }
             }


### PR DESCRIPTION
Followup to #3555

*Edit:*
Linux tests are failing because of
```
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/u/util-linux/uuid-dev_2.39.3-9ubuntu6.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
Fetched 7228 kB in 4s (1758 kB/s)
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/u/util-linux/libblkid-dev_2.39.3-9ubuntu6.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/u/util-linux/libmount-dev_2.39.3-9ubuntu6.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```