### PR TITLE
Add `IsSceneActor` method to physics backend. Check if physx actor exists before removing from scene.

### DIFF
--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -2032,12 +2032,34 @@ void PhysicsBackend::AddSceneActor(void* scene, void* actor)
 void PhysicsBackend::RemoveSceneActor(void* scene, void* actor, bool immediately)
 {
     auto scenePhysX = (ScenePhysX*)scene;
+    bool actorExists = IsSceneActor(scene, actor);
+    if (!actorExists)
+        return;
     FlushLocker.Lock();
     if (immediately)
         scenePhysX->Scene->removeActor(*(PxActor*)actor);
     else
         scenePhysX->RemoveActors.Add((PxActor*)actor);
     FlushLocker.Unlock();
+}
+
+bool PhysicsBackend::IsSceneActor(void* scene, void* actor)
+{
+    auto scenePhysX = (ScenePhysX*)scene;
+    PxActor** actors;
+    PxU32 nbActors = scenePhysX->Scene->getNbActors(PxActorTypeFlag::eRIGID_STATIC | PxActorTypeFlag::eRIGID_DYNAMIC);
+    scenePhysX->Scene->getActors(PxActorTypeFlag::eRIGID_STATIC | PxActorTypeFlag::eRIGID_DYNAMIC, actors, nbActors, 0);
+    bool actorExists = false;
+    for (PxU32 i = 0; i < nbActors; i++)
+    {
+        auto pxActor = actors[i];
+        if (pxActor == actor)
+        {
+            actorExists = true;
+            break;
+        }
+    }
+    return actorExists;
 }
 
 void PhysicsBackend::AddSceneActorAction(void* scene, void* actor, ActionType action)

--- a/Source/Engine/Physics/PhysicsBackend.h
+++ b/Source/Engine/Physics/PhysicsBackend.h
@@ -114,6 +114,7 @@ public:
     static void SetSceneOrigin(void* scene, const Vector3& oldOrigin, const Vector3& newOrigin);
     static void AddSceneActor(void* scene, void* actor);
     static void RemoveSceneActor(void* scene, void* actor, bool immediately = false);
+    static bool IsSceneActor(void* scene, void* actor);
     static void AddSceneActorAction(void* scene, void* actor, ActionType action);
 #if COMPILE_WITH_PROFILER
     static void GetSceneStatistics(void* scene, PhysicsStatistics& result);


### PR DESCRIPTION
Prevents a disabled terrain from throwing errors in the phyx backend. I dont think  the errors are harmful, so this may just add overhead... but it is an option to do this.