### PR TITLE
Auto scroll to new track when adding track to animation

### DIFF
--- a/Source/Editor/GUI/Timeline/Timeline.cs
+++ b/Source/Editor/GUI/Timeline/Timeline.cs
@@ -229,7 +229,7 @@ namespace FlaxEditor.GUI.Timeline
         private List<Track> _mediaMoveStartTracks;
         private byte[][] _mediaMoveStartData;
         private float _zoom = 1.0f;
-        private float _tracksVScrollTarget = 0f;
+        private float _tracksVScrollTarget;
         private bool _isMovingPositionHandle;
         private bool _canPlayPause = true, _canStop = true;
         private List<IUndoAction> _batchedUndoActions;
@@ -899,8 +899,6 @@ namespace FlaxEditor.GUI.Timeline
             };
             UpdatePositionHandle();
             PlaybackState = PlaybackStates.Disabled;
-
-            _tracksVScrollTarget = _tracksPanelArea.VScrollBar.TargetValue;
         }
 
         private void UpdatePositionHandle()
@@ -2042,14 +2040,20 @@ namespace FlaxEditor.GUI.Timeline
             // Synchronize scroll vertical bars for tracks and media panels to keep the view in sync
             var tracksVScroll = _tracksPanelArea.VScrollBar;
             var backgroundVScroll = _backgroundArea.VScrollBar;
-            bool forceBackgroundToTracksScroll = !Mathf.WithinEpsilon(_tracksVScrollTarget - tracksVScroll.Value, 0f, 5f);
-            if (tracksVScroll.IsThumbClicked || _tracksPanelArea.IsMouseOver || forceBackgroundToTracksScroll)
+            bool forceBackgroundToTracksScroll = _tracksVScrollTarget > 0;
+            if (forceBackgroundToTracksScroll)
+            {
+                backgroundVScroll.TargetValue = tracksVScroll.Value;
+
+                if (Mathf.Abs(tracksVScroll.Value - _tracksVScrollTarget) < 0.5f)
+                    _tracksVScrollTarget = 0f;
+            }
+            else if (tracksVScroll.IsThumbClicked || _tracksPanelArea.IsMouseOver)
             {
                 backgroundVScroll.TargetValue = tracksVScroll.Value;
             }
             else
             {
-                _tracksVScrollTarget = 0f;
                 tracksVScroll.TargetValue = backgroundVScroll.Value;
             }
 

--- a/Source/Editor/GUI/Timeline/Timeline.cs
+++ b/Source/Editor/GUI/Timeline/Timeline.cs
@@ -229,6 +229,7 @@ namespace FlaxEditor.GUI.Timeline
         private List<Track> _mediaMoveStartTracks;
         private byte[][] _mediaMoveStartData;
         private float _zoom = 1.0f;
+        private float _tracksVScrollTarget = 0f;
         private bool _isMovingPositionHandle;
         private bool _canPlayPause = true, _canStop = true;
         private List<IUndoAction> _batchedUndoActions;
@@ -898,6 +899,8 @@ namespace FlaxEditor.GUI.Timeline
             };
             UpdatePositionHandle();
             PlaybackState = PlaybackStates.Disabled;
+
+            _tracksVScrollTarget = _tracksPanelArea.VScrollBar.TargetValue;
         }
 
         private void UpdatePositionHandle()
@@ -1305,6 +1308,10 @@ namespace FlaxEditor.GUI.Timeline
             MarkAsEdited();
             if (withUndo)
                 Undo?.AddAction(new AddRemoveTrackAction(this, track, true));
+
+            // Scroll to track
+            _tracksPanelArea.ScrollViewTo(track);
+            _tracksVScrollTarget = _tracksPanelArea.VScrollBar.TargetValue;
         }
 
         /// <summary>
@@ -2033,12 +2040,18 @@ namespace FlaxEditor.GUI.Timeline
             base.Update(deltaTime);
 
             // Synchronize scroll vertical bars for tracks and media panels to keep the view in sync
-            var scroll1 = _tracksPanelArea.VScrollBar;
-            var scroll2 = _backgroundArea.VScrollBar;
-            if (scroll1.IsThumbClicked || _tracksPanelArea.IsMouseOver)
-                scroll2.TargetValue = scroll1.Value;
+            var tracksVScroll = _tracksPanelArea.VScrollBar;
+            var backgroundVScroll = _backgroundArea.VScrollBar;
+            bool forceBackgroundToTracksScroll = !Mathf.WithinEpsilon(_tracksVScrollTarget - tracksVScroll.Value, 0f, 5f);
+            if (tracksVScroll.IsThumbClicked || _tracksPanelArea.IsMouseOver || forceBackgroundToTracksScroll)
+            {
+                backgroundVScroll.TargetValue = tracksVScroll.Value;
+            }
             else
-                scroll1.TargetValue = scroll2.Value;
+            {
+                _tracksVScrollTarget = 0f;
+                tracksVScroll.TargetValue = backgroundVScroll.Value;
+            }
 
             // Batch undo actions
             if (_batchedUndoActions != null && _batchedUndoActions.Count != 0)


### PR DESCRIPTION
It's a bit more complicated than just calling
```cs
_tracksPanelArea.ScrollViewTo(track);
```
because we want the scroll to be smooth and not abrupt. So we need extra logic because the scrollbar sync code in `Update` would fight with the smooth scroll.
An abrupt scroll could be disorienting for the user and does not provide any feedback about what just happened.

Closes #3943.