### PR TITLE
Run editor with selected project configuration in launchSettings.json

### DIFF
--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -311,6 +311,7 @@ namespace Flax.Build.Projects.VisualStudio
             }
             csProjectFileContent.AppendLine(string.Format("    <DocumentationFile>{0}\\{1}.CSharp.xml</DocumentationFile>", outputPath, project.BaseName));
             csProjectFileContent.AppendLine("    <UseVSHostingProcess>true</UseVSHostingProcess>");
+            csProjectFileContent.AppendLine(string.Format("    <FlaxConfiguration>{0}</FlaxConfiguration>", configuration.ConfigurationName));
 
             csProjectFileContent.AppendLine("  </PropertyGroup>");
 

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/VisualStudioProjectGenerator.cs
@@ -630,7 +630,7 @@ namespace Flax.Build.Projects.VisualStudio
             {
                 var profiles = new Dictionary<string, string>();
                 var profile = new StringBuilder();
-                var configuration = "Development";
+                var configuration = "$(FlaxConfiguration)";
                 var editorPath = Utilities.NormalizePath(Path.Combine(Globals.EngineRoot, Platform.GetEditorBinaryDirectory(), configuration, $"FlaxEditor{Utilities.GetPlatformExecutableExt()}")).Replace('\\', '/');
                 var workspacePath = Utilities.NormalizePath(solutionDirectory).Replace('\\', '/');
                 foreach (var project in projects)


### PR DESCRIPTION
Previously the default generated launch task for game projects used the `Development` configuration to launch the editor with, but we can use and evaluate the matching configuration from MSBuild properties to launch the editor built with the currently selected solution configuration instead.