### PR TITLE
Fix issue with tabs not collapsing panel 1 if no tabs on panel 1.

### DIFF
--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -491,10 +491,15 @@ namespace FlaxEditor.Modules
                         Editor.LogWarning("Empty panel inside layout.");
                         p.RemoveIt();
                     }
+                    else
+                    {
+                        p.CollapseEmptyTabsProxy();
+                    }
                 }
             }
 
             panel.SelectTab(selectedTab);
+            panel.CollapseEmptyTabsProxy();
         }
 
         private static void SaveBounds(XmlWriter writer, Window win)


### PR DESCRIPTION
There was an issue where if all of the tabs are move to split panel 2, panel 1 stays open but is blank with no tabs. this fixes that and "collapses" panel 1 if there are no tabs on it.