### PR TITLE
Add "*" to editor settings window title when settings are dirty

### DIFF
--- a/Source/Editor/Windows/EditorOptionsWindow.cs
+++ b/Source/Editor/Windows/EditorOptionsWindow.cs
@@ -45,7 +45,7 @@ namespace FlaxEditor.Windows
             {
                 Parent = this
             };
-            _saveButton = (ToolStripButton)toolstrip.AddButton(editor.Icons.Save64, SaveData).LinkTooltip("Save");
+            _saveButton = (ToolStripButton)toolstrip.AddButton(editor.Icons.Save64, SaveData).LinkTooltip("Save.");
             _saveButton.Enabled = false;
 
             _tabs = new Tabs
@@ -104,6 +104,8 @@ namespace FlaxEditor.Windows
             {
                 _saveButton.Enabled = true;
                 _isDataDirty = true;
+                if (!Title.EndsWith('*'))
+                    Title += "*";
             }
         }
 
@@ -113,6 +115,8 @@ namespace FlaxEditor.Windows
             {
                 _saveButton.Enabled = false;
                 _isDataDirty = false;
+                if (Title.EndsWith('*'))
+                    Title = Title.Remove(Title.Length - 1);
             }
         }
 


### PR DESCRIPTION
I don't know if this is the ideal way to do this, but it works.
This always super annoyed me, because I rely on that "*" being there to tell if the settings are dirty and need to be saved.

<img width="168" height="92" alt="image" src="https://github.com/user-attachments/assets/d3864f95-2c1f-4551-bf0f-36f49eeb1e5a" />

<img width="212" height="113" alt="image" src="https://github.com/user-attachments/assets/87e7ab4a-1abe-4eb2-b681-462c59fe1333" />
