### PR TITLE
Add allowable characters enum to text box

### DIFF
--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 #if FLAX_EDITOR
 using FlaxEditor.Options;
 #endif
@@ -41,6 +43,38 @@ namespace FlaxEngine.GUI
             '>',
             '<',
         };
+
+        /// <summary>
+        /// The allowable characters to use for the text.
+        /// </summary>
+        [Flags]
+        public enum AllowableCharacters
+        {
+            /// <summary>
+            /// Wether to not allow any character in the text.
+            /// </summary>
+            None = 0,
+            
+            /// <summary>
+            /// Whether to use letters in the text.
+            /// </summary>
+            Letters = 1 << 0,
+
+            /// <summary>
+            /// Whether to use numbers in the text.
+            /// </summary>
+            Numbers = 1 << 1,
+
+            /// <summary>
+            /// Whether to use symbols in the text.
+            /// </summary>
+            Symbols = 1 << 2,
+            
+            /// <summary>
+            /// Whether to use all characters in the text.
+            /// </summary>
+            All = Letters | Numbers | Symbols,
+        }
 
         /// <summary>
         /// Default height of the text box
@@ -86,6 +120,11 @@ namespace FlaxEngine.GUI
         /// Flag used to indicate whenever text can contain multiple lines.
         /// </summary>
         protected bool _isMultiline;
+        
+        /// <summary>
+        /// The characters to allow in the text.
+        /// </summary>
+        protected AllowableCharacters _charactersToAllow = AllowableCharacters.All;
 
         /// <summary>
         /// Flag used to indicate whenever text is read-only and cannot be modified by the user.
@@ -186,6 +225,16 @@ namespace FlaxEngine.GUI
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// The character to allow in the text.
+        /// </summary>
+        [EditorOrder(41), Tooltip("The character to allow in the text.")]
+        public AllowableCharacters CharactersToAllow
+        { 
+            get => _charactersToAllow;
+            set => _charactersToAllow = value;
         }
 
         /// <summary>
@@ -395,15 +444,42 @@ namespace FlaxEngine.GUI
                 value = value.GetLines()[0];
             }
 
-            if (_text != value)
+            if (_text.Equals(value, StringComparison.Ordinal))
+                return;
+
+            if (CharactersToAllow != AllowableCharacters.All)
             {
-                Deselect();
-                ResetViewOffset();
-
-                _text = value;
-
-                OnTextChanged();
+                if (CharactersToAllow == AllowableCharacters.None)
+                {
+                    value = string.Empty;
+                }
+                else
+                {
+                    if (!CharactersToAllow.HasFlag(AllowableCharacters.Letters))
+                    {
+                        if (value != null)
+                            value = new string(value.Where(c => !char.IsLetter(c)).ToArray());
+                    }
+                    if (!CharactersToAllow.HasFlag(AllowableCharacters.Numbers))
+                    {
+                        if (value != null)
+                            value = new string(value.Where(c => !char.IsNumber(c)).ToArray());
+                    }
+                    if (!CharactersToAllow.HasFlag(AllowableCharacters.Symbols))
+                    {
+                        if (value != null)
+                            value = new string(value.Where(c => !char.IsSymbol(c)).ToArray());
+                    }
+                    value ??= string.Empty;
+                }
             }
+                
+            Deselect();
+            ResetViewOffset();
+
+            _text = value;
+
+            OnTextChanged();
         }
 
         /// <summary>


### PR DESCRIPTION
Adds to only allow letters, numbers, or symbols as text in the text box.