### PR TITLE
fix crash on asset auto-upgrade

### DIFF
--- a/Source/Engine/Content/Factories/BinaryAssetFactory.cpp
+++ b/Source/Engine/Content/Factories/BinaryAssetFactory.cpp
@@ -146,6 +146,10 @@ bool BinaryAssetFactoryBase::UpgradeAsset(const AssetInfo& info, FlaxStorage* st
         context.Input = context.Output;
     } while (upgrader->ShouldUpgrade(context.Input.SerializedVersion));
 
+    // Prevent other threads from loading the storage when it is upgrading
+    // It works because CriticalSection allows recursion
+    ScopeLock upgradeLock(storage->_loadLocker);
+
     // Release storage internal data (should also close file handles)
     {
         // HACK: file is locked by some tasks: the current one that called asset data upgrade (LoadAssetTask)


### PR DESCRIPTION
This is a fix for the asset upgrade logic. The code is practically hibernating right now, but I randomly ran into it so I did the fix😂.

It's basically caused by a data race: while the upgrade logic is writing the upgraded data to the file, another thread tries to load it,  fails, and incorrectly delete the still-in-use FlaxStorage object.

I attached the log, just in case.
[Log.txt](https://github.com/user-attachments/files/24401117/Log.txt)
