### PR TITLE
Make particle age/ lifetime nodes more clear

### DIFF
--- a/Source/Editor/Surface/Archetypes/Particles.cs
+++ b/Source/Editor/Surface/Archetypes/Particles.cs
@@ -436,10 +436,11 @@ namespace FlaxEditor.Surface.Archetypes
             new NodeArchetype
             {
                 TypeID = 102,
-                Title = "Particle Lifetime",
-                Description = "Particle lifetime (in seconds).",
+                Title = "Total Lifetime",
+                Description = "Total particle lifetime (in seconds), assigned when the particle is created. Always the same, no matter the particles age.",
+                AlternativeTitles = new[] { "Age" },
                 Flags = NodeFlags.MaterialGraph | NodeFlags.ParticleEmitterGraph,
-                Size = new Float2(200, 30),
+                Size = new Float2(180, 30),
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Output(0, string.Empty, typeof(float), 0),
@@ -449,9 +450,10 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 103,
                 Title = "Particle Age",
-                Description = "Particle age (in seconds).",
+                Description = "Particle age (in seconds). How long the particle has been alive since it was created.",
+                AlternativeTitles = new[] { "Lifetime" },
                 Flags = NodeFlags.MaterialGraph | NodeFlags.ParticleEmitterGraph,
-                Size = new Float2(200, 30),
+                Size = new Float2(170, 30),
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Output(0, string.Empty, typeof(float), 0),
@@ -533,9 +535,10 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 110,
                 Title = "Particle Normalized Age",
-                Description = "Particle normalized age to range 0-1 (age divided by lifetime).",
+                Description = "Particle normalized age represented as from 0 (max lifetime) - 1 (max age) (age divided by lifetime).",
+                AlternativeTitles = new[] { "Lifetime" },
                 Flags = NodeFlags.MaterialGraph | NodeFlags.ParticleEmitterGraph,
-                Size = new Float2(230, 30),
+                Size = new Float2(250, 30),
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Output(0, string.Empty, typeof(float), 0),


### PR DESCRIPTION
**You can find the changes made listed out below, feel free to give me your opinions on them :)**

This pr aims to make particle age/ lifetime related nodes more clear in what they do and what differentiates them (for reasons look at #3308).

It also adjusts the size of the nodes to make them more visually pleasing.

There are some new alternative titles/ names for the nodes, so that every node can be found just by searching "Age" or "Lifetime", which should further minimize confusion, since all options are immediately shown, and the new names and descriptions are more clear.

*New:*
<img width="301" height="327" alt="image" src="https://github.com/user-attachments/assets/062621b5-2830-4566-a825-5624cc4fcbfa" />


### Total Lifetime
Previous name: `Particle Lifetime`
Previous description: `Particle lifetime (in seconds).`
New name: `Total Lifetime`
New description: `Total particle lifetime (in seconds), assigned when the particle is created. Always the same, no matter the particles age.`


### Particle Age
Previous description: `Particle age (in seconds).`
New description: `Particle age (in seconds). How long the particle has been alive since it was created.`


### Particle Normalized Age
Previous description: `Particle normalized age to range 0-1 (age divided by lifetime).`
New description: `Particle normalized age represented as from 0 (max lifetime) - 1 (max age) (age divided by lifetime).`

In case you want to see what the nodes to for yourself, you can create a new "Constant Burst" particle emitter and modify it like this:
<img width="1089" height="839" alt="image" src="https://github.com/user-attachments/assets/73f897b2-7b2c-41d2-b1f6-14f7fa2695aa" />

Now connect the different particle lifetime/ age nodes to the color ramp and set the lifetime to something between 0 - 1.
Or you download that emitter here:
[LifetimeStuff.zip](https://github.com/user-attachments/files/22429499/LifetimeStuff.zip)



Closes #3308.