### PR TITLE
Add support for Zed code editor + Omnisharp and Rider improvements

### DIFF
--- a/Source/Editor/Modules/SourceCodeEditing/DefaultSourceCodeEditor.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/DefaultSourceCodeEditor.cs
@@ -40,10 +40,11 @@ namespace FlaxEditor.Modules.SourceCodeEditing
             var codeEditing = Editor.Instance.CodeEditing;
             var vsCode = codeEditing.GetInBuildEditor(CodeEditorTypes.VSCode);
             var rider = codeEditing.GetInBuildEditor(CodeEditorTypes.Rider);
+            var zed = codeEditing.GetInBuildEditor(CodeEditorTypes.Zed);
 
 #if PLATFORM_WINDOW
             // Favor the newest Visual Studio
-            for (int i = (int)CodeEditorTypes.VS2019; i >= (int)CodeEditorTypes.VS2008; i--)
+            for (int i = (int)CodeEditorTypes.VS2026; i >= (int)CodeEditorTypes.VS2008; i--)
             {
                 var visualStudio = codeEditing.GetInBuildEditor((CodeEditorTypes)i);
                 if (visualStudio != null)
@@ -66,6 +67,8 @@ namespace FlaxEditor.Modules.SourceCodeEditing
                 _currentEditor = vsCode;
             else if (rider != null)
                 _currentEditor = rider;
+            else if (zed != null)
+                _currentEditor = zed;
             else
                 _currentEditor = codeEditing.GetInBuildEditor(CodeEditorTypes.SystemDefault);
         }

--- a/Source/Editor/Modules/SourceCodeEditing/InBuildSourceCodeEditor.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/InBuildSourceCodeEditor.cs
@@ -66,6 +66,9 @@ namespace FlaxEditor.Modules.SourceCodeEditing
             case CodeEditorTypes.Rider:
                 Name = "Rider";
                 break;
+            case CodeEditorTypes.Zed:
+                Name = "Zed";
+                break;
             default: throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
         }
@@ -83,6 +86,7 @@ namespace FlaxEditor.Modules.SourceCodeEditing
                 case CodeEditorTypes.VSCodeInsiders:
                 case CodeEditorTypes.VSCode: return "-vscode -vs2022";
                 case CodeEditorTypes.Rider: return "-vs2022";
+                case CodeEditorTypes.Zed: return "-vs2022";
                 default: return null;
                 }
             }

--- a/Source/Editor/Modules/SourceCodeEditing/InBuildSourceCodeEditor.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/InBuildSourceCodeEditor.cs
@@ -84,9 +84,9 @@ namespace FlaxEditor.Modules.SourceCodeEditing
                 switch (Type)
                 {
                 case CodeEditorTypes.VSCodeInsiders:
-                case CodeEditorTypes.VSCode: return "-vscode -vs2022";
+                case CodeEditorTypes.VSCode: return "-vscode -vs2022 -omnisharp";
                 case CodeEditorTypes.Rider: return "-vs2022";
-                case CodeEditorTypes.Zed: return "-vs2022";
+                case CodeEditorTypes.Zed: return "-vs2022 -omnisharp";
                 default: return null;
                 }
             }

--- a/Source/Editor/Scripting/CodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditor.cpp
@@ -6,6 +6,7 @@
 #include "ScriptsBuilder.h"
 #include "CodeEditors/VisualStudioCodeEditor.h"
 #include "CodeEditors/RiderCodeEditor.h"
+#include "CodeEditors/ZedEditor.h"
 #if USE_VISUAL_STUDIO_DTE
 #include "CodeEditors/VisualStudio/VisualStudioEditor.h"
 #endif
@@ -241,6 +242,7 @@ bool CodeEditingManagerService::Init()
 #endif
     VisualStudioCodeEditor::FindEditors(&CodeEditors);
     RiderCodeEditor::FindEditors(&CodeEditors);
+    ZedEditor::FindEditors(&CodeEditors);
     CodeEditors.Add(New<SystemDefaultCodeEditor>());
 
     return false;

--- a/Source/Editor/Scripting/CodeEditor.h
+++ b/Source/Editor/Scripting/CodeEditor.h
@@ -78,6 +78,11 @@ API_ENUM(Namespace="FlaxEditor", Attributes="HideInEditor") enum class CodeEdito
     VSCodeInsiders,
 
     /// <summary>
+    /// Zed
+    /// </summary>
+    Zed,
+
+    /// <summary>
     /// Rider
     /// </summary>
     Rider,

--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -14,6 +14,9 @@
 
 #if PLATFORM_WINDOWS
 #include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
+#elif PLATFORM_MAC
+#include "Engine/Platform/Apple/AppleUtils.h"
+#include <AppKit/AppKit.h>
 #endif
 
 namespace
@@ -218,6 +221,15 @@ void RiderCodeEditor::FindEditors(Array<CodeEditor*>* output)
 #endif
 
 #if PLATFORM_MAC
+    // System installed app
+    NSURL* AppURL = [[NSWorkspace sharedWorkspace]URLForApplicationWithBundleIdentifier:@"com.jetbrains.rider"];
+    if (AppURL != nullptr)
+    {
+        const String path = AppleUtils::ToString((CFStringRef)[AppURL path]);
+        SearchDirectory(&installations, path / TEXT("/Contents/Resources"));
+    }
+
+    // JetBrains Toolbox installations
     String applicationSupportFolder;
     FileSystem::GetSpecialFolderPath(SpecialFolder::ProgramData, applicationSupportFolder);
 
@@ -232,6 +244,7 @@ void RiderCodeEditor::FindEditors(Array<CodeEditor*>* output)
 
     // Check the local installer version
     SearchDirectory(&installations, TEXT("/Applications/Rider.app/Contents/Resources"));
+    SearchDirectory(&installations, TEXT("/Applications/Rider EAP.app/Contents/Resources"));
 #endif
 
     for (const String& directory : subDirectories)

--- a/Source/Editor/Scripting/CodeEditors/ZedEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/ZedEditor.cpp
@@ -1,0 +1,208 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#include "ZedEditor.h"
+#include "Engine/Platform/FileSystem.h"
+#include "Engine/Platform/CreateProcessSettings.h"
+#include "Engine/Core/Log.h"
+#include "Editor/Editor.h"
+#include "Editor/ProjectInfo.h"
+#include "Editor/Scripting/ScriptsBuilder.h"
+#include "Engine/Engine/Globals.h"
+#if PLATFORM_LINUX
+#include <stdio.h>
+#elif PLATFORM_WINDOWS
+#include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
+#elif PLATFORM_MAC
+#include "Engine/Platform/Apple/AppleUtils.h"
+#include <AppKit/AppKit.h>
+#endif
+
+bool TryGetPathForCommand(const String& cmd, String& path)
+{
+    const StringAnsi runCommand(StringAnsi::Format("/bin/bash -c \"type -p {0}\"", cmd.ToStringAnsi()));
+    char buffer[128];
+    FILE* pipe = popen(runCommand.Get(), "r");
+    if (pipe)
+    {
+        StringAnsi pathAnsi;
+        while (fgets(buffer, sizeof(buffer), pipe) != nullptr)
+            pathAnsi += buffer;
+        pclose(pipe);
+        path = String(pathAnsi.Get(), pathAnsi.Length() != 0 ? pathAnsi.Length() - 1 : 0);
+        if (FileSystem::FileExists(path))
+        {
+            return true;
+        }
+    }
+    path = String::Empty;
+    return false;
+}
+
+ZedEditor::ZedEditor(const String& execPath)
+    : _execPath(execPath)
+    , _workspacePath(Globals::ProjectFolder)
+{
+}
+
+void ZedEditor::FindEditors(Array<CodeEditor*>* output)
+{
+#if PLATFORM_WINDOWS
+    String cmd;
+    if (Platform::ReadRegValue(HKEY_CURRENT_USER, TEXT("SOFTWARE\\Classes\\Applications\\Zed.exe\\shell\\open\\command"), TEXT(""), &cmd) || cmd.IsEmpty())
+    {
+        if (Platform::ReadRegValue(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Classes\\Applications\\Zed.exe\\shell\\open\\command"), TEXT(""), &cmd) || cmd.IsEmpty())
+        {
+            // No hits in registry, try default path instead
+        }
+    }
+    String path;
+    if (cmd.IsEmpty())
+    {
+        path = cmd.Substring(1, cmd.Length() - String(TEXT("\" \"%1\"")).Length() - 1);
+    }
+    else
+    {
+        String localAppDataPath;
+        FileSystem::GetSpecialFolderPath(SpecialFolder::LocalAppData, localAppDataPath);
+        path = localAppDataPath / TEXT("Programs/Zed/Zed.exe");
+    }
+    if (FileSystem::FileExists(path))
+    {
+        output->Add(New<ZedEditor>(path));
+    }
+#elif PLATFORM_LINUX
+    // Detect official release
+    String zedPath;
+    if (TryGetPathForCommand(TEXT("zed"), zedPath))
+    {
+        output->Add(New<ZedEditor>(zedPath));
+        return;
+    }
+    {
+        const String home = LinuxPlatform::GetHomeDirectory();
+        const String path(home / TEXT(".local/bin/zed"));
+        if (FileSystem::FileExists(path))
+        {
+            output->Add(New<ZedEditor>(path));
+            return;
+        }
+    }
+
+    // Detect unofficial releases
+    String zeditorPath;
+    if (TryGetPathForCommand(TEXT("zeditor"), zeditorPath))
+    {
+        output->Add(New<ZedEditor>(zeditorPath));
+        return;
+    }
+    String zeditPath;
+    if (TryGetPathForCommand(TEXT("zedit"), zeditPath))
+    {
+        output->Add(New<ZedEditor>(zeditPath));
+        return;
+    }
+
+    // Detect Flatpak installations
+    {
+        CreateProcessSettings procSettings;
+        procSettings.FileName = TEXT("/bin/bash -c \"flatpak list --app --columns=application | grep dev.zed.Zed -c\"");
+        procSettings.HiddenWindow = true;
+        if (Platform::CreateProcess(procSettings) == 0)
+        {
+            const String runPath(TEXT("flatpak run dev.zed.Zed"));
+            output->Add(New<ZedEditor>(runPath));
+            return;
+        }
+    }
+#elif PLATFORM_MAC
+    // Prefer the Zed CLI application over bundled app, as this handles opening files in existing instance better.
+    // The bundle also contains the CLI application under Zed.app/Contents/MacOS/zed, but using this doesn't make any difference.
+    const String cliPath(TEXT("/usr/local/bin/zed"));
+    if (FileSystem::FileExists(cliPath))
+    {
+        output->Add(New<ZedEditor>(cliPath));
+        return;
+    }
+
+    // System installed app
+    NSURL* AppURL = [[NSWorkspace sharedWorkspace]URLForApplicationWithBundleIdentifier:@"dev.zed.Zed"];
+    if (AppURL != nullptr)
+    {
+        const String path = AppleUtils::ToString((CFStringRef)[AppURL path]);
+        output->Add(New<ZedEditor>(path));
+        return;
+    }
+
+    // Predefined locations
+    String userFolder;
+    FileSystem::GetSpecialFolderPath(SpecialFolder::Documents, userFolder);
+    String paths[3] =
+    {
+        TEXT("/Applications/Zed.app"),
+        userFolder + TEXT("/../Zed.app"),
+        userFolder + TEXT("/../Downloads/Zed.app"),
+    };
+    for (const String& path : paths)
+    {
+        if (FileSystem::DirectoryExists(path))
+        {
+            output->Add(New<ZedEditor>(path));
+            break;
+        }
+    }
+#endif
+}
+
+CodeEditorTypes ZedEditor::GetType() const
+{
+    return CodeEditorTypes::Zed;
+}
+
+String ZedEditor::GetName() const
+{
+    return TEXT("Zed");
+}
+
+void ZedEditor::OpenFile(const String& path, int32 line)
+{
+    // Generate VS solution files for intellisense
+    if (!FileSystem::FileExists(Globals::ProjectFolder / Editor::Project->Name + TEXT(".sln")))
+    {
+        ScriptsBuilder::GenerateProject(TEXT("-vs2022"));
+    }
+
+    // Open file
+    line = line > 0 ? line : 1;
+    CreateProcessSettings procSettings;
+    procSettings.FileName = _execPath;
+    procSettings.Arguments = String::Format(TEXT("\"{0}\" \"{1}:{2}\""), _workspacePath, path, line);
+    procSettings.HiddenWindow = false;
+    procSettings.WaitForEnd = false;
+    procSettings.LogOutput = false;
+    procSettings.ShellExecute = true;
+    Platform::CreateProcess(procSettings);
+}
+
+void ZedEditor::OpenSolution()
+{
+    // Generate VS solution files for intellisense
+    if (!FileSystem::FileExists(Globals::ProjectFolder / Editor::Project->Name + TEXT(".sln")))
+    {
+        ScriptsBuilder::GenerateProject(TEXT("-vs2022"));
+    }
+
+    // Open solution
+    CreateProcessSettings procSettings;
+    procSettings.FileName = _execPath;
+    procSettings.Arguments = String::Format(TEXT("\"{0}\""), _workspacePath);
+    procSettings.HiddenWindow = false;
+    procSettings.WaitForEnd = false;
+    procSettings.LogOutput = false;
+    procSettings.ShellExecute = true;
+    Platform::CreateProcess(procSettings);
+}
+
+bool ZedEditor::UseAsyncForOpen() const
+{
+    return false;
+}

--- a/Source/Editor/Scripting/CodeEditors/ZedEditor.h
+++ b/Source/Editor/Scripting/CodeEditors/ZedEditor.h
@@ -1,0 +1,41 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#include "Editor/Scripting/CodeEditor.h"
+
+/// <summary>
+/// Implementation of code editor utility that is using Microsoft Visual Studio Code.
+/// </summary>
+class ZedEditor : public CodeEditor
+{
+private:
+
+    String _execPath;
+    String _workspacePath;
+
+public:
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VisualStudioEditor"/> class.
+    /// </summary>
+    /// <param name="execPath">Executable file path</param>
+    ZedEditor(const String& execPath);
+
+public:
+
+    /// <summary>
+    /// Tries to find installed Visual Studio Code instance. Adds them to the result list.
+    /// </summary>
+    /// <param name="output">The output editors.</param>
+    static void FindEditors(Array<CodeEditor*>* output);
+
+public:
+
+    // [CodeEditor]
+    CodeEditorTypes GetType() const override;
+    String GetName() const override;
+    void OpenFile(const String& path, int32 line) override;
+    void OpenSolution() override;
+    bool UseAsyncForOpen() const override;
+};

--- a/Source/Tools/Flax.Build/Build/Builder.Projects.cs
+++ b/Source/Tools/Flax.Build/Build/Builder.Projects.cs
@@ -206,6 +206,8 @@ namespace Flax.Build
                     projectFormats.Add(ProjectFormat.VisualStudioCode);
                 if (Configuration.ProjectFormatRider)
                     projectFormats.Add(ProjectFormat.VisualStudio2022);
+                if (Configuration.ProjectFormatOmnisharp)
+                    projectFormats.Add(ProjectFormat.Omnisharp);
                 if (!string.IsNullOrEmpty(Configuration.ProjectFormatCustom))
                     projectFormats.Add(ProjectFormat.Custom);
                 if (projectFormats.Count == 0)

--- a/Source/Tools/Flax.Build/Configuration.cs
+++ b/Source/Tools/Flax.Build/Configuration.cs
@@ -220,6 +220,12 @@ namespace Flax.Build
         public static bool ProjectFormatRider = false;
 
         /// <summary>
+        /// Generates Omnisharp configuration file. Valid only with -genproject option.
+        /// </summary>
+        [CommandLine("vscode", "Generates Omnisharp configuration file. Valid only with -genproject option.")]
+        public static bool ProjectFormatOmnisharp = false;
+
+        /// <summary>
         /// Generates code project files for a custom project format type. Valid only with -genproject option.
         /// </summary>
         [CommandLine("customProjectFormat", "<type>", "Generates code project files for a custom project format type. Valid only with -genproject option.")]

--- a/Source/Tools/Flax.Build/Projects/OmnisharpProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/OmnisharpProjectGenerator.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Flax.Build.Projects.VisualStudioCode
+{
+    /// <summary>
+    /// Project generator for Omnisharp.
+    /// </summary>
+    public class OmnisharpProjectGenerator : ProjectGenerator
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OmnisharpProjectGenerator"/> class.
+        /// </summary>
+        public OmnisharpProjectGenerator()
+        {
+        }
+
+        /// <inheritdoc />
+        public override string ProjectFileExtension => string.Empty;
+
+        /// <inheritdoc />
+        public override string SolutionFileExtension => string.Empty;
+
+        /// <inheritdoc />
+        public override TargetType? Type => null;
+
+        /// <inheritdoc />
+        public override Project CreateProject()
+        {
+            return new Project
+            {
+                Generator = this,
+            };
+        }
+
+        /// <inheritdoc />
+        public override void GenerateProject(Project project, string solutionPath, bool isMainProject)
+        {
+            // Not used, solution contains all projects definitions
+        }
+
+        /// <inheritdoc />
+        public override void GenerateSolution(Solution solution)
+        {
+            // Create OmniSharp configuration file
+            using (var json = new JsonWriter())
+            {
+                json.BeginRootObject();
+
+                json.BeginObject("msbuild");
+                {
+                    json.AddField("enabled", true);
+                    json.AddField("Configuration", "Editor.Debug");
+                }
+                json.EndObject();
+
+                json.EndRootObject();
+                json.Save(Path.Combine(solution.WorkspaceRootPath, "omnisharp.json"));
+            }
+        }
+    }
+}

--- a/Source/Tools/Flax.Build/Projects/OmnisharpProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/OmnisharpProjectGenerator.cs
@@ -54,7 +54,6 @@ namespace Flax.Build.Projects.VisualStudioCode
                 json.BeginObject("msbuild");
                 {
                     json.AddField("enabled", true);
-                    json.AddField("Configuration", "Editor.Debug");
                 }
                 json.EndObject();
 

--- a/Source/Tools/Flax.Build/Projects/ProjectFormat.cs
+++ b/Source/Tools/Flax.Build/Projects/ProjectFormat.cs
@@ -51,5 +51,10 @@ namespace Flax.Build.Projects
         /// XCode.
         /// </summary>
         XCode,
+
+        /// <summary>
+        /// Omnisharp.
+        /// </summary>
+        Omnisharp,
     }
 }

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VCProjectGenerator.cs
@@ -114,7 +114,7 @@ namespace Flax.Build.Projects.VisualStudio
             vcProjectFileContent.AppendLine("    <Keyword>MakeFileProj</Keyword>");
             if (Version >= VisualStudioVersion.VisualStudio2022)
                 vcProjectFileContent.AppendLine("    <ResolveNuGetPackages>false</ResolveNuGetPackages>");
-            vcProjectFileContent.AppendLine("    <VCTargetsPath Condition=\"$(Configuration.Contains('Linux'))\">./</VCTargetsPath>");
+            vcProjectFileContent.AppendLine("    <VCTargetsPath Condition=\"$(Configuration.Contains('Linux')) or $(Configuration.Contains('Mac'))\">./</VCTargetsPath>");
             vcProjectFileContent.AppendLine("  </PropertyGroup>");
 
             // Default properties

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -634,6 +634,8 @@ namespace Flax.Build.Projects.VisualStudioCode
                 json.BeginArray("recommendations");
                 {
                     json.AddUnnamedField("ms-dotnettools.csharp");
+                    json.AddUnnamedField("free-csharp-vscode");
+                    json.AddUnnamedField("ms-dotnettools.csdevkit");
 
                     if (!Globals.Project.IsCSharpOnlyProject)
                     {

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -43,94 +43,6 @@ namespace Flax.Build.Projects.VisualStudioCode
             // Not used, solution contains all projects definitions
         }
 
-        private class JsonWriter : IDisposable
-        {
-            private readonly List<string> _lines = new List<string>();
-            private string _tabs = "";
-
-            public void BeginRootObject()
-            {
-                BeginObject();
-            }
-
-            public void EndRootObject()
-            {
-                EndObject();
-                if (_tabs.Length > 0)
-                {
-                    throw new Exception("Invalid EndRootObject call before all objects and arrays have been closed.");
-                }
-            }
-
-            public void BeginObject(string name = null)
-            {
-                string prefix = name == null ? "" : Quoted(name) + ": ";
-                _lines.Add(_tabs + prefix + "{");
-                _tabs += "\t";
-            }
-
-            public void EndObject()
-            {
-                _lines[_lines.Count - 1] = _lines[_lines.Count - 1].TrimEnd(',');
-                _tabs = _tabs.Remove(_tabs.Length - 1);
-                _lines.Add(_tabs + "},");
-            }
-
-            public void BeginArray(string name = null)
-            {
-                string prefix = name == null ? "" : Quoted(name) + ": ";
-                _lines.Add(_tabs + prefix + "[");
-                _tabs += "\t";
-            }
-
-            public void EndArray()
-            {
-                _lines[_lines.Count - 1] = _lines[_lines.Count - 1].TrimEnd(',');
-                _tabs = _tabs.Remove(_tabs.Length - 1);
-                _lines.Add(_tabs + "],");
-            }
-
-            public void AddField(string name, bool value)
-            {
-                _lines.Add(_tabs + Quoted(name) + ": " + value.ToString().ToLower() + ",");
-            }
-
-            public void AddField(string name, int value)
-            {
-                _lines.Add(_tabs + Quoted(name) + ": " + value + ",");
-            }
-
-            public void AddField(string name, string value)
-            {
-                _lines.Add(_tabs + Quoted(name) + ": " + Quoted(value) + ",");
-            }
-
-            public void AddUnnamedField(string value)
-            {
-                _lines.Add(_tabs + Quoted(value) + ",");
-            }
-
-            private string Quoted(string value)
-            {
-                value = value.Replace("\\", "\\\\");
-                value = value.Replace("\"", "\\\"");
-                return "\"" + value + "\"";
-            }
-
-            public void Save(string path)
-            {
-                _lines[_lines.Count - 1] = _lines[_lines.Count - 1].TrimEnd(',');
-                Utilities.WriteFileIfChanged(path, string.Join(Environment.NewLine, _lines.ToArray()));
-            }
-
-            /// <inheritdoc />
-            public void Dispose()
-            {
-                _lines.Clear();
-                _tabs = null;
-            }
-        }
-
         /// <inheritdoc />
         public override void GenerateSolution(Solution solution)
         {
@@ -731,22 +643,6 @@ namespace Flax.Build.Projects.VisualStudioCode
 
                 json.EndRootObject();
                 json.Save(Path.Combine(vsCodeFolder, "extensions.json"));
-            }
-
-            // Create OmniSharp configuration file
-            using (var json = new JsonWriter())
-            {
-                json.BeginRootObject();
-
-                json.BeginObject("msbuild");
-                {
-                    json.AddField("enabled", true);
-                    json.AddField("Configuration", "Editor.Debug");
-                }
-                json.EndObject();
-
-                json.EndRootObject();
-                json.Save(Path.Combine(solution.WorkspaceRootPath, "omnisharp.json"));
             }
         }
     }

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -588,6 +588,7 @@ namespace Flax.Build.Projects.VisualStudioCode
                 json.AddField("grunt.autoDetect", "off");
                 json.AddField("omnisharp.defaultLaunchSolution", solution.Name + ".sln");
                 json.AddField("omnisharp.useModernNet", true);
+                json.AddField("dotnet.server.useOmnisharp", false);
                 json.EndObject();
 
                 // Folders


### PR DESCRIPTION
Adds detection and Omnisharp configuration generation for Zed. In VSCode workspaces Roslyn based LSP is now preferred over Omnisharp. Also includes small improvements for Rider detection and building on macOS.