### PR TITLE
Make double clicking properties splitter bar auto resize split

### DIFF
--- a/Source/Editor/CustomEditors/GUI/PropertiesList.cs
+++ b/Source/Editor/CustomEditors/GUI/PropertiesList.cs
@@ -70,9 +70,9 @@ namespace FlaxEditor.CustomEditors.GUI
             UpdateSplitRect();
         }
 
-        private void AutoSizeSplitter()
+        private void AutoSizeSplitter(bool ignoreCustomSplitterValue = false)
         {
-            if (_hasCustomSplitterValue || !Editor.Instance.Options.Options.Interface.AutoSizePropertiesPanelSplitter)
+            if (_hasCustomSplitterValue && !ignoreCustomSplitterValue)
                 return;
 
             Font font = Style.Current.FontMedium;
@@ -179,6 +179,21 @@ namespace FlaxEditor.CustomEditors.GUI
         }
 
         /// <inheritdoc />
+        public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
+        {
+            if (button == MouseButton.Left && _splitterRect.Contains(location))
+            {
+                if (_splitterClicked)
+                    EndTracking();
+
+                AutoSizeSplitter(true);
+                return true;
+            }
+
+            return base.OnMouseDoubleClick(location, button);
+        }
+
+        /// <inheritdoc />
         public override bool OnMouseUp(Float2 location, MouseButton button)
         {
             if (_splitterClicked)
@@ -220,7 +235,8 @@ namespace FlaxEditor.CustomEditors.GUI
             // Refresh
             UpdateSplitRect();
             PerformLayout(true);
-            AutoSizeSplitter();
+            if (Editor.Instance.Options.Options.Interface.AutoSizePropertiesPanelSplitter)
+                AutoSizeSplitter();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Makes double clicking the Properties Panel splitter bar auto calculate the split value based on #3295.

Currently this does always auto resize, ignoring the editor settings.
I did it this way because I think some users don't enable the option added in #3295 because it adds a bit of visual clutter to the properties panel. This allows them to still auto resize the split if they need too.
Also I don't see why someone would need a double click to reset it to the default split of `0.4`, because that can be done by just dragging the bar and eyeballing it.

https://github.com/user-attachments/assets/750065a3-c380-4c44-b411-39fc85ba6e9e


