### PR TITLE
Add alternative node titles to pack/unpack nodes

### DIFF
--- a/Source/Editor/Surface/Archetypes/Layers.cs
+++ b/Source/Editor/Surface/Archetypes/Layers.cs
@@ -149,7 +149,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 7,
                 Title = "Unpack Material Layer",
                 Description = "Unpack material properties",
-                AlternativeTitles = new[] { "Break Material Layers", "Deconstruct Material Layers", "Decompose Material Layers" },
+                AlternativeTitles = new[] { "Break Material Layer", "Deconstruct Material Layer", "Decompose Material Layer", "Split Material Layer" },
                 Flags = NodeFlags.MaterialGraph,
                 Size = new Float2(210, 280),
                 Elements = new[]

--- a/Source/Editor/Surface/Archetypes/Packing.cs
+++ b/Source/Editor/Surface/Archetypes/Packing.cs
@@ -486,7 +486,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 30,
                 Title = "Unpack Float2",
                 Description = "Unpack components from Float2",
-                AlternativeTitles = new[] { "Break Float2", "Deconstruct Float2", "Decompose Float2" },
+                AlternativeTitles = new[] { "Break Float2", "Deconstruct Float2", "Decompose Float2", "Split Float2" },
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(150, 40),
                 Elements = new[]
@@ -501,7 +501,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 31,
                 Title = "Unpack Float3",
                 Description = "Unpack components from Float3",
-                AlternativeTitles = new[] { "Break Float3", "Deconstruct Float3", "Decompose Float3" },
+                AlternativeTitles = new[] { "Break Float3", "Deconstruct Float3", "Decompose Float3", "Split Float3" },
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(150, 60),
                 Elements = new[]
@@ -517,7 +517,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 32,
                 Title = "Unpack Float4",
                 Description = "Unpack components from Float4",
-                AlternativeTitles = new[] { "Break Float4", "Deconstruct Float4", "Decompose Float4" },
+                AlternativeTitles = new[] { "Break Float4", "Deconstruct Float4", "Decompose Float4", "Split Float4" },
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(150, 80),
                 Elements = new[]
@@ -534,7 +534,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 33,
                 Title = "Unpack Rotation",
                 Description = "Unpack components from Rotation",
-                AlternativeTitles = new[] { "Break Rotation", "Deconstruct Rotation", "Decompose Rotation" },
+                AlternativeTitles = new[] { "Break Rotation", "Deconstruct Rotation", "Decompose Rotation", "Split Rotation" },
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(170, 60),
                 Elements = new[]
@@ -550,7 +550,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 34,
                 Title = "Unpack Transform",
                 Description = "Unpack components from Transform",
-                AlternativeTitles = new[] { "Break Transform", "Deconstruct Transform", "Decompose Transform" },
+                AlternativeTitles = new[] { "Break Transform", "Deconstruct Transform", "Decompose Transform", "Split Transform" },
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(170, 60),
                 Elements = new[]
@@ -566,7 +566,7 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 35,
                 Title = "Unpack Box",
                 Description = "Unpack components from BoundingBox",
-                AlternativeTitles = new[] { "Break BoundingBox", "Deconstruct BoundingBox", "Decompose BoundingBox" },
+                AlternativeTitles = new[] { "Break BoundingBox", "Deconstruct BoundingBox", "Decompose BoundingBox", "Split BoundingBox" },
                 Flags = NodeFlags.AllGraphs,
                 Size = new Float2(170, 40),
                 Elements = new[]
@@ -585,7 +585,7 @@ namespace FlaxEditor.Surface.Archetypes
                 IsOutputCompatible = UnpackStructureNode.IsOutputCompatible,
                 GetInputOutputDescription = UnpackStructureNode.GetInputOutputDescription,
                 Description = "Breaks the structure data to allow extracting components from it.",
-                AlternativeTitles = new[] { "Break Structure", "Deconstruct Structure", "Decompose Structure" },
+                AlternativeTitles = new[] { "Break Structure", "Deconstruct Structure", "Decompose Structure", "Split Structure" },
                 Flags = NodeFlags.VisualScriptGraph | NodeFlags.AnimGraph | NodeFlags.NoSpawnViaGUI,
                 Size = new Float2(180, 20),
                 DefaultValues = new object[]


### PR DESCRIPTION
Now every pack/ unpack node can be found by searching:
"Pack":
- Make
- Construct
- Compose

"Unpack":
-  Break
- Deconstruct
- Decompose
- Split

If there is any commonly used terminology for "pack"/ "unpack" that I have not added yet, please let me know and I will add it.

These are the names used in other engines that I could find.
I think this makes Flax more approachable and easy to switch to for new users, since they prolly have used another tool like Unreal Engine or Godot before, which all use different terminology for this operation.

Another reason as to why I think this is useful is because I always mess up what tool uses which terminology. With this pr I can just type in whatever and it will show me the correct nodes.

<img width="375" height="213" alt="image" src="https://github.com/user-attachments/assets/f2d887dc-e8ce-4495-820e-697257b9f242" />
<img width="356" height="202" alt="image" src="https://github.com/user-attachments/assets/2c313825-782c-4d02-abff-5216003eb829" />
<img width="368" height="221" alt="image" src="https://github.com/user-attachments/assets/fffbd27b-0259-4512-8621-3082b695bab2" />

<img width="348" height="228" alt="image" src="https://github.com/user-attachments/assets/4475dd42-67f7-4c17-b3a3-2ec7444ade30" />
<img width="370" height="211" alt="image" src="https://github.com/user-attachments/assets/4cf685aa-36b7-4d9b-bee0-e7571f274151" />
<img width="354" height="214" alt="image" src="https://github.com/user-attachments/assets/9fdce063-7c90-4e05-a131-fc2020d92aa4" />


