### PR TITLE
Fix out-of-bounds write while parsing command-line arguments

### DIFF
--- a/Source/Engine/Main/MainUtil.h
+++ b/Source/Engine/Main/MainUtil.h
@@ -16,7 +16,7 @@ const Char* GetCommandLine(int argc, char* argv[])
     const Char* cmdLine;
     if (length != 0)
     {
-        Char* str = (Char*)malloc(length * sizeof(Char));
+        Char* str = (Char*)malloc((length + 1) * sizeof(Char));
         cmdLine = str;
         for (int i = 1; i < argc; i++)
         {


### PR DESCRIPTION
malloc errors with `malloc(): invalid size (unsorted)` after writing past the allocated memory in `GetCommandLine`. The null terminated character was not accounted for when calculating the allocation size.