### PR TITLE
Animated model Properties Panel and skeleton debug draw improvements (+ minor spelling fix)

### DIFF
--- a/Source/Editor/Content/Import/AudioImportSettings.cs
+++ b/Source/Editor/Content/Import/AudioImportSettings.cs
@@ -12,7 +12,7 @@ namespace FlaxEngine.Tools
     {
         partial struct Options
         {
-            private bool ShowBtiDepth => Format != AudioFormat.Vorbis;
+            private bool ShowBitDepth => Format != AudioFormat.Vorbis;
         }
     }
 }

--- a/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
+++ b/Source/Editor/Viewport/Previews/AnimatedModelPreview.cs
@@ -2,6 +2,7 @@
 
 using System;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Input;
 using FlaxEngine;
 using Object = FlaxEngine.Object;
 
@@ -14,7 +15,7 @@ namespace FlaxEditor.Viewport.Previews
     public class AnimatedModelPreview : AssetPreview
     {
         private AnimatedModel _previewModel;
-        private ContextMenuButton _showNodesButton, _showBoundsButton, _showFloorButton, _showNodesNamesButton;
+        private ContextMenuButton _showNodesButton, _showBoundsButton, _showFloorButton, _showNodesNamesButton, _nodeNameSizeButton;
         private bool _showNodes, _showBounds, _showFloor, _showNodesNames;
         private StaticModel _floorModel;
         private bool _playAnimation, _playAnimationOnce;
@@ -110,8 +111,15 @@ namespace FlaxEditor.Viewport.Previews
                     ShowDebugDraw = true;
                 if (_showNodesNamesButton != null)
                     _showNodesNamesButton.Checked = value;
+                if (_nodeNameSizeButton != null)
+                    _nodeNameSizeButton.Enabled = value;
             }
         }
+
+        /// <summary>
+        /// The font size used in the node name debug draw.
+        /// </summary>
+        public int NodeNamesSize = 10;
 
         /// <summary>
         /// Gets or sets a value indicating whether show animated model bounding box debug view.
@@ -209,6 +217,15 @@ namespace FlaxEditor.Viewport.Previews
                 _showFloorButton.IndexInParent = 1;
                 _showFloorButton.CloseMenuOnClick = false;
             }
+
+            _nodeNameSizeButton = ViewWidgetButtonMenu.AddButton("Skeleton Names Size");
+            _nodeNameSizeButton.CloseMenuOnClick = false;
+            var nodeNameSizeValue = new IntValueBox(NodeNamesSize, 118, 2, 70.0f, 1, 32)
+            {
+                Parent = _nodeNameSizeButton
+            };
+            _nodeNameSizeButton.Enabled = ShowNodesNames;
+            nodeNameSizeValue.ValueChanged += () => NodeNamesSize = nodeNameSizeValue.Value;
 
             // Enable shadows
             PreviewLight.ShadowsMode = ShadowsCastingMode.All;
@@ -371,7 +388,7 @@ namespace FlaxEditor.Viewport.Previews
                             if (nodesMask != null && !nodesMask[nodeIndex])
                                 continue;
                             //var t = new Transform(pose[nodeIndex].TranslationVector, Quaternion.Identity, new Float3(0.1f));
-                            DebugDraw.DrawText(nodes[nodeIndex].Name, pose[nodeIndex].TranslationVector, Color.White, 20, 0.0f, 0.1f);
+                            DebugDraw.DrawText(nodes[nodeIndex].Name, pose[nodeIndex].TranslationVector, Color.White, NodeNamesSize, 0.0f, 0.25f);
                         }
                     }
                 }

--- a/Source/Engine/Level/Actors/AnimatedModel.h
+++ b/Source/Engine/Level/Actors/AnimatedModel.h
@@ -98,99 +98,99 @@ public:
     /// <summary>
     /// The skinned model asset used for rendering.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(10), DefaultValue(null), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(10), DefaultValue(null), EditorDisplay(\"Skeleton\")")
     AssetReference<SkinnedModel> SkinnedModel;
 
     /// <summary>
     /// The animation graph asset used for the skinned mesh skeleton bones evaluation (controls the animation).
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(15), DefaultValue(null), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(15), DefaultValue(null), EditorDisplay(\"Skeleton\")")
     AssetReference<AnimationGraph> AnimationGraph;
 
     /// <summary>
     /// If true, use per-bone motion blur on this skeletal model. It requires additional rendering, can be disabled to save performance.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(20), DefaultValue(true), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(20), DefaultValue(true), EditorDisplay(\"Rendering\")")
     bool PerBoneMotionBlur = true;
 
     /// <summary>
     /// If true, animation speed will be affected by the global timescale parameter.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(30), DefaultValue(true), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(30), DefaultValue(true), EditorDisplay(\"Update\")")
     bool UseTimeScale = true;
 
     /// <summary>
     /// If true, the animation will be updated even when an actor cannot be seen by any camera. Otherwise, the animations themselves will also stop running when the actor is off-screen.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(40), DefaultValue(false), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(40), DefaultValue(false), EditorDisplay(\"Update\")")
     bool UpdateWhenOffscreen = false;
 
     /// <summary>
     /// The animation update delta timescale. Can be used to speed up animation playback or create slow motion effect.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(45), Limit(0, float.MaxValue, 0.025f), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(45), Limit(0, float.MaxValue, 0.025f), EditorDisplay(\"Update\")")
     float UpdateSpeed = 1.0f;
 
     /// <summary>
     /// The animation update mode. Can be used to optimize the performance.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(50), DefaultValue(AnimationUpdateMode.Auto), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(50), DefaultValue(AnimationUpdateMode.Auto), EditorDisplay(\"Update\")")
     AnimationUpdateMode UpdateMode = AnimationUpdateMode::Auto;
 
     /// <summary>
     /// The master scale parameter for the actor bounding box. Helps to reduce mesh flickering effect on screen edges.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(60), DefaultValue(1.5f), Limit(0, float.MaxValue, 0.025f), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(60), DefaultValue(1.5f), Limit(0, float.MaxValue, 0.025f), EditorDisplay(\"Rendering\")")
     float BoundsScale = 1.5f;
 
     /// <summary>
     /// The custom bounds(in actor local space). If set to empty bounds then source skinned model bind pose bounds will be used.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(70), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(70), EditorDisplay(\"Rendering\")")
     BoundingBox CustomBounds = BoundingBox::Zero;
 
     /// <summary>
     /// The model Level Of Detail bias value. Allows to increase or decrease rendered model quality.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(80), DefaultValue(0), Limit(-100, 100, 0.1f), EditorDisplay(\"Skinned Model\", \"LOD Bias\")")
+    API_FIELD(Attributes="EditorOrder(80), DefaultValue(0), Limit(-100, 100, 0.1f), EditorDisplay(\"Rendering\", \"LOD Bias\")")
     int32 LODBias = 0;
 
     /// <summary>
     /// Gets the model forced Level Of Detail index. Allows to bind the given model LOD to show. Value -1 disables this feature.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(90), DefaultValue(-1), Limit(-1, 100, 0.1f), EditorDisplay(\"Skinned Model\", \"Forced LOD\")")
+    API_FIELD(Attributes="EditorOrder(90), DefaultValue(-1), Limit(-1, 100, 0.1f), EditorDisplay(\"Rendering\", \"Forced LOD\")")
     int32 ForcedLOD = -1;
 
     /// <summary>
     /// The draw passes to use for rendering this object.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(100), DefaultValue(DrawPass.Default), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(100), DefaultValue(DrawPass.Default), EditorDisplay(\"Rendering\")")
     DrawPass DrawModes = DrawPass::Default;
 
     /// <summary>
     /// The object sort order key used when sorting drawable objects during rendering. Use lower values to draw object before others, higher values are rendered later (on top). Can be used to control transparency drawing.
     /// </summary>
-    API_FIELD(Attributes="EditorDisplay(\"Skinned Model\"), EditorOrder(110), DefaultValue(0)")
+    API_FIELD(Attributes="EditorOrder(110), DefaultValue(0), EditorDisplay(\"Rendering\")")
     int8 SortOrder = 0;
 
     /// <summary>
     /// The shadows casting mode.
     /// [Deprecated on 26.10.2022, expires on 26.10.2024]
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(110), DefaultValue(ShadowsCastingMode.All), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(110), DefaultValue(ShadowsCastingMode.All), EditorDisplay(\"Rendering\")")
     DEPRECATED() ShadowsCastingMode ShadowsMode = ShadowsCastingMode::All;
 
     /// <summary>
     /// The animation root motion apply target. If not specified the animated model will apply it itself.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(120), DefaultValue(null), EditorDisplay(\"Skinned Model\")")
+    API_FIELD(Attributes="EditorOrder(120), DefaultValue(null), EditorDisplay(\"Skeleton\")")
     ScriptingObjectReference<Actor> RootMotionTarget;
 
 #if USE_EDITOR
     /// <summary>
-    /// If checked, the skeleton pose will be shawn during debug shapes drawing.
+    /// If checked, the skeleton pose will be shown during debug shapes drawing.
     /// </summary>
-    API_FIELD(Attributes="EditorOrder(200), EditorDisplay(\"Skinned Model\")") bool ShowDebugDrawSkeleton = false;
+    API_FIELD(Attributes="EditorOrder(200), EditorDisplay(\"Debug\"), VisibleIf(nameof(ShowDebugDrawOptions))") bool ShowDebugDrawSkeleton = false;
 #endif
 
 public:
@@ -440,6 +440,14 @@ public:
     API_FUNCTION() bool IsPlayingSlotAnimation(const StringView& slotName, Animation* anim = nullptr);
 
 private:
+    /// <summary>
+    /// Used to hide <paramref name="ShowDebugDrawSkeleton"/> options if when the skinned model or animation graph is null.
+    /// </summary>
+    API_PROPERTY(Attributes = "HideInEditor, NoSerialize") bool GetShowDebugDrawOptions() const
+    {
+        return SkinnedModel != nullptr && AnimationGraph != nullptr;
+    }
+
     void ApplyRootMotion(const Transform& rootMotionDelta);
     void SyncParameters();
     void RunBlendShapeDeformer(const MeshBase* mesh, struct MeshDeformationData& deformation);

--- a/Source/Engine/Level/Actors/AnimatedModel.h
+++ b/Source/Engine/Level/Actors/AnimatedModel.h
@@ -440,6 +440,7 @@ public:
     API_FUNCTION() bool IsPlayingSlotAnimation(const StringView& slotName, Animation* anim = nullptr);
 
 private:
+#if USE_EDITOR
     /// <summary>
     /// Used to hide <paramref name="ShowDebugDrawSkeleton"/> options if when the skinned model or animation graph is null.
     /// </summary>
@@ -447,6 +448,7 @@ private:
     {
         return SkinnedModel != nullptr && AnimationGraph != nullptr;
     }
+#endif
 
     void ApplyRootMotion(const Transform& rootMotionDelta);
     void SyncParameters();

--- a/Source/Engine/Tools/AudioTool/AudioTool.h
+++ b/Source/Engine/Tools/AudioTool/AudioTool.h
@@ -70,7 +70,7 @@ public:
         /// <summary>
         /// The size of a single sample in bits. The clip will be converted to this bit depth on import.
         /// </summary>
-        API_FIELD(Attributes="EditorOrder(50), VisibleIf(nameof(ShowBtiDepth))")
+        API_FIELD(Attributes="EditorOrder(50), VisibleIf(nameof(ShowBitDepth))")
         BitDepth BitDepth = BitDepth::_16;
 
         String ToString() const;


### PR DESCRIPTION
Implements [this](https://discord.com/channels/437989205315158016/438033006016462849/1484166761971454023) suggestion (which I also think is desperately needed) from discord.

I had to adjust the `scale` used in `DebugDraw.DrawText()` to something a bit higher than `0.1f` because otherwise the skeleton names text would be cut off (prolly a limitation with Flax text rendering/ `DebugDraw.DrawText()` (?)).

This also adds a visibility condition to `ShowDebugDrawSkeleton` because I found it confusing that, even though the checkbox is ticked, nothing will draw, if the Animation Graph or Animated Model are null. It will now be hidden if either of those are null/ not set.

<img width="815" height="380" alt="image" src="https://github.com/user-attachments/assets/694b66ef-7055-49ee-a874-bf418a53cdcd" />


<img width="587" height="679" alt="image" src="https://github.com/user-attachments/assets/5a0086c1-2ef8-41c1-98fd-9de0b7fd9b7c" />

