### PR TITLE
Fix Vulkan Tracy timestamp queries on MoltenVK

### DIFF
--- a/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.cpp
@@ -57,7 +57,7 @@ void CmdBufferVulkan::End()
         if (vkCmdEndDebugUtilsLabelEXT)
             vkCmdEndDebugUtilsLabelEXT(GetHandle());
 #endif
-#if GPU_ENABLE_TRACY
+#if VULKAN_USE_TRACY_GPU
         tracy::EndVkZoneScope(_tracyZones.Last().Data);
         _tracyZones.RemoveLast();
 #endif
@@ -101,7 +101,7 @@ void CmdBufferVulkan::BeginEvent(const Char* name, void* tracyContext)
     char buffer[60];
     int32 bufferSize = StringUtils::Copy(buffer, name, sizeof(buffer));
 
-#if GPU_ENABLE_TRACY
+#if VULKAN_USE_TRACY_GPU
     auto& zone = _tracyZones.AddOne();
     tracy::BeginVkZoneScope(zone.Data, tracyContext, GetHandle(), buffer, bufferSize);
 #endif
@@ -128,7 +128,7 @@ void CmdBufferVulkan::EndEvent()
         vkCmdEndDebugUtilsLabelEXT(GetHandle());
 #endif
 
-#if GPU_ENABLE_TRACY
+#if VULKAN_USE_TRACY_GPU
     tracy::EndVkZoneScope(_tracyZones.Last().Data);
     _tracyZones.RemoveLast();
 #endif

--- a/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/CmdBufferVulkan.h
@@ -43,8 +43,10 @@ private:
     FenceVulkan* _fence;
 #if GPU_ALLOW_PROFILE_EVENTS
     int32 _eventsBegin = 0;
+#if VULKAN_USE_TRACY_GPU
     struct TracyZone { byte Data[TracyVulkanZoneSize]; };
     Array<TracyZone, InlinedAllocation<32>> _tracyZones;
+#endif
 #endif
 
     // The latest value when command buffer was submitted.

--- a/Source/Engine/GraphicsDevice/Vulkan/Config.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/Config.h
@@ -49,6 +49,10 @@
 #define VULKAN_USE_TIMER_QUERIES 1
 #endif
 
+#ifndef VULKAN_USE_TRACY_GPU
+#define VULKAN_USE_TRACY_GPU (GPU_ENABLE_TRACY && VULKAN_USE_TIMER_QUERIES)
+#endif
+
 // Fence wait operation timeout in seconds
 #ifndef VULKAN_WAIT_TIMEOUT
 #define VULKAN_WAIT_TIMEOUT 5.0f

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
@@ -111,7 +111,7 @@ GPUContextVulkan::GPUContextVulkan(GPUDeviceVulkan* device, QueueVulkan* queue)
     _handlesSizes[(int32)SpirvShaderResourceBindingType::UAV] = GPU_MAX_UA_BINDED;
 #endif
 
-#if GPU_ENABLE_TRACY
+#if VULKAN_USE_TRACY_GPU
 #if VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset && !PLATFORM_SWITCH
     // Use calibrated timestamps extension
     if (vkResetQueryPoolEXT && vkGetCalibratedTimestampsEXT && _device->PhysicalDeviceFeatures12.hostQueryReset)
@@ -138,7 +138,7 @@ GPUContextVulkan::GPUContextVulkan(GPUDeviceVulkan* device, QueueVulkan* queue)
 
 GPUContextVulkan::~GPUContextVulkan()
 {
-#if GPU_ENABLE_TRACY
+#if VULKAN_USE_TRACY_GPU
     tracy::DestroyVkContext(_tracyContext);
 #endif
     for (int32 i = 0; i < _descriptorPools.Count(); i++)
@@ -799,7 +799,7 @@ void GPUContextVulkan::FrameEnd()
     // Execute any queued layout transitions that weren't already handled by the render pass
     FlushBarriers();
 
-#if GPU_ENABLE_TRACY
+#if VULKAN_USE_TRACY_GPU
     if (cmdBuffer)
         tracy::CollectVkContext(_tracyContext, cmdBuffer->GetHandle());
 #endif
@@ -813,7 +813,7 @@ void GPUContextVulkan::FrameEnd()
 void GPUContextVulkan::EventBegin(const Char* name)
 {
     const auto cmdBuffer = _cmdBufferManager->GetCmdBuffer();
-#if COMPILE_WITH_PROFILER
+#if VULKAN_USE_TRACY_GPU
     void* tracyContext = _tracyContext;
 #else
     void* tracyContext = nullptr;

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.Layers.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.Layers.cpp
@@ -45,7 +45,7 @@ static const char* GInstanceExtensions[] =
 #if defined(VK_KHR_display) && 0
     VK_KHR_DISPLAY_EXTENSION_NAME,
 #endif
-#if GPU_ENABLE_TRACY && VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset
+#if VULKAN_USE_TRACY_GPU && VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset
     VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, // Required by VK_EXT_host_query_reset (unless using Vulkan 1.1 or newer)
 #endif
     nullptr
@@ -66,7 +66,7 @@ static const char* GDeviceExtensions[] =
 #if VK_KHR_sampler_mirror_clamp_to_edge
     VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME,
 #endif
-#if GPU_ENABLE_TRACY && VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset
+#if VULKAN_USE_TRACY_GPU && VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset
     VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
     VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
 #endif

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.cpp
@@ -1677,7 +1677,7 @@ bool GPUDeviceVulkan::Init()
     VulkanPlatform::RestrictEnabledPhysicalDeviceFeatures(PhysicalDeviceFeatures, enabledFeatures);
     deviceInfo.pEnabledFeatures = &enabledFeatures;
 
-#if GPU_ENABLE_TRACY && VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset
+#if VULKAN_USE_TRACY_GPU && VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset
     VkPhysicalDeviceHostQueryResetFeatures resetFeatures;
     if (PhysicalDeviceFeatures12.hostQueryReset)
     {


### PR DESCRIPTION
## Summary

Fixes a MoltenVK warning/error caused by Vulkan Tracy GPU profiling, creating a timestamp query pool on Apple platforms even when Vulkan timer queries are disabled.

On macOS/iOS, `VULKAN_USE_TIMER_QUERIES` is already disabled because MoltenVK can fail to allocate Metal counter sample buffers for Vulkan timestamp query pools.

```text
VK_ERROR_OUT_OF_DEVICE_MEMORY: Could not create MTLCounterSampleBuffer of size 524288, for 65536 queries, in query pool of type VK_QUERY_TYPE_TIMESTAMP.
Invalid sample buffer length: 524288 B. Expected range: 8 -> 32768
```

## Changes

- Added `VULKAN_USE_TRACY_GPU`, which enables Vulkan Tracy GPU profiling only when both `GPU_ENABLE_TRACY` and `VULKAN_USE_TIMER_QUERIES` are enabled.


P.S I'm not sure about the solution; maybe I just need to reduce the query pool.
On the other hand, we've already disabled VULKAN_USE_TIMER_QUERIES to 0.
