### PR TITLE
Add zooming in and out (FOV) in editor viewport using C and Z

### DIFF
--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -347,6 +347,14 @@ namespace FlaxEditor.Options
         [EditorDisplay("Viewport"), EditorOrder(1550)]
         public InputBinding Down = new InputBinding(KeyboardKeys.Q);
 
+        [DefaultValue(typeof(InputBinding), "C")]
+        [EditorDisplay("Viewport"), EditorOrder(1551)]
+        public InputBinding ZoomIn = new InputBinding(KeyboardKeys.C);
+
+        [DefaultValue(typeof(InputBinding), "Z")]
+        [EditorDisplay("Viewport"), EditorOrder(1552)]
+        public InputBinding ZoomOut = new InputBinding(KeyboardKeys.Z);
+
         [DefaultValue(typeof(InputBinding), "None")]
         [EditorDisplay("Viewport", "Toggle Camera Rotation"), EditorOrder(1560)]
         public InputBinding CameraToggleRotation = new InputBinding(KeyboardKeys.None);

--- a/Source/Editor/Viewport/Cameras/FPSCamera.cs
+++ b/Source/Editor/Viewport/Cameras/FPSCamera.cs
@@ -21,6 +21,7 @@ namespace FlaxEditor.Viewport.Cameras
         private Transform _startMove;
         private Transform _endMove;
         private float _moveStartTime = -1;
+        private float _additionalFOV;
 
         /// <summary>
         /// Gets a value indicating whether this viewport is animating movement.
@@ -31,6 +32,15 @@ namespace FlaxEditor.Viewport.Cameras
         /// The target point location. It's used to orbit around it when user clicks Alt+LMB.
         /// </summary>
         public Vector3 TargetPoint = new Vector3(-200);
+
+        /// <summary>
+        /// Additional field of view used for zooming the camera in and out.
+        /// </summary>
+        public float AdditionalZoomFOV
+        {
+            get => _additionalFOV;
+            private set => _additionalFOV = Mathf.Clamp(value, 5 - Viewport.FieldOfView, 160f - Viewport.FieldOfView);
+        }
 
         /// <summary>
         /// Sets view.
@@ -216,7 +226,7 @@ namespace FlaxEditor.Viewport.Cameras
                 pitch += mouseDelta.Y;
             }
 
-            // Zoom in/out
+            // Zoom in/out with mouse wheel
             if (input.IsZooming && !input.IsRotating)
             {
                 position += forward * (Viewport.MouseWheelZoomSpeedFactor * input.MouseWheelDelta * 25.0f);
@@ -224,6 +234,17 @@ namespace FlaxEditor.Viewport.Cameras
                 {
                     position += forward * (Viewport.MouseSpeed * 40 * Viewport.MousePositionDelta.ValuesSum);
                 }
+            }
+
+            // Zoom in and out by changing FOV
+            if (input.IsRotating && (input.ZoomInDown || input.ZoomOutDown))
+            {
+                float delta = (input.ZoomInDown ? -0.8f : 0.8f);
+                AdditionalZoomFOV += delta;
+            }
+            else if (!input.IsRotating)
+            {
+                AdditionalZoomFOV = 0f;
             }
 
             // Move camera with the gizmo

--- a/Source/Editor/Viewport/EditorViewport.cs
+++ b/Source/Editor/Viewport/EditorViewport.cs
@@ -51,6 +51,16 @@ namespace FlaxEditor.Viewport
             public bool IsOrbiting;
 
             /// <summary>
+            /// The zoom in state.
+            /// </summary>
+            public bool ZoomInDown;
+
+            /// <summary>
+            /// The zoom out state.
+            /// </summary>
+            public bool ZoomOutDown;
+
+            /// <summary>
             /// The is control down flag.
             /// </summary>
             public bool IsControlDown;
@@ -107,6 +117,10 @@ namespace FlaxEditor.Viewport
                 IsShiftDown = window.GetKey(KeyboardKeys.Shift);
                 IsAltDown = window.GetKey(KeyboardKeys.Alt);
                 WasAltDownBefore = prevInput.WasAltDownBefore || prevInput.IsAltDown;
+
+                InputOptions inputOptions = Editor.Instance.Options.Options.Input;
+                ZoomInDown = window.GetKey(inputOptions.ZoomIn.Key);
+                ZoomOutDown = window.GetKey(inputOptions.ZoomOut.Key);
 
                 IsMouseRightDown = useMouse && window.GetMouseButton(MouseButton.Right);
                 IsMouseMiddleDown = useMouse && window.GetMouseButton(MouseButton.Middle);
@@ -1428,7 +1442,10 @@ namespace FlaxEditor.Viewport
             else
             {
                 float aspect = Width / Height;
-                Matrix.PerspectiveFov(_fieldOfView * Mathf.DegreesToRadians, aspect, _nearPlane, _farPlane, out result);
+                float fov = _fieldOfView;
+                if (_camera is FPSCamera fpsCam)
+                    fov += fpsCam.AdditionalZoomFOV;
+                Matrix.PerspectiveFov(fov * Mathf.DegreesToRadians, aspect, _nearPlane, _farPlane, out result);
             }
         }
 


### PR DESCRIPTION
Adds zooming in and out in every Editor Viewport that uses an `FPSCamera` (Prefab editor, main editor).

This feature allows to zoom in and out/ change fov of the viewport camera *if the right mouse button is held down* by pressing *C* or *Z*. 
When the user lets go of the right mouse button, the fov will be reset to the fov set in the viewport settings.
The important thing is that this is an additive thing *on top* of the viewport camera fov, the fov in the viewport settings does not get affected by this.

https://github.com/user-attachments/assets/41254425-cf0b-4592-b823-d3bb248f4b83


[Unreal engine also has this feature](https://dev.epicgames.com/documentation/en-us/unreal-engine/viewport-controls-in-unreal-engine?application_version=5.1#game-style) and I have run into quite a few situations where this would have come in really handy in Flax:

For example when the viewport camera is in a certain position, but you want to take a look at thing that's far away. You now can just zoom in, without changing the cameras actual position, rather than moving the whole camera to take a look at the far away thing.

Or if you want to see a bit more of the surrounding area, but don't want to change the viewport cameras real fov in the viewport camera options. You can now just zoom out a bit and then let go of right mouse button to reset the camera fov to the one set in the options.

This is especially useful when working with larger maps/ levels or when you want to get a quick close up view of something.