### PR TITLE
Unify both "too many audio listeners"- warnings

### DIFF
--- a/Source/Engine/Audio/AudioListener.cpp
+++ b/Source/Engine/Audio/AudioListener.cpp
@@ -37,15 +37,14 @@ void AudioListener::OnEnable()
 {
     _prevPos = GetPosition();
     _velocity = Vector3::Zero;
+
+    ASSERT(!Audio::Listeners.Contains(this));
     if (Audio::Listeners.Count() >= AUDIO_MAX_LISTENERS)
     {
-        LOG(Error, "Unsupported amount of the audio listeners!");
+        LOG(Warning, "There is more than one Audio Listener active. Please make sure only exactly one is active at any given time.");
     }
     else
     {
-        ASSERT(!Audio::Listeners.Contains(this));
-        if (Audio::Listeners.Count() > 0)
-            LOG(Warning, "There is more than one Audio Listener active. Please make sure only exactly one is active at any given time.");
         Audio::Listeners.Add(this);
         AudioBackend::Listener::Reset();
         AudioBackend::Listener::TransformChanged(GetPosition(), GetOrientation());


### PR DESCRIPTION
One checked if there are more or equal `AUDIO_MAX_LISTENERS`s (= 1) listeners and the other one checked if there already is one registered.

The first one would always fire when there is more than one listener in the scene, so I replaced the if- condition of the second one with the check for the first one.

*Look at the code, it's prolly a lot more easy to understand than my explanation*

Also, maybe I am missing something here, but this makes a lot more sense to me than what was there previously.