### PR TITLE
Fix missing include of <cstdio> in .Gen.cpp files.

### DIFF
--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -3308,6 +3308,9 @@ namespace Flax.Build.Bindings
             var binaryModuleSourcePath = Path.Combine(project.ProjectFolderPath, "Source", binaryModuleName + ".Gen.cpp");
             contents.AppendLine("// This code was auto-generated. Do not modify it.");
             contents.AppendLine();
+            contents.AppendLine("#ifndef FILE");
+            contents.AppendLine("#include <cstdio>");
+            contents.AppendLine("#endif");
             contents.AppendLine("#include \"Engine/Scripting/BinaryModule.h\"");
             contents.AppendLine($"#include \"{binaryModuleName}.Gen.h\"");
             contents.AppendLine();


### PR DESCRIPTION
In certain Linux builds, `<cstdio>` is not automatically included into `.Gen.cpp` files, causing errors, such as the following:

`[ 00:45:00.106 ]: [Info] In file included from /home/user/Documents/Game/Game-Flax/Plugins/RDNetwCore/Source/RDNetwCommon.Gen.cpp:3:
[ 00:45:00.106 ]: [Info] In file included from /home/user/.local/share/SeedLauncher/Versions/1.11/Source/Engine/Scripting/BinaryModule.h:5:
[ 00:45:00.106 ]: [Info] In file included from /home/user/.local/share/SeedLauncher/Versions/1.11/Source/Engine/Scripting/ScriptingType.h:6:
[ 00:45:00.106 ]: [Info] In file included from /home/user/.local/share/SeedLauncher/Versions/1.11/Source/Engine/Core/Types/StringView.h:7:
[ 00:45:00.106 ]: [Info] In file included from /home/user/.local/share/SeedLauncher/Versions/1.11/Source/Engine/Core/Formatting.h:7:
[ 00:45:00.106 ]: [Info] In file included from /home/user/.local/share/SeedLauncher/Versions/1.11/Source/ThirdParty/fmt/format.h:1554:
[ 00:45:00.106 ]: [Info] In file included from /usr/include/stdio.h:970:
[ 00:45:00.106 ]: [Info] /usr/include/bits/stdio.h(58,10): error: member access into incomplete type 'FILE' (aka '_IO_FILE')
[ 00:45:00.106 ]: [Info]    58 |   return __getc_unlocked_body (__fp);`
due to the lack of presence of that include.

Here, the macro `FILE` is defined in the aforementioned `<cstdio>`, raising this issue.

Adding a quick check to see if the macro `FILE` is defined (effectively checking if `<cstdio>` is included), and if not, including `<cstdio>`, fixed the issue.