### PR TITLE
Add `IncludeInheritedTypes` to `RequireActorAttribute`

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -102,11 +102,12 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     var actors = ScriptsEditor.ParentEditor.Values;
                     foreach (var a in actors)
                     {
-                        if (a.GetType() != requireActor.RequiredType)
-                        {
-                            item.Enabled = false;
-                            break;
-                        }
+                        if (a.GetType() == requireActor.RequiredType)
+                            continue;
+                        if (requireActor.IncludeInheritedTypes && a.GetType().IsSubclassOf(requireActor.RequiredType))
+                            continue;
+                        item.Enabled = false;
+                        break;
                     }
                 }
                 cm.AddItem(item);
@@ -827,7 +828,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     if (attribute != null)
                     {
                         var actor = script.Actor;
-                        if (actor.GetType() != attribute.RequiredType && !actor.GetType().IsSubclassOf(attribute.RequiredType))
+                        if (actor.GetType() != attribute.RequiredType && (attribute.IncludeInheritedTypes && !actor.GetType().IsSubclassOf(attribute.RequiredType)))
                         {
                             Editor.LogWarning($"`{Utilities.Utils.GetPropertyNameUI(scriptType.Name)}` on `{script.Actor}` is missing a required Actor of type `{attribute.RequiredType}`.");
                             hasAllRequirements = false;

--- a/Source/Engine/Scripting/Attributes/Editor/RequireActorAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/RequireActorAttribute.cs
@@ -13,13 +13,20 @@ public class RequireActorAttribute : Attribute
     /// The required type.
     /// </summary>
     public Type RequiredType;
+    
+    /// <summary>
+    /// Whether to include inherited types.
+    /// </summary>
+    public bool IncludeInheritedTypes;
 
     /// <summary>
     /// Initializes a new instance of the  <see cref="RequireActorAttribute"/> class.
     /// </summary>
     /// <param name="type">The required type.</param>
-    public RequireActorAttribute(Type type)
+    /// <param name="includeInheritedTypes">Whether to include inherited types.</param>
+    public RequireActorAttribute(Type type, bool includeInheritedTypes = false)
     {
         RequiredType = type;
+        IncludeInheritedTypes = includeInheritedTypes;
     }
 }


### PR DESCRIPTION
Lets the user choose if the script can be added to inherited types of actors.