### PR TITLE
Audio events and time slider

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/AudioSourceEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/AudioSourceEditor.cs
@@ -13,6 +13,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
     public class AudioSourceEditor : ActorEditor
     {
         private Label _infoLabel;
+        private Slider _slider;
+        private AudioSource.States _slideStartState;
 
         /// <inheritdoc />
         public override void Initialize(LayoutElementsContainer layout)
@@ -28,6 +30,13 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 _infoLabel = playbackGroup.Label(string.Empty).Label;
                 _infoLabel.AutoHeight = true;
 
+                // Play back slider
+                var sliderElement = playbackGroup.CustomContainer<Slider>();
+                _slider = sliderElement.CustomControl;
+                _slider.ThumbSize = new Float2(_slider.ThumbSize.X * 0.5f, _slider.ThumbSize.Y);
+                _slider.SlidingStart += OnSlidingStart;
+                _slider.SlidingEnd += OnSlidingEnd;
+
                 var grid = playbackGroup.UniformGrid();
                 var gridControl = grid.CustomControl;
                 gridControl.ClipChildren = false;
@@ -37,6 +46,38 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 grid.Button("Play").Button.Clicked += () => Foreach(x => x.Play());
                 grid.Button("Pause").Button.Clicked += () => Foreach(x => x.Pause());
                 grid.Button("Stop").Button.Clicked += () => Foreach(x => x.Stop());
+            }
+        }
+
+        private void OnSlidingEnd()
+        {
+            foreach (var value in Values)
+            {
+                if (value is AudioSource audioSource && audioSource.Clip)
+                {
+                    switch (_slideStartState)
+                    {
+                    case AudioSource.States.Playing:
+                        audioSource.Play();
+                        break;
+                    case AudioSource.States.Paused:
+                    case AudioSource.States.Stopped:
+                        audioSource.Pause();
+                        break;
+                    default: break;
+                    }
+                }
+            }
+        }
+
+        private void OnSlidingStart()
+        {
+            foreach (var value in Values)
+            {
+                if (value is AudioSource audioSource && audioSource.Clip)
+                {
+                    _slideStartState = audioSource.State;
+                }
             }
         }
 
@@ -51,7 +92,29 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 foreach (var value in Values)
                 {
                     if (value is AudioSource audioSource && audioSource.Clip)
+                    {
                         text += $"Time: {audioSource.Time:##0.0}s / {audioSource.Clip.Length:##0.0}s\n";
+                        _slider.Maximum = audioSource.Clip.Length;
+                        _slider.Minimum = 0;
+                        if (_slider.IsSliding)
+                        {
+                            if (audioSource.State != AudioSource.States.Playing)
+                            {
+                                // Play to move slider correctly
+                                audioSource.Play();
+                                audioSource.Time = _slider.Value;
+                            }
+                            else
+                            {
+                                audioSource.Time = _slider.Value;
+                            }
+                        }
+                        else
+                        {
+                            _slider.Value = audioSource.Time;
+                        }
+                        
+                    }
                 }
                 _infoLabel.Text = text;
             }

--- a/Source/Engine/Audio/AudioSource.cpp
+++ b/Source/Engine/Audio/AudioSource.cpp
@@ -168,7 +168,7 @@ void AudioSource::Play()
     else
     {
         // Source was nt properly added to the Audio Backend
-        LOG(Warning, "Cannot play unitialized audio source.");
+        LOG(Warning, "Cannot play uninitialized audio source.");
     }
 }
 
@@ -395,6 +395,9 @@ void AudioSource::Update()
         AudioBackend::Source::VelocityChanged(SourceID, _velocity);
     }
 
+    if (Math::NearEqual(GetTime(), _startTime) && _isActuallyPlayingSth && _startingToPlay)
+        ClipStarted();
+
     // Reset starting to play value once time is greater than zero
     if (_startingToPlay && GetTime() > 0.0f)
     {
@@ -416,6 +419,7 @@ void AudioSource::Update()
             {
                 Stop();
             }
+            ClipFinished();
         }
     }
 
@@ -486,6 +490,7 @@ void AudioSource::Update()
                 {
                     Stop();
                 }
+                ClipFinished();
             }
             ASSERT(_streamingFirstChunk < clip->Buffers.Count());
 
@@ -582,4 +587,12 @@ void AudioSource::BeginPlay(SceneBeginData* data)
         if (GetStartTime() > 0)
             SetTime(GetStartTime());
     }
+}
+
+void AudioSource::EndPlay()
+{
+    Actor::EndPlay();
+
+    ClipStarted.UnbindAll();
+    ClipFinished.UnbindAll();
 }

--- a/Source/Engine/Audio/AudioSource.h
+++ b/Source/Engine/Audio/AudioSource.h
@@ -77,6 +77,16 @@ public:
     AssetReference<AudioClip> Clip;
 
     /// <summary>
+    /// Event fired when the audio clip starts.
+    /// </summary>
+    API_EVENT() Delegate<> ClipStarted;
+
+    /// <summary>
+    /// Event fired when the audio clip finishes.
+    /// </summary>
+    API_EVENT() Delegate<> ClipFinished;
+
+    /// <summary>
     /// Gets the velocity of the source. Determines pitch in relation to AudioListener's position. Only relevant for spatial (3D) sources.
     /// </summary>
     API_PROPERTY() FORCE_INLINE const Vector3& GetVelocity() const
@@ -326,4 +336,5 @@ protected:
     void OnDisable() override;
     void OnTransformChanged() override;
     void BeginPlay(SceneBeginData* data) override;
+    void EndPlay() override;
 };


### PR DESCRIPTION
Add `ClipStarted` and `ClipFinished` events to audio source.

Add a slider to the debug editor for the audio source to select time.
<img width="460" height="158" alt="image" src="https://github.com/user-attachments/assets/d5fe1a19-d2ce-49fb-b2dd-dc6fbebc21bd" />
