### PR TITLE
Fix compute distance crash if no closest point param is defined.

### DIFF
--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -2787,7 +2787,8 @@ float PhysicsBackend::ComputeShapeSqrDistanceToPoint(void* shape, const Vector3&
 #if USE_LARGE_WORLDS
     PxVec3 closestPointPx;
     float result = PxGeometryQuery::pointDistance(C2P(point), shapePhysX->getGeometry(), trans, &closestPointPx);
-    *closestPoint = P2C(closestPointPx);
+    if (closestPoint)
+        *closestPoint = P2C(closestPointPx);
     return result;
 #else
     return PxGeometryQuery::pointDistance(C2P(point), shapePhysX->getGeometry(), trans, (PxVec3*)closestPoint);


### PR DESCRIPTION
Fixes crash on large world build if no closest point is passed in as a parameter.

Fix #3860