### PR TITLE
Fix group element header text clipping

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -909,7 +909,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 settingsButton.Tag = script;
                 settingsButton.Clicked += OnSettingsButtonClicked;
 
-                group.Panel.HeaderTextMargin = new Margin(scriptDrag.Right - 12, 15, 2, 2);
+                // Adjust margin to not overlap with other ui elements in the header
+                group.Panel.HeaderTextMargin = group.Panel.HeaderTextMargin with { Left = scriptDrag.Right - 12, Right = settingsButton.Width + Utilities.Constants.UIMargin };
                 group.Object(values, editor);
                 // Remove drop down arrows and containment lines if no objects in the group
                 if (group.Children.Count == 0)

--- a/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
@@ -44,7 +44,8 @@ namespace FlaxEditor.CustomEditors.Elements
         {
             var style = Style.Current;
             var settingsButtonSize = Panel.HeaderHeight;
-            return new Image
+            Panel.HeaderTextMargin = Panel.HeaderTextMargin with { Right = settingsButtonSize + Utilities.Constants.UIMargin };
+;           return new Image
             {
                 TooltipText = "Settings",
                 AutoFocus = true,

--- a/Source/Engine/UI/GUI/Panels/DropPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/DropPanel.cs
@@ -361,7 +361,7 @@ namespace FlaxEngine.GUI
             var style = Style.Current;
             var enabled = EnabledInHierarchy;
 
-            // Paint Background
+            // Draw Background
             var backgroundColor = BackgroundColor;
             if (backgroundColor.A > 0.0f)
             {
@@ -388,7 +388,7 @@ namespace FlaxEngine.GUI
                     ArrowImageOpened?.Draw(dropDownRect, arrowColor);
             }
 
-            // Text
+            // Header text
             var textRect = new Rectangle(textLeft, 0, Width - textLeft, HeaderHeight);
             _headerTextMargin.ShrinkRectangle(ref textRect);
             var textColor = HeaderTextColor;
@@ -397,7 +397,9 @@ namespace FlaxEngine.GUI
                 textColor *= 0.6f;
             }
 
+            Render2D.PushClip(textRect);
             Render2D.DrawText(HeaderTextFont.GetFont(), HeaderTextMaterial, HeaderText, textRect, textColor, TextAlignment.Near, TextAlignment.Center);
+            Render2D.PopClip();
 
             if (!_isClosed && EnableContainmentLines)
             {


### PR DESCRIPTION
Fixes group element header text clipping outside of the header and into the settings icon (if there is one). Also some extra code to handle script editor, as that displays some extra icons in the header.

After:
<img width="164" height="108" alt="image" src="https://github.com/user-attachments/assets/c8d14e34-2088-4784-b2c4-c5f2b0ee1494" />

*(Tab title bar Title clipping into "x" button is something that still needs fixing)*
<img width="92" height="65" alt="image" src="https://github.com/user-attachments/assets/10c538c2-3924-4e3c-b8a5-cb22e164b2c3" />

