### PR TITLE
Fix view distance light property from affecting brightness all of the time.

### DIFF
--- a/Source/Engine/Level/Actors/Light.h
+++ b/Source/Engine/Level/Actors/Light.h
@@ -63,7 +63,8 @@ protected:
         {
             const float dst2 = (float)Vector3::DistanceSquared(viewPosition, position);
             const float dst = Math::Sqrt(dst2);
-            brightness *= Math::Remap(dst, 0.9f * ViewDistance, ViewDistance, 1.0f, 0.0f);
+            if (dst < ViewDistance && dst > ViewDistance * 0.9f)
+                brightness *= Math::Remap(dst, 0.9f * ViewDistance, ViewDistance, 1.0f, 0.0f);
             return dst < ViewDistance;
         }
         return true;


### PR DESCRIPTION
Keeps the distance fade but only affects it for the first 10 percent of distance, but fixes the light brightness from being affected by view distance for the rest of the distance.

Fix #3662 