### PR TITLE
Add X11 Class hints to Linux-based windows.

### DIFF
--- a/Source/Engine/Platform/Linux/LinuxWindow.cpp
+++ b/Source/Engine/Platform/Linux/LinuxWindow.cpp
@@ -18,6 +18,7 @@
 #include "Engine/Graphics/PixelFormatSampler.h"
 #include "Engine/Graphics/Textures/TextureData.h"
 #include "IncludeX11.h"
+#include "ThirdParty/X11/Xutil.h"
 
 // ICCCM
 #define WM_NormalState 1L // window normal state
@@ -177,6 +178,20 @@ LinuxWindow::LinuxWindow(const CreateWindowSettings& settings)
 	{
 		X11::XSetTransientForHint(display, window, (X11::Window)((LinuxWindow*)settings.Parent)->GetNativePtr());
 	}
+
+    // Provides class hint for WMs like Hyprland to hook onto and apply window rules
+    X11::XClassHint* classHint = X11::XAllocClassHint();
+    if (classHint)
+    {
+        const char* className = settings.IsRegularWindow ? "FlexEditor" : "FlaxPopup";
+
+        classHint->res_name = const_cast<char*>(className);
+        classHint->res_class = const_cast<char*>(className);
+
+        X11::XSetClassHint(display, window, classHint);
+
+        XFree(classHint);
+    }
 
     _dpi = Platform::GetDpi();
     _dpiScale = (float)_dpi / (float)DefaultDPI;


### PR DESCRIPTION
Adds X11 Class hints for easy hooking by WMs for window-specific rules. Adds the "FlaxEditor" class hint to regular windows, and "FlaxPopup" to non-regular windows for easy setup of window rules.

**Some more context/info:**

I was having issues with FlaxEngine losing focus on a hanging context menu (i.e. another application window below a context menu which is partially outside the bounds of the Flax Editor window), as windows positioned underneath the context menu would steal focus from the context menu, and lead to zombie windows which did not clear until the application was restarted.

To resolve this, I tried hooking into the client info, but only the main window has title info, and there is no class info for either the main window or popups (and the popups have no identifiable hints at all!). That led me to here, hopefully this will be an easy way to apply quick/specific compatibility fixes while making things more customisable!