### PR TITLE
Add `GetBlackboard<T>()` to `BehaviorKnowledge`

### DIFF
--- a/Source/Engine/AI/BehaviorTree.cs
+++ b/Source/Engine/AI/BehaviorTree.cs
@@ -14,6 +14,17 @@ namespace FlaxEngine
     partial class BehaviorKnowledge
     {
         /// <summary>
+        /// Gets the behavior blackboard cast to the given type.
+        /// </summary>
+        /// <typeparam name="T">The blackboard type.</typeparam>
+        /// <returns>The behavior blackboard cast to the given type.</returns>
+        [Unmanaged]
+        public T GetBlackboard<T>()
+        {
+            return (T)Blackboard;
+        }
+
+        /// <summary>
         /// Checks if knowledge has a given goal (exact type match without base class check).
         /// </summary>
         /// <typeparam name="T"> goal type.</typeparam>


### PR DESCRIPTION
Add `GetBlackboard<T>()` to `BehaviorKnowledge`.
QoL, helps to reduce the noise, user side.
Since a cast failure is not an expected outcome i didn't put any extra safety around it.