### PR TITLE
Fix Rider detection on macOS when installed in the user Applications folder

### DIFF
--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -14,6 +14,9 @@
 
 #if PLATFORM_WINDOWS
 #include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
+#elif PLATFORM_MAC
+#include "Engine/Platform/Apple/AppleUtils.h"
+#include <AppKit/AppKit.h>
 #endif
 
 namespace
@@ -68,10 +71,14 @@ namespace
         if (!launcherPath.HasChars() || !FileSystem::FileExists(exePath))
             return;
 
-        if (launchOverridePath != String::Empty)
-            installations->Add(New<RiderInstallation>(launchOverridePath, versionMember->value.GetText()));
-        else
-            installations->Add(New<RiderInstallation>(exePath, versionMember->value.GetText()));
+        String installPath = launchOverridePath != String::Empty ? launchOverridePath : exePath;
+        StringUtils::PathRemoveRelativeParts(installPath);
+        for (RiderInstallation* installation : *installations)
+        {
+            if (installation->path == installPath)
+                return;
+        }
+        installations->Add(New<RiderInstallation>(installPath, versionMember->value.GetText()));
     }
 
 #if PLATFORM_WINDOWS
@@ -221,17 +228,29 @@ void RiderCodeEditor::FindEditors(Array<CodeEditor*>* output)
     String applicationSupportFolder;
     FileSystem::GetSpecialFolderPath(SpecialFolder::ProgramData, applicationSupportFolder);
 
+    NSURL* appURL = [[NSWorkspace sharedWorkspace] URLForApplicationWithBundleIdentifier:@"com.jetbrains.rider"];
+    if (appURL != nullptr)
+    {
+        const String appPath = AppleUtils::ToString((CFStringRef)[appURL path]);
+        SearchDirectory(&installations, appPath / TEXT("Contents/Resources"), appPath);
+    }
+
     Array<String> subMacDirectories;
     FileSystem::GetChildDirectories(subMacDirectories, applicationSupportFolder / TEXT("JetBrains/Toolbox/apps/Rider/ch-0/"));
     FileSystem::GetChildDirectories(subMacDirectories, applicationSupportFolder / TEXT("JetBrains/Toolbox/apps/Rider/ch-1/"));
     for (const String& directory : subMacDirectories)
     {
-        String riderAppDirectory = directory / TEXT("Rider.app/Contents/Resources");
-        SearchDirectory(&installations, riderAppDirectory);
+        String riderAppPath = directory / TEXT("Rider.app");
+        SearchDirectory(&installations, riderAppPath / TEXT("Contents/Resources"), riderAppPath);
     }
 
     // Check the local installer version
-    SearchDirectory(&installations, TEXT("/Applications/Rider.app/Contents/Resources"));
+    SearchDirectory(&installations, TEXT("/Applications/Rider.app/Contents/Resources"), TEXT("/Applications/Rider.app"));
+
+    String userFolder;
+    FileSystem::GetSpecialFolderPath(SpecialFolder::Documents, userFolder);
+    String riderAppPath = userFolder / TEXT("../Applications/Rider.app");
+    SearchDirectory(&installations, riderAppPath / TEXT("Contents/Resources"), riderAppPath);
 #endif
 
     for (const String& directory : subDirectories)


### PR DESCRIPTION
### Summary

This fixes Rider not appearing in `Source Code / Source Code Editor` on macOS when Rider is installed for the current user, for example, at `~/Applications/Rider.app`.

Previously, the Rider discovery logic only checked JetBrains Toolbox metadata locations and `/Applications/Rider.app`. However, JetBrains Toolbox on macOS can place the actual Rider application bundle in the per-user Applications folder (`~/Applications/Rider.app`). Those installations were skipped, even though the editor supports Rider itself.

### Changes

- Detect Rider on macOS via the `com.jetbrains.rider` bundle identifier using `NSWorkspace`.
- Add an explicit fallback check for `~/Applications/Rider.app`, which is used by JetBrains Toolbox on macOS.
- Deduplicate discovered Rider installations so the same app is not listed multiple times if it is found through more than one lookup path.