### PR TITLE
Add highlighted color property to Dropdown control

### DIFF
--- a/Source/Engine/UI/GUI/Common/Dropdown.cs
+++ b/Source/Engine/UI/GUI/Common/Dropdown.cs
@@ -306,7 +306,7 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Gets or sets the color used to display highlighted text.
         /// </summary>
-        [EditorDisplay("Text Style"), EditorOrder(2023), ExpandGroups]
+        [EditorDisplay("Text Style"), EditorOrder(2024), ExpandGroups]
         public Color TextColorHighlighted { get; set; }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a customizable HighlightedColor property to the Dropdown control, allowing developers to define the color used when highlighting dropdown items during hover or selection states.