### PR TITLE
Expose hideOnClose and scrollBars in constructor for CustomEditorWindows

### DIFF
--- a/Source/Editor/CustomEditorWindow.cs
+++ b/Source/Editor/CustomEditorWindow.cs
@@ -18,8 +18,8 @@ namespace FlaxEditor
             private readonly CustomEditorPresenter _presenter;
             private CustomEditorWindow _customEditor;
 
-            public Win(CustomEditorWindow customEditor)
-            : base(Editor.Instance, false, ScrollBars.Vertical)
+            public Win(CustomEditorWindow customEditor, bool hideOnClose, ScrollBars scrollBars)
+            : base(Editor.Instance, hideOnClose, scrollBars)
             {
                 Title = customEditor.GetType().Name;
                 _customEditor = customEditor;
@@ -64,9 +64,9 @@ namespace FlaxEditor
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomEditorWindow"/> class.
         /// </summary>
-        protected CustomEditorWindow()
+        protected CustomEditorWindow(bool hideOnClose = false, ScrollBars scrollBars = ScrollBars.Vertical)
         {
-            _win = new Win(this);
+            _win = new Win(this, hideOnClose, scrollBars);
             ScriptsBuilder.ScriptsReloadBegin += OnScriptsReloadBegin;
         }
 


### PR DESCRIPTION
This exposes the HideOnClose and ScrollBars arguments for CustomEditorWindows, skipping the need to re-implement the exact same logic for editor plugins that require changes to those two.
The constructor uses default values to match previous behavior, so no changes are needed for older scripts.