### PR TITLE
Bypassing Call Logic in Editor Preview

### DIFF
--- a/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
+++ b/Source/Engine/Tools/MaterialGenerator/MaterialGenerator.Material.cpp
@@ -790,9 +790,21 @@ void MaterialGenerator::ProcessGroupFunction(Box* box, Node* node, Value& value)
     // Function Input
     case 1:
     {
+        // Check the stack count.If only 1 graph is present,
+        // we are processing the graph in isolation (e.g., in the Editor Preview).
+        // In this case, we skip the caller-finding logic and use the node's default value.
+        if (_graphStack.Count() < 2)
+        {
+            // Use the default value from the function input node's box (usually box 1)
+            value = tryGetValue(node->TryGetBox(1), Value::Zero);
+            break;
+        }
+
         // Find the function call
         Node* functionCallNode = nullptr;
-        ASSERT(_graphStack.Count() >= 2);
+        
+        // The original ASSERT has been effectively replaced by the 'if' above.
+        //ASSERT(_graphStack.Count() >= 2);
         Graph* graph;
         for (int32 i = _callStack.Count() - 1; i >= 0; i--)
         {


### PR DESCRIPTION
Regarding [3800](https://github.com/FlaxEngine/FlaxEngine/issues/3800)

Seems like fix for the crash is to replace the hard assertion with a conditional check that allows the Function Input node to return its default value if there is no calling context, which should be fine for an isolated editor preview.

By implementing this change, when the generator is run directly on the Material Function for preview (stack count = 1), the Function Input node will correctly use the Default Value set on the node itself, preventing the crash.

I've only done a quick test with my project and it doesn't crash anymore.
Since I didn't work in this project before and I'm not **that** experienced with C++ projects, please review this change before considering implementation. Thanks a lot! 