### PR TITLE
Fix edge case for anim event on min or max frame when looping. Fix anim event playback when is reversed.

### DIFF
--- a/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
+++ b/Source/Engine/Animations/Graph/AnimGroup.Animation.cpp
@@ -246,7 +246,7 @@ void AnimGraphExecutor::ProcessAnimEvents(AnimGraphNode* node, bool loop, float 
             const float duration = k.Value.Duration > 1 ? k.Value.Duration : 0.0f;
 #define ADD_OUTGOING_EVENT(type) context.Data->OutgoingEvents.Add({ k.Value.Instance, (AnimatedModel*)context.Data->Object, anim, eventTime, eventDeltaTime, AnimGraphInstanceData::OutgoingEvent::type })
             if ((k.Time <= eventTimeMax && eventTimeMin <= k.Time + duration
-                && (Math::FloorToInt(animPos) != 0 && Math::FloorToInt(animPrevPos) < Math::FloorToInt(anim->GetDuration()) && Math::FloorToInt(animPrevPos) != 0 && Math::FloorToInt(animPos) < Math::FloorToInt(anim->GetDuration())))
+                && (Math::FloorToInt(animPos) != 0 && Math::CeilToInt(animPrevPos) != Math::CeilToInt(anim->GetDuration()) && Math::FloorToInt(animPrevPos) != 0 && Math::CeilToInt(animPos) != Math::CeilToInt(anim->GetDuration())))
                 // Handle the edge case of an event on 0 or on max animation duration during looping
                 || (loop && duration == 0.0f && Math::CeilToInt(animPos) == Math::CeilToInt(anim->GetDuration()) && k.Time == anim->GetDuration())
                 || (loop && Math::FloorToInt(animPos) == 0 && Math::CeilToInt(animPrevPos) == Math::CeilToInt(anim->GetDuration()) && k.Time == 0.0f)


### PR DESCRIPTION
Closes #3609 

There may be a better way to fix this, but this seems to work okay. The only issue I have found is that if playing an event at frame 0 and negative, then it will give the time of the max frame to the event even though it is triggering at the correct time.