### PR TITLE
Add shortcut to show editor windows content (Ctrl + 0)

### DIFF
--- a/Source/Editor/Options/InputOptions.cs
+++ b/Source/Editor/Options/InputOptions.cs
@@ -123,6 +123,10 @@ namespace FlaxEditor.Options
         [EditorDisplay("Common"), EditorOrder(200)]
         public InputBinding LockFocusSelection = new InputBinding(KeyboardKeys.F, KeyboardKeys.Shift);
 
+        [DefaultValue(typeof(InputBinding), "Ctrl+Alpha0")]
+        [EditorDisplay("Common"), EditorOrder(201)]
+        public InputBinding ShowEditorContents = new InputBinding(KeyboardKeys.Alpha0, KeyboardKeys.Control);
+
         [DefaultValue(typeof(InputBinding), "Ctrl+F")]
         [EditorDisplay("Common"), EditorOrder(210)]
         public InputBinding Search = new InputBinding(KeyboardKeys.F, KeyboardKeys.Control);

--- a/Source/Editor/Surface/SurfaceUtils.cs
+++ b/Source/Editor/Surface/SurfaceUtils.cs
@@ -579,7 +579,7 @@ namespace FlaxEditor.Surface
             redoButton = toolStrip.AddButton(editor.Icons.Redo64, undo.PerformRedo).LinkTooltip("Redo", ref inputOptions.Redo);
             toolStrip.AddSeparator();
             toolStrip.AddButton(editor.Icons.Search64, showSearch).LinkTooltip("Open content search tool",  ref inputOptions.Search);
-            toolStrip.AddButton(editor.Icons.CenterView64, surface.ShowWholeGraph).LinkTooltip("Show whole graph");
+            toolStrip.AddButton(editor.Icons.CenterView64, surface.ShowWholeGraph).LinkTooltip("Show whole graph", ref inputOptions.ShowEditorContents);
             var gridSnapButton = toolStrip.AddButton(editor.Icons.Grid32, surface.ToggleGridSnapping);
             gridSnapButton.LinkTooltip("Toggle grid snapping for nodes.");
             gridSnapButton.AutoCheck = true;
@@ -590,6 +590,7 @@ namespace FlaxEditor.Surface
             window.InputActions.Add(options => options.Undo, undo.PerformUndo);
             window.InputActions.Add(options => options.Redo, undo.PerformRedo);
             window.InputActions.Add(options => options.Search, showSearch);
+            window.InputActions.Add(options => options.ShowEditorContents, surface.ShowWholeGraph);
         }
     }
 }

--- a/Source/Editor/Windows/Assets/PreviewsCacheWindow.cs
+++ b/Source/Editor/Windows/Assets/PreviewsCacheWindow.cs
@@ -28,7 +28,7 @@ namespace FlaxEditor.Windows.Assets
             };
 
             // Toolstrip
-            _toolstrip.AddButton(editor.Icons.CenterView64, _preview.CenterView).LinkTooltip("Center view");
+            _toolstrip.AddButton(editor.Icons.CenterView64, _preview.CenterView).LinkTooltip("Center view", ref editor.Options.Options.Input.ShowEditorContents);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
+++ b/Source/Editor/Windows/Assets/SpriteAtlasWindow.cs
@@ -326,7 +326,9 @@ namespace FlaxEditor.Windows.Assets
                 _propertiesEditor.BuildLayout();
             }).LinkTooltip("Add a new sprite");
             _toolstrip.AddSeparator();
-            _toolstrip.AddButton(editor.Icons.CenterView64, _preview.CenterView).LinkTooltip("Center view");
+            _toolstrip.AddButton(editor.Icons.CenterView64, _preview.CenterView).LinkTooltip("Center view", ref editor.Options.Options.Input.ShowEditorContents);
+
+            InputActions.Add(options => options.ShowEditorContents, _preview.CenterView);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/Assets/TextureWindow.cs
+++ b/Source/Editor/Windows/Assets/TextureWindow.cs
@@ -260,9 +260,11 @@ namespace FlaxEditor.Windows.Assets
             _saveButton = (ToolStripButton)_toolstrip.AddButton(Editor.Icons.Save64, Save).LinkTooltip("Save", ref inputOptions.Save);
             _toolstrip.AddButton(Editor.Icons.Import64, () => Editor.ContentImporting.Reimport((BinaryAssetItem)Item)).LinkTooltip("Reimport");
             _toolstrip.AddSeparator();
-            _toolstrip.AddButton(Editor.Icons.CenterView64, _preview.CenterView).LinkTooltip("Center view");
+            _toolstrip.AddButton(Editor.Icons.CenterView64, _preview.CenterView).LinkTooltip("Center view", ref editor.Options.Options.Input.ShowEditorContents);
             _toolstrip.AddSeparator();
             _toolstrip.AddButton(editor.Icons.Docs64, () => Platform.OpenUrl(Utilities.Constants.DocsUrl + "manual/graphics/textures/index.html")).LinkTooltip("See documentation to learn more");
+
+            InputActions.Add(options => options.ShowEditorContents, _preview.CenterView);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Adds *Ctrl + 0* as a shortcut to show an editors content.

Editors this works in are:
- Texture editor
- Visject editor (materials, visual scripting, partices, ...)
- Sprite atlas editor

*Ctrl + 0* is a standart shortcut in programs like photoshop or illustrator, but also in a lot of other softwares, to display the contents of the thing you are editing (f.e. whole image in photoshop) at 100% scale. 

This isn't *exactly* what Flax will do with this pr when you press *Ctrl + 0*, but it's close and I think users will try to intuitively press *Ctrl + 0* if they want to see f.e. the whole Visject graph, especially if they have a background in Photoshop or other graphics related softwares.

I also keep wanting to press *Ctrl + 0* all the time when I want to have an overview of the whole Visject graph I'm working on, so I added it in this pr.