### PR TITLE
Tweak caret blink speed to make caret visible more of the time

### DIFF
--- a/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/RichTextBoxBase.cs
@@ -437,8 +437,8 @@ namespace FlaxEngine.GUI
             // Caret
             if (IsFocused && CaretPosition > -1)
             {
-                float alpha = Mathf.Saturate(Mathf.Cos(_animateTime * CaretFlashSpeed) * 0.5f + 0.7f);
-                alpha = alpha * alpha * alpha * alpha * alpha * alpha;
+                float alpha = Mathf.Saturate(Mathf.Cos(_animateTime * CaretFlashSpeed) * 0.5f + 0.8f);
+                alpha = alpha * alpha;
                 Render2D.FillRectangle(CaretBounds, CaretColor * alpha);
             }
 

--- a/Source/Engine/UI/GUI/Common/TextBox.cs
+++ b/Source/Engine/UI/GUI/Common/TextBox.cs
@@ -310,8 +310,8 @@ namespace FlaxEngine.GUI
             // Caret
             if (IsFocused && CaretPosition > -1)
             {
-                float alpha = Mathf.Saturate(Mathf.Cos(_animateTime * CaretFlashSpeed) * 0.5f + 0.7f);
-                alpha = alpha * alpha * alpha * alpha * alpha * alpha;
+                float alpha = Mathf.Saturate(Mathf.Cos(_animateTime * CaretFlashSpeed) * 0.5f + 0.8f);
+                alpha = alpha * alpha;
                 Render2D.FillRectangle(CaretBounds, CaretColor * alpha);
             }
 

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -275,7 +275,7 @@ namespace FlaxEngine.GUI
         /// Gets or sets the speed of the caret flashing animation.
         /// </summary>
         [EditorDisplay("Caret Style"), EditorOrder(2021), Tooltip("The speed of the caret flashing animation.")]
-        public float CaretFlashSpeed { get; set; } = 6.0f;
+        public float CaretFlashSpeed { get; set; } = 6.5f;
 
         /// <summary>
         /// Gets or sets the speed of the selection background flashing animation.


### PR DESCRIPTION
*Slightly* tweaks the speed and "smoothness" of the text caret for text boxes.

I think the text caret in Flax will show for slightly too long and stays hidden for too long, so I've tweaked the values a bit.

This makes it easier to see where the caret is at because it will show more frequently and be invisible less often.
Not seeing the caret in Flax Ui is a thing I've run into a few times now, 

It's only a small difference, but I think it still improves things.

*New caret speed:*

https://github.com/user-attachments/assets/5457a73c-9faf-4feb-83ac-59398895e715

*Old caret speed:*

https://github.com/user-attachments/assets/561c1908-9b22-483b-bfcf-0ad4a09c78c8

*Visual Studio caret speed for comparison:*

https://github.com/user-attachments/assets/229c2948-fb6c-4450-b017-ceb54279704b

*Firefox caret speed for comparison:*

https://github.com/user-attachments/assets/7d3ec35a-7d80-4f0e-9dff-e08035099fa0

