### PR TITLE
Fix compilation errors with `/permissive-` standard conformance mode

### DIFF
--- a/Source/Engine/GraphicsDevice/DirectX/DX11/GPUTextureDX11.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX11/GPUTextureDX11.cpp
@@ -553,7 +553,7 @@ void GPUTextureDX11::initHandles()
     if (useDSV && useSRV && PixelFormatExtensions::HasStencil(format))
     {
         PixelFormat stencilFormat;
-        switch (_dxgiFormatDSV)
+        switch (static_cast<PixelFormat>(_dxgiFormatDSV))
         {
         case PixelFormat::D24_UNorm_S8_UInt:
             srDesc.Format = DXGI_FORMAT_X24_TYPELESS_G8_UINT;

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.h
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.h
@@ -210,7 +210,7 @@ public:
     /// <param name="device">The graphics device.</param>
     /// <param name="name">The resource name.</param>
     GPUResourceDX12(GPUDeviceDX12* device, const StringView& name)
-        : GPUResourceBase(device, name)
+        : GPUResourceBase<GPUDeviceDX12, BaseType>(device, name)
     {
     }
 };

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUTextureDX12.cpp
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUTextureDX12.cpp
@@ -732,7 +732,7 @@ void GPUTextureDX12::initHandles()
     if (useDSV && useSRV && PixelFormatExtensions::HasStencil(format))
     {
         PixelFormat stencilFormat;
-        switch (_dxgiFormatDSV)
+        switch (static_cast<PixelFormat>(_dxgiFormatDSV))
         {
         case PixelFormat::D24_UNorm_S8_UInt:
             srDesc.Format = DXGI_FORMAT_X24_TYPELESS_G8_UINT;


### PR DESCRIPTION
Fixes couple errors when building the engine with `/permissive- /Zc:externC-` Visual Studio compiler parameters.

Maybe we should use these parameters by default with VS toolchain? The standard conformance mode especially helps me testing the compilation issues related to #3858 without having access to clang compiler. The flag `/Zc:externC-` needs to be used to avoid errors with external linkage declarations in `WindowsMinimal.h`.