### PR TITLE
Add ability for a collider to not have to be a direct child of a rigid body.

### DIFF
--- a/Source/Engine/Physics/Actors/RigidBody.h
+++ b/Source/Engine/Physics/Actors/RigidBody.h
@@ -488,6 +488,7 @@ public:
     void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
     void AddMovement(const Vector3& translation, const Quaternion& rotation) override;
 #if USE_EDITOR
+    void DrawColliders(Actor* a);
     void OnDebugDrawSelected() override;
 #endif
 

--- a/Source/Engine/Physics/Colliders/Collider.cpp
+++ b/Source/Engine/Physics/Colliders/Collider.cpp
@@ -53,7 +53,10 @@ void Collider::SetCenter(const Vector3& value)
     if (_staticActor)
         PhysicsBackend::SetShapeLocalPose(_shape, _center * GetScale(), Quaternion::Identity);
     else if (const RigidBody* rigidBody = GetAttachedRigidBody())
-        PhysicsBackend::SetShapeLocalPose(_shape, (_localTransform.Translation + _localTransform.Orientation * _center) * rigidBody->GetScale(), _localTransform.Orientation);
+    {
+        const Transform& t = rigidBody->GetTransform().WorldToLocal(GetTransform());
+        PhysicsBackend::SetShapeLocalPose(_shape, (t.Translation + t.Orientation * _center) * rigidBody->GetScale(), t.Orientation);
+    }
     UpdateBounds();
 }
 
@@ -135,7 +138,10 @@ RigidBody* Collider::GetAttachedRigidBody() const
 {
     if (_shape && _staticActor == nullptr)
     {
-        return dynamic_cast<RigidBody*>(GetParent());
+        if (_attachedRigidBody != nullptr)
+            return _attachedRigidBody;
+        else
+            return GetRigidBodyToAttach();
     }
     return nullptr;
 }
@@ -176,14 +182,17 @@ void Collider::Attach(RigidBody* rigidBody)
 
     // Attach
     PhysicsBackend::AttachShape(_shape, rigidBody->GetPhysicsActor());
-    _cachedLocalPosePos = (_localTransform.Translation + _localTransform.Orientation * _center) * rigidBody->GetScale();
-    _cachedLocalPoseRot = _localTransform.Orientation;
+    const Transform& t = rigidBody->GetTransform().WorldToLocal(GetTransform());
+    _cachedLocalPosePos = (t.Translation + t.Orientation * _center) * rigidBody->GetScale();
+    _cachedLocalPoseRot = t.Orientation;
     PhysicsBackend::SetShapeLocalPose(_shape, _cachedLocalPosePos, _cachedLocalPoseRot);
     if (rigidBody->IsDuringPlay())
     {
         rigidBody->UpdateBounds();
         rigidBody->UpdateMass();
     }
+    rigidBody->OnColliderChanged(this);
+    _attachedRigidBody = rigidBody;
 }
 
 void Collider::UpdateLayerBits()
@@ -243,7 +252,7 @@ void Collider::UpdateGeometry()
         // Reattach again (only if can, see CanAttach function)
         if (actor)
         {
-            const auto rigidBody = dynamic_cast<RigidBody*>(GetParent());
+            const auto rigidBody = GetRigidBodyToAttach();
             if (rigidBody && CanAttach(rigidBody))
             {
                 Attach(rigidBody);
@@ -288,6 +297,24 @@ void Collider::RemoveStaticActor()
     _staticActor = nullptr;
 }
 
+RigidBody* Collider::GetRigidBodyToAttach() const
+{
+    RigidBody* result = nullptr;
+    Actor* parentActor = GetParent();
+    // Get first rigid body in parents
+    while (parentActor != nullptr)
+    {
+        RigidBody* rigidCheck = dynamic_cast<RigidBody*>(parentActor);
+        if (rigidCheck)
+        {
+            result = rigidCheck;
+            break;
+        }
+        parentActor = parentActor->GetParent();
+    }
+    return result;
+}
+
 void Collider::BeginPlay(SceneBeginData* data)
 {
     // Check if has no shape created (it means no rigidbody requested it but also collider may be spawned at runtime)
@@ -296,7 +323,7 @@ void Collider::BeginPlay(SceneBeginData* data)
         CreateShape();
 
         // Check if parent is a rigidbody
-        const auto rigidBody = dynamic_cast<RigidBody*>(GetParent());
+        const auto rigidBody = GetRigidBodyToAttach();
         if (rigidBody && CanAttach(rigidBody))
         {
             // Attach to the rigidbody
@@ -338,6 +365,7 @@ void Collider::EndPlay()
         PhysicsBackend::RemoveCollider(this);
         PhysicsBackend::DestroyShape(_shape);
         _shape = nullptr;
+        _attachedRigidBody = nullptr;
     }
 }
 
@@ -377,7 +405,7 @@ void Collider::OnParentChanged()
         }
 
         // Check if the new parent is a rigidbody
-        rigidBody = dynamic_cast<RigidBody*>(GetParent());
+        rigidBody = GetRigidBodyToAttach();
         if (rigidBody && CanAttach(rigidBody))
         {
             // Attach to the rigidbody
@@ -405,11 +433,12 @@ void Collider::OnTransformChanged()
     }
     else if (const RigidBody* rigidBody = GetAttachedRigidBody())
     {
-        const Vector3 localPosePos = (_localTransform.Translation + _localTransform.Orientation * _center) * rigidBody->GetScale();
-        if (_cachedLocalPosePos != localPosePos || _cachedLocalPoseRot != _localTransform.Orientation)
+        const Transform& t = rigidBody->GetTransform().WorldToLocal(GetTransform());
+        const Vector3 localPosePos = (t.Translation + t.Orientation * _center) * rigidBody->GetScale();
+        if (_cachedLocalPosePos != localPosePos || _cachedLocalPoseRot != t.Orientation)
         {
             _cachedLocalPosePos = localPosePos;
-            _cachedLocalPoseRot = _localTransform.Orientation;
+            _cachedLocalPoseRot = t.Orientation;
             PhysicsBackend::SetShapeLocalPose(_shape, localPosePos, _cachedLocalPoseRot);
         }
     }

--- a/Source/Engine/Physics/Colliders/Collider.h
+++ b/Source/Engine/Physics/Colliders/Collider.h
@@ -32,6 +32,7 @@ protected:
     float _contactOffset;
     Vector3 _cachedLocalPosePos;
     Quaternion _cachedLocalPoseRot;
+    RigidBody* _attachedRigidBody;
 
 public:
     /// <summary>
@@ -157,6 +158,11 @@ protected:
     /// Removes the static actor.
     /// </summary>
     void RemoveStaticActor();
+
+    /// <summary>
+    /// Gets the RigidBody actor to attach this collider to.
+    /// </summary>
+    RigidBody* GetRigidBodyToAttach() const;
 
 private:
     friend RigidBody;


### PR DESCRIPTION
Allows a collider to attach to a rigid body as long as it is in the rigid body's hierarchy. Removes the need for the collider to be a direct child.

Exception to this is wheeled vehicles.

Breaks some of this out from #2325 
Better version of #1230