### PR TITLE
Fix Editor Grid Jitter After TAA Resolve

### DIFF
--- a/Source/Editor/Gizmo/GridGizmo.cs
+++ b/Source/Editor/Gizmo/GridGizmo.cs
@@ -113,7 +113,8 @@ namespace FlaxEditor.Gizmo
                 if (cb != IntPtr.Zero)
                 {
                     var data = new Data();
-                    Matrix.Multiply(ref renderContext.View.View, ref renderContext.View.Projection, out var viewProjection);
+                    var projection = renderContext.View.GetOverlayProjection();
+                    Matrix.Multiply(ref renderContext.View.View, ref projection, out var viewProjection);
                     Matrix.Transpose(ref viewProjection, out data.ViewProjectionMatrix);
                     data.ViewPos = renderContext.View.WorldPosition;
                     data.GridColor = options.Viewport.ViewportGridColor;

--- a/Source/Engine/Graphics/RenderView.cs
+++ b/Source/Engine/Graphics/RenderView.cs
@@ -34,6 +34,14 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Gets projection matrix for overlay geometry rendered after temporal anti-aliasing has been resolved.
+        /// </summary>
+        public Matrix GetOverlayProjection()
+        {
+            return IsTaaResolved ? NonJitteredProjection : Projection;
+        }
+
+        /// <summary>
         /// Initializes render view data.
         /// </summary>
         /// <param name="view">The view.</param>

--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -90,7 +90,7 @@ namespace FlaxEngine
             Matrix.Multiply(ref worldMatrix, ref renderContext.View.View, out Matrix viewMatrix);
             Matrix projectionMatrix = renderContext.View.Projection;
             if (worldSpace && (Canvas.RenderLocation == PostProcessEffectLocation.Default || Canvas.RenderLocation == PostProcessEffectLocation.AfterAntiAliasingPass))
-                projectionMatrix = renderContext.View.NonJitteredProjection; // Fix TAA jittering when rendering UI in world after TAA resolve
+                projectionMatrix = renderContext.View.GetOverlayProjection(); // Fix TAA jittering when rendering UI in world after TAA resolve
             Matrix.Multiply(ref viewMatrix, ref projectionMatrix, out Matrix viewProjectionMatrix);
 
             // Pick a depth buffer


### PR DESCRIPTION
### Problem

The editor grid can appear to slightly jitter in scene and prefab viewports when TAA is enabled. The grid is drawn after TAA resolve, but it was still using the jittered projection matrix.

### Solution

- Add `RenderView.GetOverlayProjection()`.
- Use it in `GridGizmo` when building the grid view-projection matrix.
- Update world-space `UICanvas` to use the same helper instead of directly selecting `NonJitteredProjection`.
