### PR TITLE
fix scaling for TextRender

### DIFF
--- a/Source/Engine/UI/TextRender.cpp
+++ b/Source/Engine/UI/TextRender.cpp
@@ -167,7 +167,7 @@ void TextRender::UpdateLayout()
 
     // Pick a font (remove DPI text scale as the text is being placed in the world)
     auto font = Font->CreateFont(_size);
-    float scale = 1.0f / FontManager::FontScale;
+    float scale = _layoutOptions.Scale / FontManager::FontScale;
 
     // Prepare
     FontTextureAtlas* fontAtlas = nullptr;


### PR DESCRIPTION
The scaling factor is not applied to UpdateLayout(), causing the texts to only translates but not scaling up.