### PR TITLE
Color color R G B A sockets in colors

### DIFF
--- a/Source/Editor/Surface/Elements/Box.cs
+++ b/Source/Editor/Surface/Elements/Box.cs
@@ -205,6 +205,19 @@ namespace FlaxEditor.Surface.Elements
             {
                 var hints = parentNode.Archetype.ConnectionsHints;
                 Surface.Style.GetConnectionColor(_currentType, hints, out _currentTypeColor);
+
+                if (_currentType == new ScriptType(typeof(Single)))
+                {
+                    if (archetype.Text == "R")
+                        _currentTypeColor = Color.FromHex("#D91414");
+                    if (archetype.Text == "G")
+                        _currentTypeColor = Color.FromHex("#17D11C");
+                    if (archetype.Text == "B")
+                        _currentTypeColor = Color.FromHex("#346CC7");
+                    if (archetype.Text == "A")
+                        _currentTypeColor = Color.FromHex("#AEADAD");
+                }
+
                 TooltipText = Surface.GetTypeName(CurrentType) ?? GetConnectionHintTypeName(hints);
             }
         }


### PR DESCRIPTION
Colors node output boxes with the name in their color:
- "R" -> Red
- "G" -> Green
- "B" -> Blue
- "A" -> Gray (how alpha channel is commonly represented)

It might look like a bit too much color with the current Visject theme:
<img width="228" height="432" alt="image" src="https://github.com/user-attachments/assets/0fc59c9d-a817-43ff-b7c8-6490d702f53e" />

**But** I think it looks really nice in the new theme that's in #3866:
<img width="195" height="412" alt="image" src="https://github.com/user-attachments/assets/e3c26a4a-9f80-444c-a359-27773ab27aee" />

A lot of other (node graph) tools represent color R G B A values with these colors. They also make the different color channel outputs easier to differentiate.

Comparing against box name may sound stupid at first, but I think it's actually a good way to do this because it means that every node output socket that uses R, G, B or A will automatically receive those colors, even custom ones.

PS:
[I made extra sure that the colors I picked aren't resembling a rainbow :)](https://forum.flaxengine.com/t/total-deal-breaker-for-a-mostly-non-artistic-user-of-the-amazing-flax-engine/2494)

