### PR TITLE
Interface-based object references for scripting objects

### DIFF
--- a/Source/Editor/CustomEditors/CustomEditorsUtil.cs
+++ b/Source/Editor/CustomEditors/CustomEditorsUtil.cs
@@ -58,11 +58,13 @@ namespace FlaxEditor.CustomEditors
             if (targetType.Type == typeof(object) && values.Count > 0 && values[0] != null && !values.HasDifferentTypes)
                 return CreateEditor(TypeUtils.GetObjectType(values[0]), canUseRefPicker);
 
-            // Special case if property is interface but the value is implemented as Scripting Object that should use reference picker
-            if (targetType.IsInterface && canUseRefPicker && values.Count > 0 && values[0] is FlaxEngine.Object)
-                return new DummyEditor();
-
             // Use editor for the property type
+            if (canUseRefPicker &&
+                targetType.IsInterface &&
+                values.GetAttributes().Any(x => x is ScriptingObjectInterfaceReferenceAttribute || x is SoftObjectInterfaceReferenceAttribute))
+            {
+                return new FlaxObjectRefEditor();
+            }
             return CreateEditor(targetType, canUseRefPicker);
         }
 

--- a/Source/Editor/CustomEditors/Editors/DictionaryEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/DictionaryEditor.cs
@@ -260,7 +260,7 @@ namespace FlaxEditor.CustomEditors.Editors
                     var overrideEditor = overrideEditorType != null ? (CustomEditor)Activator.CreateInstance(overrideEditorType) : null;
                     var property = panel.AddPropertyItem(new DictionaryItemLabel(this, key));
                     var itemLayout = useSharedLayout ? (LayoutElementsContainer)property : property.VerticalPanel();
-                    itemLayout.Object(new DictionaryValueContainer(valuesType, key, Values), overrideEditor);
+                    itemLayout.Object(new DictionaryValueContainer(valuesType, key, Values, attributes), overrideEditor);
                     if (_readOnly && itemLayout.Children.Count > 0)
                         GenericEditor.OnReadOnlyProperty(itemLayout);
                 }

--- a/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
@@ -48,7 +48,7 @@ namespace FlaxEditor.CustomEditors.Editors
         public IPresenterOwner PresenterContext;
 
         /// <summary>
-        /// Gets or sets the allowed objects type (given type and all subclasses). Must be <see cref="Object"/> type of any subclass.
+        /// Gets or sets the allowed objects type (given type and all subclasses). Must be <see cref="Object"/> type of any subclass or a scripting interface.
         /// </summary>
         public ScriptType Type
         {
@@ -57,11 +57,12 @@ namespace FlaxEditor.CustomEditors.Editors
             {
                 if (_type == value)
                     return;
-                if (value == ScriptType.Null || (value.Type != typeof(Object) && !value.IsSubclassOf(ScriptType.Object)))
+                if (value == ScriptType.Null || (!value.IsInterface && value.Type != typeof(Object) && !value.IsSubclassOf(ScriptType.Object)))
                     throw new ArgumentException(string.Format("Invalid type for FlaxObjectRefEditor. Input type: {0}", value != ScriptType.Null ? value.TypeName : "null"));
 
                 _type = value;
-                _supportsPickDropDown = new ScriptType(typeof(Actor)).IsAssignableFrom(value) || 
+                _supportsPickDropDown = value.IsInterface ||
+                                        new ScriptType(typeof(Actor)).IsAssignableFrom(value) ||
                                         new ScriptType(typeof(Script)).IsAssignableFrom(value);
 
                 // Deselect value if it's not valid now
@@ -149,13 +150,22 @@ namespace FlaxEditor.CustomEditors.Editors
         protected virtual bool IsValid(Object obj)
         {
             var type = TypeUtils.GetObjectType(obj);
-            return obj == null || _type.IsAssignableFrom(type) && (CheckValid == null || CheckValid(obj, type));
+            return obj == null || (!_type.IsInterface || obj is SceneObject) && _type.IsAssignableFrom(type) && (CheckValid == null || CheckValid(obj, type));
         }
 
         private void ShowDropDownMenu()
         {
             Focus();
-            if (new ScriptType(typeof(Actor)).IsAssignableFrom(_type))
+            if (_type.IsInterface)
+            {
+                SceneObjectSearchPopup.Show(this, new Float2(0, Height), IsValid, obj =>
+                {
+                    Value = obj;
+                    RootWindow.Focus();
+                    Focus();
+                }, PresenterContext);
+            }
+            else if (new ScriptType(typeof(Actor)).IsAssignableFrom(_type))
             {
                 ActorSearchPopup.Show(this, new Float2(0, Height), IsValid, actor =>
                 {

--- a/Source/Editor/CustomEditors/Values/DictionaryValueContainer.cs
+++ b/Source/Editor/CustomEditors/Values/DictionaryValueContainer.cs
@@ -14,6 +14,8 @@ namespace FlaxEditor.CustomEditors
     [HideInEditor]
     public class DictionaryValueContainer : ValueContainer
     {
+        private readonly object[] _attributes;
+
         /// <summary>
         /// The key in the collection.
         /// </summary>
@@ -36,9 +38,12 @@ namespace FlaxEditor.CustomEditors
         /// <param name="elementType">Type of the collection elements.</param>
         /// <param name="key">The key.</param>
         /// <param name="values">The collection values.</param>
-        public DictionaryValueContainer(ScriptType elementType, object key, ValueContainer values)
+        /// <param name="attributes">The dictionary property attributes to inherit.</param>
+        public DictionaryValueContainer(ScriptType elementType, object key, ValueContainer values, object[] attributes = null)
         : this(elementType, key)
         {
+            _attributes = attributes;
+
             Capacity = values.Count;
             for (int i = 0; i < values.Count; i++)
             {
@@ -122,6 +127,12 @@ namespace FlaxEditor.CustomEditors
                 _referenceValue = v[Key];
                 _hasReferenceValue = true;
             }
+        }
+
+        /// <inheritdoc />
+        public override object[] GetAttributes()
+        {
+            return _attributes ?? base.GetAttributes();
         }
     }
 }

--- a/Source/Editor/GUI/Popups/SceneObjectSearchPopup.cs
+++ b/Source/Editor/GUI/Popups/SceneObjectSearchPopup.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using System;
+using FlaxEditor.Windows;
+using FlaxEditor.Windows.Assets;
+using FlaxEngine;
+using FlaxEngine.GUI;
+using FlaxEngine.Utilities;
+
+namespace FlaxEditor.GUI
+{
+    /// <summary>
+    /// Popup that shows the list of scene objects to pick. Supports searching and basic type filtering.
+    /// </summary>
+    /// <seealso cref="FlaxEditor.GUI.ItemsListContextMenu" />
+    public class SceneObjectSearchPopup : ItemsListContextMenu
+    {
+        /// <summary>
+        /// The scene object item.
+        /// </summary>
+        /// <seealso cref="FlaxEditor.GUI.ItemsListContextMenu.Item" />
+        public class SceneObjectItemView : Item
+        {
+            private SceneObject _object;
+
+            /// <summary>
+            /// Gets the scene object.
+            /// </summary>
+            public SceneObject Object => _object;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SceneObjectItemView"/> class.
+            /// </summary>
+            /// <param name="obj">The object.</param>
+            public SceneObjectItemView(SceneObject obj)
+            {
+                _object = obj;
+                Category = obj is Actor ? "Actors" : "Scripts";
+                if (obj is Script script)
+                {
+                    var type = TypeUtils.GetObjectType(script);
+                    Name = script.Actor ? $"{type.Name} ({script.Actor.Name})" : type.Name;
+                }
+                else if (obj is Actor actor)
+                {
+                    Name = actor.Name;
+                }
+                else
+                {
+                    Name = obj.ToString();
+                }
+                TooltipText = Utilities.Utils.GetTooltip(obj);
+            }
+
+            /// <inheritdoc />
+            public override void OnDestroy()
+            {
+                _object = null;
+                base.OnDestroy();
+            }
+        }
+
+        /// <summary>
+        /// Validates if the given scene object item can be used to pick it.
+        /// </summary>
+        /// <param name="obj">The scene object.</param>
+        /// <returns>True if is valid.</returns>
+        public delegate bool IsValidDelegate(SceneObject obj);
+
+        private IsValidDelegate _isValid;
+        private Action<SceneObject> _selected;
+
+        private SceneObjectSearchPopup(IsValidDelegate isValid, Action<SceneObject> selected, CustomEditors.IPresenterOwner context)
+        {
+            _isValid = isValid;
+            _selected = selected;
+
+            ItemClicked += OnItemClicked;
+
+            if (context is PropertiesWindow || context == null)
+            {
+                // TODO: use async thread to search scenes
+                for (int i = 0; i < Level.ScenesCount; i++)
+                {
+                    Find(Level.GetScene(i));
+                }
+            }
+            else if (context is PrefabWindow prefabWindow)
+            {
+                Find(prefabWindow.Graph.MainActor);
+            }
+
+            SortItems();
+        }
+
+        private void OnItemClicked(Item item)
+        {
+            _selected(((SceneObjectItemView)item).Object);
+        }
+
+        private void Find(Actor actor)
+        {
+            if (!actor)
+                return;
+
+            if (_isValid(actor))
+                AddItem(new SceneObjectItemView(actor));
+
+            for (int i = 0; i < actor.ScriptsCount; i++)
+            {
+                var script = actor.GetScript(i);
+                if (_isValid(script))
+                    AddItem(new SceneObjectItemView(script));
+            }
+
+            for (int i = 0; i < actor.ChildrenCount; i++)
+            {
+                Find(actor.GetChild(i));
+            }
+        }
+
+        /// <summary>
+        /// Shows the popup.
+        /// </summary>
+        /// <param name="showTarget">The show target.</param>
+        /// <param name="showTargetLocation">The show target location.</param>
+        /// <param name="isValid">Event called to check if a given scene object item is valid to be used.</param>
+        /// <param name="selected">Event called on scene object item pick.</param>
+        /// <param name="context">The presenter owner context (i.e. PrefabWindow, PropertiesWindow).</param>
+        /// <returns>The dialog.</returns>
+        public static SceneObjectSearchPopup Show(Control showTarget, Float2 showTargetLocation, IsValidDelegate isValid, Action<SceneObject> selected, CustomEditors.IPresenterOwner context)
+        {
+            var popup = new SceneObjectSearchPopup(isValid, selected, context);
+            popup.Show(showTarget, showTargetLocation);
+            return popup;
+        }
+
+        /// <inheritdoc />
+        public override void OnDestroy()
+        {
+            _isValid = null;
+            _selected = null;
+            base.OnDestroy();
+        }
+    }
+}

--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -14,9 +14,6 @@
 
 #if PLATFORM_WINDOWS
 #include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
-#elif PLATFORM_MAC
-#include "Engine/Platform/Apple/AppleUtils.h"
-#include <AppKit/AppKit.h>
 #endif
 
 namespace
@@ -71,14 +68,10 @@ namespace
         if (!launcherPath.HasChars() || !FileSystem::FileExists(exePath))
             return;
 
-        String installPath = launchOverridePath != String::Empty ? launchOverridePath : exePath;
-        StringUtils::PathRemoveRelativeParts(installPath);
-        for (RiderInstallation* installation : *installations)
-        {
-            if (installation->path == installPath)
-                return;
-        }
-        installations->Add(New<RiderInstallation>(installPath, versionMember->value.GetText()));
+        if (launchOverridePath != String::Empty)
+            installations->Add(New<RiderInstallation>(launchOverridePath, versionMember->value.GetText()));
+        else
+            installations->Add(New<RiderInstallation>(exePath, versionMember->value.GetText()));
     }
 
 #if PLATFORM_WINDOWS
@@ -228,29 +221,17 @@ void RiderCodeEditor::FindEditors(Array<CodeEditor*>* output)
     String applicationSupportFolder;
     FileSystem::GetSpecialFolderPath(SpecialFolder::ProgramData, applicationSupportFolder);
 
-    NSURL* appURL = [[NSWorkspace sharedWorkspace] URLForApplicationWithBundleIdentifier:@"com.jetbrains.rider"];
-    if (appURL != nullptr)
-    {
-        const String appPath = AppleUtils::ToString((CFStringRef)[appURL path]);
-        SearchDirectory(&installations, appPath / TEXT("Contents/Resources"), appPath);
-    }
-
     Array<String> subMacDirectories;
     FileSystem::GetChildDirectories(subMacDirectories, applicationSupportFolder / TEXT("JetBrains/Toolbox/apps/Rider/ch-0/"));
     FileSystem::GetChildDirectories(subMacDirectories, applicationSupportFolder / TEXT("JetBrains/Toolbox/apps/Rider/ch-1/"));
     for (const String& directory : subMacDirectories)
     {
-        String riderAppPath = directory / TEXT("Rider.app");
-        SearchDirectory(&installations, riderAppPath / TEXT("Contents/Resources"), riderAppPath);
+        String riderAppDirectory = directory / TEXT("Rider.app/Contents/Resources");
+        SearchDirectory(&installations, riderAppDirectory);
     }
 
     // Check the local installer version
-    SearchDirectory(&installations, TEXT("/Applications/Rider.app/Contents/Resources"), TEXT("/Applications/Rider.app"));
-
-    String userFolder;
-    FileSystem::GetSpecialFolderPath(SpecialFolder::Documents, userFolder);
-    String riderAppPath = userFolder / TEXT("../Applications/Rider.app");
-    SearchDirectory(&installations, riderAppPath / TEXT("Contents/Resources"), riderAppPath);
+    SearchDirectory(&installations, TEXT("/Applications/Rider.app/Contents/Resources"));
 #endif
 
     for (const String& directory : subDirectories)

--- a/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
+++ b/Source/Editor/Scripting/CodeEditors/RiderCodeEditor.cpp
@@ -14,6 +14,9 @@
 
 #if PLATFORM_WINDOWS
 #include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
+#elif PLATFORM_MAC
+#include "Engine/Platform/Apple/AppleUtils.h"
+#include <AppKit/AppKit.h>
 #endif
 
 namespace
@@ -68,10 +71,14 @@ namespace
         if (!launcherPath.HasChars() || !FileSystem::FileExists(exePath))
             return;
 
-        if (launchOverridePath != String::Empty)
-            installations->Add(New<RiderInstallation>(launchOverridePath, versionMember->value.GetText()));
-        else
-            installations->Add(New<RiderInstallation>(exePath, versionMember->value.GetText()));
+        String installPath = launchOverridePath != String::Empty ? launchOverridePath : exePath;
+        StringUtils::PathRemoveRelativeParts(installPath);
+        for (RiderInstallation* installation : *installations)
+        {
+            if (installation->path == installPath)
+                return;
+        }
+        installations->Add(New<RiderInstallation>(installPath, versionMember->value.GetText()));
     }
 
 #if PLATFORM_WINDOWS
@@ -221,17 +228,29 @@ void RiderCodeEditor::FindEditors(Array<CodeEditor*>* output)
     String applicationSupportFolder;
     FileSystem::GetSpecialFolderPath(SpecialFolder::ProgramData, applicationSupportFolder);
 
+    NSURL* appURL = [[NSWorkspace sharedWorkspace] URLForApplicationWithBundleIdentifier:@"com.jetbrains.rider"];
+    if (appURL != nullptr)
+    {
+        const String appPath = AppleUtils::ToString((CFStringRef)[appURL path]);
+        SearchDirectory(&installations, appPath / TEXT("Contents/Resources"), appPath);
+    }
+
     Array<String> subMacDirectories;
     FileSystem::GetChildDirectories(subMacDirectories, applicationSupportFolder / TEXT("JetBrains/Toolbox/apps/Rider/ch-0/"));
     FileSystem::GetChildDirectories(subMacDirectories, applicationSupportFolder / TEXT("JetBrains/Toolbox/apps/Rider/ch-1/"));
     for (const String& directory : subMacDirectories)
     {
-        String riderAppDirectory = directory / TEXT("Rider.app/Contents/Resources");
-        SearchDirectory(&installations, riderAppDirectory);
+        String riderAppPath = directory / TEXT("Rider.app");
+        SearchDirectory(&installations, riderAppPath / TEXT("Contents/Resources"), riderAppPath);
     }
 
     // Check the local installer version
-    SearchDirectory(&installations, TEXT("/Applications/Rider.app/Contents/Resources"));
+    SearchDirectory(&installations, TEXT("/Applications/Rider.app/Contents/Resources"), TEXT("/Applications/Rider.app"));
+
+    String userFolder;
+    FileSystem::GetSpecialFolderPath(SpecialFolder::Documents, userFolder);
+    String riderAppPath = userFolder / TEXT("../Applications/Rider.app");
+    SearchDirectory(&installations, riderAppPath / TEXT("Contents/Resources"), riderAppPath);
 #endif
 
     for (const String& directory : subDirectories)

--- a/Source/Engine/Scripting/Attributes/Editor/ScriptingObjectInterfaceReferenceAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/ScriptingObjectInterfaceReferenceAttribute.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using System;
+
+namespace FlaxEngine
+{
+    /// <summary>
+    /// Marks a generated interface property as a native scripting object interface reference.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ScriptingObjectInterfaceReferenceAttribute : Attribute
+    {
+    }
+}

--- a/Source/Engine/Scripting/Attributes/Editor/SoftObjectInterfaceReferenceAttribute.cs
+++ b/Source/Engine/Scripting/Attributes/Editor/SoftObjectInterfaceReferenceAttribute.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using System;
+
+namespace FlaxEngine
+{
+    /// <summary>
+    /// Marks a generated interface property as a native soft object interface reference.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class SoftObjectInterfaceReferenceAttribute : Attribute
+    {
+    }
+}

--- a/Source/Engine/Scripting/Internal/InternalCalls.h
+++ b/Source/Engine/Scripting/Internal/InternalCalls.h
@@ -37,7 +37,7 @@ struct FLAXENGINE_API VTableFunctionInjector
 
 #if USE_NETCORE
 #define ADD_INTERNAL_CALL(fullName, method)
-#define DEFINE_INTERNAL_CALL(returnType) extern "C" DLLEXPORT returnType
+#define DEFINE_INTERNAL_CALL(returnType) extern "C" DLLEXPORT USED returnType
 #else
 extern "C" FLAXENGINE_API void mono_add_internal_call(const char* name, const void* method);
 #define ADD_INTERNAL_CALL(fullName, method) mono_add_internal_call(fullName, (const void*)method)

--- a/Source/Engine/Scripting/Internal/ManagedDictionary.cpp
+++ b/Source/Engine/Scripting/Internal/ManagedDictionary.cpp
@@ -15,4 +15,160 @@ MMethod* ManagedDictionary::CreateInstance;
 MMethod* ManagedDictionary::AddDictionaryItem;
 MMethod* ManagedDictionary::GetDictionaryKeys;
 #endif
+
+ManagedDictionary::ManagedDictionary(MObject* instance)
+{
+    Instance = instance;
+
+#if !USE_MONO_AOT
+    // Cache the thunks of the dictionary helper methods
+    if (MakeGenericType == nullptr)
+    {
+        MClass* scriptingClass = Scripting::GetStaticClass();
+        CHECK(scriptingClass);
+
+        MMethod* makeGenericTypeMethod = scriptingClass->GetMethod("MakeGenericType", 2);
+        CHECK(makeGenericTypeMethod);
+        MakeGenericType = (MakeGenericTypeThunk)makeGenericTypeMethod->GetThunk();
+
+        MMethod* createInstanceMethod = StdTypesContainer::Instance()->ActivatorClass->GetMethod("CreateInstance", 2);
+        CHECK(createInstanceMethod);
+        CreateInstance = (CreateInstanceThunk)createInstanceMethod->GetThunk();
+
+        MMethod* addDictionaryItemMethod = scriptingClass->GetMethod("AddDictionaryItem", 3);
+        CHECK(addDictionaryItemMethod);
+        AddDictionaryItem = (AddDictionaryItemThunk)addDictionaryItemMethod->GetThunk();
+
+        MMethod* getDictionaryKeysItemMethod = scriptingClass->GetMethod("GetDictionaryKeys", 1);
+        CHECK(getDictionaryKeysItemMethod);
+        GetDictionaryKeys = (GetDictionaryKeysThunk)getDictionaryKeysItemMethod->GetThunk();
+    }
+#else
+    if (MakeGenericType == nullptr)
+    {
+        MClass* scriptingClass = Scripting::GetStaticClass();
+        CHECK(scriptingClass);
+
+        MakeGenericType = scriptingClass->GetMethod("MakeGenericType", 2);
+        CHECK(MakeGenericType);
+
+        CreateInstance = StdTypesContainer::Instance()->ActivatorClass->GetMethod("CreateInstance", 2);
+        CHECK(CreateInstance);
+
+        AddDictionaryItem = scriptingClass->GetMethod("AddDictionaryItem", 3);
+        CHECK(AddDictionaryItem);
+
+        GetDictionaryKeys = scriptingClass->GetMethod("GetDictionaryKeys", 1);
+        CHECK(GetDictionaryKeys);
+    }
+#endif
+}
+
+MTypeObject* ManagedDictionary::GetClass(MType* keyType, MType* valueType)
+{
+    // Check if the generic type was generated earlier
+    KeyValueType cacheKey = { keyType, valueType };
+    MTypeObject* dictionaryType;
+    if (CachedTypes.TryGet(cacheKey, dictionaryType))
+        return dictionaryType;
+
+    MTypeObject* genericType = MUtils::GetType(StdTypesContainer::Instance()->DictionaryClass);
+#if USE_NETCORE
+    MArray* genericArgs = MCore::Array::New(MCore::TypeCache::IntPtr, 2);
+#else
+    MArray* genericArgs = MCore::Array::New(MCore::TypeCache::Object, 2);
+#endif
+    MTypeObject** genericArgsPtr = MCore::Array::GetAddress<MTypeObject*>(genericArgs);
+    genericArgsPtr[0] = INTERNAL_TYPE_GET_OBJECT(keyType);
+    genericArgsPtr[1] = INTERNAL_TYPE_GET_OBJECT(valueType);
+
+    MObject* exception = nullptr;
+#if !USE_MONO_AOT
+    dictionaryType = MakeGenericType(nullptr, genericType, genericArgs, &exception);
+#else
+    void* params[2];
+    params[0] = genericType;
+    params[1] = genericArgs;
+    dictionaryType = (MTypeObject*)MakeGenericType->Invoke(nullptr, params, &exception);
+#endif
+    if (exception)
+    {
+        MException ex(exception);
+        ex.Log(LogType::Error, TEXT(""));
+        return nullptr;
+    }
+    CachedTypes.Add(cacheKey, dictionaryType);
+    return dictionaryType;
+}
+
+ManagedDictionary ManagedDictionary::New(MType* keyType, MType* valueType)
+{
+    ManagedDictionary result;
+    MTypeObject* dictionaryType = GetClass(keyType, valueType);
+    if (!dictionaryType)
+        return result;
+
+    MObject* exception = nullptr;
+#if !USE_MONO_AOT
+    MObject* instance = CreateInstance(nullptr, dictionaryType, nullptr, &exception);
+#else
+    void* params[2];
+    params[0] = dictionaryType;
+    params[1] = nullptr;
+    MObject* instance = CreateInstance->Invoke(nullptr, params, &exception);
+#endif
+    if (exception)
+    {
+        MException ex(exception);
+        ex.Log(LogType::Error, TEXT(""));
+        return result;
+    }
+
+    result.Instance = instance;
+    return result;
+}
+
+void ManagedDictionary::Add(MObject* key, MObject* value)
+{
+    CHECK(Instance);
+
+    MObject* exception = nullptr;
+#if !USE_MONO_AOT
+    AddDictionaryItem(nullptr, Instance, key, value, &exception);
+#else
+    void* params[3];
+    params[0] = Instance;
+    params[1] = key;
+    params[2] = value;
+    AddDictionaryItem->Invoke(Instance, params, &exception);
+#endif
+    if (exception)
+    {
+        MException ex(exception);
+        ex.Log(LogType::Error, TEXT(""));
+    }
+}
+
+MArray* ManagedDictionary::GetKeys() const
+{
+    CHECK_RETURN(Instance, nullptr);
+#if !USE_MONO_AOT
+    return GetDictionaryKeys(nullptr, Instance, nullptr);
+#else
+    void* params[1];
+    params[0] = Instance;
+    return (MArray*)GetDictionaryKeys->Invoke(nullptr, params, nullptr);
+#endif
+}
+
+MObject* ManagedDictionary::GetValue(MObject* key) const
+{
+    CHECK_RETURN(Instance, nullptr);
+    MClass* klass = MCore::Object::GetClass(Instance);
+    MMethod* getItemMethod = klass->GetMethod("System.Collections.IDictionary.get_Item", 1);
+    CHECK_RETURN(getItemMethod, nullptr);
+    void* params[1];
+    params[0] = key;
+    return getItemMethod->Invoke(Instance, params, nullptr);
+}
 #endif

--- a/Source/Engine/Scripting/Internal/ManagedDictionary.h
+++ b/Source/Engine/Scripting/Internal/ManagedDictionary.h
@@ -57,53 +57,7 @@ private:
 public:
     MObject* Instance;
 
-    ManagedDictionary(MObject* instance = nullptr)
-    {
-        Instance = instance;
-
-#if !USE_MONO_AOT
-        // Cache the thunks of the dictionary helper methods
-        if (MakeGenericType == nullptr)
-        {
-            MClass* scriptingClass = Scripting::GetStaticClass();
-            CHECK(scriptingClass);
-
-            MMethod* makeGenericTypeMethod = scriptingClass->GetMethod("MakeGenericType", 2);
-            CHECK(makeGenericTypeMethod);
-            MakeGenericType = (MakeGenericTypeThunk)makeGenericTypeMethod->GetThunk();
-
-            MMethod* createInstanceMethod = StdTypesContainer::Instance()->ActivatorClass->GetMethod("CreateInstance", 2);
-            CHECK(createInstanceMethod);
-            CreateInstance = (CreateInstanceThunk)createInstanceMethod->GetThunk();
-
-            MMethod* addDictionaryItemMethod = scriptingClass->GetMethod("AddDictionaryItem", 3);
-            CHECK(addDictionaryItemMethod);
-            AddDictionaryItem = (AddDictionaryItemThunk)addDictionaryItemMethod->GetThunk();
-            
-            MMethod* getDictionaryKeysItemMethod = scriptingClass->GetMethod("GetDictionaryKeys", 1);
-            CHECK(getDictionaryKeysItemMethod);
-            GetDictionaryKeys = (GetDictionaryKeysThunk)getDictionaryKeysItemMethod->GetThunk();
-        }
-#else
-        if (MakeGenericType == nullptr)
-        {
-            MClass* scriptingClass = Scripting::GetStaticClass();
-            CHECK(scriptingClass);
-
-            MakeGenericType = scriptingClass->GetMethod("MakeGenericType", 2);
-            CHECK(MakeGenericType);
-
-            CreateInstance = StdTypesContainer::Instance()->ActivatorClass->GetMethod("CreateInstance", 2);
-            CHECK(CreateInstance);
-
-            AddDictionaryItem = scriptingClass->GetMethod("AddDictionaryItem", 3);
-            CHECK(AddDictionaryItem);
-
-            GetDictionaryKeys = scriptingClass->GetMethod("GetDictionaryKeys", 1);
-            CHECK(GetDictionaryKeys);
-        }
-#endif
-    }
+    ManagedDictionary(MObject* instance = nullptr);
 
     template<typename KeyType, typename ValueType>
     static MObject* ToManaged(const Dictionary<KeyType, ValueType>& data, MType* keyType, MType* valueType)
@@ -154,113 +108,15 @@ public:
         return result;
     }
 
-    static MTypeObject* GetClass(MType* keyType, MType* valueType)
-    {
-        // Check if the generic type was generated earlier
-        KeyValueType cacheKey = { keyType, valueType };
-        MTypeObject* dictionaryType;
-        if (CachedTypes.TryGet(cacheKey, dictionaryType))
-            return dictionaryType;
+    static MTypeObject* GetClass(MType* keyType, MType* valueType);
 
-        MTypeObject* genericType = MUtils::GetType(StdTypesContainer::Instance()->DictionaryClass);
-#if USE_NETCORE
-        MArray* genericArgs = MCore::Array::New(MCore::TypeCache::IntPtr, 2);
-#else
-        MArray* genericArgs = MCore::Array::New(MCore::TypeCache::Object, 2);
-#endif
-        MTypeObject** genericArgsPtr = MCore::Array::GetAddress<MTypeObject*>(genericArgs);
-        genericArgsPtr[0] = INTERNAL_TYPE_GET_OBJECT(keyType);
-        genericArgsPtr[1] = INTERNAL_TYPE_GET_OBJECT(valueType);
+    static ManagedDictionary New(MType* keyType, MType* valueType);
 
-        MObject* exception = nullptr;
-#if !USE_MONO_AOT
-        dictionaryType = MakeGenericType(nullptr, genericType, genericArgs, &exception);
-#else
-        void* params[2];
-        params[0] = genericType;
-        params[1] = genericArgs;
-        dictionaryType = (MTypeObject*)MakeGenericType->Invoke(nullptr, params, &exception);
-#endif
-        if (exception)
-        {
-            MException ex(exception);
-            ex.Log(LogType::Error, TEXT(""));
-            return nullptr;
-        }
-        CachedTypes.Add(cacheKey, dictionaryType);
-        return dictionaryType;
-    }
+    void Add(MObject* key, MObject* value);
 
-    static ManagedDictionary New(MType* keyType, MType* valueType)
-    {
-        ManagedDictionary result;
-        MTypeObject* dictionaryType = GetClass(keyType, valueType);
-        if (!dictionaryType)
-            return result;
+    MArray* GetKeys() const;
 
-        MObject* exception = nullptr;
-#if !USE_MONO_AOT
-        MObject* instance = CreateInstance(nullptr, dictionaryType, nullptr, &exception);
-#else
-        void* params[2];
-        params[0] = dictionaryType;
-        params[1] = nullptr;
-        MObject* instance = CreateInstance->Invoke(nullptr, params, &exception);
-#endif
-        if (exception)
-        {
-            MException ex(exception);
-            ex.Log(LogType::Error, TEXT(""));
-            return result;
-        }
-
-        result.Instance = instance;
-        return result;
-    }
-
-    void Add(MObject* key, MObject* value)
-    {
-        CHECK(Instance);
-
-        MObject* exception = nullptr;
-#if !USE_MONO_AOT
-        AddDictionaryItem(nullptr, Instance, key, value, &exception);
-#else
-        void* params[3];
-        params[0] = Instance;
-        params[1] = key;
-        params[2] = value;
-        AddDictionaryItem->Invoke(Instance, params, &exception);
-#endif
-        if (exception)
-        {
-            MException ex(exception);
-            ex.Log(LogType::Error, TEXT(""));
-        }
-    }
-
-    MArray* GetKeys() const
-    {
-        CHECK_RETURN(Instance, nullptr);
-#if !USE_MONO_AOT
-        return GetDictionaryKeys(nullptr, Instance, nullptr);
-#else
-        void* params[1];
-        params[0] = Instance;
-        return (MArray*)GetDictionaryKeys->Invoke(nullptr, params, nullptr);
-#endif
-    }
-
-    MObject* GetValue(MObject* key) const
-    {
-        CHECK_RETURN(Instance, nullptr);
-        MClass* klass = MCore::Object::GetClass(Instance);
-        MMethod* getItemMethod = klass->GetMethod("System.Collections.IDictionary.get_Item", 1);
-        CHECK_RETURN(getItemMethod, nullptr);
-        void* params[1];
-        params[0] = key;
-        return getItemMethod->Invoke(Instance, params, nullptr);
-    }
+    MObject* GetValue(MObject* key) const;
 };
 
 inline uint32 GetHash(const ManagedDictionary::KeyValueType& other)

--- a/Source/Engine/Scripting/ManagedCLR/MUtils.h
+++ b/Source/Engine/Scripting/ManagedCLR/MUtils.h
@@ -278,6 +278,10 @@ struct MConverter<T, typename TEnableIf<TIsBaseOf<class ScriptingObject, T>::Val
 // Converter for ScriptingObject References.
 template<typename T>
 class ScriptingObjectReference;
+template<typename T>
+class ScriptingObjectInterfaceReference;
+template<typename T>
+class SoftObjectInterfaceReference;
 
 template<typename T>
 struct MConverter<ScriptingObjectReference<T>>
@@ -309,6 +313,50 @@ struct MConverter<ScriptingObjectReference<T>>
         for (int32 i = 0; i < result.Length(); i++)
             result.Get()[i] = (T*)ScriptingObject::ToNative(dataPtr[i]);
     }
+};
+
+template<typename TReference, typename TInterface>
+struct MInterfaceReferenceConverter
+{
+    MObject* Box(const TReference& data, const MClass* klass)
+    {
+        return data.GetManagedInstance();
+    }
+
+    void Unbox(TReference& result, MObject* data)
+    {
+        result = ScriptingObject::ToInterface<TInterface>(ScriptingObject::ToNative(data));
+    }
+
+    void ToManagedArray(MArray* result, const Span<TReference>& data)
+    {
+        if (data.Length() == 0)
+            return;
+        MObject** objects = (MObject**)Allocator::Allocate(data.Length() * sizeof(MObject*));
+        for (int32 i = 0; i < data.Length(); i++)
+            objects[i] = data[i].GetManagedInstance();
+        MCore::GC::WriteArrayRef(result, Span<MObject*>(objects, data.Length()));
+        Allocator::Free(objects);
+    }
+
+    void ToNativeArray(Span<TReference>& result, const MArray* data)
+    {
+        MObject** dataPtr = MCore::Array::GetAddress<MObject*>(data);
+        for (int32 i = 0; i < result.Length(); i++)
+            result.Get()[i] = ScriptingObject::ToInterface<TInterface>(ScriptingObject::ToNative(dataPtr[i]));
+    }
+};
+
+// Converter for Scripting Interface References.
+template<typename T>
+struct MConverter<ScriptingObjectInterfaceReference<T>> : MInterfaceReferenceConverter<ScriptingObjectInterfaceReference<T>, T>
+{
+};
+
+// Converter for Soft Object Interface References.
+template<typename T>
+struct MConverter<SoftObjectInterfaceReference<T>> : MInterfaceReferenceConverter<SoftObjectInterfaceReference<T>, T>
+{
 };
 
 // Converter for Asset References.

--- a/Source/Engine/Scripting/ScriptingObject.cpp
+++ b/Source/Engine/Scripting/ScriptingObject.cpp
@@ -717,6 +717,12 @@ DEFINE_INTERNAL_CALL(MString*) ObjectInternal_GetTypeName(ScriptingObject* obj)
     return MUtils::ToString(obj->GetType().Fullname);
 }
 
+FORCE_INLINE bool ObjectInternal_MatchesType(ScriptingObject* obj, MClass* klass)
+{
+    return !klass ||
+           (klass->IsInterface() ? obj->GetClass()->HasInterface(klass) : obj->Is(klass));
+}
+
 DEFINE_INTERNAL_CALL(MObject*) ObjectInternal_FindObject(Guid* id, MTypeObject* type, bool skipLog = false)
 {
     if (!id->IsValid())
@@ -732,7 +738,7 @@ DEFINE_INTERNAL_CALL(MObject*) ObjectInternal_FindObject(Guid* id, MTypeObject* 
     }
     if (obj)
     {
-        if (klass && !obj->Is(klass))
+        if (!ObjectInternal_MatchesType(obj, klass))
         {
             if (!skipLog)
             {
@@ -762,7 +768,7 @@ DEFINE_INTERNAL_CALL(MObject*) ObjectInternal_FindObject(Guid* id, MTypeObject* 
 DEFINE_INTERNAL_CALL(MObject*) ObjectInternal_TryFindObject(Guid* id, MTypeObject* type)
 {
     ScriptingObject* obj = Scripting::TryFindObject(*id);
-    if (obj && !obj->Is(MUtils::GetClass(type)))
+    if (obj && !ObjectInternal_MatchesType(obj, MUtils::GetClass(type)))
         obj = nullptr;
     return obj ? obj->GetOrCreateManagedInstance() : nullptr;
 }

--- a/Source/Engine/Scripting/ScriptingObjectInterfaceReference.h
+++ b/Source/Engine/Scripting/ScriptingObjectInterfaceReference.h
@@ -1,0 +1,195 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#include "Engine/Scripting/ScriptingObjectInterfaceReferenceUtils.h"
+
+/// <summary>
+/// The scene object interface reference.
+/// </summary>
+/// <typeparam name="T">The type of the scripting interface.</typeparam>
+template<typename T>
+API_CLASS(InBuild) class ScriptingObjectInterfaceReference : public ScriptingObjectReferenceBase
+{
+    typedef ScriptingObjectInterfaceReferenceHelper<T> Helper;
+
+public:
+    typedef ScriptingObjectInterfaceReference<T> Type;
+
+public:
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScriptingObjectInterfaceReference"/> class.
+    /// </summary>
+    ScriptingObjectInterfaceReference()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScriptingObjectInterfaceReference"/> class.
+    /// </summary>
+    /// <param name="obj">The object to link.</param>
+    ScriptingObjectInterfaceReference(SceneObject* obj)
+        : ScriptingObjectReferenceBase(Helper::IsValidObject(obj) ? obj : nullptr)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScriptingObjectInterfaceReference"/> class.
+    /// </summary>
+    /// <param name="interfaceObj">The interface object to link.</param>
+    ScriptingObjectInterfaceReference(T* interfaceObj)
+        : ScriptingObjectReferenceBase(Helper::GetSceneObject(interfaceObj))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScriptingObjectInterfaceReference"/> class.
+    /// </summary>
+    /// <param name="other">The other property.</param>
+    ScriptingObjectInterfaceReference(const ScriptingObjectInterfaceReference& other)
+        : ScriptingObjectReferenceBase(other._object)
+    {
+    }
+
+    ScriptingObjectInterfaceReference(ScriptingObjectInterfaceReference&& other) noexcept
+        : ScriptingObjectReferenceBase(MoveTemp(other))
+    {
+    }
+
+    /// <summary>
+    /// Finalizes an instance of the <see cref="ScriptingObjectInterfaceReference"/> class.
+    /// </summary>
+    ~ScriptingObjectInterfaceReference()
+    {
+    }
+
+public:
+    FORCE_INLINE bool operator==(SceneObject* other) const
+    {
+        return _object == other;
+    }
+
+    FORCE_INLINE bool operator!=(SceneObject* other) const
+    {
+        return _object != other;
+    }
+
+    FORCE_INLINE bool operator==(T* other) const
+    {
+        return Get() == other;
+    }
+
+    FORCE_INLINE bool operator!=(T* other) const
+    {
+        return Get() != other;
+    }
+
+    FORCE_INLINE bool operator==(const ScriptingObjectInterfaceReference& other) const
+    {
+        return _object == other._object;
+    }
+
+    FORCE_INLINE bool operator!=(const ScriptingObjectInterfaceReference& other) const
+    {
+        return _object != other._object;
+    }
+
+    FORCE_INLINE ScriptingObjectInterfaceReference& operator=(SceneObject* other)
+    {
+        OnSet(Helper::IsValidObject(other) ? other : nullptr);
+        return *this;
+    }
+
+    FORCE_INLINE ScriptingObjectInterfaceReference& operator=(T* other)
+    {
+        OnSet(Helper::GetSceneObject(other));
+        return *this;
+    }
+
+    ScriptingObjectInterfaceReference& operator=(const ScriptingObjectInterfaceReference& other)
+    {
+        OnSet(other._object);
+        return *this;
+    }
+
+    ScriptingObjectInterfaceReference& operator=(ScriptingObjectInterfaceReference&& other) noexcept
+    {
+        ScriptingObjectReferenceBase::operator=(MoveTemp(other));
+        return *this;
+    }
+
+    FORCE_INLINE ScriptingObjectInterfaceReference& operator=(const Guid& id)
+    {
+        OnSet(Helper::FindSceneObject(id));
+        return *this;
+    }
+
+    /// <summary>
+    /// Implicit conversion to the interface.
+    /// </summary>
+    FORCE_INLINE operator T*() const
+    {
+        return Get();
+    }
+
+    /// <summary>
+    /// Implicit conversion to boolean value.
+    /// </summary>
+    FORCE_INLINE operator bool() const
+    {
+        return _object != nullptr;
+    }
+
+    /// <summary>
+    /// Interface accessor.
+    /// </summary>
+    FORCE_INLINE T* operator->() const
+    {
+        return Get();
+    }
+
+    /// <summary>
+    /// Gets the interface pointer.
+    /// </summary>
+    FORCE_INLINE T* Get() const
+    {
+        return ScriptingObject::ToInterface<T>(_object);
+    }
+
+    /// <summary>
+    /// Gets the referenced object.
+    /// </summary>
+    FORCE_INLINE SceneObject* GetObject() const
+    {
+        return static_cast<SceneObject*>(_object);
+    }
+
+    /// <summary>
+    /// Copies the object ID into the raw storage.
+    /// </summary>
+    FORCE_INLINE void CopyID(uint32 id[4]) const
+    {
+        memset(id, 0, sizeof(uint32) * 4);
+        if (_object)
+        {
+            const Guid value = GetID();
+            memcpy(id, &value, sizeof(uint32) * 4);
+        }
+    }
+
+    /// <summary>
+    /// Gets the object as a given type (static cast).
+    /// </summary>
+    template<typename U>
+    FORCE_INLINE U* As() const
+    {
+        return static_cast<U*>(_object);
+    }
+
+};
+
+template<typename T>
+uint32 GetHash(const ScriptingObjectInterfaceReference<T>& key)
+{
+    return GetHash(key.GetID());
+}

--- a/Source/Engine/Scripting/ScriptingObjectInterfaceReferenceUtils.h
+++ b/Source/Engine/Scripting/ScriptingObjectInterfaceReferenceUtils.h
@@ -1,0 +1,30 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#include "Engine/Scripting/ScriptingObjectReference.h"
+#include "Engine/Level/SceneObject.h"
+
+/// <summary>
+/// Utility methods for scene object interface references.
+/// </summary>
+/// <typeparam name="T">The type of the scripting interface.</typeparam>
+template<typename T>
+struct ScriptingObjectInterfaceReferenceHelper
+{
+    FORCE_INLINE static bool IsValidObject(const SceneObject* obj)
+    {
+        return !obj || obj->GetType().GetInterface(T::TypeInitializer) != nullptr;
+    }
+
+    FORCE_INLINE static SceneObject* GetSceneObject(T* interfaceObj)
+    {
+        return ScriptingObject::Cast<SceneObject>(ScriptingObject::FromInterface<T>(interfaceObj));
+    }
+
+    FORCE_INLINE static SceneObject* FindSceneObject(const Guid& id)
+    {
+        SceneObject* obj = static_cast<SceneObject*>(FindObject(id, SceneObject::GetStaticClass()));
+        return IsValidObject(obj) ? obj : nullptr;
+    }
+};

--- a/Source/Engine/Scripting/SoftObjectInterfaceReference.h
+++ b/Source/Engine/Scripting/SoftObjectInterfaceReference.h
@@ -1,0 +1,258 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#include "Engine/Scripting/SoftObjectReference.h"
+#include "Engine/Scripting/ScriptingObjectInterfaceReferenceUtils.h"
+
+/// <summary>
+/// The scene object soft interface reference. Objects gets referenced on use (ID reference is resolving it).
+/// </summary>
+/// <typeparam name="T">The type of the scripting interface.</typeparam>
+template<typename T>
+API_CLASS(InBuild) class SoftObjectInterfaceReference : public SoftObjectReferenceBase
+{
+    typedef ScriptingObjectInterfaceReferenceHelper<T> Helper;
+
+public:
+    typedef SoftObjectInterfaceReference<T> Type;
+
+public:
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoftObjectInterfaceReference"/> class.
+    /// </summary>
+    SoftObjectInterfaceReference()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoftObjectInterfaceReference"/> class.
+    /// </summary>
+    /// <param name="obj">The object to link.</param>
+    SoftObjectInterfaceReference(SceneObject* obj)
+    {
+        OnSet(Helper::IsValidObject(obj) ? obj : nullptr);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoftObjectInterfaceReference"/> class.
+    /// </summary>
+    /// <param name="interfaceObj">The interface object to link.</param>
+    SoftObjectInterfaceReference(T* interfaceObj)
+    {
+        OnSet(Helper::GetSceneObject(interfaceObj));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoftObjectInterfaceReference"/> class.
+    /// </summary>
+    /// <param name="other">The other property.</param>
+    SoftObjectInterfaceReference(const SoftObjectInterfaceReference& other)
+    {
+        OnSet(other.GetID());
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoftObjectInterfaceReference"/> class.
+    /// </summary>
+    /// <param name="other">The other property.</param>
+    SoftObjectInterfaceReference(SoftObjectInterfaceReference&& other)
+    {
+        OnSet(other.GetID());
+        other.OnSet(nullptr);
+    }
+
+    /// <summary>
+    /// Finalizes an instance of the <see cref="SoftObjectInterfaceReference"/> class.
+    /// </summary>
+    ~SoftObjectInterfaceReference()
+    {
+    }
+
+public:
+    FORCE_INLINE bool operator==(SceneObject* other)
+    {
+        return GetObject() == other;
+    }
+
+    FORCE_INLINE bool operator!=(SceneObject* other)
+    {
+        return GetObject() != other;
+    }
+
+    FORCE_INLINE bool operator==(T* other)
+    {
+        return Get() == other;
+    }
+
+    FORCE_INLINE bool operator!=(T* other)
+    {
+        return Get() != other;
+    }
+
+    FORCE_INLINE bool operator==(const SoftObjectInterfaceReference& other)
+    {
+        return GetID() == other.GetID();
+    }
+
+    FORCE_INLINE bool operator!=(const SoftObjectInterfaceReference& other)
+    {
+        return GetID() != other.GetID();
+    }
+
+    SoftObjectInterfaceReference& operator=(const SoftObjectInterfaceReference& other)
+    {
+        if (this != &other)
+            OnSet(other.GetID());
+        return *this;
+    }
+
+    SoftObjectInterfaceReference& operator=(SoftObjectInterfaceReference&& other)
+    {
+        if (this != &other)
+        {
+            OnSet(other.GetID());
+            other.OnSet(nullptr);
+        }
+        return *this;
+    }
+
+    FORCE_INLINE SoftObjectInterfaceReference& operator=(SceneObject* other)
+    {
+        OnSet(Helper::IsValidObject(other) ? other : nullptr);
+        return *this;
+    }
+
+    FORCE_INLINE SoftObjectInterfaceReference& operator=(T* other)
+    {
+        OnSet(Helper::GetSceneObject(other));
+        return *this;
+    }
+
+    FORCE_INLINE SoftObjectInterfaceReference& operator=(const Guid& id)
+    {
+        OnSet(id);
+        return *this;
+    }
+
+    /// <summary>
+    /// Implicit conversion to the interface.
+    /// </summary>
+    FORCE_INLINE operator T*() const
+    {
+        return Get();
+    }
+
+    /// <summary>
+    /// Implicit conversion to boolean value.
+    /// </summary>
+    FORCE_INLINE operator bool() const
+    {
+        return Get() != nullptr;
+    }
+
+    /// <summary>
+    /// Interface accessor.
+    /// </summary>
+    FORCE_INLINE T* operator->() const
+    {
+        return Get();
+    }
+
+    /// <summary>
+    /// Gets the object as a given type (static cast).
+    /// </summary>
+    template<typename U>
+    FORCE_INLINE U* As() const
+    {
+        return static_cast<U*>(GetObject());
+    }
+
+public:
+    /// <summary>
+    /// Gets the interface pointer.
+    /// </summary>
+    FORCE_INLINE T* Get() const
+    {
+        return ScriptingObject::ToInterface<T>(GetObject());
+    }
+
+    /// <summary>
+    /// Gets the referenced object.
+    /// </summary>
+    SceneObject* GetObject() const
+    {
+        if (!_object)
+            const_cast<SoftObjectInterfaceReference*>(this)->OnResolve(SceneObject::GetStaticClass());
+        return Helper::IsValidObject(static_cast<SceneObject*>(_object)) ? static_cast<SceneObject*>(_object) : nullptr;
+    }
+
+    /// <summary>
+    /// Gets managed instance object (or null if no object linked).
+    /// </summary>
+    MObject* GetManagedInstance() const
+    {
+        auto object = GetObject();
+        return object ? object->GetOrCreateManagedInstance() : nullptr;
+    }
+
+    /// <summary>
+    /// Determines whether object is assigned and managed instance of the object is alive.
+    /// </summary>
+    bool HasManagedInstance() const
+    {
+        auto object = GetObject();
+        return object && object->HasManagedInstance();
+    }
+
+    /// <summary>
+    /// Gets the managed instance object or creates it if missing or null if not assigned.
+    /// </summary>
+    MObject* GetOrCreateManagedInstance() const
+    {
+        auto object = GetObject();
+        return object ? object->GetOrCreateManagedInstance() : nullptr;
+    }
+
+    /// <summary>
+    /// Copies the object ID into the raw storage.
+    /// </summary>
+    FORCE_INLINE void CopyID(uint32 id[4]) const
+    {
+        const Guid value = GetID();
+        memcpy(id, &value, sizeof(uint32) * 4);
+    }
+
+    /// <summary>
+    /// Sets the object.
+    /// </summary>
+    /// <param name="id">The object ID. Uses Scripting to find the registered object of the given ID.</param>
+    FORCE_INLINE void Set(const Guid& id)
+    {
+        OnSet(id);
+    }
+
+    /// <summary>
+    /// Sets the object.
+    /// </summary>
+    /// <param name="object">The object.</param>
+    FORCE_INLINE void Set(SceneObject* object)
+    {
+        OnSet(Helper::IsValidObject(object) ? object : nullptr);
+    }
+
+    /// <summary>
+    /// Sets the object.
+    /// </summary>
+    /// <param name="interfaceObj">The interface object.</param>
+    FORCE_INLINE void Set(T* interfaceObj)
+    {
+        OnSet(Helper::GetSceneObject(interfaceObj));
+    }
+};
+
+template<typename T>
+uint32 GetHash(const SoftObjectInterfaceReference<T>& key)
+{
+    return GetHash(key.GetID());
+}

--- a/Source/Engine/Serialization/JsonCustomSerializers/ExtendedDefaultContractResolver.cs
+++ b/Source/Engine/Serialization/JsonCustomSerializers/ExtendedDefaultContractResolver.cs
@@ -12,6 +12,7 @@ namespace FlaxEngine.Json.JsonCustomSerializers
     internal class ExtendedDefaultContractResolver : DefaultContractResolver
     {
         private readonly Type _flaxType = typeof(Object);
+        private static readonly JsonConverter InterfaceObjectReferenceConverterInstance = new InterfaceObjectReferenceConverter();
 
         private readonly Type[] AttributesIgnoreList =
         {
@@ -33,6 +34,88 @@ namespace FlaxEngine.Json.JsonCustomSerializers
             _attributesIgnoreList = isManagedOnly ? AttributesIgnoreListManaged : AttributesIgnoreList;
         }
 
+        private static bool HasObjectInterfaceReferenceAttribute(IEnumerable<Attribute> attributes)
+        {
+            return attributes.Any(x => x is ScriptingObjectInterfaceReferenceAttribute || x is SoftObjectInterfaceReferenceAttribute);
+        }
+
+        private static Type GetCollectionItemType(Type type)
+        {
+            if (type.IsArray)
+                return type.GetElementType();
+            if (!type.IsGenericType || type == typeof(string))
+                return null;
+
+            var types = type.GetInterfaces().Concat(new[] { type });
+            var dictionaryType = types.FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+            if (dictionaryType != null)
+                return dictionaryType.GetGenericArguments()[1];
+            var enumerableType = types.FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+            return enumerableType?.GetGenericArguments()[0];
+        }
+
+        private static void SetupInterfaceObjectReferenceItems(JsonContainerContract contract, Type itemType)
+        {
+            if (itemType?.IsInterface == true)
+            {
+                contract.ItemReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+                contract.ItemConverter = InterfaceObjectReferenceConverterInstance;
+            }
+        }
+
+        private void SetupObjectReferenceProperty(JsonProperty jsonProperty, Type type, IEnumerable<Attribute> attributes)
+        {
+            var hasObjectInterfaceReferenceAttribute = HasObjectInterfaceReferenceAttribute(attributes);
+            if (_flaxType.IsAssignableFrom(type) || (type.IsInterface && hasObjectInterfaceReferenceAttribute))
+            {
+                jsonProperty.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+                jsonProperty.Converter = JsonSerializer.ObjectConverter;
+            }
+            if (hasObjectInterfaceReferenceAttribute && GetCollectionItemType(type)?.IsInterface == true)
+            {
+                jsonProperty.ItemReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+                jsonProperty.ItemConverter = JsonSerializer.ObjectConverter;
+            }
+        }
+
+        private sealed class InterfaceObjectReferenceConverter : JsonConverter
+        {
+            public override unsafe void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+            {
+                if (value is Object obj)
+                {
+                    var id = obj.ID;
+                    writer.WriteValue(JsonSerializer.GetStringID(&id));
+                }
+                else if (value == null)
+                {
+                    writer.WriteNull();
+                }
+                else
+                {
+                    serializer.Serialize(writer, value, value.GetType());
+                }
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.String && JsonSerializer.TryParseID((string)reader.Value, out var id))
+                {
+                    return Object.Find(ref id, objectType, true);
+                }
+                if (reader.TokenType == JsonToken.Null)
+                    return null;
+                // objectType is the same interface item type that selected this converter. Passing it back to
+                // Newtonsoft can cause this converter to be chosen again and recurse until the stack overflows.
+                return Newtonsoft.Json.Linq.JToken.Load(reader).ToObject<object>(serializer);
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType.IsInterface;
+            }
+        }
+
         /// <inheritdoc />
         protected override JsonContract CreateContract(Type objectType)
         {
@@ -48,9 +131,21 @@ namespace FlaxEngine.Json.JsonCustomSerializers
         }
 
         /// <inheritdoc />
+        protected override JsonArrayContract CreateArrayContract(Type objectType)
+        {
+            var contract = base.CreateArrayContract(objectType);
+
+            SetupInterfaceObjectReferenceItems(contract, contract.CollectionItemType);
+
+            return contract;
+        }
+
+        /// <inheritdoc />
         protected override JsonDictionaryContract CreateDictionaryContract(Type objectType)
         {
             var contract = base.CreateDictionaryContract(objectType);
+
+            SetupInterfaceObjectReferenceItems(contract, contract.DictionaryValueType);
 
             // Override contract to save enums keys as integer
             if (contract.DictionaryKeyType?.IsEnum ?? false)
@@ -108,11 +203,7 @@ namespace FlaxEngine.Json.JsonCustomSerializers
                 jsonProperty.Writable = true;
                 jsonProperty.Readable = true;
 
-                if (_flaxType.IsAssignableFrom(f.FieldType))
-                {
-                    jsonProperty.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
-                    jsonProperty.Converter = JsonSerializer.ObjectConverter;
-                }
+                SetupObjectReferenceProperty(jsonProperty, f.FieldType, attributes);
 
                 result.Add(jsonProperty);
             }
@@ -151,11 +242,7 @@ namespace FlaxEngine.Json.JsonCustomSerializers
                 jsonProperty.Writable = true;
                 jsonProperty.Readable = !isObsolete;
 
-                if (_flaxType.IsAssignableFrom(p.PropertyType))
-                {
-                    jsonProperty.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
-                    jsonProperty.Converter = JsonSerializer.ObjectConverter;
-                }
+                SetupObjectReferenceProperty(jsonProperty, p.PropertyType, attributes);
 
                 result.Add(jsonProperty);
             }

--- a/Source/Engine/Serialization/JsonSerializer.cs
+++ b/Source/Engine/Serialization/JsonSerializer.cs
@@ -619,82 +619,71 @@ namespace FlaxEngine.Json
         }
 
         /// <summary>
+        /// Tries to parse the given object identifier represented in the internal serialization format.
+        /// </summary>
+        /// <param name="str">The ID string.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>True if parsing succeeded, otherwise false.</returns>
+        public static unsafe bool TryParseID(string str, out Guid id)
+        {
+            id = Guid.Empty;
+            if (str == null || str.Length != 32)
+                return false;
+
+            GuidInterop g;
+            if (!TryParseHex(str, 0, 8, out g.A) ||
+                !TryParseHex(str, 8, 8, out g.B) ||
+                !TryParseHex(str, 16, 8, out g.C) ||
+                !TryParseHex(str, 24, 8, out g.D))
+            {
+                return false;
+            }
+
+            id = *(Guid*)&g;
+            return true;
+        }
+
+        /// <summary>
         /// Parses the given object identifier represented in the internal serialization format.
         /// </summary>
         /// <param name="str">The ID string.</param>
         /// <param name="id">The identifier.</param>
         public static unsafe void ParseID(string str, out Guid id)
         {
-            GuidInterop g;
-
-            // Broken after VS 15.5
-            /*fixed (char* a = str)
-            {
-                char* b = a + 8;
-                char* c = b + 8;
-                char* d = c + 8;
-
-                ParseHex(a, 8, out g.A);
-                ParseHex(b, 8, out g.B);
-                ParseHex(c, 8, out g.C);
-                ParseHex(d, 8, out g.D);
-            }*/
-
-            // Temporary fix (not using raw char* pointer)
-            ParseHex(str, 0, 8, out g.A);
-            ParseHex(str, 8, 8, out g.B);
-            ParseHex(str, 16, 8, out g.C);
-            ParseHex(str, 24, 8, out g.D);
-
-            id = *(Guid*)&g;
+            TryParseID(str, out id);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ParseHex(char* str, int length, out uint result)
         {
-            uint sum = 0;
-            char* p = str;
-            char* end = str + length;
-
-            if (*p == '0' && *(p + 1) == 'x')
-                p += 2;
-
-            while (p < end && *p != 0)
-            {
-                int c = *p - '0';
-
-                if (c < 0 || c > 9)
-                {
-                    c = char.ToLower(*p) - 'a' + 10;
-                    if (c < 10 || c > 15)
-                    {
-                        result = 0;
-                        return;
-                    }
-                }
-
-                sum = 16 * sum + (uint)c;
-
-                p++;
-            }
-
-            result = sum;
+            TryParseHex(new ReadOnlySpan<char>(str, length), out result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ParseHex(string str, int start, int length, out uint result)
         {
-            uint sum = 0;
-            int p = start;
-            int end = start + length;
+            TryParseHex(str, start, length, out result);
+        }
 
-            if (str.Length < end)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryParseHex(string str, int start, int length, out uint result)
+        {
+            if (str.Length < start + length)
             {
                 result = 0;
-                return;
+                return false;
             }
+            return TryParseHex(str.AsSpan(start, length), out result);
+        }
 
-            if (str[p] == '0' && str[p + 1] == 'x')
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryParseHex(ReadOnlySpan<char> str, out uint result)
+        {
+            uint sum = 0;
+            int p = 0;
+            int end = str.Length;
+
+            if (p + 1 < end && str[p] == '0' && str[p + 1] == 'x')
                 p += 2;
 
             while (p < end && str[p] != 0)
@@ -707,7 +696,7 @@ namespace FlaxEngine.Json
                     if (c < 10 || c > 15)
                     {
                         result = 0;
-                        return;
+                        return false;
                     }
                 }
 
@@ -717,6 +706,7 @@ namespace FlaxEngine.Json
             }
 
             result = sum;
+            return p == end;
         }
     }
 }

--- a/Source/Engine/Serialization/ReadStream.h
+++ b/Source/Engine/Serialization/ReadStream.h
@@ -134,7 +134,23 @@ public:
     }
 
     template<typename T>
+    FORCE_INLINE void Read(ScriptingObjectInterfaceReference<T>& v)
+    {
+        uint32 id[4];
+        ReadBytes(id, sizeof(id));
+        v = *(Guid*)id;
+    }
+
+    template<typename T>
     FORCE_INLINE void Read(SoftObjectReference<T>& v)
+    {
+        uint32 id[4];
+        ReadBytes(id, sizeof(id));
+        v.Set(*(Guid*)id);
+    }
+
+    template<typename T>
+    FORCE_INLINE void Read(SoftObjectInterfaceReference<T>& v)
     {
         uint32 id[4];
         ReadBytes(id, sizeof(id));

--- a/Source/Engine/Serialization/Serialization.h
+++ b/Source/Engine/Serialization/Serialization.h
@@ -14,7 +14,11 @@ struct VariantType;
 template<typename T>
 class ScriptingObjectReference;
 template<typename T>
+class ScriptingObjectInterfaceReference;
+template<typename T>
 class SoftObjectReference;
+template<typename T>
+class SoftObjectInterfaceReference;
 template<typename T>
 class AssetReference;
 template<typename T>
@@ -454,7 +458,6 @@ namespace Serialization
     }
 
     FLAXENGINE_API bool ShouldSerializeRef(const SceneObject* v, const SceneObject* other);
-
     template<typename T>
     inline typename TEnableIf<TAnd<TIsBaseOf<ScriptingObject, T>, TNot<TIsBaseOf<SceneObject, T>>>::Value, bool>::Type ShouldSerialize(const T* v, const void* otherObj)
     {
@@ -470,7 +473,7 @@ namespace Serialization
     {
         Guid id;
         Deserialize(stream, id, modifier);
-		modifier->IdsMapping.TryGet(id, id);
+        modifier->IdsMapping.TryGet(id, id);
         v = (T*)::FindObject(id, T::GetStaticClass());
     }
 
@@ -497,7 +500,28 @@ namespace Serialization
     {
         Guid id;
         Deserialize(stream, id, modifier);
-		modifier->IdsMapping.TryGet(id, id);
+        modifier->IdsMapping.TryGet(id, id);
+        v = id;
+    }
+
+    // Scripting Interface Reference
+
+    template<typename T>
+    inline bool ShouldSerialize(const ScriptingObjectInterfaceReference<T>& v, const void* otherObj)
+    {
+        return !otherObj || ShouldSerializeRef(v.GetObject(), ((ScriptingObjectInterfaceReference<T>*)otherObj)->GetObject());
+    }
+    template<typename T>
+    inline void Serialize(ISerializable::SerializeStream& stream, const ScriptingObjectInterfaceReference<T>& v, const void* otherObj)
+    {
+        stream.Guid(v.GetID());
+    }
+    template<typename T>
+    inline void Deserialize(ISerializable::DeserializeStream& stream, ScriptingObjectInterfaceReference<T>& v, ISerializeModifier* modifier)
+    {
+        Guid id;
+        Deserialize(stream, id, modifier);
+        modifier->IdsMapping.TryGet(id, id);
         v = id;
     }
 
@@ -518,7 +542,28 @@ namespace Serialization
     {
         Guid id;
         Deserialize(stream, id, modifier);
-		modifier->IdsMapping.TryGet(id, id);
+        modifier->IdsMapping.TryGet(id, id);
+        v = id;
+    }
+
+    // Soft Object Interface Reference
+
+    template<typename T>
+    inline bool ShouldSerialize(const SoftObjectInterfaceReference<T>& v, const void* otherObj)
+    {
+        return !otherObj || ShouldSerializeRef(v.GetObject(), ((SoftObjectInterfaceReference<T>*)otherObj)->GetObject());
+    }
+    template<typename T>
+    inline void Serialize(ISerializable::SerializeStream& stream, const SoftObjectInterfaceReference<T>& v, const void* otherObj)
+    {
+        stream.Guid(v.GetID());
+    }
+    template<typename T>
+    inline void Deserialize(ISerializable::DeserializeStream& stream, SoftObjectInterfaceReference<T>& v, ISerializeModifier* modifier)
+    {
+        Guid id;
+        Deserialize(stream, id, modifier);
+        modifier->IdsMapping.TryGet(id, id);
         v = id;
     }
 

--- a/Source/Engine/Serialization/Stream.h
+++ b/Source/Engine/Serialization/Stream.h
@@ -17,7 +17,11 @@ class ScriptingObject;
 template<typename T>
 class ScriptingObjectReference;
 template<typename T>
+class ScriptingObjectInterfaceReference;
+template<typename T>
 class SoftObjectReference;
+template<typename T>
+class SoftObjectInterfaceReference;
 template<typename T>
 class AssetReference;
 template<typename T>

--- a/Source/Engine/Serialization/WriteStream.h
+++ b/Source/Engine/Serialization/WriteStream.h
@@ -156,11 +156,29 @@ public:
     {
         Write(v.Get());
     }
+
+    template<typename T>
+    FORCE_INLINE void Write(const ScriptingObjectInterfaceReference<T>& v)
+    {
+        uint32 id[4];
+        v.CopyID(id);
+        WriteBytes(id, sizeof(id));
+    }
+
     template<typename T>
     FORCE_INLINE void Write(const SoftObjectReference<T>& v)
     {
         Write(v.Get());
     }
+
+    template<typename T>
+    FORCE_INLINE void Write(const SoftObjectInterfaceReference<T>& v)
+    {
+        uint32 id[4];
+        v.CopyID(id);
+        WriteBytes(id, sizeof(id));
+    }
+
     template<typename T>
     FORCE_INLINE void Write(const AssetReference<T>& v)
     {

--- a/Source/Engine/Tests/TestScripting.h
+++ b/Source/Engine/Tests/TestScripting.h
@@ -6,6 +6,8 @@
 #include "Engine/Core/Math/Vector3.h"
 #include "Engine/Core/Collections/Array.h"
 #include "Engine/Scripting/ScriptingObject.h"
+#include "Engine/Scripting/ScriptingObjectInterfaceReference.h"
+#include "Engine/Scripting/SoftObjectInterfaceReference.h"
 #include "Engine/Scripting/SerializableScriptingObject.h"
 #include "Engine/Scripting/SoftTypeReference.h"
 #include "Engine/Content/SceneReference.h"
@@ -177,6 +179,10 @@ public:
 
     // Test struct
     API_FIELD() TestStruct SimpleStruct;
+    // Test interface reference
+    API_FIELD() ScriptingObjectInterfaceReference<ITestInterface> InterfaceRef;
+    // Test soft interface reference
+    API_FIELD() SoftObjectInterfaceReference<ITestInterface> SoftInterfaceRef;
 
     // Test event
     API_EVENT() Delegate<int32, Float3, const String&, String&, TestStruct&, const Array<TestStruct>&, Array<TestStruct>&> SimpleEvent;

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -108,7 +108,7 @@ namespace Flax.Build.Bindings
                 if (attribute && valueType != null && !valueType.IsArray)
                 {
                     //if (valueType.Type == "")
-                    //ScriptingObjectReference
+                    //ScriptingObjectReference, ScriptingObjectInterfaceReference, SoftObjectInterfaceReference
                     apiType = FindApiTypeInfo(buildData, valueType, caller);
 
                     // Object reference
@@ -350,6 +350,10 @@ namespace Flax.Build.Bindings
             if (CSharpNativeToManagedDefault.TryGetValue(typeInfo.Type, out result))
                 return result;
 
+            // Interface reference property
+            if (typeInfo.IsInterfaceRef)
+                return marshalling ? "IntPtr" : GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[0], caller, marshalling);
+
             // Object reference property
             if (typeInfo.IsObjectRef)
                 return GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[0], caller, marshalling);
@@ -556,6 +560,10 @@ namespace Flax.Build.Bindings
                 }
                 return string.Empty;
             default:
+                // Interface reference property
+                if (typeInfo.IsInterfaceRef)
+                    return string.Format("FlaxEngine.Object.GetUnmanagedInterface({{0}}, typeof({0}))", GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[0], caller));
+
                 var apiType = FindApiTypeInfo(buildData, typeInfo, caller);
                 if (apiType != null)
                 {
@@ -778,8 +786,16 @@ namespace Flax.Build.Bindings
                 }
             }
 #endif
+            const string interfaceResultName = "__interfaceResult";
+
+            var returnInterfaceRef = !functionInfo.Glue.UseReferenceForResult && functionInfo.ReturnType.IsInterfaceRef;
+
             if (functionInfo.Glue.UseReferenceForResult)
             {
+            }
+            else if (returnInterfaceRef)
+            {
+                contents.Append("var ").Append(interfaceResultName).Append(" = ");
             }
             else if (!functionInfo.ReturnType.IsVoid)
             {
@@ -851,6 +867,11 @@ namespace Flax.Build.Bindings
             }
 
             contents.Append(')');
+            if (returnInterfaceRef)
+            {
+                var managedType = GenerateCSharpNativeToManaged(buildData, functionInfo.ReturnType.GenericArgs[0], caller);
+                contents.Append("; return ").Append(interfaceResultName).Append(" != IntPtr.Zero ? Unsafe.As<").Append(managedType).Append(">(ManagedHandle.FromIntPtr(").Append(interfaceResultName).Append(").Target) : null");
+            }
             if ((functionInfo.ReturnType.Type == "Array" || functionInfo.ReturnType.Type == "Span" || functionInfo.ReturnType.Type == "DataContainer") && functionInfo.ReturnType.GenericArgs != null)
             {
                 // Convert array that uses different type for marshalling
@@ -987,6 +1008,12 @@ namespace Flax.Build.Bindings
         private static void GenerateCSharpAttributes(BuildData buildData, StringBuilder contents, string indent, ApiTypeInfo apiTypeInfo, MemberInfo memberInfo, bool useUnmanaged, string defaultValue = null, TypeInfo defaultValueType = null)
         {
             GenerateCSharpAttributes(buildData, contents, indent, apiTypeInfo, memberInfo.Attributes, memberInfo.Comment, true, useUnmanaged, defaultValue, memberInfo.DeprecatedMessage, defaultValueType);
+            var memberType = (memberInfo as FieldInfo)?.Type ?? (memberInfo as PropertyInfo)?.Type;
+            if (memberType != null && memberType.IsInterfaceRef)
+            {
+                var attribute = memberType.Type == "SoftObjectInterfaceReference" ? "SoftObjectInterfaceReference" : "ScriptingObjectInterfaceReference";
+                contents.Append(indent).Append("[FlaxEngine.").Append(attribute).AppendLine("]");
+            }
         }
 
         private static bool GenerateCSharpStructureUseDefaultInitialize(BuildData buildData, StructureInfo structureInfo)

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -315,6 +315,83 @@ namespace Flax.Build.Bindings
             return value;
         }
 
+        private static bool IsInterfaceRefArrayLike(TypeInfo typeInfo)
+        {
+            return typeInfo != null &&
+                   (typeInfo.Type == "Array" || typeInfo.Type == "Span" || typeInfo.Type == "DataContainer") &&
+                   typeInfo.GenericArgs != null &&
+                   typeInfo.GenericArgs.Count != 0 &&
+                   typeInfo.GenericArgs[0].IsInterfaceRef;
+        }
+
+        private static bool IsInterfaceRefDictionary(TypeInfo typeInfo)
+        {
+            return typeInfo != null &&
+                   typeInfo.Type == "Dictionary" &&
+                   typeInfo.GenericArgs != null &&
+                   typeInfo.GenericArgs.Count == 2 &&
+                   (typeInfo.GenericArgs[0].IsInterfaceRef || typeInfo.GenericArgs[1].IsInterfaceRef);
+        }
+
+        private static bool IsInterfaceRefContainer(TypeInfo typeInfo)
+        {
+            return IsInterfaceRefArrayLike(typeInfo) || IsInterfaceRefDictionary(typeInfo);
+        }
+
+        private static TypeInfo GetInterfaceRefElementType(TypeInfo typeInfo)
+        {
+            if (typeInfo == null)
+                return null;
+            if (typeInfo.IsInterfaceRef)
+                return typeInfo;
+            if (IsInterfaceRefArrayLike(typeInfo))
+                return typeInfo.GenericArgs[0];
+            if (IsInterfaceRefDictionary(typeInfo))
+                return typeInfo.GenericArgs[1].IsInterfaceRef ? typeInfo.GenericArgs[1] : typeInfo.GenericArgs[0];
+            return null;
+        }
+
+        private static string GenerateInterfaceRefToNative(BuildData buildData, TypeInfo interfaceRefType, ApiTypeInfo caller, string value)
+        {
+            return $"FlaxEngine.Object.GetUnmanagedInterface({value}, typeof({GenerateCSharpNativeToManaged(buildData, interfaceRefType.GenericArgs[0], caller)}))";
+        }
+
+        private static string GenerateInterfaceRefToManaged(BuildData buildData, TypeInfo interfaceRefType, ApiTypeInfo caller, string value, bool fromHandle)
+        {
+            var managedType = GenerateCSharpNativeToManaged(buildData, interfaceRefType.GenericArgs[0], caller);
+            return fromHandle
+                ? $"{value} != IntPtr.Zero ? Unsafe.As<{managedType}>(ManagedHandle.FromIntPtr({value}).Target) : null"
+                : $"{value} != null ? Unsafe.As<{managedType}>({value}) : null";
+        }
+
+        private static string GenerateInterfaceRefContainerToNative(TypeInfo typeInfo)
+        {
+            if (IsInterfaceRefArrayLike(typeInfo))
+                return "{0} != null ? FlaxEngine.Interop.NativeInterop.ManagedArrayToGCHandleArray({0}) : null";
+            if (IsInterfaceRefDictionary(typeInfo))
+            {
+                var keyConverter = typeInfo.GenericArgs[0].IsInterfaceRef ? "(object)x.Key" : "x.Key";
+                var valueConverter = typeInfo.GenericArgs[1].IsInterfaceRef ? "(object)x.Value" : "x.Value";
+                return $"{{0}} != null ? System.Linq.Enumerable.ToDictionary({{0}}, x => {keyConverter}, x => {valueConverter}) : null";
+            }
+            return string.Empty;
+        }
+
+        private static string GenerateInterfaceRefContainerToManaged(BuildData buildData, TypeInfo typeInfo, ApiTypeInfo caller, string value)
+        {
+            if (IsInterfaceRefArrayLike(typeInfo))
+                return $"{value}?.ConvertArray(x => {GenerateInterfaceRefToManaged(buildData, typeInfo.GenericArgs[0], caller, "x", true)})";
+            if (IsInterfaceRefDictionary(typeInfo))
+            {
+                var keyTypeInfo = typeInfo.GenericArgs[0];
+                var valueTypeInfo = typeInfo.GenericArgs[1];
+                var keyConverter = keyTypeInfo.IsInterfaceRef ? GenerateInterfaceRefToManaged(buildData, keyTypeInfo, caller, "x.Key", false) : "x.Key";
+                var valueConverter = valueTypeInfo.IsInterfaceRef ? GenerateInterfaceRefToManaged(buildData, valueTypeInfo, caller, "x.Value", false) : "x.Value";
+                return $"{value} != null ? System.Linq.Enumerable.ToDictionary({value}, x => {keyConverter}, x => {valueConverter}) : null";
+            }
+            return value;
+        }
+
         private static string GenerateCSharpNativeToManaged(BuildData buildData, TypeInfo typeInfo, ApiTypeInfo caller, bool marshalling = false)
         {
             string result;
@@ -554,29 +631,25 @@ namespace Flax.Build.Bindings
             case "Array":
             case "Span":
             case "DataContainer":
+                if (IsInterfaceRefArrayLike(typeInfo))
+                    return GenerateInterfaceRefContainerToNative(typeInfo);
                 if (typeInfo.GenericArgs != null)
                 {
                     // Convert array that uses different type for marshalling
                     var arrayTypeInfo = typeInfo.GenericArgs[0];
-                    if (arrayTypeInfo.IsInterfaceRef)
-                        return "{0} != null ? FlaxEngine.Interop.NativeInterop.ManagedArrayToGCHandleArray({0}) : null";
                     var arrayApiType = FindApiTypeInfo(buildData, arrayTypeInfo, caller);
                     if (arrayApiType != null && arrayApiType.MarshalAs != null)
                         return $"{{0}}.ConvertArray(x => ({GenerateCSharpNativeToManaged(buildData, arrayApiType.MarshalAs, caller)})x)";
                 }
                 return string.Empty;
             case "Dictionary":
-                if (typeInfo.GenericArgs != null && typeInfo.GenericArgs.Count == 2 && (typeInfo.GenericArgs[0].IsInterfaceRef || typeInfo.GenericArgs[1].IsInterfaceRef))
-                {
-                    var keyConverter = typeInfo.GenericArgs[0].IsInterfaceRef ? "(object)x.Key" : "x.Key";
-                    var valueConverter = typeInfo.GenericArgs[1].IsInterfaceRef ? "(object)x.Value" : "x.Value";
-                    return $"{{0}} != null ? System.Linq.Enumerable.ToDictionary({{0}}, x => {keyConverter}, x => {valueConverter}) : null";
-                }
+                if (IsInterfaceRefDictionary(typeInfo))
+                    return GenerateInterfaceRefContainerToNative(typeInfo);
                 return string.Empty;
             default:
                 // Interface reference property
                 if (typeInfo.IsInterfaceRef)
-                    return string.Format("FlaxEngine.Object.GetUnmanagedInterface({{0}}, typeof({0}))", GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[0], caller));
+                    return GenerateInterfaceRefToNative(buildData, typeInfo, caller, "{0}");
 
                 var apiType = FindApiTypeInfo(buildData, typeInfo, caller);
                 if (apiType != null)
@@ -801,20 +874,10 @@ namespace Flax.Build.Bindings
             }
 #endif
             const string interfaceResultName = "__interfaceResult";
-            const string interfaceArrayResultName = "__interfaceArrayResult";
-            const string interfaceDictionaryResultName = "__interfaceDictionaryResult";
+            const string interfaceContainerResultName = "__interfaceContainerResult";
 
             var returnInterfaceRef = !functionInfo.Glue.UseReferenceForResult && functionInfo.ReturnType.IsInterfaceRef;
-            var returnInterfaceRefArray = !functionInfo.Glue.UseReferenceForResult &&
-                                          (functionInfo.ReturnType.Type == "Array" || functionInfo.ReturnType.Type == "Span" || functionInfo.ReturnType.Type == "DataContainer") &&
-                                          functionInfo.ReturnType.GenericArgs != null &&
-                                          functionInfo.ReturnType.GenericArgs.Count != 0 &&
-                                          functionInfo.ReturnType.GenericArgs[0].IsInterfaceRef;
-            var returnInterfaceRefDictionary = !functionInfo.Glue.UseReferenceForResult &&
-                                               functionInfo.ReturnType.Type == "Dictionary" &&
-                                               functionInfo.ReturnType.GenericArgs != null &&
-                                               functionInfo.ReturnType.GenericArgs.Count == 2 &&
-                                               (functionInfo.ReturnType.GenericArgs[0].IsInterfaceRef || functionInfo.ReturnType.GenericArgs[1].IsInterfaceRef);
+            var returnInterfaceRefContainer = !functionInfo.Glue.UseReferenceForResult && IsInterfaceRefContainer(functionInfo.ReturnType);
 
             if (functionInfo.Glue.UseReferenceForResult)
             {
@@ -823,13 +886,9 @@ namespace Flax.Build.Bindings
             {
                 contents.Append("var ").Append(interfaceResultName).Append(" = ");
             }
-            else if (returnInterfaceRefArray)
+            else if (returnInterfaceRefContainer)
             {
-                contents.Append("var ").Append(interfaceArrayResultName).Append(" = ");
-            }
-            else if (returnInterfaceRefDictionary)
-            {
-                contents.Append("var ").Append(interfaceDictionaryResultName).Append(" = ");
+                contents.Append("var ").Append(interfaceContainerResultName).Append(" = ");
             }
             else if (!functionInfo.ReturnType.IsVoid)
             {
@@ -903,21 +962,11 @@ namespace Flax.Build.Bindings
             contents.Append(')');
             if (returnInterfaceRef)
             {
-                var managedType = GenerateCSharpNativeToManaged(buildData, functionInfo.ReturnType.GenericArgs[0], caller);
-                contents.Append("; return ").Append(interfaceResultName).Append(" != IntPtr.Zero ? Unsafe.As<").Append(managedType).Append(">(ManagedHandle.FromIntPtr(").Append(interfaceResultName).Append(").Target) : null");
+                contents.Append("; return ").Append(GenerateInterfaceRefToManaged(buildData, functionInfo.ReturnType, caller, interfaceResultName, true));
             }
-            else if (returnInterfaceRefArray)
+            else if (returnInterfaceRefContainer)
             {
-                var managedType = GenerateCSharpNativeToManaged(buildData, functionInfo.ReturnType.GenericArgs[0].GenericArgs[0], caller);
-                contents.Append("; return ").Append(interfaceArrayResultName).Append("?.ConvertArray(x => x != IntPtr.Zero ? Unsafe.As<").Append(managedType).Append(">(ManagedHandle.FromIntPtr(x).Target) : null)");
-            }
-            else if (returnInterfaceRefDictionary)
-            {
-                var keyTypeInfo = functionInfo.ReturnType.GenericArgs[0];
-                var valueTypeInfo = functionInfo.ReturnType.GenericArgs[1];
-                var keyConverter = keyTypeInfo.IsInterfaceRef ? $"x.Key != null ? Unsafe.As<{GenerateCSharpNativeToManaged(buildData, keyTypeInfo.GenericArgs[0], caller)}>(x.Key) : null" : "x.Key";
-                var valueConverter = valueTypeInfo.IsInterfaceRef ? $"x.Value != null ? Unsafe.As<{GenerateCSharpNativeToManaged(buildData, valueTypeInfo.GenericArgs[0], caller)}>(x.Value) : null" : "x.Value";
-                contents.Append("; return ").Append(interfaceDictionaryResultName).Append(" != null ? System.Linq.Enumerable.ToDictionary(").Append(interfaceDictionaryResultName).Append(", x => ").Append(keyConverter).Append(", x => ").Append(valueConverter).Append(") : null");
+                contents.Append("; return ").Append(GenerateInterfaceRefContainerToManaged(buildData, functionInfo.ReturnType, caller, interfaceContainerResultName));
             }
             else if ((functionInfo.ReturnType.Type == "Array" || functionInfo.ReturnType.Type == "Span" || functionInfo.ReturnType.Type == "DataContainer") && functionInfo.ReturnType.GenericArgs != null)
             {
@@ -1056,22 +1105,8 @@ namespace Flax.Build.Bindings
         {
             GenerateCSharpAttributes(buildData, contents, indent, apiTypeInfo, memberInfo.Attributes, memberInfo.Comment, true, useUnmanaged, defaultValue, memberInfo.DeprecatedMessage, defaultValueType);
             var memberType = (memberInfo as FieldInfo)?.Type ?? (memberInfo as PropertyInfo)?.Type;
-            var interfaceRefType = memberType;
-            if ((memberType?.Type == "Array" || memberType?.Type == "Span" || memberType?.Type == "DataContainer") &&
-                memberType.GenericArgs != null &&
-                memberType.GenericArgs.Count != 0 &&
-                memberType.GenericArgs[0].IsInterfaceRef)
-            {
-                interfaceRefType = memberType.GenericArgs[0];
-            }
-            else if (memberType?.Type == "Dictionary" &&
-                     memberType.GenericArgs != null &&
-                     memberType.GenericArgs.Count == 2 &&
-                     (memberType.GenericArgs[0].IsInterfaceRef || memberType.GenericArgs[1].IsInterfaceRef))
-            {
-                interfaceRefType = memberType.GenericArgs[1].IsInterfaceRef ? memberType.GenericArgs[1] : memberType.GenericArgs[0];
-            }
-            if (interfaceRefType != null && interfaceRefType.IsInterfaceRef)
+            var interfaceRefType = GetInterfaceRefElementType(memberType);
+            if (interfaceRefType != null)
             {
                 var attribute = interfaceRefType.Type == "SoftObjectInterfaceReference" ? "SoftObjectInterfaceReference" : "ScriptingObjectInterfaceReference";
                 contents.Append(indent).Append("[FlaxEngine.").Append(attribute).AppendLine("]");

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.CSharp.cs
@@ -375,12 +375,16 @@ namespace Flax.Build.Bindings
                     if (arrayApiType != null && arrayApiType.MarshalAs != null)
                         arrayTypeInfo = arrayApiType.MarshalAs;
                 }
-                return GenerateCSharpNativeToManaged(buildData, arrayTypeInfo, caller) + "[]";
+                return GenerateCSharpNativeToManaged(buildData, arrayTypeInfo, caller, marshalling) + "[]";
             }
 
             // Dictionary
             if (typeInfo.Type == "Dictionary" && typeInfo.GenericArgs != null)
-                return string.Format("System.Collections.Generic.Dictionary<{0}, {1}>", GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[0], caller, marshalling), GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[1], caller, marshalling));
+            {
+                var keyType = marshalling && typeInfo.GenericArgs[0].IsInterfaceRef ? "object" : GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[0], caller, marshalling);
+                var valueType = marshalling && typeInfo.GenericArgs[1].IsInterfaceRef ? "object" : GenerateCSharpNativeToManaged(buildData, typeInfo.GenericArgs[1], caller, marshalling);
+                return string.Format("System.Collections.Generic.Dictionary<{0}, {1}>", keyType, valueType);
+            }
 
             // HashSet
             if (typeInfo.Type == "HashSet" && typeInfo.GenericArgs != null)
@@ -554,9 +558,19 @@ namespace Flax.Build.Bindings
                 {
                     // Convert array that uses different type for marshalling
                     var arrayTypeInfo = typeInfo.GenericArgs[0];
+                    if (arrayTypeInfo.IsInterfaceRef)
+                        return "{0} != null ? FlaxEngine.Interop.NativeInterop.ManagedArrayToGCHandleArray({0}) : null";
                     var arrayApiType = FindApiTypeInfo(buildData, arrayTypeInfo, caller);
                     if (arrayApiType != null && arrayApiType.MarshalAs != null)
                         return $"{{0}}.ConvertArray(x => ({GenerateCSharpNativeToManaged(buildData, arrayApiType.MarshalAs, caller)})x)";
+                }
+                return string.Empty;
+            case "Dictionary":
+                if (typeInfo.GenericArgs != null && typeInfo.GenericArgs.Count == 2 && (typeInfo.GenericArgs[0].IsInterfaceRef || typeInfo.GenericArgs[1].IsInterfaceRef))
+                {
+                    var keyConverter = typeInfo.GenericArgs[0].IsInterfaceRef ? "(object)x.Key" : "x.Key";
+                    var valueConverter = typeInfo.GenericArgs[1].IsInterfaceRef ? "(object)x.Value" : "x.Value";
+                    return $"{{0}} != null ? System.Linq.Enumerable.ToDictionary({{0}}, x => {keyConverter}, x => {valueConverter}) : null";
                 }
                 return string.Empty;
             default:
@@ -787,8 +801,20 @@ namespace Flax.Build.Bindings
             }
 #endif
             const string interfaceResultName = "__interfaceResult";
+            const string interfaceArrayResultName = "__interfaceArrayResult";
+            const string interfaceDictionaryResultName = "__interfaceDictionaryResult";
 
             var returnInterfaceRef = !functionInfo.Glue.UseReferenceForResult && functionInfo.ReturnType.IsInterfaceRef;
+            var returnInterfaceRefArray = !functionInfo.Glue.UseReferenceForResult &&
+                                          (functionInfo.ReturnType.Type == "Array" || functionInfo.ReturnType.Type == "Span" || functionInfo.ReturnType.Type == "DataContainer") &&
+                                          functionInfo.ReturnType.GenericArgs != null &&
+                                          functionInfo.ReturnType.GenericArgs.Count != 0 &&
+                                          functionInfo.ReturnType.GenericArgs[0].IsInterfaceRef;
+            var returnInterfaceRefDictionary = !functionInfo.Glue.UseReferenceForResult &&
+                                               functionInfo.ReturnType.Type == "Dictionary" &&
+                                               functionInfo.ReturnType.GenericArgs != null &&
+                                               functionInfo.ReturnType.GenericArgs.Count == 2 &&
+                                               (functionInfo.ReturnType.GenericArgs[0].IsInterfaceRef || functionInfo.ReturnType.GenericArgs[1].IsInterfaceRef);
 
             if (functionInfo.Glue.UseReferenceForResult)
             {
@@ -796,6 +822,14 @@ namespace Flax.Build.Bindings
             else if (returnInterfaceRef)
             {
                 contents.Append("var ").Append(interfaceResultName).Append(" = ");
+            }
+            else if (returnInterfaceRefArray)
+            {
+                contents.Append("var ").Append(interfaceArrayResultName).Append(" = ");
+            }
+            else if (returnInterfaceRefDictionary)
+            {
+                contents.Append("var ").Append(interfaceDictionaryResultName).Append(" = ");
             }
             else if (!functionInfo.ReturnType.IsVoid)
             {
@@ -872,7 +906,20 @@ namespace Flax.Build.Bindings
                 var managedType = GenerateCSharpNativeToManaged(buildData, functionInfo.ReturnType.GenericArgs[0], caller);
                 contents.Append("; return ").Append(interfaceResultName).Append(" != IntPtr.Zero ? Unsafe.As<").Append(managedType).Append(">(ManagedHandle.FromIntPtr(").Append(interfaceResultName).Append(").Target) : null");
             }
-            if ((functionInfo.ReturnType.Type == "Array" || functionInfo.ReturnType.Type == "Span" || functionInfo.ReturnType.Type == "DataContainer") && functionInfo.ReturnType.GenericArgs != null)
+            else if (returnInterfaceRefArray)
+            {
+                var managedType = GenerateCSharpNativeToManaged(buildData, functionInfo.ReturnType.GenericArgs[0].GenericArgs[0], caller);
+                contents.Append("; return ").Append(interfaceArrayResultName).Append("?.ConvertArray(x => x != IntPtr.Zero ? Unsafe.As<").Append(managedType).Append(">(ManagedHandle.FromIntPtr(x).Target) : null)");
+            }
+            else if (returnInterfaceRefDictionary)
+            {
+                var keyTypeInfo = functionInfo.ReturnType.GenericArgs[0];
+                var valueTypeInfo = functionInfo.ReturnType.GenericArgs[1];
+                var keyConverter = keyTypeInfo.IsInterfaceRef ? $"x.Key != null ? Unsafe.As<{GenerateCSharpNativeToManaged(buildData, keyTypeInfo.GenericArgs[0], caller)}>(x.Key) : null" : "x.Key";
+                var valueConverter = valueTypeInfo.IsInterfaceRef ? $"x.Value != null ? Unsafe.As<{GenerateCSharpNativeToManaged(buildData, valueTypeInfo.GenericArgs[0], caller)}>(x.Value) : null" : "x.Value";
+                contents.Append("; return ").Append(interfaceDictionaryResultName).Append(" != null ? System.Linq.Enumerable.ToDictionary(").Append(interfaceDictionaryResultName).Append(", x => ").Append(keyConverter).Append(", x => ").Append(valueConverter).Append(") : null");
+            }
+            else if ((functionInfo.ReturnType.Type == "Array" || functionInfo.ReturnType.Type == "Span" || functionInfo.ReturnType.Type == "DataContainer") && functionInfo.ReturnType.GenericArgs != null)
             {
                 // Convert array that uses different type for marshalling
                 var arrayTypeInfo = functionInfo.ReturnType.GenericArgs[0];
@@ -1009,9 +1056,24 @@ namespace Flax.Build.Bindings
         {
             GenerateCSharpAttributes(buildData, contents, indent, apiTypeInfo, memberInfo.Attributes, memberInfo.Comment, true, useUnmanaged, defaultValue, memberInfo.DeprecatedMessage, defaultValueType);
             var memberType = (memberInfo as FieldInfo)?.Type ?? (memberInfo as PropertyInfo)?.Type;
-            if (memberType != null && memberType.IsInterfaceRef)
+            var interfaceRefType = memberType;
+            if ((memberType?.Type == "Array" || memberType?.Type == "Span" || memberType?.Type == "DataContainer") &&
+                memberType.GenericArgs != null &&
+                memberType.GenericArgs.Count != 0 &&
+                memberType.GenericArgs[0].IsInterfaceRef)
             {
-                var attribute = memberType.Type == "SoftObjectInterfaceReference" ? "SoftObjectInterfaceReference" : "ScriptingObjectInterfaceReference";
+                interfaceRefType = memberType.GenericArgs[0];
+            }
+            else if (memberType?.Type == "Dictionary" &&
+                     memberType.GenericArgs != null &&
+                     memberType.GenericArgs.Count == 2 &&
+                     (memberType.GenericArgs[0].IsInterfaceRef || memberType.GenericArgs[1].IsInterfaceRef))
+            {
+                interfaceRefType = memberType.GenericArgs[1].IsInterfaceRef ? memberType.GenericArgs[1] : memberType.GenericArgs[0];
+            }
+            if (interfaceRefType != null && interfaceRefType.IsInterfaceRef)
+            {
+                var attribute = interfaceRefType.Type == "SoftObjectInterfaceReference" ? "SoftObjectInterfaceReference" : "ScriptingObjectInterfaceReference";
                 contents.Append(indent).Append("[FlaxEngine.").Append(attribute).AppendLine("]");
             }
         }

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -167,6 +167,8 @@ namespace Flax.Build.Bindings
                 return $"Variant(StringView({value}))";
             if (typeInfo.Type == "StringAnsi")
                 return $"Variant(StringAnsiView({value}))";
+            if (typeInfo.IsInterfaceRef)
+                return $"Variant({value}.GetObject())";
             if (typeInfo.IsObjectRef)
                 return $"Variant({value}.Get())";
             if (typeInfo.Type == "SoftTypeReference")
@@ -307,6 +309,8 @@ namespace Flax.Build.Bindings
                 return $"((StringView){value}).GetText()"; // (StringView)Variant, if not empty, is guaranteed to point to a null-terminated buffer.
             if (typeInfo.Type == "ScriptingObjectReference" || typeInfo.Type == "SoftObjectReference")
                 return $"ScriptingObject::Cast<{typeInfo.GenericArgs[0].Type}>((ScriptingObject*){value})";
+            if (typeInfo.IsInterfaceRef)
+                return $"ScriptingObject::ToInterface<{typeInfo.GenericArgs[0].Type}>((ScriptingObject*){value})";
             if (typeInfo.IsObjectRef)
                 return $"ScriptingObject::Cast<{typeInfo.GenericArgs[0].Type}>((Asset*){value})";
             if (typeInfo.Type == "SoftTypeReference")
@@ -797,6 +801,19 @@ namespace Flax.Build.Bindings
                 type = "MObject*";
                 return "MUtils::ToNative({0})";
             default:
+                // Interface reference property
+                if (typeInfo.IsInterfaceRef)
+                {
+                    if (CppNonPodTypesConvertingGeneration)
+                    {
+                        type = "MObject*";
+                        return "ScriptingObject::ToInterface<" + typeInfo.GenericArgs[0].Type + ">(ScriptingObject::ToNative({0}))";
+                    }
+
+                    type = typeInfo.GenericArgs[0].Type + '*';
+                    return string.Empty;
+                }
+
                 // Object reference property
                 if (typeInfo.IsObjectRef)
                 {

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -656,8 +656,8 @@ namespace Flax.Build.Bindings
                 {
                     CppIncludeFiles.Add("Engine/Scripting/Internal/ManagedDictionary.h");
                     type = "MObject*";
-                    var keyClass = GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[0], caller, functionInfo);
-                    var valueClass = GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[1], caller, functionInfo);
+                    var keyClass = typeInfo.GenericArgs[0].IsInterfaceRef ? "MCore::TypeCache::Object->GetType()" : GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[0], caller, functionInfo);
+                    var valueClass = typeInfo.GenericArgs[1].IsInterfaceRef ? "MCore::TypeCache::Object->GetType()" : GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[1], caller, functionInfo);
                     return "ManagedDictionary::ToManaged({0}, " + keyClass + ", " + valueClass + ")";
                 }
 
@@ -1023,8 +1023,8 @@ namespace Flax.Build.Bindings
             if (typeInfo.Type == "Dictionary" && typeInfo.GenericArgs != null)
             {
                 CppIncludeFiles.Add("Engine/Scripting/Internal/ManagedDictionary.h");
-                var keyClass = GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[0], caller);
-                var valueClass = GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[1], caller);
+                var keyClass = typeInfo.GenericArgs[0].IsInterfaceRef ? "MCore::TypeCache::Object->GetType()" : GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[0], caller);
+                var valueClass = typeInfo.GenericArgs[1].IsInterfaceRef ? "MCore::TypeCache::Object->GetType()" : GenerateCppGetNativeType(buildData, typeInfo.GenericArgs[1], caller);
                 return $"ManagedDictionary::ToManaged({value}, {keyClass}, {valueClass})";
             }
 

--- a/Source/Tools/Flax.Build/Bindings/ClassInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/ClassInfo.cs
@@ -18,6 +18,8 @@ namespace Flax.Build.Bindings
             "ManagedScriptingObject",
             "PersistentScriptingObject",
             "ScriptingObjectReference",
+            "ScriptingObjectInterfaceReference",
+            "SoftObjectInterfaceReference",
             "AssetReference",
             "BinaryAsset",
             "SceneObject",

--- a/Source/Tools/Flax.Build/Bindings/TypeInfo.cs
+++ b/Source/Tools/Flax.Build/Bindings/TypeInfo.cs
@@ -38,10 +38,18 @@ namespace Flax.Build.Bindings
         /// Gets a value indicating whether this type is a reference to another object.
         /// </summary>
         public bool IsObjectRef => (Type == "ScriptingObjectReference" ||
+                                    Type == "ScriptingObjectInterfaceReference" ||
                                     Type == "AssetReference" ||
                                     Type == "WeakAssetReference" ||
                                     Type == "SoftAssetReference" ||
-                                    Type == "SoftObjectReference") && GenericArgs != null;
+                                    Type == "SoftObjectReference" ||
+                                    Type == "SoftObjectInterfaceReference") && GenericArgs != null;
+
+        /// <summary>
+        /// Gets a value indicating whether this type is a reference to another object filtered by interface.
+        /// </summary>
+        public bool IsInterfaceRef => (Type == "ScriptingObjectInterfaceReference" ||
+                                       Type == "SoftObjectInterfaceReference") && GenericArgs != null;
 
         public TypeInfo()
         {


### PR DESCRIPTION
## Summary

This PR adds interface-based object references for scripting objects:

- `ScriptingObjectInterfaceReference<T>`
- `SoftObjectInterfaceReference<T>`

They work similarly to `ScriptingObjectReference<T>` and `SoftObjectReference<T>`, but the generic type is an interface. The stored object is still represented as a scene object reference/object ID, while access to the value is validated through the requested interface type.

## Details

- Added native hard and soft interface reference wrappers with shared interface validation helpers.
- Added C# editor attributes:
  - `ScriptingObjectInterfaceReferenceAttribute`
  - `SoftObjectInterfaceReferenceAttribute`
- Added bindings generator support for:
  - single interface references
  - array-like containers (`Array`, `Span`, `DataContainer`)
  - dictionaries with interface reference values
- Added editor picker support for interface-typed object references, including collection and dictionary value editors.
- Added JSON serialization/deserialization support for C# interface object references and interface reference collections, so editor undo/snapshots and reloads can preserve selected objects by ID.
- Added `JsonSerializer.TryParseID` and refactored GUID hex parsing to share one checked implementation between `ParseID`, `ParseHex`, and safe interface-reference JSON reads.
- Updated `Object.Find` and `Object.TryFind` to support interface type matching consistently.
- Added managed/native conversion support for interface references and dictionary marshalling.

## Notes

For native code, the new wrappers are intended for API fields/properties such as:

```cpp
API_FIELD() ScriptingObjectInterfaceReference<IMyInterface> Target;
API_FIELD() SoftObjectInterfaceReference<IMyInterface> SoftTarget;
API_FIELD() Array<ScriptingObjectInterfaceReference<IMyInterface>> Targets;
```

For C# scripts, interface object references use attributes on interface-typed fields/properties:

```csharp
[ScriptingObjectInterfaceReference]
public IMyInterface Target;

[ScriptingObjectInterfaceReference]
public List<IMyInterface> Targets;
```