### PR TITLE
Add incrementing/ decrementing value boxe's value with arrow keys

### DIFF
--- a/Source/Editor/GUI/Input/ValueBox.cs
+++ b/Source/Editor/GUI/Input/ValueBox.cs
@@ -252,7 +252,7 @@ namespace FlaxEditor.GUI.Input
                 bool altDown = Root.GetKey(KeyboardKeys.Alt);
                 bool shiftDown = Root.GetKey(KeyboardKeys.Shift);
                 bool controlDown = Root.GetKey(KeyboardKeys.Control);
-                float deltaValue = altDown ? 0.1f : (shiftDown ? 10f : (controlDown ? 100f : 1));
+                float deltaValue = altDown ? 0.1f : (shiftDown ? 10f : (controlDown ? 100f : 1f));
                 float slideDelta = key == KeyboardKeys.ArrowUp ? deltaValue : -deltaValue;
 
                 _startSlideValue = Value;


### PR DESCRIPTION
Does what the title says.

Useful when you want to modify a value by a precise amount (1 by default, holding alt/ shift/ control allows you to change how much the value changes to 0.1/ 10/ 100).

I encountered a few times now where I missed this feature, so I decided to pr it in.