### PR TITLE
Add ability to loop root node in behavior trees.

### DIFF
--- a/Source/Engine/AI/Behavior.cpp
+++ b/Source/Engine/AI/Behavior.cpp
@@ -106,7 +106,19 @@ void Behavior::UpdateAsync()
     const BehaviorUpdateResult result = tree->Graph.Root->InvokeUpdate(context);
     if (result != BehaviorUpdateResult::Running)
         _result = result;
-    if (_result != BehaviorUpdateResult::Running)
+    if (_result != BehaviorUpdateResult::Running && tree->Graph.Root->Loop)
+    {
+        // Ensure to have tree loaded on play
+        CHECK(Tree && !Tree->WaitForLoaded());
+        BehaviorTree* tree = Tree.Get();
+        CHECK(tree->Graph.Root);
+
+        // Setup state
+        _result = BehaviorUpdateResult::Running;
+        _accumulatedTime = 0.0f;
+        _totalTime = 0;
+    }
+    else if (_result != BehaviorUpdateResult::Running)
     {
         Finished();
     }

--- a/Source/Engine/AI/BehaviorTreeNodes.h
+++ b/Source/Engine/AI/BehaviorTreeNodes.h
@@ -96,6 +96,10 @@ API_CLASS(Sealed) class FLAXENGINE_API BehaviorTreeRootNode : public BehaviorTre
     // The target amount of the behavior logic updates per second.
     API_FIELD(Attributes="EditorOrder(100)")
     float UpdateFPS = 10.0f;
+
+    // Whether to loop the root node.
+    API_FIELD(Attributes="EditorOrder(200)")
+    bool Loop = true;
 };
 
 /// <summary>


### PR DESCRIPTION
Will loop the tree forever until stop is called if Loop is checked in the root node. This will also keep the state of the knowledge without re-initializing it.