### PR TITLE
fix: support for non-standard library/executable paths on linux

### DIFF
--- a/Development/Scripts/Linux/CallBuildTool.sh
+++ b/Development/Scripts/Linux/CallBuildTool.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) Wojciech Figat. All rights reserved.
 
 set -e

--- a/Development/Scripts/Mac/CallBuildTool.sh
+++ b/Development/Scripts/Mac/CallBuildTool.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) Wojciech Figat. All rights reserved
 
 set -e

--- a/Source/Editor/Scripting/CodeEditors/VisualStudioCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/VisualStudioCodeEditor.cpp
@@ -53,7 +53,7 @@ void VisualStudioCodeEditor::FindEditors(Array<CodeEditor*>* output)
     }
 #elif PLATFORM_LINUX
     char buffer[128];
-    FILE* pipe = popen("/bin/bash -c \"type -p code\"", "r");
+    FILE* pipe = popen("/usr/bin/env bash -c \"type -p code\"", "r");
     if (pipe)
     {
         StringAnsi pathAnsi;
@@ -79,7 +79,7 @@ void VisualStudioCodeEditor::FindEditors(Array<CodeEditor*>* output)
     // Detect Flatpak installations
     {
         CreateProcessSettings procSettings;
-        procSettings.FileName = TEXT("/bin/bash -c \"flatpak list --app --columns=application | grep com.visualstudio.code -c\"");
+        procSettings.FileName = TEXT("/usr/bin/env bash -c \"flatpak list --app --columns=application | grep com.visualstudio.code -c\"");
         procSettings.HiddenWindow = true;
         if (Platform::CreateProcess(procSettings) == 0)
         {

--- a/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
+++ b/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
@@ -17,8 +17,46 @@
 #include <string.h>
 #include <stdlib.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <vector>
 
 const DateTime UnixEpoch(1970, 1, 1);
+
+bool LinuxFileSystem::FindProgramInPath(const char* program, char* outPath, size_t outSize)
+{
+    if (!program || !*program || !outPath || outSize == 0)
+        return false;
+
+    if (strchr(program, '/'))
+    {
+        char resolved[PATH_MAX];
+        if (realpath(program, resolved) == NULL || access(resolved, X_OK) != 0)
+            return false;
+        snprintf(outPath, outSize, "%s", resolved);
+        return true;
+    }
+
+    // Search for the program in the PATH environment variable
+    const char* pathEnv = getenv("PATH");
+    // Fallback to well-known locations if PATH is not available.
+    if (!pathEnv || !*pathEnv)
+        pathEnv = "/usr/bin:/bin";
+
+    char pathCopy[PATH_MAX];
+    strncpy(pathCopy, pathEnv, sizeof(pathCopy) - 1);
+    pathCopy[sizeof(pathCopy) - 1] = '\0';
+
+    char* savePtr = NULL;
+    for (char* dir = strtok_r(pathCopy, ":", &savePtr); dir; dir = strtok_r(NULL, ":", &savePtr))
+    {
+        int written = snprintf(outPath, outSize, "%s/%s", dir, program);
+        if (written > 0 && (size_t)written < outSize && access(outPath, X_OK) == 0)
+            return true;
+    }
+
+    outPath[0] = '\0';
+    return false;
+}
 
 bool LinuxFileSystem::ShowOpenFileDialog(Window* parentWindow, const StringView& initialDirectory, const StringView& filter, bool multiSelect, const StringView& title, Array<String, HeapAllocation>& filenames)
 {
@@ -31,37 +69,46 @@ bool LinuxFileSystem::ShowOpenFileDialog(Window* parentWindow, const StringView&
     Platform::GetEnvironmentVariable(TEXT("XDG_CURRENT_DESKTOP"), xdgCurrentDesktop);
     StringUtils::GetZZString(filter.Get()).Split('\0', fileFilterEntries);
 
-    const bool zenitySupported = FileSystem::FileExists(TEXT("/usr/bin/zenity"));
-    const bool kdialogSupported = FileSystem::FileExists(TEXT("/usr/bin/kdialog"));
-    char cmd[2048];
+    char zenityPath[PATH_MAX];
+    char kdialogPath[PATH_MAX];
+    const bool zenitySupported = FindProgramInPath("zenity", zenityPath, sizeof(zenityPath));
+    const bool kdialogSupported = FindProgramInPath("kdialog", kdialogPath, sizeof(kdialogPath));
+    char cmd[PATH_MAX];
     if (zenitySupported && (xdgCurrentDesktop != TEXT("KDE") || !kdialogSupported)) // Prefer kdialog when running on KDE
     {
-        for (int32 i = 1; i < fileFilterEntries.Count(); i += 2)
+        const int32 pairCount = fileFilterEntries.Count() / 2;
+        for (int32 pairIndex = 0; pairIndex < pairCount; pairIndex++)
         {
-            String extensions(fileFilterEntries[i]);
-            fileFilterEntries[i].Replace(TEXT(";"), TEXT(" "));
-            fileFilter.Append(String::Format(TEXT("{0}--file-filter=\"{1}|{2}\""), i > 1 ? TEXT(" ") : TEXT(""), fileFilterEntries[i-1].Get(), extensions.Get()));
+            const int32 nameIndex = pairIndex * 2;
+            const int32 extensionsIndex = nameIndex + 1;
+            String extensions(fileFilterEntries[extensionsIndex]);
+            fileFilterEntries[extensionsIndex].Replace(TEXT(";"), TEXT(" "));
+            fileFilter.Append(String::Format(TEXT("{0}--file-filter=\"{1}|{2}\""), pairIndex > 0 ? TEXT(" ") : TEXT(""), fileFilterEntries[nameIndex].Get(), extensions.Get()));
         }
 
-        sprintf(cmd, "/usr/bin/zenity --modal --file-selection %s--filename=\"%s\" --title=\"%s\" %s ", multiSelect ? "--multiple --separator=$'\n' " : " ", initDir, titleAnsi.Get(), fileFilter.ToStringView().ToStringAnsi().GetText());
+        sprintf(cmd, "\"%s\" --modal --file-selection %s--filename=\"%s\" --title=\"%s\" %s ", zenityPath, multiSelect ? "--multiple --separator=$'\n' " : " ", initDir, titleAnsi.Get(), fileFilter.ToStringView().ToStringAnsi().GetText());
     }
     else if (kdialogSupported)
     {
-        for (int32 i = 1; i < fileFilterEntries.Count(); i += 2)
+        const int32 pairCount = fileFilterEntries.Count() / 2;
+        for (int32 pairIndex = 0; pairIndex < pairCount; pairIndex++)
         {
-            String extensions(fileFilterEntries[i]);
-            fileFilterEntries[i].Replace(TEXT(";"), TEXT(" "));
-            fileFilter.Append(String::Format(TEXT("{0}\"{1}({2})\""), i > 1 ? TEXT(" ") : TEXT(""), fileFilterEntries[i-1].Get(), extensions.Get()));
+            const int32 nameIndex = pairIndex * 2;
+            const int32 extensionsIndex = nameIndex + 1;
+            String extensions(fileFilterEntries[extensionsIndex]);
+            fileFilterEntries[extensionsIndex].Replace(TEXT(";"), TEXT(" "));
+            fileFilter.Append(String::Format(TEXT("{0}\"{1}({2})\""), pairIndex > 0 ? TEXT(" ") : TEXT(""), fileFilterEntries[nameIndex].Get(), extensions.Get()));
         }
         fileFilter.Append(String::Format(TEXT("{0}\"{1}({2})\""), TEXT(" "), TEXT("many things"), TEXT("*.png *.jpg")));
 
-        sprintf(cmd, "/usr/bin/kdialog --getopenfilename %s--title \"%s\" \"%s\" %s ", multiSelect ? "--multiple --separate-output " : " ", titleAnsi.Get(), initDir, fileFilter.ToStringView().ToStringAnsi().GetText());
+        sprintf(cmd, "\"%s\" --getopenfilename %s--title \"%s\" \"%s\" %s ", kdialogPath, multiSelect ? "--multiple --separate-output " : " ", titleAnsi.Get(), initDir, fileFilter.ToStringView().ToStringAnsi().GetText());
     }
     else
     {
         LOG(Error, "Missing file picker (install zenity or kdialog).");
-        return true;    
+        return true;
     }
+
     FILE* f = popen(cmd, "r");
     char buf[2048];
     char* writePointer = buf;
@@ -113,21 +160,23 @@ bool LinuxFileSystem::ShowBrowseFolderDialog(Window* parentWindow, const StringV
 
     // TODO: support initialDirectory
 
-    const bool zenitySupported = FileSystem::FileExists(TEXT("/usr/bin/zenity"));
-    const bool kdialogSupported = FileSystem::FileExists(TEXT("/usr/bin/kdialog"));
-    char cmd[2048];
+    char zenityPath[PATH_MAX];
+    char kdialogPath[PATH_MAX];
+    const bool zenitySupported = FindProgramInPath("zenity", zenityPath, sizeof(zenityPath));
+    const bool kdialogSupported = FindProgramInPath("kdialog", kdialogPath, sizeof(kdialogPath));
+    char cmd[PATH_MAX];
     if (zenitySupported && (xdgCurrentDesktop != TEXT("KDE") || !kdialogSupported)) // Prefer kdialog when running on KDE
     {
-        sprintf(cmd, "/usr/bin/zenity --modal --file-selection --directory --title=\"%s\" ", titleAnsi.Get());
+        sprintf(cmd, "\"%s\" --modal --file-selection --directory --title=\"%s\" ", zenityPath, titleAnsi.Get());
     }
     else if (kdialogSupported)
     {
-        sprintf(cmd, "/usr/bin/kdialog --getexistingdirectory --title \"%s\" ", titleAnsi.Get());
+        sprintf(cmd, "\"%s\" --getexistingdirectory --title \"%s\" ", kdialogPath, titleAnsi.Get());
     }
     else
     {
         LOG(Error, "Missing file picker (install zenity or kdialog).");
-        return true;    
+        return true;
     }
     FILE* f = popen(cmd, "r");
     char buf[2048];
@@ -248,16 +297,18 @@ bool LinuxFileSystem::MoveFileToRecycleBin(const StringView& path)
     {
         const String ext = GetExtension(path);
         dst = filesDir / getNameWithoutExtension(path) + TEXT("XXXXXX.") + ext;
-        const char *templateString = dst.ToStringAnsi().Get();
-        char writableName[strlen(templateString) + 1];
-        strcpy(writableName, templateString);
-        fd = mkstemps(writableName, ext.Length() + 1);
+        const auto templateStringAnsi = dst.ToStringAnsi();
+        const char* templateString = templateStringAnsi.Get();
+        const size_t templateLength = strlen(templateString);
+        std::vector<char> writableName(templateLength + 1);
+        strcpy(writableName.data(), templateString);
+        fd = mkstemps(writableName.data(), ext.Length() + 1);
         if (fd < 0)
         {
-            LOG(Error, "Cannot create a temporary file as {0}, errno={1}", String(writableName), errno);
+            LOG(Error, "Cannot create a temporary file as {0}, errno={1}", String(writableName.data()), errno);
             return true;
         }
-        dst = String(writableName);
+        dst = String(writableName.data());
         trashName = getBaseName(dst);
     }
     if (fd != -1)
@@ -268,17 +319,17 @@ bool LinuxFileSystem::MoveFileToRecycleBin(const StringView& path)
         // Not MoveFile means success so write the info file
         const String infoFile = infoDir / trashName + TEXT(".trashinfo");
         StringBuilder trashInfo;
-        const char *ansiPath = path.ToStringAnsi().Get();
-        const int maxLength = strlen(ansiPath) * 3 + 1; // in the worst case the length will be tripled
-        char encoded[maxLength];
-        if (!UrnEncodePath(ansiPath, encoded, maxLength))
+        const char* ansiPath = path.ToStringAnsi().Get();
+        const int maxLength = static_cast<int>(strlen(ansiPath) * 3 + 1); // in the worst case the length will be tripled
+        std::vector<char> encoded(static_cast<size_t>(maxLength));
+        if (!UrnEncodePath(ansiPath, encoded.data(), maxLength))
         {
             // unlikely but better keep something
-            strcpy(encoded, ansiPath);
+            strcpy(encoded.data(), ansiPath);
         }
         const DateTime now = DateTime::Now();
         const String rfcDate = String::Format(TEXT("{0}-{1:0>2}-{2:0>2}T{3:0>2}:{4:0>2}:{5:0>2}"), now.GetYear(), now.GetMonth(), now.GetDay(), now.GetHour(), now.GetMinute(), now.GetSecond());
-        trashInfo.AppendLine(TEXT("[Trash Info]")).Append(TEXT("Path=")).Append(encoded).Append(TEXT('\n'));
+        trashInfo.AppendLine(TEXT("[Trash Info]")).Append(TEXT("Path=")).Append(encoded.data()).Append(TEXT('\n'));
         trashInfo.Append(TEXT("DeletionDate=")).Append(rfcDate).Append(TEXT("\n\0"));
 
         // a failure to write the info file is considered non-fatal according to the FreeDesktop.org specification

--- a/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
+++ b/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
@@ -155,7 +155,7 @@ bool LinuxFileSystem::ShowFileExplorer(const StringView& path)
     const StringAsUTF8<> pathAnsi(*path, path.Length());
     char cmd[2048];
     sprintf(cmd, "xdg-open %s &", pathAnsi.Get());
-    system(cmd);
+    (void)system(cmd);
     return false;
 }
 

--- a/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
+++ b/Source/Engine/Platform/Linux/LinuxFileSystem.cpp
@@ -131,8 +131,10 @@ bool LinuxFileSystem::ShowBrowseFolderDialog(Window* parentWindow, const StringV
     }
     FILE* f = popen(cmd, "r");
     char buf[2048];
-    fgets(buf, ARRAY_COUNT(buf), f); 
+    const char* readResult = fgets(buf, ARRAY_COUNT(buf), f);
     int result = pclose(f);
+    if (!readResult)
+        return true;
     if (result != 0)
         return true;
 

--- a/Source/Engine/Platform/Linux/LinuxFileSystem.h
+++ b/Source/Engine/Platform/Linux/LinuxFileSystem.h
@@ -5,6 +5,7 @@
 #if PLATFORM_LINUX
 
 #include "Engine/Platform/Unix/UnixFileSystem.h"
+#include <stddef.h>
 
 /// <summary>
 /// Linux platform implementation of filesystem service.
@@ -19,6 +20,9 @@ public:
     static bool CopyFile(const StringView& dst, const StringView& src);
     static bool MoveFileToRecycleBin(const StringView& path);
     static void GetSpecialFolderPath(const SpecialFolder type, String& result);
+
+    // [LinuxFileSystem]
+    static bool FindProgramInPath(const char* program, char* outPath, size_t outSize);
 
 private:
     static bool UrnEncodePath(const char *path, char *result, int maxLength);

--- a/Source/ThirdParty/libportal/libportal.Build.cs
+++ b/Source/ThirdParty/libportal/libportal.Build.cs
@@ -29,10 +29,15 @@ public class libportal : EngineDepsModule
         case TargetPlatform.Linux:
             options.OutputFiles.Add(Path.Combine(depsRoot, "libportal.a"));
 
-            options.PublicIncludePaths.Add("/usr/include/glib-2.0");
-            options.PublicIncludePaths.Add("/usr/lib/glib-2.0/include");
-            if (options.Architecture == TargetArchitecture.x64)
-                options.PublicIncludePaths.Add("/usr/lib/x86_64-linux-gnu/glib-2.0/include");
+            // Attempt to get library locations with pkg-config first.
+            if (!PkgConfig.TryAddIncludePaths(options, "glib-2.0 gio-2.0 gobject-2.0"))
+            {
+                // Fallback to standard FHS locations.
+                options.PublicIncludePaths.Add("/usr/include/glib-2.0");
+                options.PublicIncludePaths.Add("/usr/lib/glib-2.0/include");
+                if (options.Architecture == TargetArchitecture.x64)
+                    options.PublicIncludePaths.Add("/usr/lib/x86_64-linux-gnu/glib-2.0/include");
+            }
 
             //options.SourceFiles.Add(Path.Combine(FolderPath, "portal-enums.c"));
             options.SourceFiles.AddRange(Directory.GetFiles(FolderPath, "*.c", SearchOption.TopDirectoryOnly));

--- a/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Linux/LinuxToolchain.cs
@@ -27,6 +27,61 @@ namespace Flax.Build.Platforms
     /// <seealso cref="UnixToolchain" />
     public class LinuxToolchain : UnixToolchain
     {
+        private List<string> GetPkgConfigLibDirs()
+        {
+            var targetTriple = Architecture switch
+            {
+                TargetArchitecture.x86 => "i686-linux-gnu",
+                TargetArchitecture.x64 => "x86_64-linux-gnu",
+                TargetArchitecture.ARM => "arm-linux-gnueabihf",
+                TargetArchitecture.ARM64 => "aarch64-linux-gnu",
+                _ => null,
+            };
+
+            var result = new List<string>();
+            foreach (var path in new[]
+            {
+                Path.Combine(ToolsetRoot, "usr", "lib", "pkgconfig"),
+                Path.Combine(ToolsetRoot, "usr", "share", "pkgconfig"),
+                Path.Combine(ToolsetRoot, "lib", "pkgconfig"),
+                Path.Combine(ToolsetRoot, "share", "pkgconfig"),
+                string.IsNullOrEmpty(targetTriple) ? null : Path.Combine(ToolsetRoot, "usr", "lib", targetTriple, "pkgconfig"),
+                string.IsNullOrEmpty(targetTriple) ? null : Path.Combine(ToolsetRoot, "lib", targetTriple, "pkgconfig"),
+            })
+            {
+                if (!string.IsNullOrEmpty(path) && Directory.Exists(path) && !result.Contains(path))
+                    result.Add(path);
+            }
+            return result;
+        }
+
+        private static string FindFirstExistingDirectory(params string[] candidates)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (!string.IsNullOrEmpty(candidate) && Directory.Exists(candidate))
+                    return candidate;
+            }
+            return null;
+        }
+
+        private string TryGetClangResourceIncludePath()
+        {
+            try
+            {
+                var resourceDir = Utilities.ReadProcessOutput(ClangPath, "-print-resource-dir");
+                if (!string.IsNullOrWhiteSpace(resourceDir))
+                {
+                    var includePath = Path.Combine(resourceDir.Trim(), "include");
+                    if (Directory.Exists(includePath))
+                        return includePath;
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="LinuxToolchain"/> class.
         /// </summary>
@@ -40,26 +95,43 @@ namespace Flax.Build.Platforms
                 Log.Error($"Old Clang version {ClangVersion}. Minimum supported is {minClangVer}.");
 
             // Setup system paths
-            var includePath = Path.Combine(ToolsetRoot, "usr", "include");
-            if (Directory.Exists(includePath))
-                SystemIncludePaths.Add(includePath);
-            else
-                Log.Error($"Missing toolset header files location {includePath}");
-            var cppIncludePath = Path.Combine(includePath, "c++", LibStdCppVersion);
-            if (Directory.Exists(cppIncludePath))
-                SystemIncludePaths.Add(cppIncludePath);
-            else
-                Log.Verbose($"Missing Clang {ClangVersion} C++ header files location {cppIncludePath}");
-            var clangLibPath = Path.Combine(ToolsetRoot, "usr", "lib", "clang");
-            var clangIncludePath = Path.Combine(clangLibPath, ClangVersion.Major.ToString(), "include");
-            if (!Directory.Exists(clangIncludePath))
+            var includePath = FindFirstExistingDirectory(
+                Path.Combine(ToolsetRoot, "usr", "include"),
+                Path.Combine(ToolsetRoot, "include"));
+            if (includePath != null)
             {
-                var error = $"Missing Clang {ClangVersion} header files location {clangIncludePath}";
-                clangIncludePath = Path.Combine(clangLibPath, ClangVersion.ToString(), "include");
-                if (!Directory.Exists(clangIncludePath))
-                    Log.Error(error);
+                SystemIncludePaths.Add(includePath);
+
+                var cppIncludePath = Path.Combine(includePath, "c++", LibStdCppVersion);
+                if (Directory.Exists(cppIncludePath))
+                    SystemIncludePaths.Add(cppIncludePath);
+                else
+                    Log.Verbose($"Missing Clang {ClangVersion} C++ header files location {cppIncludePath}");
             }
-            SystemIncludePaths.Add(clangIncludePath);
+            else
+            {
+                Log.Verbose($"Missing toolset header files location under {ToolsetRoot}");
+            }
+
+            var clangIncludePath = TryGetClangResourceIncludePath();
+            if (clangIncludePath == null)
+            {
+                var clangVersionMajor = ClangVersion.Major.ToString();
+                var clangVersionFull = ClangVersion.ToString();
+                var clangIncludeCandidates = new[]
+                {
+                    Path.Combine(ToolsetRoot, "usr", "lib", "clang", clangVersionMajor, "include"),
+                    Path.Combine(ToolsetRoot, "usr", "lib", "clang", clangVersionFull, "include"),
+                    Path.Combine(ToolsetRoot, "lib", "clang", clangVersionMajor, "include"),
+                    Path.Combine(ToolsetRoot, "lib", "clang", clangVersionFull, "include"),
+                };
+                clangIncludePath = FindFirstExistingDirectory(clangIncludeCandidates);
+            }
+
+            if (clangIncludePath != null)
+                SystemIncludePaths.Add(clangIncludePath);
+            else
+                Log.Error($"Missing Clang {ClangVersion} header files location (resource-dir and sysroot probes failed).");
         }
 
         /// <inheritdoc />
@@ -138,21 +210,12 @@ namespace Flax.Build.Platforms
             args.Add("-lz");
 
             // Link X11
-            args.Add("-L/usr/X11R6/lib");
-            args.Add("-lX11");
-            args.Add("-lXcursor");
-            args.Add("-lXinerama");
-            args.Add("-lXfixes");
+            PkgConfig.AddLibsOrFallback(args, "x11 xcursor xinerama xfixes", new[] { "-lX11", "-lXcursor", "-lXinerama", "-lXfixes" }, ToolsetRoot, GetPkgConfigLibDirs());
 
             if (EngineConfiguration.WithSDL(options))
             {
-                // Link Wayland
-                args.Add("-lwayland-client");
-
-                // Link GLib for libportal
-                args.Add("-lglib-2.0");
-                args.Add("-lgio-2.0");
-                args.Add("-lgobject-2.0");
+                // Link Wayland + GLib for libportal
+                PkgConfig.AddLibsOrFallback(args, "wayland-client glib-2.0 gio-2.0 gobject-2.0", new[] { "-lwayland-client", "-lglib-2.0", "-lgio-2.0", "-lgobject-2.0" }, ToolsetRoot, GetPkgConfigLibDirs());
             }
         }
 

--- a/Source/Tools/Flax.Build/Utilities/PkgConfig.cs
+++ b/Source/Tools/Flax.Build/Utilities/PkgConfig.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using Flax.Build.NativeCpp;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Flax.Build
+{
+    /// <summary>
+    /// Helper methods for querying <c>pkg-config</c>.
+    /// </summary>
+    public static class PkgConfig
+    {
+        private const string ToolName = "pkg-config";
+
+        /// <summary>
+        /// Tries to run <c>pkg-config</c> with the specified arguments.
+        /// </summary>
+        /// <param name="arguments">Arguments for <c>pkg-config</c>.</param>
+        /// <param name="output">The trimmed standard output on success.</param>
+        /// <param name="sysroot">Optional sysroot to set via <c>PKG_CONFIG_SYSROOT_DIR</c>.</param>
+        /// <param name="pkgConfigLibDirs">Optional package config search directories for <c>PKG_CONFIG_LIBDIR</c>.</param>
+        /// <returns><see langword="true"/> on success, otherwise <see langword="false"/>.</returns>
+        public static bool TryRun(string arguments, out string output, string sysroot = null, IEnumerable<string> pkgConfigLibDirs = null)
+        {
+            output = null;
+            try
+            {
+                using (var process = new Process())
+                {
+                    process.StartInfo = new ProcessStartInfo
+                    {
+                        FileName = ToolName,
+                        Arguments = arguments,
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = true,
+                    };
+
+                    process.StartInfo.EnvironmentVariables["PKG_CONFIG_DIR"] = string.Empty;
+                    if (!string.IsNullOrEmpty(sysroot))
+                        process.StartInfo.EnvironmentVariables["PKG_CONFIG_SYSROOT_DIR"] = sysroot;
+
+                    if (pkgConfigLibDirs != null)
+                    {
+                        var dirs = new List<string>();
+                        foreach (var dir in pkgConfigLibDirs)
+                        {
+                            if (!string.IsNullOrEmpty(dir) && !dirs.Contains(dir))
+                                dirs.Add(dir);
+                        }
+                        if (dirs.Count > 0)
+                            process.StartInfo.EnvironmentVariables["PKG_CONFIG_LIBDIR"] = string.Join(System.IO.Path.PathSeparator.ToString(), dirs);
+                    }
+
+                    process.Start();
+                    output = process.StandardOutput.ReadToEnd().Trim();
+                    var error = process.StandardError.ReadToEnd().Trim();
+                    process.WaitForExit();
+                    if (process.ExitCode == 0)
+                        return true;
+
+                    if (!string.IsNullOrEmpty(error))
+                        Log.Verbose($"{ToolName} {arguments} failed: {error}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Verbose($"{ToolName} unavailable: {ex.Message}");
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to add include paths returned by <c>pkg-config --cflags-only-I</c>.
+        /// </summary>
+        /// <param name="options">Build options to modify.</param>
+        /// <param name="packages">Space-separated package names.</param>
+        /// <param name="sysroot">Optional sysroot to set via <c>PKG_CONFIG_SYSROOT_DIR</c>.</param>
+        /// <param name="pkgConfigLibDirs">Optional package config search directories for <c>PKG_CONFIG_LIBDIR</c>.</param>
+        /// <returns><see langword="true"/> if at least one include path was added.</returns>
+        public static bool TryAddIncludePaths(BuildOptions options, string packages, string sysroot = null, IEnumerable<string> pkgConfigLibDirs = null)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            if (!TryRun($"--silence-errors --cflags-only-I {packages}", out var output, sysroot, pkgConfigLibDirs) || string.IsNullOrWhiteSpace(output))
+                return false;
+
+            var addedAny = false;
+            var tokens = output.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var token in tokens)
+            {
+                if (!token.StartsWith("-I"))
+                    continue;
+
+                var includePath = token.Substring(2).Trim('"');
+                if (string.IsNullOrEmpty(includePath) || options.PublicIncludePaths.Contains(includePath))
+                    continue;
+
+                options.PublicIncludePaths.Add(includePath);
+                addedAny = true;
+            }
+
+            return addedAny;
+        }
+
+        /// <summary>
+        /// Adds library linker arguments from <c>pkg-config --libs</c> or fallback flags if unavailable.
+        /// </summary>
+        /// <param name="args">Linker arguments list to modify.</param>
+        /// <param name="packages">Space-separated package names.</param>
+        /// <param name="fallbackLibraries">Fallback linker flags if pkg-config query fails.</param>
+        /// <param name="sysroot">Optional sysroot to set via <c>PKG_CONFIG_SYSROOT_DIR</c>.</param>
+        /// <param name="pkgConfigLibDirs">Optional package config search directories for <c>PKG_CONFIG_LIBDIR</c>.</param>
+        public static void AddLibsOrFallback(List<string> args, string packages, IEnumerable<string> fallbackLibraries, string sysroot = null, IEnumerable<string> pkgConfigLibDirs = null)
+        {
+            if (args == null)
+                throw new ArgumentNullException(nameof(args));
+
+            if (TryRun($"--silence-errors --libs {packages}", out var libs, sysroot, pkgConfigLibDirs) && !string.IsNullOrWhiteSpace(libs))
+            {
+                args.AddRange(libs.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
+            }
+            else if (fallbackLibraries != null)
+            {
+                args.AddRange(fallbackLibraries);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I ran into some issues on a distro which doesn't use the Filesystem Hierarchy Standard. However I believe these fixes will help for situations other than just NixOS.

Changes have been tested on Ubuntu 26.04 LTS and NixOS.

This PR does a few things:

## Replaces `#!/bin/bash` with `#!/usr/bin/env bash` 

This is considered best practice due to some systems storing the shell binary in different locations.
I made this change for the MacOS code too, as the same situation applies.

## Checks the PATH for zenity/kdialog.

On some systems, these programs aren't necessarily in `/usr/bin`, so it now looks for them in the PATH.

## Uses `pkg-config` for library discovery

I've created a PkgConfig helper class that shells out to pkg-config when looking for libraries such as `glib`, `gio`, and `gobject`. it still falls back to the old paths if pkg-config is unavailable.

