### PR TITLE
Support Visual Studio 2026 as a generator for CMake dependencies

### DIFF
--- a/Source/Tools/Flax.Build/Deploy/VCEnvironment.cs
+++ b/Source/Tools/Flax.Build/Deploy/VCEnvironment.cs
@@ -241,7 +241,11 @@ namespace Flax.Deploy
 
             if (!File.Exists(solutionFile))
             {
-                throw new Exception(string.Format("Unable to build solution {0}. Solution file not found.", solutionFile));
+                // CMake VS2026 generator prefers .slnx solution files, just swap the extension for CMake dependencies
+                if (File.Exists(Path.ChangeExtension(solutionFile, "slnx")))
+                    solutionFile = Path.ChangeExtension(solutionFile, "slnx");
+                else
+                    throw new Exception(string.Format("Unable to build solution {0}. Solution file not found.", solutionFile));
             }
 
             string cmdLine = string.Format("\"{0}\" /m /t:Restore,Build /p:Configuration=\"{1}\" /p:Platform=\"{2}\" {3} /nologo", solutionFile, buildConfig, buildPlatform, Verbosity);

--- a/Source/Tools/Flax.Build/Deps/Dependency.cs
+++ b/Source/Tools/Flax.Build/Deps/Dependency.cs
@@ -47,6 +47,24 @@ namespace Flax.Deps
         /// </summary>
         protected static TargetPlatform BuildPlatform => Platform.BuildPlatform.Target;
 
+
+        private static Version? _cmakeVersion;
+        protected static Version CMakeVersion
+        {
+            get
+            {
+                if (_cmakeVersion == null)
+                {
+                    var versionOutput = Utilities.ReadProcessOutput("cmake", "--version");
+                    var versionStart = versionOutput.IndexOf("cmake version ") + "cmake version ".Length;
+                    var versionEnd = versionOutput.IndexOfAny(['-', '\n', '\r'], versionStart); // End of line or dash before Git hash
+                    var versionString = versionOutput.Substring(versionStart, versionEnd - versionStart);
+                    _cmakeVersion = new Version(versionString);
+                }
+                return _cmakeVersion;
+            }
+        }
+
         /// <summary>
         /// Gets the platforms list supported by this dependency to build on the current build platform (based on <see cref="Platform.BuildPlatform"/>).
         /// </summary>
@@ -309,7 +327,13 @@ namespace Flax.Deps
                     break;
                 default: throw new InvalidArchitectureException(architecture);
                 }
-                cmdLine = string.Format("CMakeLists.txt -G \"Visual Studio 17 2022\" -A {0}", arch);
+                if (CMakeVersion.Major > 4 || (CMakeVersion.Major == 4 && CMakeVersion.Minor >= 2))
+                {
+                    // This generates both .sln and .slnx solution files
+                    cmdLine = string.Format("CMakeLists.txt -G \"Visual Studio 17 2022\" -G \"Visual Studio 18 2026\" -A {0}", arch);
+                }
+                else
+                    cmdLine = string.Format("CMakeLists.txt -G \"Visual Studio 17 2022\" -A {0}", arch);
                 break;
             }
             case TargetPlatform.PS4:


### PR DESCRIPTION
Generate CMake solution for both VS 2026 and 2022 if the detected CMake version supports VS 2026.

Cherry-picked change from #3746