### PR TITLE
Add being able to move move Visject nodes in smaller increments (& some smaller fixes/ improvements related to changing selected box with arrow keys))

### DIFF
--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -777,11 +777,8 @@ namespace FlaxEditor.Surface
                     if (selectedBox != null)
                     {
                         Box toSelect = null;
-                        if ((key == KeyboardKeys.ArrowRight && selectedBox.IsOutput) || (key == KeyboardKeys.ArrowLeft && !selectedBox.IsOutput))
+                        if (((key == KeyboardKeys.ArrowRight && selectedBox.IsOutput) || (key == KeyboardKeys.ArrowLeft && !selectedBox.IsOutput)) && selectedBox.HasAnyConnection)
                         {
-                            if (_selectedConnectionIndex < 0 || _selectedConnectionIndex >= selectedBox.Connections.Count)
-                                _selectedConnectionIndex = 0;
-
                             toSelect = selectedBox.Connections[_selectedConnectionIndex];
                         }
                         else

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -721,7 +721,12 @@ namespace FlaxEditor.Surface
 
             if (HasNodesSelection)
             {
-                var keyMoveRange = 50;
+                var keyMoveDelta = 50;
+                bool altDown = RootWindow.GetKey(KeyboardKeys.Alt);
+                bool shiftDown = RootWindow.GetKey(KeyboardKeys.Shift);
+                if (altDown || shiftDown)
+                    keyMoveDelta = shiftDown ? 10 : 25;
+
                 switch (key)
                 {
                 case KeyboardKeys.Backspace:
@@ -759,7 +764,7 @@ namespace FlaxEditor.Surface
                     else if (!IsMovingSelection && CanEdit)
                     {
                         // Move selected nodes
-                        var delta = new Float2(0, key == KeyboardKeys.ArrowUp ? -keyMoveRange : keyMoveRange);
+                        var delta = new Float2(0, key == KeyboardKeys.ArrowUp ? -keyMoveDelta : keyMoveDelta);
                         MoveSelectedNodes(delta);
                     }
                     return true;
@@ -775,9 +780,8 @@ namespace FlaxEditor.Surface
                         if ((key == KeyboardKeys.ArrowRight && selectedBox.IsOutput) || (key == KeyboardKeys.ArrowLeft && !selectedBox.IsOutput))
                         {
                             if (_selectedConnectionIndex < 0 || _selectedConnectionIndex >= selectedBox.Connections.Count)
-                            {
                                 _selectedConnectionIndex = 0;
-                            }
+
                             toSelect = selectedBox.Connections[_selectedConnectionIndex];
                         }
                         else
@@ -805,7 +809,7 @@ namespace FlaxEditor.Surface
                     else if (!IsMovingSelection && CanEdit)
                     {
                         // Move selected nodes
-                        var delta = new Float2(key == KeyboardKeys.ArrowLeft ? -keyMoveRange : keyMoveRange, 0);
+                        var delta = new Float2(key == KeyboardKeys.ArrowLeft ? -keyMoveDelta : keyMoveDelta, 0);
                         MoveSelectedNodes(delta);
                     }
                     return true;
@@ -821,13 +825,9 @@ namespace FlaxEditor.Surface
                         return true;
 
                     if (Root.GetKey(KeyboardKeys.Shift))
-                    {
                         _selectedConnectionIndex = ((_selectedConnectionIndex - 1) % connectionCount + connectionCount) % connectionCount;
-                    }
                     else
-                    {
                         _selectedConnectionIndex = (_selectedConnectionIndex + 1) % connectionCount;
-                    }
                     return true;
                 }
                 }

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -754,12 +754,13 @@ namespace FlaxEditor.Surface
                     Box selectedBox = GetSelectedBox(SelectedNodes);
                     if (selectedBox != null)
                     {
-                        Box toSelect = (key == KeyboardKeys.ArrowUp) ? selectedBox?.ParentNode.GetPreviousBox(selectedBox) : selectedBox?.ParentNode.GetNextBox(selectedBox);
-                        if (toSelect != null && toSelect.IsOutput == selectedBox.IsOutput)
-                        {
-                            Select(toSelect.ParentNode);
-                            toSelect.ParentNode.SelectBox(toSelect);
-                        }
+                        int delta = key == KeyboardKeys.ArrowDown ? 1 : -1;
+                        List<Box> boxes = selectedBox.ParentNode.GetBoxes().FindAll(b => b.IsOutput == selectedBox.IsOutput);
+                        int selectedIndex = boxes.IndexOf(selectedBox);
+                        Box toSelect = boxes[Mathf.Wrap(selectedIndex + delta, 0, boxes.Count - 1)];
+
+                        Select(toSelect.ParentNode);
+                        toSelect.ParentNode.SelectBox(toSelect);
                     }
                     else if (!IsMovingSelection && CanEdit)
                     {


### PR DESCRIPTION
### Smaller move distance
This pr makes it able to move visject nodes using the arrow keys in smaller increments.
I found the current default value to be a bit much per key press, but its also useful for moving nodes large distances. That's why this pr adds holding shift or alt + arrow keys to move the selected nodes over smaller distances.

### Fix
This pr also fixes an error that occurred when changing the selected box with the arrow left/ right key:
```
[ 00:00:10.723 ]: Exception has been thrown during Window.OnKeyDown. Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
Stack strace:
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at FlaxEditor.Surface.VisjectSurface.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Editor\Surface\VisjectSurface.Input.cs:line 781
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEditor.GUI.Docking.DockWindow.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Editor\GUI\Docking\DockWindow.cs:line 475
   at FlaxEditor.Windows.EditorWindow.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Editor\Windows\EditorWindow.cs:line 278
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at FlaxEngine.GUI.ContainerControl.OnKeyDown(KeyboardKeys key) in F:\FlaxDev\FlaxEngine\Source\Engine\UI\GUI\ContainerControl.cs:line 1213
   at lambda_method744(Closure, Window, KeyboardKeys&)
   at FlaxEngine.Interop.NativeInterop.Invoker.InvokerNoRet1`2.MarshalAndInvoke(Object delegateContext, ManagedHandle instancePtr, IntPtr paramPtr) in F:\FlaxDev\FlaxEngine\Source\Engine\Engine\NativeInterop.Invoker.cs:line 334
   at FlaxEngine.Interop.NativeInterop.InvokeMethod(ManagedHandle instanceHandle, ManagedHandle methodHandle, IntPtr paramPtr, IntPtr exceptionPtr) in F:\FlaxDev\FlaxEngine\Source\Engine\Engine\NativeInterop.Unmanaged.cs:line 724
[ 00:00:10.723 ]: Exception has been thrown during Window.OnKeyDown.
Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
```

### Changing selected box with arrow up/ down keys loop
This pr also makes changing the selected box with the arrow up/ down key loop over the node, similar to changing the box with the left and right key.
This means that if the most bottom box in a node is reached, it will select the topmost box in the node when the user presses arrow down again.