### PR TITLE
Allow entering numbers with digit separator into value boxes (f.e. 1_000)

### DIFF
--- a/Source/Editor/Utilities/ShuntingYardParser.cs
+++ b/Source/Editor/Utilities/ShuntingYardParser.cs
@@ -444,6 +444,9 @@ namespace FlaxEditor.Utilities
         /// <returns>The result value.</returns>
         public static double Parse(string text)
         {
+            // Hack to allow parsing numbers while using "_" as a separator (like this: 1_000)
+            text = text.Replace("_", string.Empty);
+
             var tokens = Tokenize(text);
             var rpn = OrderTokens(tokens);
             return EvaluateRPN(rpn);


### PR DESCRIPTION
Allow entering numbers with digit separator into value boxes (f.e. 100_000_000).

Useful when dealing with large numbers or copy pasting numbers between C# in your IDE and the Flax editor.

I like to use "_" to separate numbers because it makes it easier to read them, now this can be done in Flax as well.
This notation is also supported in C# [since C#7](https://devblogs.microsoft.com/dotnet/new-features-in-c-7-0/#literal-improvements).

Please take a look at the code, it's *a bit* hacky, but it works and does not modify the underlying algorithm.

Closes #3330