### PR TITLE
Add "Script obsolete" and "Script only in prefab instance" buttons to the script header bar

### DIFF
--- a/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
+++ b/Source/Editor/CustomEditors/Elements/Container/GroupElement.cs
@@ -52,6 +52,7 @@ namespace FlaxEditor.CustomEditors.Elements
         public Image AddHeaderButton(string tooltipText, float xOffset, SpriteHandle sprite)
         {
             var style = Style.Current;
+            const float padding = 2.0f;
             var settingsButtonSize = Panel.HeaderHeight;
             return new Image
             {
@@ -59,7 +60,7 @@ namespace FlaxEditor.CustomEditors.Elements
                 AutoFocus = true,
                 AnchorPreset = AnchorPresets.TopRight,
                 Parent = Panel,
-                Bounds = new Rectangle(Panel.Width - settingsButtonSize - xOffset, 0, settingsButtonSize, settingsButtonSize),
+                Bounds = new Rectangle(Panel.Width - settingsButtonSize - xOffset, padding * 0.5f, settingsButtonSize - padding, settingsButtonSize - padding),
                 IsScrollable = false,
                 Color = style.ForegroundGrey,
                 Margin = new Margin(1),


### PR DESCRIPTION
```cs
using System;
using FlaxEngine;

namespace Game;

[Obsolete("The message", DiagnosticId = "This is the ID")]
public class ObsoleteScript : Script
{
}
```

results in:

<img width="354" height="114" alt="image" src="https://github.com/user-attachments/assets/0c02ff2f-db30-4927-b02a-6fd6e0d6e4aa" />

<img width="350" height="44" alt="image" src="https://github.com/user-attachments/assets/aa5e4e1c-ec2e-4405-93b3-cc60de8167fa" />


Closes #3845 (sorry for opening an issue first, I thought I wouldn't have the time to do PRs for the time being)

**EDIT:**
Now also closes #3842


<img width="351" height="234" alt="image" src="https://github.com/user-attachments/assets/75a9d659-48c0-4a70-b581-8da2d9208943" />
