### PR TITLE
Change the default for showing debug draw to be on by default

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -123,7 +123,7 @@ namespace FlaxEditor.Windows
         private readonly ScaledRenderOutputControl _viewport;
         private readonly GameRoot _guiRoot;
         private bool _showGUI = true, _editGUI = true;
-        private bool _showDebugDraw = false;
+        private bool _showDebugDraw = true;
         private bool _audioMuted = false;
         private float _audioVolume = 1;
         private bool _isMaximized = false, _isUnlockingMouse = false;


### PR DESCRIPTION
Looking through the history of the discord, I've seen enough people not know why their Debug Draws weren't drawing in the game. It is pretty sensible for a new user to try to draw a debug thing and expect it to just work without having to ask how to see it.