### PR TITLE
feat(Editor): Add MenuItemAttribute for automatic main menu registration

### DIFF
--- a/Source/Editor/Editor.cs
+++ b/Source/Editor/Editor.cs
@@ -135,6 +135,11 @@ namespace FlaxEditor
         public ProgressReportingModule ProgressReporting;
 
         /// <summary>
+        /// The menu item module.
+        /// </summary>
+        public MenuItemModule MenuItems;
+        
+        /// <summary>
         /// The content editing module.
         /// </summary>
         public ContentEditingModule ContentEditing;
@@ -294,6 +299,7 @@ namespace FlaxEditor
             RegisterModule(CodeDocs = new CodeDocsModule(this));
             RegisterModule(ProgressReporting = new ProgressReportingModule(this));
             RegisterModule(ContentFinding = new ContentFindingModule(this));
+            RegisterModule(MenuItems = new MenuItemModule(this));
             Profiler.EndEvent();
 
             StateMachine = new EditorStateMachine(this);

--- a/Source/Editor/Modules/MenuItemModule.cs
+++ b/Source/Editor/Modules/MenuItemModule.cs
@@ -1,0 +1,279 @@
+﻿// Copyright (c) Wojciech Figat. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FlaxEditor.GUI.ContextMenu;
+using FlaxEngine;
+
+namespace FlaxEditor.Modules
+{
+    /// <summary>
+    /// Manages menu items registered via <see cref="MenuItemAttribute"/>.
+    /// Scans assemblies for static methods decorated with [MenuItem] and registers them to the editor main menu.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.Modules.EditorModule" />
+    public sealed class MenuItemModule : EditorModule
+    {
+        /// <summary>
+        /// Represents a menu item entry scanned from assemblies.
+        /// </summary>
+        private struct MenuItemEntry
+        {
+            /// <summary>
+            /// The menu path (e.g., "Tools/My Tool").
+            /// </summary>
+            public string Path;
+
+            /// <summary>
+            /// The sorting priority. Lower values appear first.
+            /// </summary>
+            public int Priority;
+
+            /// <summary>
+            /// The shortcut text to display.
+            /// </summary>
+            public string Shortcut;
+
+            /// <summary>
+            /// The method to invoke when the menu item is clicked.
+            /// </summary>
+            public MethodInfo Method;
+        }
+
+        private readonly List<MenuItemEntry> _entries = new List<MenuItemEntry>();
+        private readonly List<ContextMenuButton> _registeredButtons = new List<ContextMenuButton>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuItemModule"/> class.
+        /// </summary>
+        /// <param name="editor">The editor instance.</param>
+        internal MenuItemModule(Editor editor)
+        : base(editor)
+        {
+            // Initialize after UIModule to ensure MainMenu exists
+            InitOrder = -900;
+        }
+
+        /// <inheritdoc />
+        public override void OnInit()
+        {
+            ScriptsBuilder.ScriptsReloadEnd += OnScriptsReloadEnd;
+            ScanAndRegisterMenuItems();
+        }
+
+        /// <inheritdoc />
+        public override void OnExit()
+        {
+            ScriptsBuilder.ScriptsReloadEnd -= OnScriptsReloadEnd;
+            ClearRegisteredItems();
+        }
+
+        /// <summary>
+        /// Called when scripts reload ends. Re-scans and re-registers all menu items.
+        /// </summary>
+        private void OnScriptsReloadEnd()
+        {
+            ClearRegisteredItems();
+            ScanAndRegisterMenuItems();
+        }
+
+        /// <summary>
+        /// Clears all registered menu item buttons and entries.
+        /// </summary>
+        private void ClearRegisteredItems()
+        {
+            for (int i = 0; i < _registeredButtons.Count; i++)
+            {
+                _registeredButtons[i]?.Dispose();
+            }
+            _registeredButtons.Clear();
+            _entries.Clear();
+        }
+
+        /// <summary>
+        /// Scans all loaded assemblies for methods decorated with <see cref="MenuItemAttribute"/> and registers them to the main menu.
+        /// </summary>
+        private void ScanAndRegisterMenuItems()
+        {
+            // Scan all assemblies for [MenuItem] methods
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                var assembly = assemblies[i];
+                if (!ShouldScanAssembly(assembly))
+                    continue;
+
+                try
+                {
+                    ScanAssembly(assembly);
+                }
+                catch (Exception ex)
+                {
+                    Editor.LogWarning(string.Format("Failed to scan assembly '{0}' for menu items: {1}", assembly.FullName, ex.Message));
+                }
+            }
+
+            // Sort by priority (lower values first)
+            _entries.Sort((a, b) => a.Priority.CompareTo(b.Priority));
+
+            // Register to main menu
+            RegisterAllMenuItems();
+        }
+
+        /// <summary>
+        /// Determines whether the specified assembly should be scanned for menu items.
+        /// </summary>
+        /// <param name="assembly">The assembly to check.</param>
+        /// <returns><c>true</c> if the assembly should be scanned; otherwise, <c>false</c>.</returns>
+        private bool ShouldScanAssembly(Assembly assembly)
+        {
+            var name = assembly.GetName().Name;
+
+            // Skip system and engine core assemblies
+            if (name.StartsWith("System") ||
+                name.StartsWith("Microsoft") ||
+                name.StartsWith("mscorlib") ||
+                name == "FlaxEngine.CSharp" ||
+                name == "Newtonsoft.Json")
+                return false;
+
+            // Only scan assemblies that reference FlaxEngine
+            var references = assembly.GetReferencedAssemblies();
+            for (int i = 0; i < references.Length; i++)
+            {
+                if (references[i].Name == "FlaxEngine.CSharp")
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Scans the specified assembly for methods decorated with <see cref="MenuItemAttribute"/>.
+        /// </summary>
+        /// <param name="assembly">The assembly to scan.</param>
+        private void ScanAssembly(Assembly assembly)
+        {
+            var types = assembly.GetTypes();
+            for (int i = 0; i < types.Length; i++)
+            {
+                var type = types[i];
+                var methods = type.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+                for (int j = 0; j < methods.Length; j++)
+                {
+                    var method = methods[j];
+                    var attr = method.GetCustomAttribute<MenuItemAttribute>();
+                    if (attr == null)
+                        continue;
+
+                    // Validate method signature: must be parameterless
+                    if (method.GetParameters().Length > 0)
+                    {
+                        Editor.LogWarning(string.Format("[MenuItem] method '{0}.{1}' must be parameterless", type.FullName, method.Name));
+                        continue;
+                    }
+
+                    // Validate path: must not be empty
+                    if (string.IsNullOrEmpty(attr.Path))
+                    {
+                        Editor.LogWarning(string.Format("[MenuItem] method '{0}.{1}' has empty path", type.FullName, method.Name));
+                        continue;
+                    }
+
+                    _entries.Add(new MenuItemEntry
+                    {
+                        Path = attr.Path,
+                        Priority = attr.Priority,
+                        Shortcut = attr.Shortcut,
+                        Method = method
+                    });
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers all scanned menu item entries to the editor main menu.
+        /// </summary>
+        private void RegisterAllMenuItems()
+        {
+            var mainMenu = Editor.UI.MainMenu;
+            if (mainMenu == null)
+                return;
+
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                try
+                {
+                    RegisterMenuItem(_entries[i]);
+                }
+                catch (Exception ex)
+                {
+                    Editor.LogWarning(string.Format("Failed to register menu item '{0}': {1}", _entries[i].Path, ex.Message));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers a single menu item entry to the editor main menu.
+        /// </summary>
+        /// <param name="entry">The menu item entry to register.</param>
+        private void RegisterMenuItem(MenuItemEntry entry)
+        {
+            var parts = entry.Path.Split('/');
+            if (parts.Length < 2)
+            {
+                Editor.LogWarning(string.Format("[MenuItem] path '{0}' is invalid, requires at least 'Menu/Item' format", entry.Path));
+                return;
+            }
+
+            // Get or create top-level menu button
+            var topMenuName = parts[0].Trim();
+            var topMenu = Editor.UI.MainMenu.GetOrAddButton(topMenuName);
+            var contextMenu = topMenu.ContextMenu;
+
+            // Navigate or create submenu hierarchy
+            ContextMenuChildMenu currentChildMenu = null;
+            for (int i = 1; i < parts.Length - 1; i++)
+            {
+                var subMenuName = parts[i].Trim();
+                if (currentChildMenu == null)
+                    currentChildMenu = contextMenu.GetOrAddChildMenu(subMenuName);
+                else
+                    currentChildMenu = currentChildMenu.ContextMenu.GetOrAddChildMenu(subMenuName);
+                
+                currentChildMenu.ContextMenu.AutoSort = true;
+            }
+
+            // Add the menu item button to the target context menu
+            var itemName = parts[parts.Length - 1].Trim();
+            var method = entry.Method;
+            var targetMenu = currentChildMenu?.ContextMenu ?? contextMenu;
+
+            ContextMenuButton button;
+            if (!string.IsNullOrEmpty(entry.Shortcut))
+                button = targetMenu.AddButton(itemName, entry.Shortcut, () => InvokeMenuItem(method));
+            else
+                button = targetMenu.AddButton(itemName, () => InvokeMenuItem(method));
+
+            _registeredButtons.Add(button);
+        }
+
+        /// <summary>
+        /// Invokes the specified menu item method.
+        /// </summary>
+        /// <param name="method">The method to invoke.</param>
+        private void InvokeMenuItem(MethodInfo method)
+        {
+            try
+            {
+                method.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                Editor.LogError(string.Format("Failed to invoke menu item '{0}.{1}': {2}", method.DeclaringType?.FullName, method.Name, ex));
+            }
+        }
+    }
+}

--- a/Source/Engine/Scripting/Attributes/Editor/MenuItemAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/MenuItemAttribute.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Wojciech Figat. All rights reserved.
+
+using System;
+
+namespace FlaxEngine
+{
+    /// <summary>
+    /// Marks a static method to be registered as a menu item in the editor main menu.
+    /// </summary>
+    /// <remarks>
+    /// The method must be static and parameterless. Use "/" to create submenus, e.g., "Tools/My Tool".
+    /// </remarks>
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class MenuItemAttribute : Attribute
+    {
+        /// <summary>
+        /// The menu item path. Use "/" to separate menu levels (e.g., "Tools/My Tool" or "Window/Custom/My Window").
+        /// </summary>
+        public string Path;
+
+        /// <summary>
+        /// The sorting priority. Lower values appear first. Default is 1000.
+        /// </summary>
+        public int Priority = 1000;
+
+        /// <summary>
+        /// The shortcut text to display (for display only, does not auto-bind input).
+        /// </summary>
+        public string Shortcut;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuItemAttribute"/> class.
+        /// </summary>
+        public MenuItemAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuItemAttribute"/> class.
+        /// </summary>
+        /// <param name="path">The menu item path (e.g., "Tools/My Tool").</param>
+        public MenuItemAttribute(string path)
+        {
+            Path = path;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuItemAttribute"/> class.
+        /// </summary>
+        /// <param name="path">The menu item path (e.g., "Tools/My Tool").</param>
+        /// <param name="priority">The sorting priority (lower values appear first).</param>
+        public MenuItemAttribute(string path, int priority)
+        {
+            Path = path;
+            Priority = priority;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a `[MenuItem]` attribute system that allows developers to easily register static methods as menu items in the editor's main menu, similar to Unity's MenuItemAttribute.

## Changes
- **New file**: `Source/Engine/Scripting/Attributes/Editor/MenuItemAttribute.cs`
  - Defines the `[MenuItem]` attribute with `Path`, `Priority`, and `Shortcut` properties
- **New file**: `Source/Editor/Modules/MenuItemModule.cs`
  - Scans assemblies for methods decorated with `[MenuItem]`
  - Dynamically registers them to the editor main menu
  - Handles scripts reload to keep menu items up-to-date
- **Modified**: `Source/Editor/Editor.cs`
  - Registers the new `MenuItemModule`

## Usage Example
``` csharp
public static class MyEditorTools
{
    [MenuItem("Tools/My Custom Tool")]
    public static void OpenMyTool()
    {
        Debug.Log("My tool opened!");
    }

    [MenuItem("Window/Custom/My Window", Priority = 100, Shortcut = "Ctrl+Shift+M")]
    public static void OpenMyWindow()
    {
        // Open custom window
    }
}
```
## Notes
- Methods must be static and parameterless
- Use / to create submenus (e.g., "Tools/SubMenu/Item")
- Lower priority values appear first in the menu
- Shortcut is for display only; actual input binding requires separate setup