### PR TITLE
Spline editor improvements

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/SplineEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/SplineEditor.cs
@@ -219,7 +219,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     var size = Size;
                     var textHeight = 30.0f;
                     // Make icons smaller when tabs get thinner
-                    var iconSize = Mathf.Clamp(Mathf.Min(size.Y - textHeight, size.X), 15.0f, float.MaxValue);
+                    var iconSize = size.Y - textHeight;
                     var iconRect = new Rectangle((Width - iconSize) / 2, 0, iconSize, iconSize);
                     if (tab._mirrorIcon)
                     {
@@ -232,7 +232,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     var textRect = new Rectangle(0, size.Y - textHeight, size.X, textHeight);
                     Render2D.PushClip(new Rectangle(Float2.Zero, Size));
                     Render2D.DrawSprite(tab._customIcon, iconRect, color);
-                    Render2D.DrawText(style.FontMedium, tab._customText, textRect, color, TextAlignment.Center, TextAlignment.Center, TextWrapping.WrapWords);
+                    Render2D.DrawText(style.FontMedium, tab._customText, textRect, color, TextAlignment.Center, TextAlignment.Center, TextWrapping.WrapWords, 0.65f);
                     Render2D.PopClip();
                 }
             }


### PR DESCRIPTION
- Fix text clipping outside of "All Points" and "Selected Point" buttons
- Enable text wrapping on text and increase button height to make sure text fits even when buttons are narrow
- Move "Selected Point" buttons above spline keyframes array to make the buttons accessible without scrolling for an eternity when spline keyframes are expanded
- Move button groups into property panel groups

Before:
<img width="236" height="588" alt="image" src="https://github.com/user-attachments/assets/cd42a42e-fc40-4143-9a19-7c085751d433" />

After:
<img width="250" height="577" alt="image" src="https://github.com/user-attachments/assets/1591d5e5-8e02-44e4-b182-dfa7b1460f4f" />


