### PR TITLE
Add ribbon menu buttons to quick open product local folder

### DIFF
--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -78,6 +78,7 @@ namespace FlaxEditor.Modules
         private ContextMenuButton _menuToolsProfilerWindow;
         private ContextMenuButton _menuToolsSetTheCurrentSceneViewAsDefault;
         private ContextMenuButton _menuToolsTakeScreenshot;
+        private ContextMenuButton _menuToolsOpenLocalFolder;
         private ContextMenuChildMenu _menuWindowApplyWindowLayout;
 
         private ToolStripButton _toolStripSaveAll;
@@ -623,6 +624,13 @@ namespace FlaxEditor.Modules
             _menuToolsTakeScreenshot = cm.AddButton("Take screenshot", inputOptions.TakeScreenshot, Editor.Windows.TakeScreenshot);
             cm.AddSeparator();
             cm.AddButton("Plugins", () => Editor.Windows.PluginsWin.Show());
+            cm.AddSeparator();
+            var childMenu = cm.AddChildMenu("Open product local folder");
+            childMenu.ContextMenu.AddButton("Editor", () => FileSystem.ShowFileExplorer(Globals.ProductLocalFolder));
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            GameSettings settings = GameSettings.Load<GameSettings>();
+            string path = Path.Combine(localAppData, settings.CompanyName, settings.ProductName);
+            _menuToolsOpenLocalFolder = childMenu.ContextMenu.AddButton("Cooked game", () => FileSystem.ShowFileExplorer(path));
 
             // Window
             MenuWindow = MainMenu.AddButton("Window");
@@ -949,6 +957,10 @@ namespace FlaxEditor.Modules
             _menuToolsBuildNavMesh.Enabled = canEdit;
             _menuToolsCancelBuilding.Enabled = GameCooker.IsRunning;
             _menuToolsSetTheCurrentSceneViewAsDefault.Enabled = Level.ScenesCount > 0;
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            GameSettings settings = GameSettings.Load<GameSettings>();
+            string path = Path.Combine(localAppData, settings.CompanyName, settings.ProductName);
+            _menuToolsOpenLocalFolder.Enabled = Directory.Exists(path);
 
             c.PerformLayout();
         }


### PR DESCRIPTION
This would have been super useful when debugging issues related to f.e. a save system or other data that is stored in the local folder.
When dealing with that I always felt like a quick and reliable way to open that folder would make the whole process a lot easier.

<img width="460" height="452" alt="image" src="https://github.com/user-attachments/assets/faee31a8-22f0-4097-a514-489b37748101" />

There is an `Editor` and a `Cooked game` option, because the path of `Globals.ProductLocalFolder` is different in editor vs. a cooked game.

I have only tested this on windows, but the api used looks like it accounts for different operating systems.
