### PR TITLE
Fix the cursor not hiding when right click dragging on the main editor viewport if the game panel has focus and both panels are docked

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -662,8 +662,8 @@ namespace FlaxEditor.Windows
         {
             base.OnMouseLeave();
 
-            // Remove focus from game window when mouse moves out and the cursor is hidden during game
-            if (ContainsFocus && Parent != null && Editor.IsPlayMode && !Screen.CursorVisible && Screen.CursorLock == CursorLockMode.None)
+            // Remove focus from game window
+            if ((ContainsFocus && Parent != null) && !Editor.IsPlayMode || Editor.IsPlayMode && !Screen.CursorVisible && Screen.CursorLock == CursorLockMode.None)
             {
                 Parent.Focus();
             }

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -664,9 +664,7 @@ namespace FlaxEditor.Windows
 
             // Remove focus from game window
             if ((ContainsFocus && Parent != null) && !Editor.IsPlayMode || Editor.IsPlayMode && !Screen.CursorVisible && Screen.CursorLock == CursorLockMode.None)
-            {
                 Parent.Focus();
-            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #4040 

Basically performs the same logic that was before only executed during play mode during editor mode