### PR TITLE
Show properties without getter in generic editor

### DIFF
--- a/Source/Editor/CustomEditors/Editors/GenericEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/GenericEditor.cs
@@ -247,7 +247,7 @@ namespace FlaxEditor.CustomEditors.Editors
         /// <returns>The items.</returns>
         protected virtual List<ItemInfo> GetItemsForType(ScriptType type)
         {
-            return GetItemsForType(type, type.IsClass, true);
+            return GetItemsForType(type, type.IsClass, true, true);
         }
 
         /// <summary>
@@ -275,6 +275,10 @@ namespace FlaxEditor.CustomEditors.Editors
 
                     // Skip properties without getter or setter
                     if (!p.HasGet || (!p.HasSet && !showInEditor && !usePropertiesWithoutSetter))
+                        continue;
+
+                    // Skip getter-only properties declared in built-in types
+                    if (!p.HasSet && usePropertiesWithoutSetter && p.Type.DeclaringType.Assembly == typeof(Editor).Assembly)
                         continue;
 
                     // Skip hidden fields, handle special attributes


### PR DESCRIPTION
Fixes properties without getter (including shorthand properties) not showing up in the editor views. Now by default all getter-only properties are shown but any getter-only properties originating from in-built types (like `FlaxEngine.Object` `ID` etc.) are not shown to avoid polluting the view unnecessarily.