### PR TITLE
Fix being able to open/ close script editor with no fields

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ScriptsEditor.cs
@@ -914,9 +914,11 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 // Remove drop down arrows and containment lines if no objects in the group
                 if (group.Children.Count == 0)
                 {
+                    group.Panel.Close();
                     group.Panel.ArrowImageOpened = null;
                     group.Panel.ArrowImageClosed = null;
                     group.Panel.EnableContainmentLines = false;
+                    group.Panel.CanOpenClose = false;
                 }
 
                 // Scripts arrange bar

--- a/Source/Engine/UI/GUI/Panels/DropPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/DropPanel.cs
@@ -104,13 +104,20 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets a value indicating whether enable drop down icon drawing.
         /// </summary>
-        [EditorOrder(1)]
+        [EditorOrder(2)]
         public bool EnableDropDownIcon { get; set; }
+
+        /// <summary>
+        /// Get or sets a value indicating whether the panel can be opened or closed via the user interacting with the ui.
+        /// Changing the open/ closed state from code or the Properties panel will still work regardless.
+        /// </summary>
+        [EditorOrder(1)]
+        public bool CanOpenClose { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable containment line drawing,
         /// </summary>
-        [EditorOrder(2)]
+        [EditorOrder(3)]
         public bool EnableContainmentLines { get; set; } = false;
 
         /// <summary>
@@ -369,7 +376,7 @@ namespace FlaxEngine.GUI
             }
 
             // Header
-            var color = _mouseOverHeader ? HeaderColorMouseOver : HeaderColor;
+            var color = _mouseOverHeader && CanOpenClose ? HeaderColorMouseOver : HeaderColor;
             if (color.A > 0.0f)
             {
                 Render2D.FillRectangle(new Rectangle(0, 0, Width, HeaderHeight), color);
@@ -510,7 +517,7 @@ namespace FlaxEngine.GUI
             if (button == MouseButton.Left && _mouseButtonLeftDown)
             {
                 _mouseButtonLeftDown = false;
-                if (_mouseOverHeader)
+                if (_mouseOverHeader && CanOpenClose)
                     Toggle();
                 return true;
             }
@@ -540,7 +547,7 @@ namespace FlaxEngine.GUI
             if (button == MouseButton.Left && _mouseButtonLeftDown)
             {
                 _mouseButtonLeftDown = false;
-                if (_mouseOverHeader)
+                if (_mouseOverHeader && CanOpenClose)
                     Toggle();
                 return true;
             }


### PR DESCRIPTION
Does what the title says.
Also fixes bigger margin below script with no fields (was caused by script still being expanded, just not showing any contents because they have none).

In order to reproduce this on master, just create a new script and attach it to an actor. Then click the script header and observe how the height slightly changes (aka. the script editor expands/ closes).

Before:
<img width="456" height="201" alt="image" src="https://github.com/user-attachments/assets/246aef13-c525-40f3-9caa-866c6e963f7b" />


After:
<img width="458" height="196" alt="image" src="https://github.com/user-attachments/assets/40e8aeb2-4194-4d52-9c5e-8b1e8080bfde" />

Introduces "CanOpenClose" to DropPanel.
If false, will ignore the user clicking on the header (or the arrow) to open or collapse the panel.

Kind of a followup to #2630