### PR TITLE
Fix default for prefab canvas size index being 0 instead of -1.

### DIFF
--- a/Source/Editor/Viewport/PrefabWindowViewport.cs
+++ b/Source/Editor/Viewport/PrefabWindowViewport.cs
@@ -74,7 +74,7 @@ namespace FlaxEditor.Viewport
         private PrefabUIEditorRoot _uiRoot;
         private bool _showUI = false;
 
-        private int _defaultScaleActiveIndex = 0;
+        private int _defaultScaleActiveIndex = -1;
         private int _customScaleActiveIndex = -1;
         private ContextMenuButton _uiModeButton;
         private ContextMenuChildMenu _uiViewOptions;


### PR DESCRIPTION
-1 is unselected which will just use the default size and not pick one from the list. 0 is for free aspect which can't be applied to prefabs.

Fix #3762 
Fix #3691