### PR TITLE
Support for nested physics actors

### DIFF
--- a/Source/Engine/Core/Config.h
+++ b/Source/Engine/Core/Config.h
@@ -45,6 +45,9 @@
 // Enable/disable assertion for Engine low layers
 #define ENABLE_ASSERTION_LOW_LAYERS ENABLE_ASSERTION && (BUILD_DEBUG || FLAX_TESTS)
 
+// Enable nested physics bodies
+#define NESTED_PHYSICS_BODIES 1
+
 // Scripting API defines (see C++ scripting documentation for more info)
 #define API_ENUM(...)
 #define API_CLASS(...)

--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -29,6 +29,10 @@
 #include "Engine/Serialization/MemoryReadStream.h"
 #include "Engine/Serialization/MemoryWriteStream.h"
 
+#if NESTED_PHYSICS_BODIES
+#include "Engine/Physics/Actors/IPhysicsActor.h"
+#endif
+
 #if USE_EDITOR
 #include "Editor/Editor.h"
 #define CHECK_EXECUTE_IN_EDITOR if (Editor::IsPlayMode || script->_executeInEditor)
@@ -257,6 +261,42 @@ const Guid& Actor::GetSceneObjectId() const
     return GetID();
 }
 
+#if NESTED_PHYSICS_BODIES
+static void PropagateSolverDepth(Actor* actor, int parentDepth)
+{
+    auto physicsActor = dynamic_cast<IPhysicsActor*>(actor);
+    if (physicsActor)
+    {
+        parentDepth++;
+        physicsActor->SolverDepth = parentDepth;
+    }
+
+    // Propagate downwards to update solver depth for nested physics actors
+    for (auto child : actor->Children)
+    {
+        PropagateSolverDepth(child, parentDepth);
+    }
+}
+
+static void CalculateSolverDepth(Actor* actor)
+{
+    // find the depth of the closest ancestor that is a physics actor
+    auto parent = actor->GetParent();
+    int depth = -1;
+    while (parent)
+    {
+        auto physicsActor = dynamic_cast<IPhysicsActor*>(parent);
+        if (physicsActor)
+        {
+            depth = physicsActor->SolverDepth;
+            break;
+        }
+        parent = parent->GetParent();
+    }
+    PropagateSolverDepth(actor, depth);
+}
+#endif
+
 void Actor::SetParent(Actor* value, bool worldPositionsStays, bool canBreakPrefabLink)
 {
     if (_parent == value)
@@ -366,6 +406,10 @@ void Actor::SetParent(Actor* value, bool worldPositionsStays, bool canBreakPrefa
         }
         Level::callActorEvent(Level::ActorEventType::OnActorSpawned, this, nullptr);
     }
+
+#if NESTED_PHYSICS_BODIES
+    CalculateSolverDepth(this);
+#endif
 }
 
 void Actor::SetParent(Actor* value, bool canBreakPrefabLink)
@@ -982,6 +1026,11 @@ void Actor::BeginPlay(SceneBeginData* data)
 
     // Set flag
     Flags |= ObjectFlags::IsDuringPlay;
+
+#if NESTED_PHYSICS_BODIES
+    // set up initial depth values for nested bodies
+    CalculateSolverDepth(this);
+#endif
 
     OnBeginPlay();
 

--- a/Source/Engine/Physics/Actors/IPhysicsActor.h
+++ b/Source/Engine/Physics/Actors/IPhysicsActor.h
@@ -25,4 +25,11 @@ public:
     /// This event is called internally by the Physics service and should not be used by the others.
     /// </remarks>
     virtual void OnActiveTransformChanged() = 0;
+
+#if NESTED_PHYSICS_BODIES
+    /// <summary>
+    /// Represents how many tiers of IPhysicsActors are above this in its heirarchy.
+    /// </summary>
+    int SolverDepth = 0;
+#endif
 };

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -1903,9 +1903,25 @@ void PhysicsBackend::StartSimulateScene(void* scene, float dt)
     scenePhysX->Stepper.renderDone();
 }
 
-PxActor** CachedActiveActors;
+int CachedBucketIndex;
 int64 CachedActiveActorsCount;
 volatile int64 CachedActiveActorIndex;
+#if NESTED_PHYSICS_BODIES
+// if the nesting is greater than this max depth then there could potentially be ordering issues
+#define MAX_SOLVER_DEPTH 32
+Array<Array<IPhysicsActor*>, FixedAllocation<MAX_SOLVER_DEPTH>> SolverDepthBuckets;
+void FlushActiveTransforms(int32 i)
+{
+    PROFILE_CPU();
+    int64 index;
+    auto bucket = SolverDepthBuckets[CachedBucketIndex];
+    while ((index = Platform::InterlockedIncrement(&CachedActiveActorIndex)) < CachedActiveActorsCount)
+    {
+        bucket[index]->OnActiveTransformChanged();
+    }
+}
+#else
+PxActor** CachedActiveActors;
 
 void FlushActiveTransforms(int32 i)
 {
@@ -1919,6 +1935,7 @@ void FlushActiveTransforms(int32 i)
             actor->OnActiveTransformChanged();
     }
 }
+#endif
 
 void PhysicsBackend::EndSimulateScene(void* scene)
 {
@@ -1939,6 +1956,57 @@ void PhysicsBackend::EndSimulateScene(void* scene)
         PxU32 activeActorsCount;
         PxActor** activeActors = scenePhysX->Scene->getActiveActors(activeActorsCount);
 
+#if NESTED_PHYSICS_BODIES
+        if (activeActorsCount > 0)
+        {
+            // initialize buckets
+            if (SolverDepthBuckets.IsEmpty())
+            {
+                SolverDepthBuckets.AddDefault(MAX_SOLVER_DEPTH);
+            }
+
+            // load buckets
+            int maxDepth = 0;
+            for (uint32 i = 0; i < activeActorsCount; i++)
+            {
+                const auto pxActor = (PxRigidActor*)*activeActors++;
+                auto actor = static_cast<IPhysicsActor*>(pxActor->userData);
+                if (actor)
+                {
+                    int depth = Math::Min(actor->SolverDepth, MAX_SOLVER_DEPTH - 1);
+                    SolverDepthBuckets[depth].Add(actor);
+                    maxDepth = Math::Max(depth, maxDepth);
+                }
+            }
+
+            // process buckets, deepest first
+            for (int32 i = maxDepth; i >= 0; i--)
+            {
+                auto bucket = SolverDepthBuckets[i];
+                if (bucket.Count() > 25 && JobSystem::GetThreadsCount() > 1)
+                {
+                    // Run in async via job system if there a lot of items
+                    CachedBucketIndex = i;
+                    CachedActiveActorsCount = bucket.Count();
+                    CachedActiveActorIndex = -1;
+                    JobSystem::Execute(FlushActiveTransforms, JobSystem::GetThreadsCount());
+                }
+                else
+                {
+                    for (auto actor : bucket)
+                    {
+                        actor->OnActiveTransformChanged();
+                    }
+                }
+            }
+
+            // clear buckets
+            for (uint32 i = 0; i <= maxDepth; i++)
+            {
+                SolverDepthBuckets[i].Clear();
+            }
+        }
+#else
         // Update changed transformations
         if (activeActorsCount > 50 && JobSystem::GetThreadsCount() > 1)
         {
@@ -1958,6 +2026,7 @@ void PhysicsBackend::EndSimulateScene(void* scene)
                     actor->OnActiveTransformChanged();
             }
         }
+#endif
     }
 
 #if WITH_CLOTH


### PR DESCRIPTION
This allows for nested rigid bodies and character controllers. It keeps track of IPhysicsActors' nested depth during parenting changes. This requires some calculations from all Actors' parenting changes. When flushing transforms, it performs them grouped by depth, doing the lowest depth ones first, asynchronously if reasonable.

I'm not sure if 25 is a reasonable async limit? It was 50 before but since it's being divided I thought I should lower it, but I'm not sure. I also made this an option since not everyone might need it and there is some overhead. I'm not sure if that's the right place to define the flag.