### PR TITLE
Fix incorrect class namespace in bindings class name lookups

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -387,17 +387,7 @@ namespace Flax.Build.Bindings
 
             // Find namespace for this type to build a fullname
             if (apiType != null)
-            {
-                var e = apiType.Parent;
-                while (!(e is FileInfo))
-                {
-                    e = e.Parent;
-                }
-                if (e is FileInfo fileInfo && !managedType.StartsWith(fileInfo.Namespace))
-                {
-                    managedType = fileInfo.Namespace + '.' + managedType.Replace(".", "+");
-                }
-            }
+                managedType = apiType.Namespace + '.' + managedType.Replace(".", "+");
 
             // Use runtime lookup from fullname of the C# class
             return "Scripting::FindClass(\"" + managedType + "\")";


### PR DESCRIPTION
The bindings generator used the wrong class namespace used in runtime class lookups (`Scripting::FindClass`) for the following types :
- `Guid` (should be `System.Guid`, not `FlaxEngine.Guid`)
- `NetworkChannelType` (should be `FlaxEngine.Networking.NetworkChannelType`, not `FlaxEngine.NetworkChannelType`)
- `OnlineLeaderboardSortModes` and `OnlineLeaderboardValueFormats` (both should be under `FlaxEngine.Online`, not `FlaxEngine`)