### PR TITLE
Change windows meta data to show project name as application name

### DIFF
--- a/Source/FlaxGame.Build.cs
+++ b/Source/FlaxGame.Build.cs
@@ -19,16 +19,6 @@ public class FlaxGame : EngineTarget
         ConfigurationName = "Game";
         IsPreBuilt = false;
         IsMonolithicExecutable = false;
-        
-        // Load project in workspace and set project name for meta data purposes on Windows
-        var projectFiles = Directory.GetFiles(Globals.Root, "*.flaxproj", SearchOption.TopDirectoryOnly);
-        if (projectFiles.Length == 0)
-            throw new Exception("Missing project file. Folder: " + Globals.Root);
-        else if (projectFiles.Length > 1)
-            throw new Exception("Too many project files. Don't know which to pick. Folder: " + Globals.Root);
-        var project = ProjectInfo.Load(projectFiles[0]);
-        
-        ProjectName = project.Name;
     }
 
     /// <inheritdoc />

--- a/Source/FlaxGame.Build.cs
+++ b/Source/FlaxGame.Build.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
+using System;
 using System.IO;
 using Flax.Build;
 using Flax.Build.NativeCpp;
@@ -18,6 +19,16 @@ public class FlaxGame : EngineTarget
         ConfigurationName = "Game";
         IsPreBuilt = false;
         IsMonolithicExecutable = false;
+        
+        // Load project in workspace and set project name for meta data purposes on Windows
+        var projectFiles = Directory.GetFiles(Globals.Root, "*.flaxproj", SearchOption.TopDirectoryOnly);
+        if (projectFiles.Length == 0)
+            throw new Exception("Missing project file. Folder: " + Globals.Root);
+        else if (projectFiles.Length > 1)
+            throw new Exception("Too many project files. Don't know which to pick. Folder: " + Globals.Root);
+        var project = ProjectInfo.Load(projectFiles[0]);
+        
+        ProjectName = project.Name;
     }
 
     /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchain.cs
@@ -137,7 +137,7 @@ namespace Flax.Build.Platforms
                 foreach (var definition in options.CompileEnv.PreprocessorDefinitions)
                     args.Add(string.Format("/D \"{0}\"", definition));
                 args.Add(string.Format("/D \"ORIGINAL_FILENAME=\\\"{0}\\\"\"", Path.GetFileName(outputFilePath)));
-                args.Add(string.Format("/D \"PRODUCT_NAME=\\\"{0}\\\"\"", options.Target.ProjectName + " " + options.Target.ConfigurationName));
+                args.Add(string.Format("/D \"PRODUCT_NAME=\\\"{0}\\\"\"", options.Target.ProjectName));
                 args.Add(string.Format("/D \"PRODUCT_NAME_INTERNAL=\\\"{0}\\\"\"", options.Target.Name));
 
                 // Add include paths

--- a/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Windows/WindowsToolchain.cs
@@ -133,60 +133,24 @@ namespace Flax.Build.Platforms
                 // Language
                 args.Add("/l 0x0409");
 
-                string targetName = options.Target.ProjectName;
-                if (options.Target.ProjectName == "Flax" && options.Target.ConfigurationName == "Game")
-                {
-                    
-                    // Load project in workspace and set project name for meta data purposes on Windows
-                    var projectFiles = Directory.GetFiles(Globals.Root, "*.flaxproj", SearchOption.TopDirectoryOnly);
-                    if (projectFiles.Length == 0)
-                        throw new Exception("Missing project file. Folder: " + Globals.Root);
-                    else if (projectFiles.Length > 1)
-                        throw new Exception("Too many project files. Don't know which to pick. Folder: " + Globals.Root);
-                    var project = ProjectInfo.Load(projectFiles[0]);
-                    
-                    // Default values
-                    string productName = project.Name;
-                    string companyName = string.IsNullOrEmpty(project.Company) ? "MyCompany" : project.Company;
-                    string outputNameTemplate = "${PROJECT_NAME}";
-
-                    // Parse GameSettings.json
-                    var gameSettingsPath = Path.Combine(Globals.Root, "Content", "GameSettings.json");
-                    var jsonProductName = GetJsonValue(gameSettingsPath, "ProductName");
-                    if (!string.IsNullOrEmpty(jsonProductName))
-                        productName = jsonProductName;
-                    var jsonCompanyName = GetJsonValue(gameSettingsPath, "CompanyName");
-                    if (!string.IsNullOrEmpty(jsonCompanyName))
-                        companyName = jsonCompanyName;
-
-                    // Parse Build Settings.json
-                    var buildSettingsPath = Path.Combine(Globals.Root, "Content", "Settings", "Build Settings.json");
-                    var jsonOutputName = GetJsonValue(buildSettingsPath, "OutputName");
-                    if (!string.IsNullOrEmpty(jsonOutputName))
-                        outputNameTemplate = jsonOutputName;
-
-                    if (string.IsNullOrEmpty(outputNameTemplate))
-                        outputNameTemplate = "FlaxGame";
-
-                    // Token replacement matching EditorUtilities.cpp behavior
-                    string finalName = outputNameTemplate.Replace("${PROJECT_NAME}", productName, StringComparison.OrdinalIgnoreCase).Replace("${COMPANY_NAME}", companyName, StringComparison.OrdinalIgnoreCase);
-
-                    // Strip invalid filename characters
-                    foreach (char c in Path.GetInvalidFileNameChars())
-                    {
-                        finalName = finalName.Replace(c.ToString(), "");
-                    }
-
-                    targetName = finalName;
-                }
-                Log.Warning("ProjectName: " + targetName);
-
                 // Add preprocessor definitions
                 foreach (var definition in options.CompileEnv.PreprocessorDefinitions)
                     args.Add(string.Format("/D \"{0}\"", definition));
                 args.Add(string.Format("/D \"ORIGINAL_FILENAME=\\\"{0}\\\"\"", Path.GetFileName(outputFilePath)));
-                args.Add(string.Format("/D \"PRODUCT_NAME=\\\"{0}\\\"\"", options.Target.ProjectName));
-                args.Add(string.Format("/D \"PRODUCT_NAME_INTERNAL=\\\"{0}\\\"\"", options.Target.Name));
+                if (TryGetGameProductName(options, out var productName))
+                {
+                    if (!HasDefinition(options.CompileEnv.PreprocessorDefinitions, "PRODUCT_NAME"))
+                        args.Add(string.Format("/D \"PRODUCT_NAME=\\\"{0}\\\"\"", productName));
+                    if (!HasDefinition(options.CompileEnv.PreprocessorDefinitions, "PRODUCT_NAME_INTERNAL"))
+                        args.Add(string.Format("/D \"PRODUCT_NAME_INTERNAL=\\\"{0}\\\"\"", productName));
+                }
+                else
+                {
+                    if (!HasDefinition(options.CompileEnv.PreprocessorDefinitions, "PRODUCT_NAME"))
+                        args.Add(string.Format("/D \"PRODUCT_NAME=\\\"{0}\\\"\"", options.Target.ProjectName));
+                    if (!HasDefinition(options.CompileEnv.PreprocessorDefinitions, "PRODUCT_NAME_INTERNAL"))
+                        args.Add(string.Format("/D \"PRODUCT_NAME_INTERNAL=\\\"{0}\\\"\"", options.Target.Name));
+                }
 
                 // Add include paths
                 foreach (var includePath in options.CompileEnv.IncludePaths)
@@ -213,13 +177,81 @@ namespace Flax.Build.Platforms
 
             base.LinkFiles(graph, options, outputFilePath);
         }
-        
+
+        private static bool HasDefinition(IEnumerable<string> definitions, string name)
+        {
+            var prefix = name + "=";
+            foreach (var definition in definitions)
+            {
+                if (definition.StartsWith(prefix, StringComparison.Ordinal))
+                    return true;
+            }
+            return false;
+        }
+
+        private static bool TryGetGameProductName(BuildOptions options, out string finalName)
+        {
+            finalName = null;
+            if (options.LinkEnv.Output != LinkerOutput.Executable)
+                return false;
+            if (!string.Equals(options.Target.ConfigurationName, "Game", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            // Prefer the workspace project (game), fallback to target project.
+            ProjectInfo project = Globals.Project;
+            if (project == null || string.Equals(project.Name, "Flax", StringComparison.OrdinalIgnoreCase))
+            {
+                if (options.Target is ProjectTarget projectTarget && projectTarget.Project != null)
+                    project = projectTarget.Project;
+            }
+            if (project == null)
+                return false;
+
+            // Default values
+            string productName = project.Name;
+            string companyName = string.IsNullOrEmpty(project.Company) ? "MyCompany" : project.Company;
+            string outputNameTemplate = "${PROJECT_NAME}";
+
+            // Parse GameSettings.json
+            var gameSettingsPath = Path.Combine(project.ProjectFolderPath, "Content", "GameSettings.json");
+            var jsonProductName = GetJsonValue(gameSettingsPath, "ProductName");
+            if (!string.IsNullOrEmpty(jsonProductName))
+                productName = jsonProductName;
+            var jsonCompanyName = GetJsonValue(gameSettingsPath, "CompanyName");
+            if (!string.IsNullOrEmpty(jsonCompanyName))
+                companyName = jsonCompanyName;
+
+            // Parse Build Settings.json
+            var buildSettingsPath = Path.Combine(project.ProjectFolderPath, "Content", "Settings", "Build Settings.json");
+            var jsonOutputName = GetJsonValue(buildSettingsPath, "OutputName");
+            if (!string.IsNullOrEmpty(jsonOutputName))
+                outputNameTemplate = jsonOutputName;
+
+            if (string.IsNullOrEmpty(outputNameTemplate))
+                outputNameTemplate = "FlaxGame";
+
+            // Token replacement matching EditorUtilities.cpp behavior
+            string resolvedName = outputNameTemplate
+                .Replace("${PROJECT_NAME}", productName, StringComparison.OrdinalIgnoreCase)
+                .Replace("${COMPANY_NAME}", companyName, StringComparison.OrdinalIgnoreCase);
+
+            // Strip invalid filename characters
+            foreach (char c in Path.GetInvalidFileNameChars())
+                resolvedName = resolvedName.Replace(c.ToString(), "");
+
+            if (string.IsNullOrEmpty(resolvedName))
+                return false;
+
+            finalName = resolvedName;
+            return true;
+        }
+
         private static string GetJsonValue(string path, string propertyName)
         {
             if (!File.Exists(path))
                 return null;
             var content = File.ReadAllText(path);
-            
+
             // Search for "PropertyName": "Value" or "PropertyName":"Value"
             var search = $"\"{propertyName}\"";
             int keyIdx = content.IndexOf(search, StringComparison.Ordinal);
@@ -233,7 +265,7 @@ namespace Flax.Build.Platforms
             int quoteStart = content.IndexOf('"', colonIdx + 1);
             if (quoteStart == -1)
                 return null;
-            
+
             int quoteEnd = content.IndexOf('"', quoteStart + 1);
             if (quoteEnd == -1)
                 return null;


### PR DESCRIPTION
There could be a better way to fix this... The current issue is that all of the meta data for a cooked game on windows is using FlaxGame. It is nicer if it shows the product name itself. 

I think it would be good to do something similar with the product version and copyright, but this was not as easy to tap into since that is set from the Flax Engine version and copyright defines.

This will change the windows meta data set from the .rc file to be the game name instead of just FlaxGame.
Before:
<img width="426" height="281" alt="image" src="https://github.com/user-attachments/assets/de9e4bbe-8229-4b59-8fdc-b9ded51dceb9" />

After:
<img width="422" height="248" alt="image" src="https://github.com/user-attachments/assets/00f97157-70ff-43a1-80c6-44506268292e" />

This also makes it so the process name is changed to be the game name instead of FlaxGame.
Before:
<img width="336" height="67" alt="image" src="https://github.com/user-attachments/assets/5f3c4150-75e6-4144-8d29-162fb4949e20" />

After:
<img width="663" height="82" alt="image" src="https://github.com/user-attachments/assets/2cb5e4e6-2f36-473b-a8aa-2eaad6a383fd" />



Issues with the current setup:
- Reliant on Build Settings path

