### PR TITLE
Fix Content Panel navigation bar scroll bar colors

### DIFF
--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -142,6 +142,7 @@ namespace FlaxEditor.Windows
         {
             Title = "Content";
             Icon = editor.Icons.Folder32;
+            var style = Style.Current;
 
             FlaxEditor.Utilities.Utils.SetupCommonInputActions(this);
 
@@ -164,6 +165,8 @@ namespace FlaxEditor.Windows
             _navigationBar = new NavigationBar
             {
                 Parent = _toolStrip,
+                ScrollbarTrackColor = style.Background,
+                ScrollbarThumbColor = style.ForegroundGrey,
             };
 
             // Split panel
@@ -179,7 +182,7 @@ namespace FlaxEditor.Windows
             var headerPanel = new ContainerControl
             {
                 AnchorPreset = AnchorPresets.HorizontalStretchTop,
-                BackgroundColor = Style.Current.Background,
+                BackgroundColor = style.Background,
                 IsScrollable = false,
                 Offsets = new Margin(0, 0, 0, 18 + 6),
             };


### PR DESCRIPTION
Fixes the scrollbar colors to be more visible against the dark background.

Related: 
- https://github.com/FlaxEngine/FlaxEngine/commit/b965ca6c8cb0d2c2faca2174177096a91628d2f5
- #3326

Same concept as in #2581.

<img width="228" height="92" alt="image" src="https://github.com/user-attachments/assets/4426ca73-314f-48a2-9ecd-313e92c4c605" />
