### PR TITLE
Add some utility for copying parameter names to parameter right clickmenu

### DIFF
--- a/Source/Editor/Surface/VisjectSurfaceWindow.cs
+++ b/Source/Editor/Surface/VisjectSurfaceWindow.cs
@@ -723,6 +723,9 @@ namespace FlaxEditor.Surface
             foreach (var param in ((IVisjectSurfaceWindow)Values[0]).VisjectSurface.Parameters)
             {
                 string cleanParamName = param.Name.Replace(" ", "");
+                // Filter out headers and other non-parameter entries that can be present in the parameters list
+                if (string.IsNullOrEmpty(cleanParamName))
+                    continue;
                 allParamNames += $"private const string {cleanParamName}ParameterName = \"{param.Name}\";\n";
             }
 


### PR DESCRIPTION
Adds two new buttons to Visject paramter right click menu:
- Copy parameter name
- Copy all names 

<img width="261" height="392" alt="image" src="https://github.com/user-attachments/assets/34565625-343f-48cc-a22f-9c60b971b225" />

"Copy parameter" name will copy the name of the right clicked parameter into the clipboard.

"Copy all names" will copy all parameters names into the clipboard and format them as private C# constant strings 
(like this: 
```cs
private const string "name of parameter without whitespaces"ParameterName = "name of parameter";
```

This allows the user to easily transfer all the parameter names into their code, without having to copying their names one by one or typing each name out again.

(I swear doing this has driven me nuts in the past, you always make at least one typo or accidentally save the script so Flax will recompile it, so you will have to wait again).

I think this fits in very well with Flaxs goal of being agile and fast to use.

Here's a demo for how quick this is (using the an animation graph from my project):



https://github.com/user-attachments/assets/b9b7038e-8053-49e6-9fae-7bb7fffa3ddf



