### PR TITLE
Remove lingering create script items when add script menu is cleared after query did not match any existing script (& fixes and polish)

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -117,10 +117,10 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 if (!IsValidScriptName(text))
                 {
                     // Remove NewScriptItems
-                    List<Control> die = cm.ItemsPanel.Children.FindAll(c => c is NewScriptItem);
-                    foreach (var c in die)
+                    List<Control> newScriptItems = cm.ItemsPanel.Children.FindAll(c => c is NewScriptItem);
+                    foreach (var item in newScriptItems)
                     {
-                        cm.ItemsPanel.RemoveChild(c);
+                        cm.ItemsPanel.RemoveChild(item);
                     }
 
                     return;

--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -70,7 +70,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
             var buttonHeight = (textSize.Y < 18) ? 18 : textSize.Y + 4;
             _addScriptsButton = new Button
             {
-                TooltipText = "Add new scripts to the actor",
+                TooltipText = "Add new scripts to the actor.",
                 AnchorPreset = AnchorPresets.MiddleCenter,
                 Text = buttonText,
                 Parent = this,
@@ -114,7 +114,16 @@ namespace FlaxEditor.CustomEditors.Dedicated
             cm.TextChanged += text =>
             {
                 if (!IsValidScriptName(text))
+                {
+                    // Remove NewScriptItems
+                    List<Control> die = cm.ItemsPanel.Children.FindAll(c => c is NewScriptItem);
+                    foreach (var c in die)
+                    {
+                        cm.ItemsPanel.RemoveChild(c);
+                    }
+
                     return;
+                }
                 if (!cm.ItemsPanel.Children.Any(x => x.Visible && x is not NewScriptItem))
                 {
                     // If there are no visible items, that means the search failed so we can find the create script button or create one if it's the first time
@@ -876,7 +885,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 // Add drag button to the group
                 var scriptDrag = new DragImage
                 {
-                    TooltipText = "Script reference",
+                    TooltipText = "Script reference.",
                     AutoFocus = true,
                     IsScrollable = false,
                     Color = FlaxEngine.GUI.Style.Current.ForegroundGrey,

--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -36,6 +36,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
         {
             ScriptName = scriptName;
             TooltipText = "Create a new script";
+            DrawHighlights = false;
         }
     }
 

--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -52,6 +52,11 @@ namespace FlaxEditor.GUI
             public float SortScore;
 
             /// <summary>
+            /// Wether the query highlights should be draw.
+            /// </summary>
+            public bool DrawHighlights = true;
+
+            /// <summary>
             /// Occurs when items gets clicked by the user.
             /// </summary>
             public event Action<Item> Clicked;
@@ -165,7 +170,7 @@ namespace FlaxEditor.GUI
                     Render2D.FillRectangle(new Rectangle(Float2.Zero, Size), style.BackgroundHighlighted);
 
                 // Draw all highlights
-                if (_highlights != null)
+                if (DrawHighlights && _highlights != null)
                 {
                     var color = style.ProgressNormal * 0.6f;
                     for (int i = 0; i < _highlights.Count; i++)

--- a/Source/Editor/Windows/Profiler/Timeline.cs
+++ b/Source/Editor/Windows/Profiler/Timeline.cs
@@ -100,6 +100,7 @@ namespace FlaxEditor.Windows.Profiler
         /// Timeline track label
         /// </summary>
         /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
+        [HideInEditor]
         public class TrackLabel : ContainerControl
         {
             /// <summary>

--- a/Source/Editor/Windows/Profiler/Timeline.cs
+++ b/Source/Editor/Windows/Profiler/Timeline.cs
@@ -100,7 +100,6 @@ namespace FlaxEditor.Windows.Profiler
         /// Timeline track label
         /// </summary>
         /// <seealso cref="FlaxEngine.GUI.ContainerControl" />
-        [HideInEditor]
         public class TrackLabel : ContainerControl
         {
             /// <summary>


### PR DESCRIPTION
### Remove create new script items when searchbox is cleared using backspace

*Before:*
<img width="284" height="160" alt="image" src="https://github.com/user-attachments/assets/9986776a-b0b5-462d-a954-8a67612cb418" />

*Now:*
<img width="242" height="137" alt="image" src="https://github.com/user-attachments/assets/8e76591e-c647-4160-b124-d941d02a558e" />


### Don't show search query highlights on new script items
*Fixed:*
<img width="256" height="91" alt="image" src="https://github.com/user-attachments/assets/37b00e3c-8fa2-4f33-bd9d-e8247978480a" />

*Before:*
<img width="271" height="121" alt="image" src="https://github.com/user-attachments/assets/76b6a652-eb3b-4fee-86e9-00f52df3fb3d" />


