### PR TITLE
Add sliders to float and int value boxes in Visject

### DIFF
--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -1524,6 +1524,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 10,
                 Title = "Color Gradient",
+                AlternativeTitles = new [] { "Color Ramp" },
                 Create = (id, context, arch, groupArch) => new ColorGradientNode(id, context, arch, groupArch),
                 Description = "Linear color gradient sampler",
                 Flags = NodeFlags.AllGraphs | NodeFlags.FixedSize,

--- a/Source/Editor/Surface/Elements/FloatValue.cs
+++ b/Source/Editor/Surface/Elements/FloatValue.cs
@@ -34,10 +34,6 @@ namespace FlaxEditor.Surface.Elements
             Archetype = archetype;
 
             ParentNode.ValuesChanged += OnNodeValuesChanged;
-
-            // Disable slider if surface doesn't allow it
-            if (ParentNode.Surface != null && !ParentNode.Surface.CanLivePreviewValueChanges)
-                _slideSpeed = 0.0f;
         }
 
         private void OnNodeValuesChanged()

--- a/Source/Editor/Surface/Elements/InputBox.cs
+++ b/Source/Editor/Surface/Elements/InputBox.cs
@@ -29,6 +29,8 @@ namespace FlaxEditor.Surface.Elements
     [HideInEditor]
     public interface IDefaultValueEditor
     {
+        internal const float FloatBoxSlideSpeed = 0.01f;
+
         /// <summary>
         /// Checks if the handles supports the given type.
         /// </summary>
@@ -311,13 +313,13 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new RealValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new RealValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new RealValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new RealValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -385,19 +387,19 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new RealValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new RealValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new RealValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new RealValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatY.BoxValueChanged += OnValueChanged;
-            var floatZ = new RealValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatZ = new RealValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -468,25 +470,25 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new RealValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new RealValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new RealValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new RealValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatY.BoxValueChanged += OnValueChanged;
-            var floatZ = new RealValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatZ = new RealValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatZ.BoxValueChanged += OnValueChanged;
-            var floatW = new RealValueBox(value.W, width * 3 + 6, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatW = new RealValueBox(value.W, width * 3 + 6, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -561,13 +563,13 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -635,19 +637,19 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatY.BoxValueChanged += OnValueChanged;
-            var floatZ = new FloatValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatZ = new FloatValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -718,25 +720,25 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatY.BoxValueChanged += OnValueChanged;
-            var floatZ = new FloatValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatZ = new FloatValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatZ.BoxValueChanged += OnValueChanged;
-            var floatW = new FloatValueBox(value.W, width * 3 + 6, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatW = new FloatValueBox(value.W, width * 3 + 6, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -811,13 +813,13 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new DoubleValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new DoubleValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new DoubleValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new DoubleValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -885,19 +887,19 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new DoubleValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new DoubleValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new DoubleValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new DoubleValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatY.BoxValueChanged += OnValueChanged;
-            var floatZ = new DoubleValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatZ = new DoubleValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -968,25 +970,25 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new DoubleValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new DoubleValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new DoubleValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new DoubleValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatY.BoxValueChanged += OnValueChanged;
-            var floatZ = new DoubleValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatZ = new DoubleValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatZ.BoxValueChanged += OnValueChanged;
-            var floatW = new DoubleValueBox(value.W, width * 3 + 6, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatW = new DoubleValueBox(value.W, width * 3 + 6, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
@@ -1061,19 +1063,19 @@ namespace FlaxEditor.Surface.Elements
                 Parent = box.Parent,
                 Tag = box,
             };
-            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatX = new FloatValueBox(value.X, 0, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatX.BoxValueChanged += OnValueChanged;
-            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatY = new FloatValueBox(value.Y, width + 2, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,
             };
             floatY.BoxValueChanged += OnValueChanged;
-            var floatZ = new FloatValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, 0.0f)
+            var floatZ = new FloatValueBox(value.Z, width * 2 + 4, 0, width, float.MinValue, float.MaxValue, IDefaultValueEditor.FloatBoxSlideSpeed)
             {
                 Height = bounds.Height,
                 Parent = control,

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -603,7 +603,7 @@ namespace FlaxEditor.Surface
         public virtual bool UseContextMenuDescriptionPanel => false;
 
         /// <summary>
-        /// Gets a value indicating whether surface supports/allows live previewing graph modifications due to value sliders and color pickers. True by default but disabled for shader surfaces that generate and compile shader source at flight.
+        /// Gets a value indicating whether surface supports/allows live previewing graph modifications originating from color pickers. True by default but disabled for shader surfaces that generate and compile shader source at flight.
         /// </summary>
         public virtual bool CanLivePreviewValueChanges => true;
 


### PR DESCRIPTION
This pr adds sliders to all float and integer (input) value boxes in Visject.

<img width="798" height="547" alt="image" src="https://github.com/user-attachments/assets/cccfbe30-c7ca-4419-b4ed-536bb6123107" />


The were partially disabled in material graphs because the material will recompile on every "drag step" of the value box (every time the value is changed while the user drags the value box's slider).

I think having a bit of lag due to shader/ material recompilation is far better than having no sliders. I think the UX shouldn't be made worse by a whole lot just because dragging on a slider will create some lag in certain cases. Obviously the shader recompilation lag is not ideal either, but I think the benefit of having sliders for value boxes outweighs that disadvantage.

Having sliders is a lot better for tweaking and playing around in materials, because it is far quicker and much less tedious than typing new values in by hand.

Also it is up to the user if they want to use the sliders (and experience a bit of lag) or just play with values the old and tedious way (by manually typing in the next value via the keyboard until they find something fit).


I added the slide speed as a constant in `IDefaultValueEditor`. I think it is fine to have a constant in an interface in this case, because it is kind of part of the implementation of the interface (i.e. the interface controls the speed of the sliders).
But I can also replace the constant with just floats on every occurrence if this is considered bad code. 

This pr also adds "Color Ramp" as an alternative title to the `Color Gradient` node.