### PR TITLE
Use standard output for logging by default

### DIFF
--- a/Source/Engine/Core/Log.cpp
+++ b/Source/Engine/Core/Log.cpp
@@ -133,7 +133,11 @@ void Log::Logger::Write(const StringView& msg)
     IsDuringLog = true;
 
     // Send message to standard process output
+#if BUILD_RELEASE
     if (CommandLine::Options.Std.IsTrue())
+#else
+    if (!CommandLine::Options.Std.IsFalse())
+#endif
     {
 #if PLATFORM_TEXT_IS_CHAR16
         StringAnsi ansi(msg);


### PR DESCRIPTION
For Unix platforms we should assume the engine is launched from terminal or through a debugger so we wont miss any important output without the `-std` parameter.