### PR TITLE
Auto scroll the content panel navigation bar to the current folder (if needed)

### DIFF
--- a/Source/Editor/Windows/ContentWindow.Navigation.cs
+++ b/Source/Editor/Windows/ContentWindow.Navigation.cs
@@ -257,6 +257,17 @@ namespace FlaxEditor.Windows
             _navigationBar.IsLayoutLocked = wasLayoutLocked;
             _navigationBar.PerformLayout();
             UpdateNavigationBarBounds();
+
+            ScrollNavigationBarToCurrentFolder();
+        }
+
+        private void ScrollNavigationBarToCurrentFolder()
+        {
+            if (_navigationBar != null && _navigationBar.ChildrenCount != 0 && _navigationBar.HScrollBar.Visible)
+            {
+                _navigationBar.HScrollBar.TargetValue = _navigationBar.HScrollBar.Maximum;
+                _navigationBar.HScrollBar.FastScroll();
+            }
         }
 
         /// <summary>

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -1775,6 +1775,14 @@ namespace FlaxEditor.Windows
         }
 
         /// <inheritdoc />
+        protected override void OnSizeChanged()
+        {
+            base.OnSizeChanged();
+
+            ScrollNavigationBarToCurrentFolder();
+        }
+
+        /// <inheritdoc />
         protected override void PerformLayoutBeforeChildren()
         {
             base.PerformLayoutBeforeChildren();

--- a/Source/Editor/Windows/ContentWindow.cs
+++ b/Source/Editor/Windows/ContentWindow.cs
@@ -559,7 +559,7 @@ namespace FlaxEditor.Windows
         }
 
         /// <summary>
-        ///  Enables or disables vertical and horizontal scrolling on the content tree panel
+        /// Enables or disables vertical and horizontal scrolling on the content tree panel
         /// </summary>
         /// <param name="enabled">The state to set scrolling to</param>
         public void ScrollingOnTreeView(bool enabled)
@@ -571,7 +571,7 @@ namespace FlaxEditor.Windows
         }
 
         /// <summary>
-        ///  Enables or disables vertical and horizontal scrolling on the content view panel
+        /// Enables or disables vertical and horizontal scrolling on the content view panel
         /// </summary>
         /// <param name="enabled">The state to set scrolling to</param>
         public void ScrollingOnContentView(bool enabled)
@@ -1555,6 +1555,7 @@ namespace FlaxEditor.Windows
                     PerformLayout();
                 }
                 UpdateViewDropdownBounds();
+                ScrollNavigationBarToCurrentFolder();
             }
         }
 


### PR DESCRIPTION
Automatically scrolls the Content Panel navigation bar horizontal scroll bar to the current (the last in the navigation bar) folder:

https://github.com/user-attachments/assets/98680e67-51a1-4460-ac68-4b02c35a4580

This makes it far easier to navigate back. 
Showing the folder path from the current folder on and keeping folders higher in the folder structure out of view, if necessary due to limited space, is the expected behavior that is also used in windows file explorer and many other softwares.

This makes sense since you are most likely going to use the navigation bar to go back folders from the current folder, not select an entirely new folder starting from the root folder.


