### PR TITLE
Rename Sphere Mask node A and B inputs to be more clear what they do

### DIFF
--- a/Source/Editor/Surface/Archetypes/Material.cs
+++ b/Source/Editor/Surface/Archetypes/Material.cs
@@ -807,8 +807,8 @@ namespace FlaxEditor.Surface.Archetypes
                 },
                 Elements = new[]
                 {
-                    NodeElementArchetype.Factory.Input(0, "A", true, null, 0),
-                    NodeElementArchetype.Factory.Input(1, "B", true, null, 1),
+                    NodeElementArchetype.Factory.Input(0, "UV", true, null, 0),
+                    NodeElementArchetype.Factory.Input(1, "Center", true, null, 1),
                     NodeElementArchetype.Factory.Input(2, "Radius", true, typeof(float), 2, 0),
                     NodeElementArchetype.Factory.Input(3, "Hardness", true, typeof(float), 3, 1),
                     NodeElementArchetype.Factory.Input(4, "Invert", true, typeof(bool), 4, 2),


### PR DESCRIPTION
Renames the Sphere Mask node inputs "A" and "B" to "UV" and "Center", as that gives a hint to the user as to what the node expects as an input. Someone [asked on Discord](https://discord.com/channels/437989205315158016/438021321134309377/1503724484740517918) what the inputs do and I think this makes it a lot more clear.

The names reflect what [Unity is using](https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/Sphere-Mask-Node.html) (while Unreal uses A and B).

It also follows the naming of the Rectangle Mask node:

<img width="783" height="374" alt="image" src="https://github.com/user-attachments/assets/9a1712de-09d7-4930-a96f-bc5034ff7595" />
