### PR TITLE
Add being able to rotate view with direction gizmo

### DIFF
--- a/Source/Editor/Gizmo/DirectionGizmo.cs
+++ b/Source/Editor/Gizmo/DirectionGizmo.cs
@@ -36,8 +36,10 @@ internal class DirectionGizmo : ContainerControl
     private List<AxisData> _axisData = new List<AxisData>();
     private int _hoveredAxisIndex = -1;
 
+    private bool _mouseDown;
+    private Float2 _mouseDownLocation;
+
     private SpriteHandle _posHandle;
-    private SpriteHandle _negHandle;
 
     private FontReference _fontReference;
 
@@ -110,7 +112,6 @@ internal class DirectionGizmo : ContainerControl
 
         var editor = Editor.Instance;
         _posHandle = editor.Icons.VisjectBoxClosed32;
-        _negHandle = editor.Icons.VisjectBoxOpen32;
 
         _fontReference = new FontReference(Style.Current.FontSmall);
 
@@ -142,7 +143,25 @@ internal class DirectionGizmo : ContainerControl
     public override void OnMouseMove(Float2 location)
     {
         _hoveredAxisIndex = -1;
+        
+        if (_mouseDown)
+        {
+            StartMouseCapture();
+            Cursor = CursorType.Hidden;
 
+            const float sensitivity = 0.125f;
+            Float2 delta = Input.MousePositionDelta;
+            delta *= Mathf.DegreesToRadians;
+            delta *= sensitivity;
+
+            const float orbitRadius = 500f;
+            Quaternion newOrientation = _viewport.ViewOrientation * Quaternion.RotationYawPitchRoll(delta.X , delta.Y, 0f);
+            Vector3 orbitCenter = _viewport.ViewPosition + _viewport.ViewDirection * orbitRadius;
+            _viewport.ViewportCamera.SetArcBallView(newOrientation, orbitCenter, orbitRadius);
+
+            return;
+        }
+         
         // Check which axis is being hovered - check from closest to farthest for proper layering
         for (int i = _spritePositions.Count - 1; i >= 0; i--)
         {
@@ -156,9 +175,27 @@ internal class DirectionGizmo : ContainerControl
         base.OnMouseMove(location);
     }
 
+    public override bool OnMouseDown(Float2 location, MouseButton button)
+    {
+        _mouseDown = true;
+        _mouseDownLocation = location;
+        return true;
+    }
+
     /// <inheritdoc />
     public override bool OnMouseUp(Float2 location, MouseButton button)
     {
+        if (_mouseDown && _mouseDownLocation != location)
+        {
+            _mouseDown = false;
+            EndMouseCapture();
+            Root.MousePosition = PointToParent(Root, _mouseDownLocation);
+            Cursor = CursorType.Default;
+            return true;
+        }
+
+        _mouseDown = false;
+
         if (base.OnMouseUp(location, button))
             return true;
 
@@ -269,7 +306,12 @@ internal class DirectionGizmo : ContainerControl
         // Rebuild sprite positions list for hover detection
         _spritePositions.Clear();
 
-        Render2D.DrawSprite(_posHandle, new Rectangle(0, 0, Size), Color.Black.AlphaMultiplied(_backgroundOpacity));
+        if (IsMouseOver)
+        {
+            Rectangle backgroundRect = new Rectangle(0, 0, Size);
+            Color backgroundColor = Color.DarkGray.AlphaMultiplied(_backgroundOpacity);
+            Render2D.DrawSprite(_posHandle, backgroundRect, backgroundColor);
+        }
 
         // Draw in order from farthest to closest
         for (int i = 0; i < _axisData.Count; i++)

--- a/Source/Editor/Gizmo/DirectionGizmo.cs
+++ b/Source/Editor/Gizmo/DirectionGizmo.cs
@@ -146,7 +146,7 @@ internal class DirectionGizmo : ContainerControl
         
         if (_mouseDown)
         {
-            StartMouseCapture();
+            StartMouseCapture(true);
             Cursor = CursorType.Hidden;
 
             const float sensitivity = 0.125f;

--- a/Source/Editor/Gizmo/DirectionGizmo.cs
+++ b/Source/Editor/Gizmo/DirectionGizmo.cs
@@ -185,16 +185,19 @@ internal class DirectionGizmo : ContainerControl
     /// <inheritdoc />
     public override bool OnMouseUp(Float2 location, MouseButton button)
     {
-        if (_mouseDown && _mouseDownLocation != location)
+        if (_mouseDown)
         {
             _mouseDown = false;
-            EndMouseCapture();
-            Root.MousePosition = PointToParent(Root, _mouseDownLocation);
-            Cursor = CursorType.Default;
-            return true;
+    
+            if (_mouseDownLocation != location)
+            {
+                _mouseDown = false;
+                EndMouseCapture();
+                Root.MousePosition = PointToParent(Root, _mouseDownLocation);
+                Cursor = CursorType.Default;
+                return true;
+            }
         }
-
-        _mouseDown = false;
 
         if (base.OnMouseUp(location, button))
             return true;

--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -187,7 +187,7 @@ namespace FlaxEditor.Options
         public float DirectionGizmoScale { get; set; } = 1f;
 
         /// <summary>
-        /// Gets or sets a value for the opacity of the main viewports <see cref="Gizmo.DirectionGizmo"/> background.
+        /// Gets or sets a value for the opacity of the main viewports <see cref="Gizmo.DirectionGizmo"/> background. Background will only show when the gizmo is hovered.
         /// </summary>
         [DefaultValue(0.1f), Limit(0.0f, 1.0f)]
         [EditorDisplay("Direction Gizmo"), EditorOrder(502), Tooltip("The background opacity of the of the direction gizmo in the main viewport.")]

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -706,7 +706,7 @@ namespace FlaxEditor.Viewport
         {
             base.OnLeftMouseButtonDown();
 
-            if (!IsAltKeyDown)
+            if (!IsAltKeyDown && !_directionGizmo.IsMouseOver)
                 _rubberBandSelector.TryStartingRubberBandSelection(_viewMousePos);
         }
 
@@ -714,7 +714,7 @@ namespace FlaxEditor.Viewport
         protected override void OnLeftMouseButtonUp()
         {
             // Skip if was controlling mouse or mouse is not over the area
-            if (_prevInput.IsControllingMouse || !Bounds.Contains(ref _viewMousePos))
+            if (_prevInput.IsControllingMouse || !Bounds.Contains(ref _viewMousePos) || _directionGizmo.IsMouseOver)
                 return;
 
             // Select rubberbanded rect actor nodes or pick with gizmo

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -572,12 +572,12 @@ namespace FlaxEngine.GUI
         /// <summary>
         /// Starts the mouse tracking. Used by the scrollbars, splitters, etc.
         /// </summary>
-        /// <param name="useMouseScreenOffset">If set to <c>true</c> will use mouse screen offset.</param>
+        /// <param name="screenSpaceMouseWrap">If set to <c>true</c> will wrap when it hits a screen border.</param>
         [NoAnimate]
-        public void StartMouseCapture(bool useMouseScreenOffset = false)
+        public void StartMouseCapture(bool screenSpaceMouseWrap = false)
         {
             var parent = Root;
-            parent?.StartTrackingMouse(this, useMouseScreenOffset);
+            parent?.StartTrackingMouse(this, screenSpaceMouseWrap);
         }
 
         /// <summary>


### PR DESCRIPTION

It will rotate the camera around a point some distance in front of the editor camera. Also made the background only show on mouse hover as a hint to the user that they can click and drag the direction gizmo. This is what Blender and Godot do.

https://github.com/user-attachments/assets/b10faa22-87a8-4d89-ba6f-950960c86246

I also renamed the `useMouseScreenOffset` method parameter in `Control`s `StartMouseCapture()` to `screenSpaceMouseWrap`, as that name reflects what it does more closely (it wraps the mouse around screen borders).


