### PR TITLE
Add C++ preprocessor definitions `FLAX_EDITOR` and `FLAX_GAME`

### DIFF
--- a/Source/FlaxEditor.Build.cs
+++ b/Source/FlaxEditor.Build.cs
@@ -30,6 +30,7 @@ public class FlaxEditor : EngineTarget
             TargetArchitecture.ARM64,
         };
         GlobalDefinitions.Add("USE_EDITOR");
+        GlobalDefinitions.Add("FLAX_EDITOR");
 
         Modules.Add("Editor");
         Modules.Add("CSG");

--- a/Source/Tools/Flax.Build/Build/GameTarget.cs
+++ b/Source/Tools/Flax.Build/Build/GameTarget.cs
@@ -21,6 +21,8 @@ namespace Flax.Build
             LinkType = TargetLinkType.Monolithic;
             OutputType = TargetOutputType.Executable;
             Modules.Add("Main");*/
+
+            GlobalDefinitions.Add("FLAX_GAME");
         }
     }
 
@@ -51,6 +53,7 @@ namespace Flax.Build
             };
             ConfigurationName = "Editor";
             GlobalDefinitions.Add("USE_EDITOR");
+            GlobalDefinitions.Add("FLAX_EDITOR");
         }
     }
 }


### PR DESCRIPTION
Fixes inconsistent preprocessor definitions for both editor and game builds for C++ scripts. For C# scripts these definitions are present and supported in both editor and game builds respectively, but for C++ scripting user is expected to use the `USE_EDITOR` definition over these ones.