### PR TITLE
Add industry standard shortcut for editor settings

### DIFF
--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -669,7 +669,7 @@ namespace FlaxEditor.Modules
                 if (item != null)
                     Editor.ContentEditing.Open(item);
             });
-            cm.AddButton("Editor Options", () => Editor.Windows.EditorOptionsWin.Show());
+            cm.AddButton("Editor Options", inputOptions.EditorOptionsWindow, () => Editor.Windows.EditorOptionsWin.Show());
 
             // Scene
             MenuScene = MainMenu.AddButton("Scene");

--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -650,6 +650,10 @@ namespace FlaxEditor.Options
         [EditorDisplay("Windows"), EditorOrder(4020)]
         public InputBinding VisualScriptDebuggerWindow = new InputBinding(KeyboardKeys.None);
 
+        [DefaultValue(typeof(InputBinding), "Control+Comma")]
+        [EditorDisplay("Windows"), EditorOrder(4030)]
+        public InputBinding EditorOptionsWindow = new InputBinding(KeyboardKeys.Comma, KeyboardKeys.Control);
+
         #endregion
 
         #region Node Editors

--- a/Source/Editor/Windows/EditorWindow.cs
+++ b/Source/Editor/Windows/EditorWindow.cs
@@ -116,6 +116,11 @@ namespace FlaxEditor.Windows
                 if (InputOptions.WindowShortcutsAvaliable)
                     Editor.Windows.VisualScriptDebuggerWin.FocusOrShow();
             });
+            InputActions.Add(options => options.EditorOptionsWindow, () =>
+            {
+                if (InputOptions.WindowShortcutsAvaliable)
+                    Editor.Windows.EditorOptionsWin.FocusOrShow();
+            });
 
             // Register
             Editor.Windows.OnWindowAdd(this);


### PR DESCRIPTION
I have recently discovered this shortcut and have been using it a bunch in other programs like Ableton or Blender to access the options. Now this shortcut works in Flax as well.

I thought about adding a similar shortcut for the Game Settings, but those can always be accessed via the quick search (Control + O).

<img width="391" height="379" alt="image" src="https://github.com/user-attachments/assets/65c7e4e9-6c64-4591-adcf-28b08e66c988" />

<img width="944" height="337" alt="image" src="https://github.com/user-attachments/assets/8409b3c0-203f-4f6b-a832-dc135e8aad55" />
