### PR TITLE
Fix gizmo to not use viewport fov and to only change cam orientation on MouseUp

### DIFF
--- a/Source/Editor/Gizmo/DirectionGizmo.cs
+++ b/Source/Editor/Gizmo/DirectionGizmo.cs
@@ -55,9 +55,13 @@ internal class DirectionGizmo : ContainerControl
         {
             // Inline EditorViewport.ProjectPoint to save on calculation for large set of points
             _viewport = new FlaxEngine.Viewport(0, 0, editorViewport.Width, editorViewport.Height);
+            // Force the FOV to 60° (viewport default) to keep the gizmo size consistent regardless of the editor viewport FOV setting
+            float fieldOfView = editorViewport.FieldOfView; 
+            editorViewport.FieldOfView = 60f;
             _frustum = editorViewport.ViewFrustum;
             _viewProjection = _frustum.Matrix;
             _origin = editorViewport.Task.View.Origin;
+            editorViewport.FieldOfView = fieldOfView;
         }
 
         public void ProjectPoint(Vector3 worldSpaceLocation, out Float2 viewportSpaceLocation)
@@ -157,9 +161,9 @@ internal class DirectionGizmo : ContainerControl
     }
 
     /// <inheritdoc />
-    public override bool OnMouseDown(Float2 location, MouseButton button)
+    public override bool OnMouseUp(Float2 location, MouseButton button)
     {
-        if (base.OnMouseDown(location, button))
+        if (base.OnMouseUp(location, button))
             return true;
 
         // Check which axis is being clicked - check from closest to farthest for proper layering


### PR DESCRIPTION
See *Title*.

Fixes this from happening at lower/ higher editor camera fov than 60°:
<img width="420" height="183" alt="image" src="https://github.com/user-attachments/assets/81c1ce1f-e3d8-4592-8f6f-92355706b862" />

I don't know why when I modify the `editorViewport` to `60f` it will also modify the main editor viewport fov????
Like it's not passed as a reference or anything??
Prolly a skill issue on my end.

Anyways I ended up fixing this by just caching the fov and then re- applying it.

Blender btw does the same thing. The gizmo fov is always a fixed number no matter the editor camera one.

Also makes the camera only change direction when the mouse button is let go off (default button behavior).



