### PR TITLE
Feature/Json DefaultValueHandling

### DIFF
--- a/Source/Engine/Serialization/JsonCustomSerializers/ExtendedDefaultContractResolver.cs
+++ b/Source/Engine/Serialization/JsonCustomSerializers/ExtendedDefaultContractResolver.cs
@@ -108,6 +108,8 @@ namespace FlaxEngine.Json.JsonCustomSerializers
                 jsonProperty.Writable = true;
                 jsonProperty.Readable = true;
 
+                jsonProperty.DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate;
+
                 if (_flaxType.IsAssignableFrom(f.FieldType))
                 {
                     jsonProperty.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
@@ -150,6 +152,8 @@ namespace FlaxEngine.Json.JsonCustomSerializers
                 var jsonProperty = CreateProperty(p, memberSerialization);
                 jsonProperty.Writable = true;
                 jsonProperty.Readable = !isObsolete;
+
+                jsonProperty.DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate;
 
                 if (_flaxType.IsAssignableFrom(p.PropertyType))
                 {


### PR DESCRIPTION
This pull request enhances the JSON serialization behavior in `ExtendedDefaultContractResolver` by setting `DefaultValueHandling` to `IgnoreAndPopulate` for both fields and properties.

Previously, default values were not consistently handled during deserialization, which could lead to unexpected behavior when properties or fields were missing from the JSON payload.

With this change, `DefaultValueHandling.IgnoreAndPopulate` ensures the following:
* **Ignore:** Properties with default values will not be serialized if their current value matches the default. This helps reduce the size of the serialized JSON.
* **Populate:** If a property is missing from the JSON, it will be populated with its default value during deserialization, ensuring data consistency and preventing null reference exceptions for properties that should have a default.

This change improves the robustness and efficiency of JSON serialization and deserialization processes, especially when dealing with optional or evolving data structures.

### Usage Example:

This change enables more reliable handling of default values during deserialization. For instance, in a FlaxEngine script, you can now rely on properties being populated with their default (e.g., `null` for reference types) even if they are not explicitly present in the serialized data. This allows for validation or other logic within property setters to be consistently triggered upon instantiation.

```csharp
using FlaxEngine;

namespace Game;

/// <summary>
/// MyScript Script.
/// </summary>
public class MyScript : Script
{
    private Actor _myActor;
    public Actor MyActor
    {
        get => _myActor;
        set
        {
            #if FLAX_EDITOR
            if (!FlaxEditor.Editor.IsPlayMode)
            {
                // Don't perform validation in the editor, outside of play mode.
                return;
            }
            #endif
            // Because the serializer now populates default values (null for reference types), the setter will always be called when the SceneObject is instantiated.
            // This lets us do cool stuff like this:
            if (value == null)
            {
                Debug.LogError("I should not be null!");
            }
            _myActor = value;
        }
    }

    /* ... */

}