### PR TITLE
Removed incorrect binding generation

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -1300,10 +1300,7 @@ namespace Flax.Build.Bindings
                 else if (parameterInfo.Type.IsRef && !parameterInfo.Type.IsConst)
                 {
                     // Non-const lvalue reference parameters needs to be passed via temporary value
-                    if (parameterInfo.IsOut || parameterInfo.IsRef)
-                        contents.Append(indent).AppendFormat("{2}& {0}Temp = {1};", parameterInfo.Name, param, parameterInfo.Type.ToString(false)).AppendLine();
-                    else
-                        contents.Append(indent).AppendFormat("{2} {0}Temp = {1};", parameterInfo.Name, param, parameterInfo.Type.ToString(false)).AppendLine();
+                    contents.Append(indent).AppendFormat("{2}& {0}Temp = {1};", parameterInfo.Name, param, parameterInfo.Type.ToString(false)).AppendLine();
                     callParams += parameterInfo.Name;
                     callParams += "Temp";
                 }


### PR DESCRIPTION
I noticed that `GPUTexture.DownloadData()` stopped working. I tracked it down to a change in the Cpp wrapper generator. It has the condition `if (parameterInfo.IsOut || parameterInfo.IsRef)` and creates `&Temp` or `Temp` depending on the result. But `Temp` doesn't make sense, since the parameter is already always a reference type in the main conditional it's under (`parameterInfo.Type.IsRef`). It would just be an unused copy.

I'm not 100% I'm interpreting this all correctly, since I'm not that familiar with the binding system. But I removed the else condition and DownloadData seems to be working correctly now (no longer always null). Is this the right fix for this bug?