### PR TITLE
Fix mouse position in events reported from caption area on Windows

### DIFF
--- a/Source/Engine/Platform/Windows/WindowsInput.cpp
+++ b/Source/Engine/Platform/Windows/WindowsInput.cpp
@@ -189,6 +189,7 @@ bool WindowsMouse::WndProc(Window* window, const UINT msg, WPARAM wParam, LPARAM
     POINT p;
     p.x = static_cast<LONG>(WINDOWS_GET_X_LPARAM(lParam));
     p.y = static_cast<LONG>(WINDOWS_GET_Y_LPARAM(lParam));
+    const Float2 mousePosScreen(static_cast<float>(p.x), static_cast<float>(p.y));
     ::ClientToScreen(window->GetHWND(), &p);
     const Float2 mousePos(static_cast<float>(p.x), static_cast<float>(p.y));
 
@@ -203,7 +204,8 @@ bool WindowsMouse::WndProc(Window* window, const UINT msg, WPARAM wParam, LPARAM
     }    
     case WM_NCMOUSEMOVE:
     {
-        OnMouseMove(mousePos, window);
+        // The position in the message is already reported in screen-space
+        OnMouseMove(mousePosScreen, window);
         result = true;
         break;
     }


### PR DESCRIPTION
This fixes some Editor controls registering false hover over effects when the mouse is moved in the caption area of the window.