### PR TITLE
Fixed missing move semantics in script object reference

### DIFF
--- a/Source/Engine/Scripting/ScriptingObjectReference.h
+++ b/Source/Engine/Scripting/ScriptingObjectReference.h
@@ -33,6 +33,13 @@ public:
     {
     }
 
+    ScriptingObjectReferenceBase(ScriptingObjectReferenceBase&& other) noexcept
+        : _object(nullptr)
+    {
+        OnSet(other._object);
+        other.OnSet(nullptr);
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ScriptingObjectReferenceBase"/> class.
     /// </summary>
@@ -96,6 +103,16 @@ protected:
     void OnSet(ScriptingObject* object);
 
     void OnDeleted(ScriptingObject* obj);
+
+    ScriptingObjectReferenceBase& operator=(ScriptingObjectReferenceBase&& other) noexcept
+    {
+        if (this != &other)
+        {
+            OnSet(other._object);
+            other.OnSet(nullptr);
+        }
+        return *this;
+    }
 };
 
 /// <summary>
@@ -130,6 +147,11 @@ public:
     /// <param name="other">The other property.</param>
     ScriptingObjectReference(const ScriptingObjectReference& other)
         : ScriptingObjectReferenceBase(other._object)
+    {
+    }
+
+    ScriptingObjectReference(ScriptingObjectReference&& other) noexcept
+        : ScriptingObjectReferenceBase(MoveTemp(other))
     {
     }
 
@@ -170,6 +192,12 @@ public:
     ScriptingObjectReference& operator=(const ScriptingObjectReference& other)
     {
         OnSet(other._object);
+        return *this;
+    }
+
+    ScriptingObjectReference& operator=(ScriptingObjectReference&& other) noexcept
+    {
+        ScriptingObjectReferenceBase::operator=(MoveTemp(other));
         return *this;
     }
 


### PR DESCRIPTION
This fixes some crashes in the `NetworkReplicator`.
The NetworkReplicator stores `NetworkReplicatedObject`s in a HashSet.
NetworkReplicatedObject contains a ScriptingObjectReference, and during rehash/compact in the HashSet, it is converted using Move. Without its own Move semantics, this falls back to the copy path: both references remain attached to the same deleted  delegate, which can later lead to duplicate Unbind/Use-after-free. The Move variants transfer the binding correctly and resets the source.