### PR TITLE
Check if control is control meant for gui editor use in "Create Widget" dialog 

### DIFF
--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using System;
+using System.Linq;
 using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -117,7 +118,8 @@ namespace FlaxEditor.Content.Create
 
             private static bool IsValid(Type type)
             {
-                return (type.IsPublic || type.IsNestedPublic) && !type.IsAbstract && !type.IsGenericType;
+                var controlTypes = Editor.Instance.CodeEditing.Controls.Get();
+                return (type.IsPublic || type.IsNestedPublic) && !type.IsAbstract && !type.IsGenericType && controlTypes.Any(c => c.Type == type);
             }
         }
 

--- a/Source/Editor/Content/Create/PrefabCreateEntry.cs
+++ b/Source/Editor/Content/Create/PrefabCreateEntry.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using System;
-using System.Linq;
 using FlaxEditor.Scripting;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -119,7 +118,7 @@ namespace FlaxEditor.Content.Create
             private static bool IsValid(Type type)
             {
                 var controlTypes = Editor.Instance.CodeEditing.Controls.Get();
-                return (type.IsPublic || type.IsNestedPublic) && !type.IsAbstract && !type.IsGenericType && controlTypes.Any(c => c.Type == type);
+                return (type.IsPublic || type.IsNestedPublic) && !type.IsAbstract && !type.IsGenericType && controlTypes.Contains(new ScriptType(type));
             }
         }
 


### PR DESCRIPTION
This pr fixes a bug where the user is able to create a widget with a base control of *any* class that is a control, even ones that are hidden in the gui editor.

*Before:*
<img width="522" height="418" alt="image" src="https://github.com/user-attachments/assets/591a7e8d-2361-43cb-801c-f912370a15e8" />


*After:*
<img width="524" height="420" alt="image" src="https://github.com/user-attachments/assets/252bd356-ad9a-484c-af26-4ab9aa632cff" />
