### PR TITLE
No path in window title

### DIFF
--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -829,9 +829,9 @@ namespace FlaxEditor.Modules
             projectPath = projectPath.Replace('/', '\\');
 #endif
 
-            string largeWorld = "Large Worlds Enabled: false";
+            string largeWorld = "Large Worlds Disabled";
 #if USE_LARGE_WORLDS
-            largeWorld = "Large Worlds Enabled: true";
+            largeWorld = "Large Worlds Enabled";
 #endif
 
             WindowDecorations = new MainWindowDecorations(mainWindow, !Utilities.Utils.UseCustomWindowDecorations(true))

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -829,15 +829,15 @@ namespace FlaxEditor.Modules
             projectPath = projectPath.Replace('/', '\\');
 #endif
 
-            string largeWorld = "Large Worlds Disabled";
+            string largeWorld = "";
 #if USE_LARGE_WORLDS
-            largeWorld = "Large Worlds Enabled";
+            largeWorld = "\nLarge Worlds Enabled";
 #endif
 
             WindowDecorations = new MainWindowDecorations(mainWindow, !Utilities.Utils.UseCustomWindowDecorations(true))
             {
                 Parent = mainWindow,
-                IconTooltipText = $"{mainWindow.RootWindow.Title}\nPath {projectPath}\n\nEngine Version {Globals.EngineVersion}\n{largeWorld}\nConfiguration {configuration}\n\nGraphics {GPUDevice.Instance.RendererType}{driver}",
+                IconTooltipText = $"{mainWindow.RootWindow.Title}\nPath {projectPath}\n\nEngine Version {Globals.EngineVersion}{largeWorld}\nConfiguration {configuration}\n\nGraphics {GPUDevice.Instance.RendererType}{driver}",
             };
         }
 

--- a/Source/Editor/Modules/UIModule.cs
+++ b/Source/Editor/Modules/UIModule.cs
@@ -824,10 +824,20 @@ namespace FlaxEditor.Modules
                 driver = $" ({driver})";
 #endif
 
+            var projectPath = Globals.ProjectFolder;
+#if PLATFORM_WINDOWS
+            projectPath = projectPath.Replace('/', '\\');
+#endif
+
+            string largeWorld = "Large Worlds Enabled: false";
+#if USE_LARGE_WORLDS
+            largeWorld = "Large Worlds Enabled: true";
+#endif
+
             WindowDecorations = new MainWindowDecorations(mainWindow, !Utilities.Utils.UseCustomWindowDecorations(true))
             {
                 Parent = mainWindow,
-                IconTooltipText = $"{mainWindow.RootWindow.Title}\nVersion {Globals.EngineVersion}\nConfiguration {configuration}\nGraphics {GPUDevice.Instance.RendererType}{driver}",
+                IconTooltipText = $"{mainWindow.RootWindow.Title}\nPath {projectPath}\n\nEngine Version {Globals.EngineVersion}\n{largeWorld}\nConfiguration {configuration}\n\nGraphics {GPUDevice.Instance.RendererType}{driver}",
             };
         }
 

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -191,13 +191,9 @@ namespace FlaxEditor.Modules
             var mainWindow = MainWindow;
             if (mainWindow)
             {
-                var projectPath = Globals.ProjectFolder;
-#if PLATFORM_WINDOWS
-                projectPath = projectPath.Replace('/', '\\');
-#endif
                 var engineVersion = Editor.EngineProject.Version;
                 var engineVersionText = engineVersion.Revision > 0 ? $"{engineVersion.Major}.{engineVersion.Minor}.{engineVersion.Revision}" : $"{engineVersion.Major}.{engineVersion.Minor}";
-                var title = $"Flax Editor {engineVersionText} - \'{projectPath}\'";
+                var title = $"Flax Editor {engineVersionText} - \'{Editor.GameProject.Name}\'";
                 mainWindow.Title = title;
             }
         }


### PR DESCRIPTION
[Someone suggested](https://discord.com/channels/437989205315158016/438033006016462849/1508958411000250368) removing the project path from the main window title for privacy reason in screenshots/ screen recordings and I agree.

It also looks more clean.

This pr also adds the project path into the main window icon tooltip. It also adds info about if the current engine build is large worlds enabled. I frequently run into the problem of not really knowing if the engine build I have the project opened in has large world enabled or not, so this is a nice and quick way to check that.


<img width="247" height="209" alt="image" src="https://github.com/user-attachments/assets/895c2406-a5ac-4ead-915c-63a168d9bd7e" />

<img width="1916" height="217" alt="image" src="https://github.com/user-attachments/assets/bcb94c3f-037b-4cb0-ab1f-b47e1bd85373" />
