### PR TITLE
Fix discarding unsaved asset editor changes

### DIFF
--- a/Source/Editor/Windows/Assets/AssetEditorWindow.cs
+++ b/Source/Editor/Windows/Assets/AssetEditorWindow.cs
@@ -132,10 +132,22 @@ namespace FlaxEditor.Windows.Assets
                         // Cancel closing
                         return true;
                     }
+                    else
+                    {
+                        // Discard and close
+                        DiscardChanges();
+                    }
                 }
             }
 
             return base.OnClosing(reason);
+        }
+
+        /// <summary>
+        /// Discards unsaved asset changes before closing the window.
+        /// </summary>
+        protected virtual void DiscardChanges()
+        {
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/Assets/JsonAssetWindow.cs
+++ b/Source/Editor/Windows/Assets/JsonAssetWindow.cs
@@ -243,6 +243,14 @@ namespace FlaxEditor.Windows.Assets
             base.OnAssetLoaded();
         }
 
+        /// <inheritdoc />
+        protected override void DiscardChanges()
+        {
+            Asset?.ClearInstance();
+            _object = null;
+            base.DiscardChanges();
+        }
+
         private void OpenOptionsContextMenu()
         {
             if (_optionsCM != null)

--- a/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
+++ b/Source/Editor/Windows/Assets/MaterialInstanceWindow.cs
@@ -64,8 +64,14 @@ namespace FlaxEditor.Windows.Assets
         [CustomEditor(typeof(ParametersEditor))]
         private sealed class PropertiesProxy
         {
+            private struct ParameterState
+            {
+                public object Value;
+                public bool IsOverride;
+            }
+
             private MaterialBase _restoreBase;
-            private Dictionary<string, object> _restoreParams;
+            private Dictionary<string, ParameterState> _restoreParams;
 
             [EditorDisplay("General"), Tooltip("The base material used to override it's properties")]
             public MaterialBase BaseMaterial
@@ -181,9 +187,16 @@ namespace FlaxEditor.Windows.Assets
                 var material = Window.Asset;
                 _restoreBase = material.BaseMaterial;
                 var parameters = material.Parameters;
-                _restoreParams = new Dictionary<string, object>();
+                _restoreParams = new Dictionary<string, ParameterState>();
                 for (int i = 0; i < parameters.Length; i++)
-                    _restoreParams[parameters[i].Name] = parameters[i].Value;
+                {
+                    var p = parameters[i];
+                    _restoreParams[p.Name] = new ParameterState
+                    {
+                        Value = p.Value,
+                        IsOverride = p.IsOverride,
+                    };
+                }
             }
 
             /// <summary>
@@ -191,7 +204,7 @@ namespace FlaxEditor.Windows.Assets
             /// </summary>
             public void DiscardChanges()
             {
-                if (Window == null)
+                if (Window == null || _restoreParams == null)
                     return;
 
                 var material = Window.Asset;
@@ -200,9 +213,10 @@ namespace FlaxEditor.Windows.Assets
                 for (int i = 0; i < parameters.Length; i++)
                 {
                     var p = parameters[i];
-                    if (p.IsPublic && _restoreParams.TryGetValue(p.Name, out var value))
+                    if (p.IsPublic && _restoreParams.TryGetValue(p.Name, out var state))
                     {
-                        p.Value = value;
+                        p.Value = state.Value;
+                        p.IsOverride = state.IsOverride;
                     }
                 }
             }

--- a/Source/Editor/Windows/Assets/ModelBaseWindow.cs
+++ b/Source/Editor/Windows/Assets/ModelBaseWindow.cs
@@ -835,6 +835,13 @@ namespace FlaxEditor.Windows.Assets
         }
 
         /// <inheritdoc />
+        protected override void DiscardChanges()
+        {
+            _asset?.Reload();
+            base.DiscardChanges();
+        }
+
+        /// <inheritdoc />
         public override void OnItemReimported(ContentItem item)
         {
             // Discard any old mesh data cache

--- a/Source/Engine/Content/JsonAsset.cs
+++ b/Source/Engine/Content/JsonAsset.cs
@@ -93,5 +93,15 @@ namespace FlaxEngine
             string str = instance != null ? JsonSerializer.Serialize(instance) : null;
             Data = str;
         }
+
+#if FLAX_EDITOR
+        /// <summary>
+        /// Clears the cached managed instance. The next <see cref="Instance"/> access will recreate it from the asset data.
+        /// </summary>
+        public void ClearInstance()
+        {
+            _instance = null;
+        }
+#endif
     }
 }


### PR DESCRIPTION
Fixes cases where choosing **No** in the "Save before closing?" dialog discarded asset edits on disk, but left the edited state alive in the editor/runtime asset cache.

Some asset editors modify the loaded asset instance directly, so changes are visible immediately in previews and the editor scene. If the user closes the editor window and chooses not to save, the file remains unchanged, but reopening the asset could still show the unsaved values because the modified in-memory object was reused.

This change adds an explicit discard hook to `AssetEditorWindow` and uses it only when the user chooses **No**:

- `JsonAssetWindow` clears the cached managed Json asset instance so the next open recreates it from file data.
- `MaterialInstanceWindow` now restores both parameter values and override flags when closing without saving.
- `ModelBaseWindow` reloads the model asset from disk on discard, covering model state edited directly in memory.

The discard work is lazy and only runs when the user explicitly rejects saving. Normal asset opening/editing paths are unchanged.