### PR TITLE
Add Game View and show/ hiding Navigation debug draw similar to unreal engine

### DIFF
--- a/Source/Editor/Gizmo/TransformGizmo.cs
+++ b/Source/Editor/Gizmo/TransformGizmo.cs
@@ -31,6 +31,7 @@ namespace FlaxEditor.Gizmo
 
         private readonly List<SceneGraphNode> _selection = new List<SceneGraphNode>();
         private readonly List<SceneGraphNode> _selectionParents = new List<SceneGraphNode>();
+        private bool _visible = true;
 
         /// <summary>
         /// The event to apply objects transformation.
@@ -51,6 +52,11 @@ namespace FlaxEditor.Gizmo
         /// Gets the array of selected parent objects (as actors).
         /// </summary>
         public List<SceneGraphNode> SelectedParents => _selectionParents;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="TransformGizmo"/> is visible.
+        /// </summary>
+        public bool Visible { get { return _visible; } set { _visible = value; } }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TransformGizmo" /> class.
@@ -270,6 +276,13 @@ namespace FlaxEditor.Gizmo
             SceneGraphTools.BuildNodesParents(_selection, _selectionParents);
 
             base.OnSelectionChanged(newSelection);
+        }
+
+        /// <inheritdoc />
+        public override void Draw(ref RenderContext renderContext)
+        {
+            if (Visible)
+                base.Draw(ref renderContext);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -387,6 +387,14 @@ namespace FlaxEditor.Options
         [EditorDisplay("Viewport"), EditorOrder(1760)]
         public InputBinding ToggleOrthographic = new InputBinding(KeyboardKeys.NumpadDecimal);
 
+        [DefaultValue(typeof(InputBinding), "G")]
+        [EditorDisplay("Viewport"), EditorOrder(1770)]
+        public InputBinding ToggleGameView = new InputBinding(KeyboardKeys.G);
+
+        [DefaultValue(typeof(InputBinding), "P")]
+        [EditorDisplay("Viewport"), EditorOrder(1770)]
+        public InputBinding ToggleNavMeshVisibility = new InputBinding(KeyboardKeys.P);
+
         #endregion
 
         #region Debug Views

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -108,6 +108,12 @@ namespace FlaxEditor.Viewport
         private EditorSpritesRenderer _editorSpritesRenderer;
         private ViewportRubberBandSelector _rubberBandSelector;
 
+        private bool _gameViewActive;
+        private ViewFlags _preGameViewFlags;
+        private bool _gameViewWasGridShown;
+        private bool _gameViewWasFpsCounterShown;
+        private bool _gameViewWasNagivationShown;
+
         /// <summary>
         /// Drag and drop handlers
         /// </summary>
@@ -259,6 +265,29 @@ namespace FlaxEditor.Viewport
             InputActions.Add(options => options.FocusSelection, FocusSelection);
             InputActions.Add(options => options.RotateSelection, RotateSelection);
             InputActions.Add(options => options.Delete, _editor.SceneEditing.Delete);
+            InputActions.Add(options => options.ToggleNavMeshVisibility, () => ShowNavigation = !ShowNavigation);
+
+            // Game View
+            InputActions.Add(options => options.ToggleGameView, () =>
+            {
+                if (!_gameViewActive)
+                {
+                    _preGameViewFlags = Task.ViewFlags;
+                    _gameViewWasGridShown = ShowFpsCounter;
+                    _gameViewWasFpsCounterShown = ShowNavigation;
+                    _gameViewWasNagivationShown = Grid.Enabled;
+                }
+
+                Task.ViewFlags = _gameViewActive ? _preGameViewFlags : ViewFlags.GameView;
+                ShowFpsCounter = _gameViewActive ? _gameViewWasGridShown : false;
+                ShowNavigation = _gameViewActive ? _gameViewWasFpsCounterShown : false;
+                Grid.Enabled = _gameViewActive ? _gameViewWasNagivationShown : false;
+
+                _gameViewActive = !_gameViewActive;
+
+                TransformGizmo.Visible = !_gameViewActive;
+                SelectionOutline.ShowSelectionOutline = !_gameViewActive;
+            });
         }
 
         /// <inheritdoc />

--- a/Source/Engine/Graphics/Enums.h
+++ b/Source/Engine/Graphics/Enums.h
@@ -1082,6 +1082,11 @@ API_ENUM(Attributes="Flags") enum class ViewFlags : uint64
     /// Default flags for materials/models previews generating.
     /// </summary>
     DefaultAssetPreview = Reflections | Decals | DirectionalLights | PointLights | SpotLights | SkyLights | SpecularLight | AntiAliasing | Bloom | ToneMapping | EyeAdaptation | CameraArtifacts | LensFlares | ContactShadows | Sky,
+    
+    /// <summary>
+    /// Default flags for game view.
+    /// </summary>
+    GameView = AntiAliasing | Shadows | Reflections | SSR | AO | GI | DirectionalLights | PointLights | SpotLights | SkyLights | Sky | Fog | SpecularLight | Decals | CustomPostProcess | Bloom | ToneMapping | EyeAdaptation | CameraArtifacts | LensFlares | MotionBlur | ContactShadows | DepthOfField,
 };
 
 DECLARE_ENUM_OPERATORS(ViewFlags);


### PR DESCRIPTION
Adds a game view functionality similar to unreal engine and toggling navigation debug draw similar to unreal engine. Can be accessed via keyboard shortcuts (G for game view, P for navigation, changeable in Input Editor Settings).

Game view restores previous View Flags and grid/ fps counter/ navigation visibility after it is disabled.

I remember missing this feature a lot of times and also people requesting it on the discord.

https://github.com/user-attachments/assets/e66ef032-acfd-497e-b2c9-6983b1ed622e

