### PR TITLE
Clear up naming of "Pre-skinning Local Vertex Pos"

### DIFF
--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -584,10 +584,11 @@ namespace FlaxEditor.Surface.Archetypes
             new NodeArchetype
             {
                 TypeID = 13,
-                Title = "Pre-skinned Local Position",
+                Title = "Pre-skinning Local Vertex Pos",
                 Description = "Per vertex local position (before skinning)",
+                AlternativeTitles = new[] { "Vertex Position", "Pre skinning Local Vertex Pos" },
                 Flags = NodeFlags.MaterialGraph,
-                Size = new Float2(230, 40),
+                Size = new Float2(270, 40),
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Output(0, string.Empty, typeof(Float3), 0),
@@ -596,10 +597,11 @@ namespace FlaxEditor.Surface.Archetypes
             new NodeArchetype
             {
                 TypeID = 14,
-                Title = "Pre-skinned Local Normal",
+                Title = "Pre-skinning Local Normal",
                 Description = "Per vertex local normal (before skinning)",
+                AlternativeTitles = new[] { "Pre skinning Local Normal" },
                 Flags = NodeFlags.MaterialGraph,
-                Size = new Float2(230, 40),
+                Size = new Float2(270, 40),
                 Elements = new[]
                 {
                     NodeElementArchetype.Factory.Output(0, string.Empty, typeof(Float3), 0),


### PR DESCRIPTION
Addresses/ closes #3983

I've also added the names of the nodes without the "-" as alternative titles because the node search won't display the nodes when the user searches "Pre skinning Local Vertex Pos" (the name without the "-").
