### PR TITLE
Add editor option for Header text alignment and add some margin/ padding

### DIFF
--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -347,7 +347,7 @@ namespace FlaxEditor.CustomEditors
             var size = element.Label.Font.GetFont().MeasureText(header.Text);
             element.Label.Height = size.Y;
             element.Label.HorizontalAlignment = Editor.Instance.Options.Options.Interface.HeaderTextAlignment;
-            element.Label.Margin = new Margin(3);
+            element.Label.Margin = new Margin(Utilities.Constants.UIMargin);
             return element;
         }
 

--- a/Source/Editor/CustomEditors/LayoutElementsContainer.cs
+++ b/Source/Editor/CustomEditors/LayoutElementsContainer.cs
@@ -332,6 +332,8 @@ namespace FlaxEditor.CustomEditors
         {
             var element = Label(text);
             element.Label.Font = new FontReference(Style.Current.FontLarge);
+            element.Label.HorizontalAlignment = Editor.Instance.Options.Options.Interface.HeaderTextAlignment;
+            element.Label.Margin = new Margin(3);
             return element;
         }
 
@@ -344,6 +346,8 @@ namespace FlaxEditor.CustomEditors
                 element.Label.TextColor = Color.FromRGB(header.Color);
             var size = element.Label.Font.GetFont().MeasureText(header.Text);
             element.Label.Height = size.Y;
+            element.Label.HorizontalAlignment = Editor.Instance.Options.Options.Interface.HeaderTextAlignment;
+            element.Label.Margin = new Margin(3);
             return element;
         }
 

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -264,7 +264,7 @@ namespace FlaxEditor.Options
         /// <summary>
         /// Gets or sets header text alignment.
         /// </summary>
-        [DefaultValue(TextAlignment.Center)]
+        [DefaultValue(TextAlignment.Near)]
         [EditorDisplay("Interface"), EditorOrder(322)]
         public TextAlignment HeaderTextAlignment = TextAlignment.Near;
 

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -262,10 +262,17 @@ namespace FlaxEditor.Options
         private TextAlignment _tooltipTextAlignment = TextAlignment.Center;
 
         /// <summary>
+        /// Gets or sets header text alignment.
+        /// </summary>
+        [DefaultValue(TextAlignment.Center)]
+        [EditorDisplay("Interface"), EditorOrder(322)]
+        public TextAlignment HeaderTextAlignment = TextAlignment.Near;
+
+        /// <summary>
         /// Whether to scroll to the script when a script is added to an actor.
         /// </summary>
         [DefaultValue(true)]
-        [EditorDisplay("Interface"), EditorOrder(322)]
+        [EditorDisplay("Interface"), EditorOrder(323)]
         public bool ScrollToScriptOnAdd { get; set; } = true;
 
 #if PLATFORM_WINDOWS


### PR DESCRIPTION
Adds a text alignment option to the editor options as well as some margin to headers to make them look nicer.
I added this because I don't like having my headers aligned left and I think center alignment is better for readability and makes the header stand out more from the other properties.
I also don't think this is something that should be specifieable per header attribute. Having it as an editor option allows everyone to set it to whatever they prefer.

Center alignment:
<img width="364" height="230" alt="image" src="https://github.com/user-attachments/assets/025fd3d4-d46b-4784-a2df-75ef4a8cfbb4" />
<img width="350" height="297" alt="image" src="https://github.com/user-attachments/assets/0302cac3-d50d-40f8-9fad-03f1c1c8f9ca" />
<img width="255" height="115" alt="image" src="https://github.com/user-attachments/assets/b52a2339-03f9-435e-80f6-2757ee61abec" />