### PR TITLE
Fix infinite loop on rich text box tag parsing with incomplete end of tag.

### DIFF
--- a/Source/Engine/Utilities/HtmlParser.cs
+++ b/Source/Engine/Utilities/HtmlParser.cs
@@ -204,6 +204,10 @@ namespace FlaxEngine.Utilities
             SkipWhitespace();
             while (Peek() != '>')
             {
+                // Return false if start of new html tag is detected.
+                if (Peek() == '<')
+                    return false;
+                
                 if (Peek() == '/')
                 {
                     // Handle trailing forward slash

--- a/Source/Engine/Utilities/HtmlParser.cs
+++ b/Source/Engine/Utilities/HtmlParser.cs
@@ -134,6 +134,10 @@ namespace FlaxEngine.Utilities
                     if (isLeadingSlash)
                         Move();
 
+                    // Dont process if wrong slash is used.
+                    if (c =='\\')
+                        return false;
+
                     // Parse tag
                     bool result = ParseTag(ref tag, name);
 


### PR DESCRIPTION
Fixes an issue with parsing looping infinitely if two '<' '<' are found before a closing bracket or EOF. This also fixes an infinite loop occurring if the wrong kind of slash is used, now it just wont process the closing tag.