### PR TITLE
Add ui edit mode to edit game window and remove from game window

### DIFF
--- a/Source/Editor/Gizmo/UIEditorGizmo.cs
+++ b/Source/Editor/Gizmo/UIEditorGizmo.cs
@@ -116,7 +116,7 @@ namespace FlaxEditor
                 if (RayCastChildren(ref location, out hit))
                     return true;
 
-                // Check external roots
+                // Check external root
                 var uiRoot = (UIEditorRoot)Parent;
                 if (uiRoot.ExternalRoot != null)
                 {

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -245,7 +245,7 @@ namespace FlaxEditor.Viewport
                 // Use the actual content size (resolution) of the game viewport
                 _guiRoot.SetViewSize(gameViewport.ContentSize);
                 if (_guiRoot.ExternalRoot == null)
-                    _guiRoot.ExternalRoot = RootControl.GameRoot;
+                    _guiRoot.ExternalRoot = RootControl.CanvasRoot;
             }
 
             // Link UI canvases to the viewport

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -234,9 +234,6 @@ namespace FlaxEditor.Viewport
 
         private void UpdateLinkage()
         {
-            //if (Editor.IsPlayMode)
-                //return;
-
             // Clear flag
             _hasUILinked = false;
             _guiRoot.ExternalRoot = null;
@@ -264,13 +261,6 @@ namespace FlaxEditor.Viewport
             {
                 if (uiCanvas.IsActiveInHierarchy && uiCanvas.GUI.Visible && uiCanvas.GUI.Parent != null)
                 {
-                    /*
-                    if (_guiRoot.ExternalRoot == uiCanvas.GUI.Parent)
-                    {
-                        _guiRoot.ExternalRoot = uiCanvas.GUI.Parent;
-                    }
-                    */
-                    //_guiRoot.ExternalRoots.Add(uiCanvas.GUI);
                     _hasUILinked = true;
                 }
             }

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -2,11 +2,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FlaxEditor.Content;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.Scripting;
+using FlaxEditor.Viewport.Cameras;
 using FlaxEditor.Viewport.Modes;
 using FlaxEditor.Windows;
 using FlaxEngine;
@@ -176,6 +178,107 @@ namespace FlaxEditor.Viewport
         /// The edit foliage gizmo.
         /// </summary>
         public Tools.Foliage.EditFoliageGizmoMode EditFoliageGizmo;
+        
+        [HideInEditor]
+        private sealed class EditGameUIEditorRoot : UIEditorRoot
+        {
+            private readonly MainEditorGizmoViewport _viewport;
+
+            private bool UI => _viewport.ShowUI;
+
+            public EditGameUIEditorRoot(MainEditorGizmoViewport viewport)
+            : base(true)
+            {
+                _viewport = viewport;
+                Parent = viewport;
+            }
+
+            public override bool EnableInputs => !UI;
+            public override bool EnableSelecting => UI;
+            public override bool EnableBackground => UI;
+            public override TransformGizmo TransformGizmo => _viewport.TransformGizmo;
+        }
+        
+        internal bool _hasUILinked;
+        private EditGameUIEditorRoot _guiRoot;
+        private bool _showUI = false;
+
+        public bool ShowUI
+        {
+            get => _showUI;
+            set
+            {
+                _showUI = value;
+                if (_showUI)
+                {
+                    // UI widget
+                    Gizmos.Active = null;
+                    ViewportCamera = new UIEditorCamera { UIEditor = _guiRoot };
+
+                    // Show whole UI on startup
+                    var canvas = (CanvasRootControl)_guiRoot.UIRoot.Children.FirstOrDefault(x => x is CanvasRootControl);
+                    if (canvas != null)
+                        ViewportCamera.ShowActor(canvas.Canvas);
+
+                    _guiRoot.Visible = true;
+                }
+                else
+                {
+                    // Generic prefab
+                    Gizmos.Active = TransformGizmo;
+                    ViewportCamera = new FPSCamera();
+                    _guiRoot.Visible = false;
+                }
+            }
+        }
+
+        private void UpdateLinkage()
+        {
+            //if (Editor.IsPlayMode)
+                //return;
+
+            // Clear flag
+            _hasUILinked = false;
+            _guiRoot.ExternalRoot = null;
+            
+            // Sync UI editor view size with Game Window viewport
+            if (_editor.Windows.GameWin != null && _editor.Windows.GameWin.Viewport != null)
+            {
+                var gameViewport = _editor.Windows.GameWin.Viewport;
+                // Use the actual content size (resolution) of the game viewport
+                _guiRoot.SetViewSize(gameViewport.ContentSize);
+                if (_guiRoot.ExternalRoot == null)
+                    _guiRoot.ExternalRoot = RootControl.GameRoot;
+            }
+
+            // Link UI canvases to the viewport
+            foreach (var scene in Level.Scenes)
+            {
+                LinkCanvas(scene);
+            }
+        }
+
+        private void LinkCanvas(Actor actor)
+        {
+            if (actor is UICanvas uiCanvas)
+            {
+                if (uiCanvas.IsActiveInHierarchy && uiCanvas.GUI.Visible && uiCanvas.GUI.Parent != null)
+                {
+                    /*
+                    if (_guiRoot.ExternalRoot == uiCanvas.GUI.Parent)
+                    {
+                        _guiRoot.ExternalRoot = uiCanvas.GUI.Parent;
+                    }
+                    */
+                    //_guiRoot.ExternalRoots.Add(uiCanvas.GUI);
+                    _hasUILinked = true;
+                }
+            }
+
+            var children = actor.ChildrenCount;
+            for (int i = 0; i < children; i++)
+                LinkCanvas(actor.GetChild(i));
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MainEditorGizmoViewport"/> class.
@@ -253,6 +356,16 @@ namespace FlaxEditor.Viewport
                 // Activate transform mode first
                 Gizmos.SetActiveMode<TransformGizmoMode>();
             }
+            
+            // Use custom UI root
+            _guiRoot = new EditGameUIEditorRoot(this);
+            _guiRoot.IndexInParent = 0;
+            _guiRoot.Visible = false;
+
+            // UI mode buton
+            var uiModeButton = ViewWidgetShowMenu.AddButton("UI Mode", button => ShowUI = button.Checked);
+            uiModeButton.AutoCheck = true;
+            uiModeButton.VisibleChanged += control => (control as ContextMenuButton).Checked = ShowUI;
 
             // Setup input actions
             InputActions.Add(options => options.LockFocusSelection, LockFocusSelection);
@@ -289,6 +402,11 @@ namespace FlaxEditor.Viewport
 
                 var focusDistance = Mathf.Max(selectionBounds.Radius * 2d, 100d);
                 ViewPosition = selectionBounds.Center + (-ViewDirection * (focusDistance + _lockedFocusOffset));
+            }
+            
+            if (Level.ScenesCount > 0)
+            {
+                UpdateLinkage();
             }
         }
 

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -355,9 +355,9 @@ namespace FlaxEditor.Windows
         }
 
         /// <summary>
-        /// Root control for game UI preview in Editor. Supports basic UI editing via <see cref="UIEditorRoot"/>.
+        /// Root control for game UI preview in Editor.
         /// </summary>
-        private class GameRoot /*: UIEditorRoot*/ : ContainerControl
+        private class GameRoot : ContainerControl
         {
             public bool EnableEvents => !Time.GamePaused;
 

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -122,7 +122,7 @@ namespace FlaxEditor.Windows
     {
         private readonly ScaledRenderOutputControl _viewport;
         private readonly GameRoot _guiRoot;
-        private bool _showGUI = true, _editGUI = true;
+        private bool _showGUI = true;
         private bool _showDebugDraw = false;
         private bool _audioMuted = false;
         private float _audioVolume = 1;
@@ -191,22 +191,6 @@ namespace FlaxEditor.Windows
                 {
                     _showGUI = value;
                     _guiRoot.Visible = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether allow editing game GUI in the view or keep it visible-only.
-        /// </summary>
-        public bool EditGUI
-        {
-            get => _editGUI;
-            set
-            {
-                if (value != _editGUI)
-                {
-                    _editGUI = value;
-                    _guiRoot.Editable = value;
                 }
             }
         }
@@ -373,12 +357,133 @@ namespace FlaxEditor.Windows
         /// <summary>
         /// Root control for game UI preview in Editor. Supports basic UI editing via <see cref="UIEditorRoot"/>.
         /// </summary>
-        private class GameRoot : UIEditorRoot
+        private class GameRoot /*: UIEditorRoot*/ : ContainerControl
         {
-            internal bool Editable = true;
-            public override bool EnableInputs => !Time.GamePaused && Editor.IsPlayMode;
-            public override bool EnableSelecting => (!Editor.IsPlayMode || Time.GamePaused) && Editable;
-            public override TransformGizmo TransformGizmo => Editor.Instance.MainTransformGizmo;
+            public bool EnableEvents => !Time.GamePaused;
+
+            public override bool RayCast(ref Float2 location, out Control hit)
+            {
+                return RayCastChildren(ref location, out hit);
+            }
+
+            public override bool ContainsPoint(ref Float2 location, bool precise = false)
+            {
+                if (precise)
+                    return false;
+                return base.ContainsPoint(ref location, precise);
+            }
+
+            public override bool OnCharInput(char c)
+            {
+                if (!EnableEvents)
+                    return false;
+
+                return base.OnCharInput(c);
+            }
+
+            public override DragDropEffect OnDragDrop(ref Float2 location, DragData data)
+            {
+                if (!EnableEvents)
+                    return DragDropEffect.None;
+
+                return base.OnDragDrop(ref location, data);
+            }
+
+            public override DragDropEffect OnDragEnter(ref Float2 location, DragData data)
+            {
+                if (!EnableEvents)
+                    return DragDropEffect.None;
+
+                return base.OnDragEnter(ref location, data);
+            }
+
+            public override void OnDragLeave()
+            {
+                if (!EnableEvents)
+                    return;
+
+                base.OnDragLeave();
+            }
+
+            public override DragDropEffect OnDragMove(ref Float2 location, DragData data)
+            {
+                if (!EnableEvents)
+                    return DragDropEffect.None;
+
+                return base.OnDragMove(ref location, data);
+            }
+
+            public override bool OnKeyDown(KeyboardKeys key)
+            {
+                if (!EnableEvents)
+                    return false;
+
+                return base.OnKeyDown(key);
+            }
+
+            public override void OnKeyUp(KeyboardKeys key)
+            {
+                if (!EnableEvents)
+                    return;
+
+                base.OnKeyUp(key);
+            }
+
+            public override bool OnMouseDoubleClick(Float2 location, MouseButton button)
+            {
+                if (!EnableEvents)
+                    return false;
+
+                return base.OnMouseDoubleClick(location, button);
+            }
+
+            public override bool OnMouseDown(Float2 location, MouseButton button)
+            {
+                if (!EnableEvents)
+                    return false;
+
+                return base.OnMouseDown(location, button);
+            }
+
+            public override void OnMouseEnter(Float2 location)
+            {
+                if (!EnableEvents)
+                    return;
+
+                base.OnMouseEnter(location);
+            }
+
+            public override void OnMouseLeave()
+            {
+                if (!EnableEvents)
+                    return;
+
+                base.OnMouseLeave();
+            }
+
+            public override void OnMouseMove(Float2 location)
+            {
+                if (!EnableEvents)
+                    return;
+
+                base.OnMouseMove(location);
+            }
+
+            public override bool OnMouseUp(Float2 location, MouseButton button)
+            {
+                if (!EnableEvents)
+                    return false;
+
+                return base.OnMouseUp(location, button);
+            }
+
+            public override bool OnMouseWheel(Float2 location, float delta)
+            {
+                if (!EnableEvents)
+                    return false;
+
+                return base.OnMouseWheel(location, delta);
+            }
         }
 
         /// <summary>
@@ -407,9 +512,12 @@ namespace FlaxEditor.Windows
             // Override the game GUI root
             _guiRoot = new GameRoot
             {
-                Parent = _viewport
+                Parent = _viewport,
+                AnchorPreset = AnchorPresets.StretchAll,
+                AutoFocus = false,
+                Offsets = Margin.Zero,
             };
-            RootControl.GameRoot = _guiRoot.UIRoot;
+            RootControl.GameRoot = _guiRoot;
 
             SizeChanged += control => { ResizeViewport(); };
 
@@ -737,13 +845,6 @@ namespace FlaxEditor.Windows
                 checkbox.StateChanged += x => ShowGUI = x.Checked;
             }
 
-            // Edit GUI
-            {
-                var button = menu.AddButton("Edit GUI");
-                var checkbox = new CheckBox(140, 2, EditGUI) { Parent = button };
-                checkbox.StateChanged += x => EditGUI = x.Checked;
-            }
-
             // Show Debug Draw
             {
                 var button = menu.AddButton("Show Debug Draw");
@@ -1037,7 +1138,6 @@ namespace FlaxEditor.Windows
         public override void OnLayoutSerialize(XmlWriter writer)
         {
             writer.WriteAttributeString("ShowGUI", ShowGUI.ToString());
-            writer.WriteAttributeString("EditGUI", EditGUI.ToString());
             writer.WriteAttributeString("ShowDebugDraw", ShowDebugDraw.ToString());
             writer.WriteAttributeString("DefaultViewportScalingIndex", _defaultScaleActiveIndex.ToString());
             writer.WriteAttributeString("CustomViewportScalingIndex", _customScaleActiveIndex.ToString());
@@ -1048,8 +1148,6 @@ namespace FlaxEditor.Windows
         {
             if (bool.TryParse(node.GetAttribute("ShowGUI"), out bool value1))
                 ShowGUI = value1;
-            if (bool.TryParse(node.GetAttribute("EditGUI"), out value1))
-                EditGUI = value1;
             if (bool.TryParse(node.GetAttribute("ShowDebugDraw"), out value1))
                 ShowDebugDraw = value1;
             if (int.TryParse(node.GetAttribute("DefaultViewportScalingIndex"), out int value2))
@@ -1083,7 +1181,6 @@ namespace FlaxEditor.Windows
         public override void OnLayoutDeserialize()
         {
             ShowGUI = true;
-            EditGUI = true;
             ShowDebugDraw = false;
         }
     }


### PR DESCRIPTION
This will remove the ability to edit UI from the game window and adds the option to edit the UI in the editor window using the GUI editor. The size of the UI editor background will match the resolution selected in the game window.

<img width="1667" height="901" alt="image" src="https://github.com/user-attachments/assets/c397ec0d-611d-4cd4-8b06-f4d1b7023ece" />



Bugs:
- Seems like Canvas scalar or panel with no colors under UICanvas can not be selected. Maybe something with the raycasting logic?

- Free Aspect and Aspect Ratio game viewport options give not great results for the ui editor view. They will scale the background of the UI editor to be the same size as the game viewport. I am open to suggestions on how to handle this. We could tie this into its own scaling options, but I thought it would be nice to set both in 1 spot.