### PR TITLE
Fix MacOS Delete key handling in editor views.

### DIFF
--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using FlaxEditor.GUI.Drag;
 using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
+using FlaxEditor.Utilities;
 using FlaxEditor.Windows;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -747,6 +748,16 @@ namespace FlaxEditor.Content.GUI
         /// <inheritdoc />
         public override bool OnKeyDown(KeyboardKeys key)
         {
+            // Perform deletion
+            if (InputUtils.IsKeyPerformDeletion(key))
+            {
+                if (HasSelection)
+                {
+                    OnDelete?.Invoke(_selection);
+                    return true;
+                }
+            }
+
             // Navigate backward
             if (key == KeyboardKeys.Backspace)
             {

--- a/Source/Editor/Content/Tree/TreeViewPanel.cs
+++ b/Source/Editor/Content/Tree/TreeViewPanel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using FlaxEditor.GUI.Tree;
 using FlaxEditor.Options;
+using FlaxEditor.Utilities;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -196,6 +197,11 @@ public class TreeViewPanel : Panel
         var selection = ContentTree.Selection;
         if (selection.Count > 0)
         {
+            if (InputUtils.IsKeyPerformDeletion(key))
+            {
+                Delete();
+                return true;
+            }
             if (key == KeyboardKeys.Return)
             {
                 foreach (var node in selection)

--- a/Source/Editor/Utilities/InputUtils.cs
+++ b/Source/Editor/Utilities/InputUtils.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using FlaxEngine;
+
+namespace FlaxEditor.Utilities
+{
+    /// <summary>
+    /// Editor input utilities.
+    /// </summary>
+    public static class InputUtils
+    {
+        /// <summary>
+        /// Checks if the key should perform deletion on the current platform.
+        /// </summary>
+        /// <param name="key">The keyboard key.</param>
+        /// <returns>True if the key should perform deletion.</returns>
+        public static bool IsKeyPerformDeletion(KeyboardKeys key)
+        {
+#if PLATFORM_MAC
+            return key == KeyboardKeys.Backspace;
+#else
+            return false;
+#endif
+        }
+    }
+}

--- a/Source/Editor/Viewport/MainEditorGizmoViewport.cs
+++ b/Source/Editor/Viewport/MainEditorGizmoViewport.cs
@@ -8,6 +8,7 @@ using FlaxEditor.GUI.ContextMenu;
 using FlaxEditor.Options;
 using FlaxEditor.SceneGraph;
 using FlaxEditor.Scripting;
+using FlaxEditor.Utilities;
 using FlaxEditor.Viewport.Modes;
 using FlaxEditor.Viewport.Widgets;
 using FlaxEditor.Windows;
@@ -874,6 +875,21 @@ namespace FlaxEditor.Viewport
                 _savedTask = null;
             }
             Object.Destroy(ref _savedBackBuffer);
+        }
+
+        /// <inheritdoc />
+        public override bool OnKeyDown(KeyboardKeys key)
+        {
+            if (base.OnKeyDown(key))
+                return true;
+
+            if (InputUtils.IsKeyPerformDeletion(key) && _editor.SceneEditing.HasSthSelected)
+            {
+                _editor.SceneEditing.Delete();
+                return true;
+            }
+
+            return false;
         }
 
         private void ReleaseResources()

--- a/Source/Editor/Windows/SceneEditorWindow.cs
+++ b/Source/Editor/Windows/SceneEditorWindow.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using FlaxEditor.SceneGraph;
+using FlaxEditor.Utilities;
 using FlaxEditor.Viewport;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -30,6 +31,21 @@ namespace FlaxEditor.Windows
         public void DeleteSelection()
         {
             Editor.SceneEditing.Delete();
+        }
+
+        /// <inheritdoc />
+        public override bool OnKeyDown(KeyboardKeys key)
+        {
+            if (base.OnKeyDown(key))
+                return true;
+
+            if (InputUtils.IsKeyPerformDeletion(key) && Editor.SceneEditing.HasSthSelected)
+            {
+                Editor.SceneEditing.Delete();
+                return true;
+            }
+
+            return false;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

Fix macOS Delete key handling in editor views where the physical Delete key is reported as `Backspace`.

On macOS, pressing Delete while an item is selected in the Content window could trigger folder history navigation instead of deleting the selected content item. This change adds a small shared input helper and uses it in the affected editor views so the key performs deletion when there is an active selection.

## Changes

- Added `InputUtils.IsKeyPerformDeletion()` to centralize platform-specific delete-key behavior.
- Updated the Content view to delete selected content items before falling back to Backspace navigation.
- Updated the Content tree to delete selected content items when the platform delete key is pressed.
- Updated scene editor key handling paths to use the same helper for selected scene objects.

## Notes

The macOS-specific behavior is kept inside `InputUtils`. On non-MacOS platforms, the helper does not change existing Delete shortcut handling.