### PR TITLE
Improve orthographic/ perspective viewport cam toggle

### DIFF
--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -247,8 +247,8 @@ namespace FlaxEditor.Viewport
             {
                 _movementSpeed = value;
 
-                if (_cameraButton != null)
-                    _cameraButton.Text = string.Format(MovementSpeedTextFormat, _movementSpeed);
+                if (_orthographicModeButton != null)
+                    _orthographicModeButton.Text = string.Format(MovementSpeedTextFormat, _movementSpeed);
             }
         }
 
@@ -581,7 +581,7 @@ namespace FlaxEditor.Viewport
 
                 // Camera Settings Menu
                 var cameraCM = new ContextMenu();
-                _cameraButton = new ViewportWidgetButton(string.Format(MovementSpeedTextFormat, _movementSpeed), _editor.Icons.Camera64, cameraCM, false, cameraSpeedTextWidth)
+                _cameraButton = new ViewportWidgetButton("", _editor.Icons.Camera64, cameraCM)
                 {
                     Tag = this,
                     TooltipText = "Camera Settings",
@@ -590,7 +590,7 @@ namespace FlaxEditor.Viewport
                 _cameraWidget.Parent = this;
 
                 // Orthographic/Perspective Mode Widget
-                _orthographicModeButton = new ViewportWidgetButton(string.Empty, _editor.Icons.CamSpeed32, null, true)
+                _orthographicModeButton = new OrthoCamToggleViewportWidgetButton(cameraSpeedTextWidth)
                 {
                     Checked = !_isOrtho,
                     TooltipText = "Toggle Orthographic/Perspective Mode",


### PR DESCRIPTION
Instead of the arrow (telling the user nothing about what the button does), the orthographic/ perspective toggle button now draws an orthographic or perspective view frustum, depending on its state.

I had to move the camera speed to the right of frustum button to make it look like the frustum is directly in front of the camera.

This will prevent users getting confused like in #3789.

https://github.com/user-attachments/assets/2677981f-48a2-4386-b1b7-ad7e9050d65a

Closes #3789

