### PR TITLE
Tweak visject default curvature

### DIFF
--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -502,9 +502,9 @@ namespace FlaxEditor.Options
         /// <summary>
         /// Gets or sets the curvature of the line connecting to connected visject nodes.
         /// </summary>
-        [DefaultValue(1.0f), Range(0.0f, 2.0f)]
+        [DefaultValue(0.25f), Range(0.0f, 2.0f)]
         [EditorDisplay("Visject"), EditorOrder(550)]
-        public float ConnectionCurvature { get; set; } = 1.0f;
+        public float ConnectionCurvature { get; set; } = 0.25f;
 
         /// <summary>
         /// Gets or sets a value that indicates wether the context menu description panel is shown or not.


### PR DESCRIPTION
Small followup tweak for #3987.

I think the old default value of 1 is a bit much, I have been using 0.25 for a while now and I think it looks better.

With the old curvature, the connections look like they bend too much, even if they don't have to, especially when the connection distance is small:
<img width="928" height="774" alt="image" src="https://github.com/user-attachments/assets/a9f8ecce-9097-4e79-8063-e602c906a9d0" />

This is with the new default of 0.25:
<img width="865" height="795" alt="image" src="https://github.com/user-attachments/assets/0d47752d-c5b1-4e5f-a815-e18e1f1f43b6" />

