### PR TITLE
Only set kinematic target if rigid body has kinematic flag.

### DIFF
--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -2450,7 +2450,7 @@ void PhysicsBackend::SetRigidActorPose(void* actor, const Vector3& position, con
     if (kinematic)
     {
         auto actorPhysX = (PxRigidDynamic*)actor;
-        if (actorPhysX->getActorFlags() & PxActorFlag::eDISABLE_SIMULATION)
+        if (actorPhysX->getActorFlags() & PxActorFlag::eDISABLE_SIMULATION || !(actorPhysX->getRigidBodyFlags() & PxRigidBodyFlag::eKINEMATIC))
         {
             // Ensures the disabled kinematic actor ends up in the correct pose after enabling simulation
             actorPhysX->setGlobalPose(trans, wakeUp);


### PR DESCRIPTION
Fix #3978 

Add additional check for if kinematic flag is set on physX actor before calling SetKinematicTarget method.

If we wanted to, we could force that flag at that point as well if it does not exist since it should.