### PR TITLE
Add client-side window decorations support for macOS editor windows. 

### DIFF
--- a/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
@@ -1,8 +1,8 @@
-#if PLATFORM_WINDOWS || PLATFORM_SDL
+#if PLATFORM_WINDOWS || PLATFORM_SDL || PLATFORM_MAC
 #define USE_IS_FOREGROUND
 #else
 #endif
-#if PLATFORM_SDL
+#if PLATFORM_SDL || PLATFORM_MAC
 #define USE_SDL_WORKAROUNDS
 #endif
 // Copyright (c) Wojciech Figat. All rights reserved.

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -189,12 +189,18 @@ namespace FlaxEditor.Options
             /// <summary>
             /// Determined automatically based on the system and any known compatibility issues with native decorations.
             /// </summary>
+#if PLATFORM_MAC && !PLATFORM_SDL
+            [HideInEditor]
+#endif
             Auto,
 
             /// <summary>
             /// Automatically choose most compatible window decorations for child windows, prefer custom decorations on main window.
             /// </summary>
             [EditorDisplay(Name = "Auto (Child Only)")]
+#if PLATFORM_MAC && !PLATFORM_SDL
+            [HideInEditor]
+#endif
             AutoChildOnly,
 
             /// <summary>
@@ -307,7 +313,7 @@ namespace FlaxEditor.Options
         [EditorDisplay("Interface"), EditorOrder(322)]
         public bool ScrollToScriptOnAdd { get; set; } = true;
 
-#if PLATFORM_SDL
+#if PLATFORM_SDL || PLATFORM_MAC
         /// <summary>
         /// Gets or sets a value indicating whether use native window title bar decorations in child windows. Editor restart required.
         /// </summary>

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -1293,6 +1293,12 @@ namespace FlaxEditor.Utilities
             };
 #elif PLATFORM_WINDOWS
             return !Editor.Instance.Options.Options.Interface.UseNativeWindowSystem;
+#elif PLATFORM_MAC
+            return Editor.Instance.Options.Options.Interface.WindowDecorations switch
+            {
+                Options.InterfaceOptions.WindowDecorationsType.ClientSide => true,
+                _ => false
+            };
 #else
             return false;
 #endif

--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -1009,6 +1009,10 @@ void MacWindow::Close(ClosingReason reason)
 {
     const BOOL wasKey = _window && [(NSWindow*)_window isKeyWindow];
     WindowBase::Close(reason);
+
+    // Closing can be cancelled by managed Window.Closing handlers.
+    if (!IsClosed())
+        return;
     
     if (NSWindow* window = (NSWindow*)_window)
     {

--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -200,6 +200,19 @@ Float2 GetMousePosition(MacWindow* window, NSEvent* event)
     return Float2(point.x, frame.size.height - point.y) * MacPlatform::ScreenScale - GetWindowTitleSize(window);
 }
 
+NSRect GetFrameRectForClientBounds(MacWindow* macWindow, NSWindow* window, const Rectangle& clientArea)
+{
+    const float screenScale = MacPlatform::ScreenScale;
+    NSRect rect = NSMakeRect(0, 0, clientArea.Size.X / screenScale, clientArea.Size.Y / screenScale);
+    rect = [window frameRectForContentRect:rect];
+
+    Float2 pos = AppleUtils::PosToCoca(clientArea.Location) / screenScale;
+    Float2 titleSize = GetWindowTitleSize(macWindow);
+    rect.origin.x = pos.X + titleSize.X;
+    rect.origin.y = pos.Y - rect.size.height + titleSize.Y;
+    return rect;
+}
+
 class MacDropData : public IGuiData
 {
 public:
@@ -308,6 +321,12 @@ NSDragOperation GetDragDropOperation(DragDropEffect dragDropEffect)
 {
     if (IsWindowInvalid(Window)) return;
     Window->OnLostFocus();
+}
+
+- (void)windowDidMove:(NSNotification*)notification
+{
+    if (IsWindowInvalid(Window)) return;
+    Window->SyncWindowState();
 }
 
 - (void)windowWillClose:(NSNotification*)notification
@@ -518,6 +537,28 @@ static void ConvertNSRect(NSScreen *screen, NSRect *r)
     if (IsWindowInvalid(Window)) return;
 	Float2 mousePos = GetMousePosition(Window, event);
     mousePos = Window->ClientToScreen(mousePos);
+
+    if ([event clickCount] == 1 && !Input::Mouse->IsRelative())
+    {
+        WindowHitCodes hit = WindowHitCodes::Client;
+        bool handled = false;
+        Window->OnHitTest(mousePos, hit, handled);
+
+        if (hit == WindowHitCodes::Caption)
+        {
+            bool consumed = false;
+            Window->OnLeftButtonHit(hit, consumed);
+
+            if (!consumed)
+            {
+                [(NSWindow*)Window->GetNativePtr() performWindowDragWithEvent:event];
+                Window->SyncWindowState();
+            }
+
+            return;
+        }
+    }
+
     MouseButton mouseButton = MouseButton::Left;
     if ([event clickCount] == 2 && !Input::Mouse->IsRelative())
         Input::Mouse->OnMouseDoubleClick(mousePos, mouseButton, Window);
@@ -835,15 +876,28 @@ MacWindow::MacWindow(const CreateWindowSettings& settings)
 
 MacWindow::~MacWindow()
 {
-    NSWindow* window = (NSWindow*)_window;
-    [window close];
-    [window release];
+    if (NSWindow* window = (NSWindow*)_window)
+    {
+        [window close];
+        [window release];
+    }
     _window = nullptr;
     _view = nullptr;
 }
 
+void MacWindow::SyncWindowState()
+{
+    NSWindow* window = (NSWindow*)_window;
+    if (window)
+    {
+        _minimized = window.miniaturized;
+        _maximized = window.zoomed;
+    }
+}
+
 void MacWindow::CheckForResize(float width, float height)
 {
+    SyncWindowState();
     const Float2 clientSize(width, height);
 	if (clientSize != _clientSize)
 	{
@@ -940,7 +994,7 @@ void MacWindow::Hide()
             [window orderOut:nil];
 
         // Transfer focus back to the parent when hiding popup
-        if (_settings.Parent && wasKey)
+        if (_settings.Parent && wasKey && _settings.Type != WindowType::Popup && _settings.Type != WindowType::Tooltip)
         {
             NSWindow* parent = (NSWindow*)_settings.Parent->GetNativePtr();
             [parent makeKeyAndOrderFront:nil];
@@ -948,6 +1002,23 @@ void MacWindow::Hide()
 
         // Base
         WindowBase::Hide();
+    }
+}
+
+void MacWindow::Close(ClosingReason reason)
+{
+    const BOOL wasKey = _window && [(NSWindow*)_window isKeyWindow];
+    WindowBase::Close(reason);
+    
+    if (NSWindow* window = (NSWindow*)_window)
+    {
+        [window close];
+    }
+    
+    if (_settings.Parent && wasKey && _settings.Type != WindowType::Popup && _settings.Type != WindowType::Tooltip)
+    {
+        NSWindow* parent = (NSWindow*)_settings.Parent->GetNativePtr();
+        [parent makeKeyAndOrderFront:nil];
     }
 }
 
@@ -967,17 +1038,43 @@ void MacWindow::Maximize()
     if (!_settings.AllowMaximize)
         return;
     NSWindow* window = (NSWindow*)_window;
+    if (!window)
+        return;
     if (!window.zoomed)
+    {
+        if (!_maximized)
+        {
+            _restoreClientBounds = GetClientBounds();
+            _hasRestoreClientBounds = true;
+        }
         [window zoom:nil];
+    }
+    SyncWindowState();
 }
 
 void MacWindow::Restore()
 {
     NSWindow* window = (NSWindow*)_window;
+    if (!window)
+        return;
     if (window.miniaturized)
+    {
         [window deminiaturize:nil];
+        SyncWindowState();
+    }
+    else if (_maximized && _hasRestoreClientBounds)
+    {
+        const Rectangle restoreClientBounds = _restoreClientBounds;
+        _hasRestoreClientBounds = false;
+        NSRect restoreFrame = GetFrameRectForClientBounds(this, window, restoreClientBounds);
+        [window setFrame:restoreFrame display:YES animate:YES];
+        _maximized = false;
+    }
     else if (window.zoomed)
+    {
         [window zoom:nil];
+        SyncWindowState();
+    }
 }
 
 bool MacWindow::IsForegroundWindow() const
@@ -1001,17 +1098,7 @@ void MacWindow::SetClientBounds(const Rectangle& clientArea)
     NSWindow* window = (NSWindow*)_window;
     if (!window)
         return;
-    const float screenScale = MacPlatform::ScreenScale;
-
-    NSRect oldRect = [window frame];
-    NSRect newRect = NSMakeRect(0, 0, clientArea.Size.X / screenScale, clientArea.Size.Y / screenScale);
-    newRect = [window frameRectForContentRect:newRect];
-
-    Float2 pos = AppleUtils::PosToCoca(clientArea.Location) / screenScale;
-    Float2 titleSize = GetWindowTitleSize(this);
-    newRect.origin.x = pos.X + titleSize.X;
-    newRect.origin.y = pos.Y - newRect.size.height + titleSize.Y;
-
+    NSRect newRect = GetFrameRectForClientBounds(this, window, clientArea);
     [window setFrame:newRect display:YES];
 }
 

--- a/Source/Engine/Platform/Mac/MacWindow.h
+++ b/Source/Engine/Platform/Mac/MacWindow.h
@@ -17,13 +17,16 @@ private:
     void* _window = nullptr;
     void* _view = nullptr;
     bool _isMouseOver = false;
+    bool _hasRestoreClientBounds = false;
+    Rectangle _restoreClientBounds;
     Float2 _mouseTrackPos = Float2::Minimum;
     String _dragText;
 
 public:
 	MacWindow(const CreateWindowSettings& settings);
-	~MacWindow();
+	~MacWindow() override;
 
+    void SyncWindowState();
     void CheckForResize(float width, float height);
     void SetIsMouseOver(bool value);
     const String& GetDragText() const
@@ -37,6 +40,7 @@ public:
     void OnUpdate(float dt) override;
     void Show() override;
     void Hide() override;
+    void Close(ClosingReason reason) override;
     void Minimize() override;
     void Maximize() override;
     void Restore() override;


### PR DESCRIPTION
## Summary

This change adds client-side window decoration support for native macOS editor windows and fixes related window state, closing, dragging, and context menu focus issues.

## Changes

- Exposed the `WindowDecorations` editor option on macOS and enabled `WindowDecorationsType.ClientSide` for native macOS windows.
- Hidden unsupported automatic decoration modes on non-SDL macOS builds, leaving only explicit `Native` and `Client-side` choices.
- Added borderless `NSWindow` support for editor-rendered title bars and window controls.
- Added native title-bar dragging for client-side decorated windows by routing caption hit-test results to `performWindowDragWithEvent`.
- Fixed maximize/restore behavior by saving client bounds before zooming and restoring them when leaving the maximized state.
- Added macOS window state synchronization after move, resize, minimize, maximize, and restore operations.
- Added a `MacWindow::Close` override that runs the engine close path and then closes the underlying `NSWindow` immediately.
- Prevented popup and tooltip windows from forcing focus back to their parent while hiding or closing.
- Aligned macOS context menu focus handling with the SDL workaround path to prevent popups from closing on mouse movement or transient focus loss.

## Notes

`WindowBase::Close` hides the window, sends close callbacks, unregisters it, and schedules engine object deletion through `DeleteObject(1)`. The new macOS override additionally closes the native `NSWindow` immediately so client-side decorated windows disappear without waiting for deferred object cleanup.