### PR TITLE
ResetAccumulatedGravity for CharacterController

### DIFF
--- a/Source/Engine/Physics/Colliders/CharacterController.cpp
+++ b/Source/Engine/Physics/Colliders/CharacterController.cpp
@@ -244,6 +244,16 @@ void CharacterController::Resize(float height, float radius)
     UpdateBounds();
 }
 
+void CharacterController::ResetAccumulatedGravity()
+{
+    _gravityDisplacement = Vector3::Zero;
+}
+
+Vector3 CharacterController::GetAccumulatedGravity() const
+{
+    return _gravityDisplacement;
+}
+
 #if USE_EDITOR
 
 #include "Engine/Debug/DebugDraw.h"

--- a/Source/Engine/Physics/Colliders/CharacterController.h
+++ b/Source/Engine/Physics/Colliders/CharacterController.h
@@ -207,6 +207,11 @@ public:
     /// </summary>
     API_PROPERTY() CollisionFlags GetFlags() const;
 
+    /// <summary>
+    /// Returns accumulated gravity if Auto Gravity enabled.
+    /// </summary>
+    API_PROPERTY() Vector3 GetAccumulatedGravity() const;
+
 public:
     /// <summary>
     /// Moves the character with the given speed. Gravity is automatically applied. It will slide along colliders. Result collision flags is the summary of collisions that occurred during the Move.
@@ -228,6 +233,11 @@ public:
     /// <param name="height">The height of the capsule, measured in the object's local space.</param>
     /// <param name="radius">The radius of the capsule, measured in the object's local space.</param>
     API_FUNCTION() void Resize(float height, float radius);
+
+    /// <summary>
+    /// Resets accumulated gravity if Auto Gravity enabled.
+    /// </summary>
+    API_FUNCTION() void ResetAccumulatedGravity();
 
 protected:
     /// <summary>


### PR DESCRIPTION
Added the **CharacterController.ResetAccumulatedGravity** function. It can be useful, for example, for the Double Jump mechanic, to reset the accumulated gravity before the second jump. 
Also added the **GetAccumulatedGravity** function, which returns the current accumulated gravity.