### PR TITLE
Add Nvidia PerfSDK support

### DIFF
--- a/Source/Editor/Editor.Build.cs
+++ b/Source/Editor/Editor.Build.cs
@@ -44,6 +44,8 @@ public class Editor : EditorModule
         options.ScriptingAPI.SystemReferences.Add("System.Diagnostics.Process");
         if (Profiler.Use(options))
             options.ScriptingAPI.Defines.Add("USE_PROFILER");
+        if (RenderPerf.Use(options))
+            options.ScriptingAPI.Defines.Add("COMPILE_WITH_RENDER_PERF");
 
         // Enable optimizations for Editor, disable this for debugging the editor
         if (options.Configuration == TargetConfiguration.Development)

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -125,6 +125,13 @@ namespace FlaxEditor.Modules
         /// </summary>
         public ProfilerWindow ProfilerWin;
 
+#if COMPILE_WITH_RENDER_PERF
+        /// <summary>
+        /// The PerfSDK metrics window.
+        /// </summary>
+        public PerfSdkMetricsWindow PerfSdkMetricsWin;
+#endif
+
         /// <summary>
         /// The editor options window.
         /// </summary>
@@ -807,6 +814,9 @@ namespace FlaxEditor.Modules
             GraphicsQualityWin = new GraphicsQualityWindow(Editor);
             GameCookerWin = new GameCookerWindow(Editor);
             ProfilerWin = new ProfilerWindow(Editor);
+#if COMPILE_WITH_RENDER_PERF
+            PerfSdkMetricsWin = new PerfSdkMetricsWindow(Editor);
+#endif
             EditorOptionsWin = new EditorOptionsWindow(Editor);
             PluginsWin = new PluginsWindow(Editor);
             VisualScriptDebuggerWin = new VisualScriptDebuggerWindow(Editor);

--- a/Source/Editor/Windows/PerfSdkMetricsWindow.cs
+++ b/Source/Editor/Windows/PerfSdkMetricsWindow.cs
@@ -1,0 +1,370 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#if COMPILE_WITH_RENDER_PERF
+using System;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.Windows
+{
+    /// <summary>
+    /// Editor window that shows live NVIDIA PerfSDK GPU metrics in a grouped table layout.
+    /// </summary>
+    public sealed class PerfSdkMetricsWindow : EditorWindow
+    {
+        private const float TopMargin = 8.0f;
+        private const float StatusHeight = 18.0f;
+
+        private Label _statusLabel;
+        private ChipMetricsTable _table;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PerfSdkMetricsWindow"/> class.
+        /// </summary>
+        /// <param name="editor">The editor.</param>
+        public PerfSdkMetricsWindow(Editor editor)
+        : base(editor, true, ScrollBars.None)
+        {
+            Title = "Nvidia PerfSDK Metrics";
+            Size = new Float2(430, 860);
+
+            _statusLabel = new Label
+            {
+                AnchorPreset = AnchorPresets.HorizontalStretchTop,
+                Offsets = new Margin(8, TopMargin, 8, 0),
+                Height = StatusHeight,
+                HorizontalAlignment = TextAlignment.Near,
+                IsScrollable = false,
+                TextColor = Style.Current.Foreground * 0.75f,
+                Parent = this,
+            };
+
+            _table = new ChipMetricsTable
+            {
+                AnchorPreset = AnchorPresets.StretchAll,
+                Offsets = new Margin(8, TopMargin + StatusHeight + 4.0f, 8, 8),
+                Parent = this,
+            };
+        }
+
+        /// <summary>
+        /// Shows metrics for the given GPU profiler region.
+        /// </summary>
+        /// <param name="regionName">The profiler region name.</param>
+        public void ShowRegion(string regionName)
+        {
+            string apiName = FormatRendererType(GPUDevice.Instance != null ? GPUDevice.Instance.RendererType : RendererType.Unknown);
+            Title = "Nvidia PerfSDK Metrics: " + regionName + " · " + apiName;
+            UpdateView();
+            FocusOrShow();
+        }
+
+        /// <inheritdoc />
+        public override void OnUpdate()
+        {
+            if (RenderPerfTools.IsSessionActive)
+                UpdateView();
+        }
+
+        /// <inheritdoc />
+        public override void OnExit()
+        {
+            if (RenderPerfTools.IsSessionActive)
+                RenderPerfTools.CloseRegionProfiler();
+        }
+
+        private void UpdateView()
+        {
+            _statusLabel.Text = RenderPerfTools.StatusText;
+            _table.SetRegionStats(
+                RenderPerfTools.RegionName,
+                RenderPerfTools.RegionGpuTimeMs,
+                RenderPerfTools.RegionDrawCalls,
+                RenderPerfTools.RegionTriangles,
+                RenderPerfTools.RegionVertices);
+            _table.SetChipAreasText(RenderPerfTools.ChipAreasText);
+        }
+
+        private static string FormatRendererType(RendererType type)
+        {
+            switch (type)
+            {
+            case RendererType.DirectX10: return "DirectX 10";
+            case RendererType.DirectX10_1: return "DirectX 10.1";
+            case RendererType.DirectX11: return "DirectX 11";
+            case RendererType.DirectX12: return "DirectX 12";
+            case RendererType.Vulkan: return "Vulkan";
+            case RendererType.OpenGL4_1: return "OpenGL 4.1";
+            case RendererType.OpenGL4_4: return "OpenGL 4.4";
+            case RendererType.OpenGLES3: return "OpenGL ES 3";
+            case RendererType.OpenGLES3_1: return "OpenGL ES 3.1";
+            case RendererType.Null: return "Null";
+            case RendererType.WebGPU: return "WebGPU";
+            default: return type.ToString();
+            }
+        }
+
+        private sealed class ChipMetricsTable : ContainerControl
+        {
+            private const float RowHeight = 30.0f;
+            private const float GroupHeaderHeight = 24.0f;
+            private const float HeaderRowHeight = 22.0f;
+            private const float FooterTopGap = 10.0f;
+            private const float FooterLineHeight = 18.0f;
+            private const float BarHeight = 14.0f;
+            private const float ColumnGap = 6.0f;
+            private const float GroupHeaderPadding = 8.0f;
+            private const float AreaColumnRatio = 0.22f;
+            private const float BarTrackRatio = 0.11f;
+            private const float PercentLabelWidth = 40.0f;
+            private const float BarPercentGap = 4.0f;
+
+            private enum RowKind
+            {
+                GroupHeader,
+                Metric,
+            }
+
+            private struct RowData
+            {
+                public RowKind Kind;
+                public string Title;
+                public float Target;
+                public float Display;
+                public string Detail;
+                public bool HigherIsBetter;
+            }
+
+            private RowData[] _rows = Array.Empty<RowData>();
+            private string _emptyMessage = "Collecting GPU samples...";
+            private string _regionName = string.Empty;
+            private string _regionStatsLine = string.Empty;
+
+            public void SetRegionStats(string regionName, float gpuTimeMs, int drawCalls, int triangles, int vertices)
+            {
+                _regionName = regionName ?? string.Empty;
+                _regionStatsLine = string.Format(
+                    "GPU time: {0:0.000} ms   Draw calls: {1:#,0}   Triangles: {2:#,0}   Vertices: {3:#,0}",
+                    gpuTimeMs,
+                    drawCalls,
+                    triangles,
+                    vertices);
+            }
+
+            public void SetChipAreasText(string text)
+            {
+                if (string.IsNullOrEmpty(text))
+                {
+                    _rows = Array.Empty<RowData>();
+                    return;
+                }
+
+                string[] lines = text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                var rows = new RowData[lines.Length];
+                int count = 0;
+
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string[] parts = lines[i].Split('\t');
+                    if (parts.Length < 2)
+                        continue;
+
+                    if (parts[0] == "#GROUP")
+                    {
+                        rows[count++] = new RowData
+                        {
+                            Kind = RowKind.GroupHeader,
+                            Title = parts[1],
+                        };
+                        continue;
+                    }
+
+                    if (parts.Length < 3 || !float.TryParse(parts[1], out float target))
+                        continue;
+
+                    bool higherIsBetter = parts.Length >= 4 && parts[3] == "1";
+                    float display = target;
+                    for (int j = 0; j < _rows.Length; j++)
+                    {
+                        if (_rows[j].Kind == RowKind.Metric && _rows[j].Title == parts[0])
+                        {
+                            display = _rows[j].Display;
+                            break;
+                        }
+                    }
+
+                    rows[count++] = new RowData
+                    {
+                        Kind = RowKind.Metric,
+                        Title = parts[0],
+                        Target = target,
+                        Display = display,
+                        Detail = parts[2],
+                        HigherIsBetter = higherIsBetter,
+                    };
+                }
+
+                if (count == lines.Length)
+                    _rows = rows;
+                else
+                {
+                    var trimmed = new RowData[count];
+                    Array.Copy(rows, trimmed, count);
+                    _rows = trimmed;
+                }
+            }
+
+            /// <inheritdoc />
+            public override void Update(float deltaTime)
+            {
+                if (Visible && _rows.Length > 0)
+                {
+                    float step = Mathf.Saturate(deltaTime * 6.0f);
+                    for (int i = 0; i < _rows.Length; i++)
+                    {
+                        if (_rows[i].Kind != RowKind.Metric)
+                            continue;
+
+                        RowData row = _rows[i];
+                        row.Display = Mathf.Lerp(row.Display, row.Target, step);
+                        _rows[i] = row;
+                    }
+                }
+
+                base.Update(deltaTime);
+            }
+
+            /// <inheritdoc />
+            public override void Draw()
+            {
+                base.Draw();
+
+                var style = Style.Current;
+                float contentWidth = Width;
+                float areaWidth = contentWidth * AreaColumnRatio;
+                float barTrackWidth = contentWidth * BarTrackRatio;
+                float barWidth = barTrackWidth + PercentLabelWidth + BarPercentGap;
+                float xBar = areaWidth + ColumnGap;
+                float xDetail = xBar + barWidth + ColumnGap;
+                float detailWidth = Math.Max(0.0f, contentWidth - xDetail);
+
+                DrawHeader(style, areaWidth, xBar, barWidth, xDetail, detailWidth);
+
+                if (_rows.Length == 0)
+                {
+                    var emptyRect = new Rectangle(0, HeaderRowHeight, contentWidth, RowHeight);
+                    Render2D.DrawText(style.FontMedium, _emptyMessage, emptyRect, style.ForegroundGrey, TextAlignment.Near, TextAlignment.Center);
+                    DrawFooter(style, HeaderRowHeight + RowHeight, contentWidth);
+                }
+                else
+                {
+                    float y = HeaderRowHeight;
+                    for (int i = 0; i < _rows.Length; i++)
+                    {
+                        RowData row = _rows[i];
+                        if (row.Kind == RowKind.GroupHeader)
+                        {
+                            DrawGroupHeader(style, row.Title, y, contentWidth);
+                            y += GroupHeaderHeight;
+                            continue;
+                        }
+
+                        if (IsMouseOver)
+                        {
+                            var hoverRect = new Rectangle(0, y, contentWidth, RowHeight);
+                            Render2D.FillRectangle(hoverRect, style.BackgroundHighlighted * 0.35f);
+                        }
+
+                        var areaRect = new Rectangle(0, y, areaWidth, RowHeight);
+                        Render2D.DrawText(style.FontMedium, row.Title, areaRect, style.Foreground, TextAlignment.Near, TextAlignment.Center);
+
+                        DrawThroughputBar(style, xBar, y, barTrackWidth, row);
+
+                        var detailRect = new Rectangle(xDetail, y, detailWidth, RowHeight);
+                        Render2D.DrawText(style.FontMedium, row.Detail, detailRect, style.Foreground * 0.85f, TextAlignment.Near, TextAlignment.Center);
+                        y += RowHeight;
+                    }
+
+                    DrawFooter(style, y, contentWidth);
+                }
+            }
+
+            private static void DrawGroupHeader(Style style, string title, float y, float width)
+            {
+                var rect = new Rectangle(0, y, width, GroupHeaderHeight);
+                Render2D.FillRectangle(rect, style.LightBackground * 1.15f);
+                Render2D.DrawText(
+                    style.FontMedium,
+                    title,
+                    new Rectangle(GroupHeaderPadding, y, width - GroupHeaderPadding * 2.0f, GroupHeaderHeight),
+                    style.Foreground,
+                    TextAlignment.Near,
+                    TextAlignment.Center);
+            }
+
+            private void DrawFooter(Style style, float contentBottom, float contentWidth)
+            {
+                if (string.IsNullOrEmpty(_regionName) && string.IsNullOrEmpty(_regionStatsLine))
+                    return;
+
+                float footerY = contentBottom + FooterTopGap;
+                var separatorRect = new Rectangle(0, footerY - 4.0f, contentWidth, 1.0f);
+                Render2D.FillRectangle(separatorRect, style.Foreground * 0.12f);
+
+                var regionRect = new Rectangle(0, footerY, contentWidth, FooterLineHeight);
+                Render2D.DrawText(style.FontMedium, _regionName, regionRect, style.Foreground, TextAlignment.Near, TextAlignment.Center);
+
+                var statsRect = new Rectangle(0, footerY + FooterLineHeight, contentWidth, FooterLineHeight);
+                Render2D.DrawText(style.FontMedium, _regionStatsLine, statsRect, style.Foreground * 0.85f, TextAlignment.Near, TextAlignment.Center);
+            }
+
+            private static void DrawHeader(Style style, float areaWidth, float xBar, float barWidth, float xDetail, float detailWidth)
+            {
+                var headerBg = new Rectangle(0, 0, xDetail + detailWidth, HeaderRowHeight);
+                Render2D.FillRectangle(headerBg, style.LightBackground);
+
+                Render2D.DrawText(style.FontMedium, "Area", new Rectangle(0, 0, areaWidth, HeaderRowHeight), style.Foreground, TextAlignment.Near, TextAlignment.Center);
+                Render2D.DrawText(style.FontMedium, "Throughput", new Rectangle(xBar, 0, barWidth, HeaderRowHeight), style.Foreground, TextAlignment.Near, TextAlignment.Center);
+                Render2D.DrawText(style.FontMedium, "Metrics", new Rectangle(xDetail, 0, detailWidth, HeaderRowHeight), style.Foreground, TextAlignment.Near, TextAlignment.Center);
+            }
+
+            private static void DrawThroughputBar(Style style, float x, float y, float barTrackWidth, RowData row)
+            {
+                float barY = y + (RowHeight - BarHeight) * 0.5f;
+                var bgRect = new Rectangle(x, barY, barTrackWidth, BarHeight);
+                Render2D.FillRectangle(bgRect, style.Background * 1.2f);
+
+                float fill = Mathf.Clamp(row.Display, 0.0f, 100.0f) * 0.01f;
+                if (fill > 0.001f)
+                {
+                    var fillRect = new Rectangle(x, barY, barTrackWidth * fill, BarHeight);
+                    Render2D.FillRectangle(fillRect, GetBarColor(fill * 100.0f, row.HigherIsBetter, style));
+                }
+
+                Render2D.DrawRectangle(bgRect, style.Foreground * 0.15f);
+
+                var percentRect = new Rectangle(x + barTrackWidth + BarPercentGap, y, PercentLabelWidth, RowHeight);
+                Render2D.DrawText(style.FontMedium, Mathf.RoundToInt(row.Display) + "%", percentRect, style.Foreground, TextAlignment.Far, TextAlignment.Center);
+            }
+
+            private static Color GetBarColor(float value, bool higherIsBetter, Style style)
+            {
+                if (higherIsBetter)
+                {
+                    if (value >= 75.0f)
+                        return style.ProgressNormal;
+                    if (value >= 55.0f)
+                        return Color.Lerp(style.ProgressNormal, Color.Yellow, 0.45f);
+                    return Color.Lerp(Color.OrangeRed, Color.Yellow, 0.35f);
+                }
+
+                if (value >= 90.0f)
+                    return Color.Lerp(Color.OrangeRed, style.ProgressNormal, 0.25f);
+                if (value >= 70.0f)
+                    return Color.Lerp(Color.Yellow, style.ProgressNormal, 0.35f);
+                return style.ProgressNormal;
+            }
+        }
+    }
+}
+#endif

--- a/Source/Editor/Windows/Profiler/GPU.cs
+++ b/Source/Editor/Windows/Profiler/GPU.cs
@@ -147,6 +147,13 @@ namespace FlaxEditor.Windows.Profiler
             return ((long)x).ToString("###,###,###");
         }
 
+#if COMPILE_WITH_RENDER_PERF
+        private static void OnGpuRegionClicked(string regionName, float gpuTimeMs, long drawCalls, long triangles, long vertices)
+        {
+            GpuProfilerPerfSdk.TryOpen(regionName, gpuTimeMs, drawCalls, triangles, vertices);
+        }
+#endif
+
         /// <inheritdoc />
         public override void Clear()
         {
@@ -216,6 +223,11 @@ namespace FlaxEditor.Windows.Profiler
             }
             control.Bounds = new Rectangle(x, e.Depth * Timeline.Event.DefaultHeight, width, Timeline.Event.DefaultHeight - 1);
             control.Name = name;
+            control.GpuTimeMs = (float)e.Time;
+            control.DrawCalls = e.Stats.DrawCalls + e.Stats.DispatchCalls;
+            control.Triangles = e.Stats.Triangles;
+            control.Vertices = e.Stats.Vertices;
+            control.RegionClicked = OnGpuRegionClicked;
             control.TooltipText = string.Format("{0}, {1} ms", name, ((int)(e.Time * 10000.0) / 10000.0f));
             control.Parent = parent;
 
@@ -354,7 +366,7 @@ namespace FlaxEditor.Windows.Profiler
                 }
                 else
                 {
-                    row = new Row
+                    row = new ClickableRow
                     {
                         Values = new object[6],
                         BackgroundColors = new Color[6],
@@ -362,6 +374,11 @@ namespace FlaxEditor.Windows.Profiler
                     for (int k = 0; k < row.BackgroundColors.Length; k++)
                         row.BackgroundColors[k] = Color.Transparent;
                 }
+
+                float gpuTimeMs = (e.Time * 10000.0f) / 10000.0f;
+                long drawCalls = e.Stats.DrawCalls + e.Stats.DispatchCalls;
+                long triangles = e.Stats.Triangles;
+                long vertices = e.Stats.Vertices;
                 {
                     // Event
                     row.Values[0] = name;
@@ -372,17 +389,24 @@ namespace FlaxEditor.Windows.Profiler
                     row.BackgroundColors[1] = Color.Red.AlphaMultiplied(Mathf.Min(1, rowTimePerc) * 0.5f);
 
                     // GPU ms
-                    row.Values[2] = (e.Time * 10000.0f) / 10000.0f;
+                    row.Values[2] = gpuTimeMs;
 
                     // Draw Calls
-                    row.Values[3] = e.Stats.DrawCalls + e.Stats.DispatchCalls;
+                    row.Values[3] = drawCalls;
 
                     // Triangles
-                    row.Values[4] = e.Stats.Triangles;
+                    row.Values[4] = triangles;
 
                     // Vertices
-                    row.Values[5] = e.Stats.Vertices;
+                    row.Values[5] = vertices;
                 }
+#if COMPILE_WITH_RENDER_PERF
+                if (row is ClickableRow clickableRow)
+                {
+                    clickableRow.RowLeftClick = _ =>
+                        GpuProfilerPerfSdk.TryOpen(name, gpuTimeMs, drawCalls, triangles, vertices);
+                }
+#endif
                 row.Depth = e.Depth;
                 row.Width = _table.Width;
                 row.Visible = e.Depth < 3;

--- a/Source/Editor/Windows/Profiler/GpuProfilerPerfSdk.cs
+++ b/Source/Editor/Windows/Profiler/GpuProfilerPerfSdk.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#if COMPILE_WITH_RENDER_PERF
+using FlaxEditor;
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.Windows.Profiler
+{
+    /// <summary>
+    /// Opens PerfSDK metrics window for a GPU profiler region.
+    /// </summary>
+    internal static class GpuProfilerPerfSdk
+    {
+        public static void TryOpen(string regionName, float gpuTimeMs, long drawCalls, long triangles, long vertices)
+        {
+            if (!RenderPerfTools.IsCompiled)
+                return;
+
+            if (!RenderPerfTools.TryOpenRegionProfiler(regionName, gpuTimeMs, (int)drawCalls, (int)triangles, (int)vertices))
+            {
+                string error = RenderPerfTools.ErrorText;
+                if (!string.IsNullOrEmpty(error))
+                    MessageBox.Show(error, "PerfSDK", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            Editor.Instance.Windows.PerfSdkMetricsWin.ShowRegion(regionName);
+        }
+    }
+}
+#endif

--- a/Source/Editor/Windows/Profiler/Timeline.cs
+++ b/Source/Editor/Windows/Profiler/Timeline.cs
@@ -42,6 +42,32 @@ namespace FlaxEditor.Windows.Profiler
             private Color _color;
             private string _name;
             private float _nameLength = -1;
+            private bool _leftMouseDown;
+
+            /// <summary>
+            /// GPU time in milliseconds for this event (from profiler).
+            /// </summary>
+            public float GpuTimeMs;
+
+            /// <summary>
+            /// Draw calls count for this event.
+            /// </summary>
+            public long DrawCalls;
+
+            /// <summary>
+            /// Triangles count for this event.
+            /// </summary>
+            public long Triangles;
+
+            /// <summary>
+            /// Vertices count for this event.
+            /// </summary>
+            public long Vertices;
+
+            /// <summary>
+            /// Occurs when user clicks this timeline event.
+            /// </summary>
+            public System.Action<string, float, long, long, long> RegionClicked;
 
             /// <summary>
             /// The default height of the event.
@@ -93,6 +119,39 @@ namespace FlaxEditor.Windows.Profiler
                     Render2D.DrawText(style.FontMedium, _name, bounds, Style.Current.Foreground, TextAlignment.Center, TextAlignment.Center);
                     Render2D.PopClip();
                 }
+            }
+
+            /// <inheritdoc />
+            public override bool OnMouseDown(Float2 location, MouseButton button)
+            {
+                if (button == MouseButton.Left && Bounds.Contains(location))
+                {
+                    _leftMouseDown = true;
+                    return true;
+                }
+
+                return base.OnMouseDown(location, button);
+            }
+
+            /// <inheritdoc />
+            public override bool OnMouseUp(Float2 location, MouseButton button)
+            {
+                if (button == MouseButton.Left && _leftMouseDown && Bounds.Contains(location))
+                {
+                    _leftMouseDown = false;
+                    RegionClicked?.Invoke(_name, GpuTimeMs, DrawCalls, Triangles, Vertices);
+                    return true;
+                }
+
+                _leftMouseDown = false;
+                return base.OnMouseUp(location, button);
+            }
+
+            /// <inheritdoc />
+            public override void OnMouseLeave()
+            {
+                _leftMouseDown = false;
+                base.OnMouseLeave();
             }
         }
 

--- a/Source/Engine/Graphics/GPUDevice.cpp
+++ b/Source/Engine/Graphics/GPUDevice.cpp
@@ -26,6 +26,9 @@
 #include "Engine/Engine/EngineService.h"
 #include "Engine/Profiler/Profiler.h"
 #include "Engine/Renderer/RenderList.h"
+#if COMPILE_WITH_RENDER_PERF
+#include "Engine/RenderPerf/RenderPerfTools.h"
+#endif
 #include "Engine/Scripting/Enums.h"
 
 GPUResourcePropertyBase::~GPUResourcePropertyBase()
@@ -794,6 +797,9 @@ void GPUDevice::Draw()
     // Perform actual drawing
     Engine::Draw();
     EngineService::OnDraw();
+#if COMPILE_WITH_RENDER_PERF
+    RenderPerfTools::OnGpuFrameBegin(context);
+#endif
     RenderTask::DrawAll();
 
     // End frame
@@ -803,6 +809,10 @@ void GPUDevice::Draw()
     context->FrameEnd();
 
     DrawEnd();
+#if COMPILE_WITH_RENDER_PERF
+    // After queue submit (present/flush) so Vulkan mini-trace frame markers align with completed work.
+    RenderPerfTools::OnGpuFrameEnd(context);
+#endif
 }
 
 void GPUDevice::Dispose()

--- a/Source/Engine/Graphics/GPUDevice.h
+++ b/Source/Engine/Graphics/GPUDevice.h
@@ -272,6 +272,22 @@ public:
     API_PROPERTY() virtual void* GetNativePtr() const = 0;
 
     /// <summary>
+    /// Gets the native pointer to the main graphics command queue (ID3D12CommandQueue* or VkQueue as void*). Null if not applicable.
+    /// </summary>
+    virtual void* GetNativeCommandQueue() const
+    {
+        return nullptr;
+    }
+
+    /// <summary>
+    /// Gets the Vulkan queue family index for <see cref="GetNativeCommandQueue"/>. Zero for non-Vulkan backends.
+    /// </summary>
+    virtual uint32 GetNativeCommandQueueFamilyIndex() const
+    {
+        return 0;
+    }
+
+    /// <summary>
     /// Gets the amount of memory usage by all the GPU resources (in bytes).
     /// </summary>
     API_PROPERTY() uint64 GetMemoryUsage() const;

--- a/Source/Engine/Graphics/Graphics.Build.cs
+++ b/Source/Engine/Graphics/Graphics.Build.cs
@@ -119,6 +119,9 @@ public class Graphics : EngineModule
             options.PrivateDefinitions.Add("COMPILE_WITH_GPU_PARTICLES");
         }
 
+        if (RenderPerf.Use(options))
+            options.PublicDependencies.Add("RenderPerf");
+
         // Manually include file with shared DirectX code
         if (options.PrivateDependencies.Contains("GraphicsDeviceDX11") ||
             options.PrivateDependencies.Contains("GraphicsDeviceDX12"))

--- a/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.h
+++ b/Source/Engine/GraphicsDevice/DirectX/DX12/GPUDeviceDX12.h
@@ -186,6 +186,10 @@ public:
     {
         return _device;
     }
+    void* GetNativeCommandQueue() const override
+    {
+        return GetCommandQueueDX12();
+    }
     bool Init() override;
     void DrawBegin() override;
     void RenderEnd() override;

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.Layers.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.Layers.cpp
@@ -6,6 +6,9 @@
 #include "Engine/Core/Log.h"
 #include "Engine/Core/Collections/ArrayExtensions.h"
 #include "Engine/Core/Collections/Sorting.h"
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+#include "RenderPerfVulkanExtensions.h"
+#endif
 
 #if GRAPHICS_API_VULKAN
 
@@ -404,6 +407,16 @@ void GPUDeviceVulkan::GetInstanceLayersAndExtensions(Array<const char*>& outInst
         }
     }
 
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    {
+        Array<const char*> availableExtensions;
+        availableExtensions.EnsureCapacity(foundUniqueExtensions.Count());
+        for (int32 i = 0; i < foundUniqueExtensions.Count(); i++)
+            availableExtensions.Add(foundUniqueExtensions[i].Get());
+        RenderPerfAppendVulkanInstanceExtensions(outInstanceExtensions, availableExtensions, VULKAN_API_VERSION);
+    }
+#endif
+
     TrimDuplicates(outInstanceLayers);
     if (outInstanceLayers.HasItems())
     {
@@ -573,6 +586,14 @@ void GPUDeviceVulkan::GetDeviceExtensionsAndLayers(VkPhysicalDevice gpu, Array<c
             outDeviceExtensions.Add(GDeviceExtensions[i]);
         }
     }
+
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    {
+        VkPhysicalDeviceProperties gpuProps;
+        vkGetPhysicalDeviceProperties(gpu, &gpuProps);
+        RenderPerfAppendVulkanDeviceExtensions(Instance, gpu, outDeviceExtensions, availableExtensions, gpuProps.apiVersion);
+    }
+#endif
 
     if (outDeviceExtensions.HasItems())
     {

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.cpp
@@ -20,6 +20,9 @@
 #include "QueueVulkan.h"
 #include "Config.h"
 #include "CmdBufferVulkan.h"
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+#include "RenderPerfVulkanExtensions.h"
+#endif
 #include "FlaxEngine.Gen.h"
 #include "Engine/Core/Log.h"
 #include "Engine/Core/Utilities.h"
@@ -1534,6 +1537,16 @@ void* GPUDeviceVulkan::GetNativePtr() const
     return _nativePtr;
 }
 
+void* GPUDeviceVulkan::GetNativeCommandQueue() const
+{
+    return GraphicsQueue ? (void*)GraphicsQueue->GetHandle() : nullptr;
+}
+
+uint32 GPUDeviceVulkan::GetNativeCommandQueueFamilyIndex() const
+{
+    return GraphicsQueue ? GraphicsQueue->GetFamilyIndex() : 0;
+}
+
 static int32 GetMaxSampleCount(VkSampleCountFlags counts)
 {
     if (counts & VK_SAMPLE_COUNT_64_BIT)
@@ -1685,6 +1698,10 @@ bool GPUDeviceVulkan::Init()
         resetFeatures.hostQueryReset = VK_TRUE;
         deviceInfo.pNext = &resetFeatures;
     }
+#endif
+
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    RenderPerfChainVulkanDeviceCreateInfo(&deviceInfo, gpu, deviceExtensions);
 #endif
 
     // Create the device

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.h
@@ -567,6 +567,8 @@ public:
     GPUContext* GetMainContext() override;
     GPUAdapter* GetAdapter() const override;
     void* GetNativePtr() const override;
+    void* GetNativeCommandQueue() const override;
+    uint32 GetNativeCommandQueueFamilyIndex() const override;
     bool Init() override;
     void DrawBegin() override;
     void Dispose() override;

--- a/Source/Engine/GraphicsDevice/Vulkan/GraphicsDeviceVulkan.Build.cs
+++ b/Source/Engine/GraphicsDevice/Vulkan/GraphicsDeviceVulkan.Build.cs
@@ -213,5 +213,22 @@ public class GraphicsDeviceVulkan : GraphicsDeviceBaseModule
             options.PrivateDependencies.Add("volk");
             break;
         }
+
+        if (RenderPerf.Use(options))
+        {
+            string perfSdk = Environment.GetEnvironmentVariable("NVPERF_SDK_PATH");
+            if (string.IsNullOrEmpty(perfSdk))
+                perfSdk = @"C:\Users\nproc\Downloads\PerfSDK_2025_5";
+
+            string perfInclude = Path.Combine(perfSdk, "redist", "include");
+            if (Directory.Exists(perfInclude))
+            {
+                options.PublicDefinitions.Add("COMPILE_WITH_RENDER_PERF_NVPERF=1");
+                options.PrivateIncludePaths.Add(perfInclude);
+                options.PrivateIncludePaths.Add(Path.Combine(perfInclude, "windows-desktop-x64"));
+                options.PrivateIncludePaths.Add(Path.Combine(perfSdk, "redist", "NvPerfUtility", "include"));
+                options.PrivateIncludePaths.Add(Path.Combine(perfSdk, "Samples", "NvPerfUtility", "imports", "rapidyaml-0.4.0"));
+            }
+        }
     }
 }

--- a/Source/Engine/GraphicsDevice/Vulkan/RenderPerfVulkanExtensions.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/RenderPerfVulkanExtensions.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) Flax Engine. NVIDIA PerfSDK Vulkan device setup helpers.
+
+#include "RenderPerfVulkanExtensions.h"
+
+#if COMPILE_WITH_RENDER_PERF_NVPERF && GRAPHICS_API_VULKAN
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef NOGDI
+#define NOGDI
+#endif
+
+#if PLATFORM_WIN32
+#include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
+#endif
+#include <ThirdParty/volk/volk.h>
+#include "Engine/Core/Types/String.h"
+#include "Engine/Platform/StringUtils.h"
+
+#include <NvPerfVulkan.h>
+#include <NvPerfPeriodicSamplerVulkan.h>
+#include <vector>
+
+namespace
+{
+    static bool ContainsExtension(const Array<const char*>& extensions, const char* name)
+    {
+        if (!name)
+            return false;
+        for (int32 i = 0; i < extensions.Count(); i++)
+        {
+            if (StringUtils::Compare(extensions[i], name) == 0)
+                return true;
+        }
+        return false;
+    }
+
+    static void AddUniqueExtension(Array<const char*>& outExtensions, const Array<const char*>& availableExtensions, const char* name)
+    {
+        if (!name || !ContainsExtension(availableExtensions, name) || ContainsExtension(outExtensions, name))
+            return;
+        outExtensions.Add(name);
+    }
+
+    static void AppendNames(Array<const char*>& outExtensions, const Array<const char*>& availableExtensions, const std::vector<const char*>& names)
+    {
+        for (const char* name : names)
+            AddUniqueExtension(outExtensions, availableExtensions, name);
+    }
+
+    static uint32 GetDeviceApiMajorMinor(VkPhysicalDevice physicalDevice)
+    {
+        VkPhysicalDeviceProperties properties;
+        vkGetPhysicalDeviceProperties(physicalDevice, &properties);
+        return VK_MAKE_VERSION(VK_VERSION_MAJOR(properties.apiVersion), VK_VERSION_MINOR(properties.apiVersion), 0);
+    }
+}
+
+void RenderPerfAppendVulkanInstanceExtensions(Array<const char*>& outInstanceExtensions, const Array<const char*>& availableExtensions, uint32 apiVersion)
+{
+    std::vector<const char*> requiredNames;
+    if (!nv::perf::VulkanAppendInstanceRequiredExtensions(requiredNames, apiVersion))
+        return;
+    AppendNames(outInstanceExtensions, availableExtensions, requiredNames);
+}
+
+void RenderPerfAppendVulkanDeviceExtensions(VkInstance instance, VkPhysicalDevice physicalDevice, Array<const char*>& outDeviceExtensions, const Array<const char*>& availableExtensions, uint32 physicalDeviceApiVersion)
+{
+    std::vector<const char*> requiredNames;
+
+    if (instance && physicalDevice && vkGetPhysicalDeviceProperties)
+    {
+        VkPhysicalDeviceProperties properties;
+        vkGetPhysicalDeviceProperties(physicalDevice, &properties);
+        if (properties.vendorID == 0x10DE)
+        {
+            nv::perf::VulkanAppendDeviceRequiredExtensions(instance, physicalDevice, (void*)vkGetInstanceProcAddr, requiredNames);
+        }
+    }
+
+    // NvPerf MiniTrace only lists extensions for Vulkan <= 1.1. Request them explicitly on
+    // newer GPUs too when the driver still exposes the KHR/EXT entry points.
+    const uint32_t miniTraceApiVersion = physicalDeviceApiVersion <= VK_API_VERSION_1_1 ? physicalDeviceApiVersion : VK_API_VERSION_1_1;
+    nv::perf::sampler::PeriodicSamplerTimeHistoryVulkan::AppendDeviceRequiredExtensions(miniTraceApiVersion, requiredNames);
+    AppendNames(outDeviceExtensions, availableExtensions, requiredNames);
+}
+
+void RenderPerfChainVulkanDeviceCreateInfo(VkDeviceCreateInfo* deviceCreateInfo, VkPhysicalDevice physicalDevice, const Array<const char*>& enabledDeviceExtensions)
+{
+    if (!deviceCreateInfo || !physicalDevice)
+        return;
+
+    void* next = const_cast<void*>(deviceCreateInfo->pNext);
+    const uint32 deviceApiMajorMinor = GetDeviceApiMajorMinor(physicalDevice);
+
+    // Vulkan 1.2+ uses core vkGetBufferDeviceAddress; the feature must be enabled at device creation.
+    if (deviceApiMajorMinor >= VK_API_VERSION_1_2)
+    {
+        static VkPhysicalDeviceVulkan12Features vulkan12Features;
+        vulkan12Features = {};
+        vulkan12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+        vulkan12Features.bufferDeviceAddress = VK_TRUE;
+        vulkan12Features.pNext = next;
+        deviceCreateInfo->pNext = &vulkan12Features;
+        return;
+    }
+
+    if (ContainsExtension(enabledDeviceExtensions, "VK_EXT_buffer_device_address"))
+    {
+        static VkPhysicalDeviceBufferDeviceAddressFeaturesEXT bufferDeviceAddressFeatures;
+        bufferDeviceAddressFeatures = {};
+        bufferDeviceAddressFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT;
+        bufferDeviceAddressFeatures.bufferDeviceAddress = VK_TRUE;
+        bufferDeviceAddressFeatures.pNext = next;
+        deviceCreateInfo->pNext = &bufferDeviceAddressFeatures;
+    }
+}
+
+#endif

--- a/Source/Engine/GraphicsDevice/Vulkan/RenderPerfVulkanExtensions.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/RenderPerfVulkanExtensions.h
@@ -1,0 +1,28 @@
+// Copyright (c) Flax Engine. NVIDIA PerfSDK Vulkan device setup helpers.
+
+#pragma once
+
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+
+#include "Engine/Core/Collections/Array.h"
+
+struct VkDeviceCreateInfo;
+typedef struct VkInstance_T* VkInstance;
+typedef struct VkPhysicalDevice_T* VkPhysicalDevice;
+
+/// <summary>
+/// Appends NVIDIA PerfSDK required Vulkan instance extensions when available on the driver.
+/// </summary>
+void RenderPerfAppendVulkanInstanceExtensions(Array<const char*>& outInstanceExtensions, const Array<const char*>& availableExtensions, uint32 apiVersion);
+
+/// <summary>
+/// Appends NVIDIA PerfSDK required Vulkan device extensions when available on the driver.
+/// </summary>
+void RenderPerfAppendVulkanDeviceExtensions(VkInstance instance, VkPhysicalDevice physicalDevice, Array<const char*>& outDeviceExtensions, const Array<const char*>& availableExtensions, uint32 physicalDeviceApiVersion);
+
+/// <summary>
+/// Chains required feature structs onto VkDeviceCreateInfo for enabled PerfSDK extensions.
+/// </summary>
+void RenderPerfChainVulkanDeviceCreateInfo(VkDeviceCreateInfo* deviceCreateInfo, VkPhysicalDevice physicalDevice, const Array<const char*>& enabledDeviceExtensions);
+
+#endif

--- a/Source/Engine/RenderPerf/PerfSdkHud.cpp
+++ b/Source/Engine/RenderPerf/PerfSdkHud.cpp
@@ -1,0 +1,1048 @@
+// Copyright (c) Flax Engine. Nsight Perf SDK HUD helper for RenderPerfSDK.
+
+#include "PerfSdkHud.h"
+#include "Engine/Core/Types/StringBuilder.h"
+
+#if defined(COMPILE_WITH_RENDER_PERF_NVPERF) && defined(PLATFORM_WINDOWS)
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef NOGDI
+#define NOGDI
+#endif
+
+#include <cstdarg>
+#include <cstdio>
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <d3d11.h>
+#include <d3d12.h>
+#include <dxgi.h>
+#include <wrl/client.h>
+
+#if PLATFORM_WIN32
+#include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
+#endif
+#include <ThirdParty/volk/volk.h>
+
+#define RYML_SINGLE_HDR_DEFINE_NOW
+#include <ryml_all.hpp>
+#ifndef _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
+#define _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
+#endif
+#undef RYML_SINGLE_HDR_DEFINE_NOW
+
+#include <NvPerfHudDataModel.h>
+#include <NvPerfHudTextRenderer.h>
+
+#include <NvPerfD3D11.h>
+#include <NvPerfD3D12.h>
+#include <NvPerfVulkan.h>
+#include <NvPerfMetricConfigurationsHAL.h>
+#include <NvPerfPeriodicSamplerGpu.h>
+#include <NvPerfPeriodicSamplerD3D12.h>
+#include <NvPerfPeriodicSamplerVulkan.h>
+#include <NvPerfCounterData.h>
+#include <NvPerfScopeExitGuard.h>
+
+#include "nvperf_host_impl.h"
+
+#ifdef Rectangle
+#undef Rectangle
+#endif
+
+#include "Engine/Graphics/GPUAdapter.h"
+#include "Engine/Graphics/GPUContext.h"
+#include "Engine/Graphics/GPUDevice.h"
+#include "Engine/Graphics/Enums.h"
+
+namespace
+{
+    using Microsoft::WRL::ComPtr;
+
+    static String RendererTypeToDisplayName(RendererType type)
+    {
+        switch (type)
+        {
+        case RendererType::DirectX11: return TEXT("DirectX 11");
+        case RendererType::DirectX12: return TEXT("DirectX 12");
+        case RendererType::Vulkan: return TEXT("Vulkan");
+        case RendererType::DirectX10: return TEXT("DirectX 10");
+        case RendererType::DirectX10_1: return TEXT("DirectX 10.1");
+        case RendererType::OpenGL4_1: return TEXT("OpenGL 4.1");
+        case RendererType::OpenGL4_4: return TEXT("OpenGL 4.4");
+        case RendererType::OpenGLES3: return TEXT("OpenGL ES 3");
+        case RendererType::OpenGLES3_1: return TEXT("OpenGL ES 3.1");
+        case RendererType::Null: return TEXT("Null");
+        case RendererType::WebGPU: return TEXT("WebGPU");
+        default: return TEXT("Unknown");
+        }
+    }
+
+    enum class PerfSdkBackend
+    {
+        D3D11,
+        D3D12,
+        Vulkan,
+    };
+
+    struct PerfSdkHudImpl
+    {
+        PerfSdkBackend backend = PerfSdkBackend::D3D11;
+
+        nv::perf::hud::HudPresets hudPresets;
+        nv::perf::hud::HudDataModel hudDataModel;
+        nv::perf::hud::HudTextRenderer hudTextRenderer;
+        std::string capturedHudText;
+
+        // D3D11-only path (GpuPeriodicSampler + timestamp queries)
+        nv::perf::sampler::GpuPeriodicSampler d3d11PeriodicSampler;
+        nv::perf::sampler::RingBufferCounterData d3d11CounterData;
+        ComPtr<ID3D11Device> d3d11Device;
+        ComPtr<ID3D11DeviceContext> d3d11Context;
+        ComPtr<ID3D11Query> d3d11TimestampQuery;
+        ComPtr<ID3D11Query> d3d11TimestampDisjointQuery;
+        uint32_t d3d11MaxTriggerLatency = 0;
+        bool d3d11InSession = false;
+        uint64_t d3d11PendingFrameEndTime = 0;
+
+        // D3D12 / Vulkan (PeriodicSamplerTimeHistory + mini trace)
+        nv::perf::sampler::PeriodicSamplerTimeHistoryD3D12 d3d12Sampler;
+        ComPtr<ID3D12CommandQueue> d3d12Queue;
+        nv::perf::sampler::PeriodicSamplerTimeHistoryVulkan vkSampler;
+
+        uint32_t samplingFrequencyHz = 20;
+    };
+
+    static PerfSdkHudImpl* gHudTextCapture = nullptr;
+
+    static bool TrySetNvPerfLibraryPath()
+    {
+        std::vector<std::wstring> candidates;
+        wchar_t envPath[1024];
+        if (GetEnvironmentVariableW(L"NVPERF_SDK_PATH", envPath, 1024) > 0)
+            candidates.emplace_back(envPath);
+        candidates.emplace_back(L"C:\\Users\\nproc\\Downloads\\PerfSDK_2025_5");
+
+        for (const std::wstring& root : candidates)
+        {
+            const std::wstring binPath = root + L"\\NvPerf\\bin\\x64";
+            if (GetFileAttributesW(binPath.c_str()) == INVALID_FILE_ATTRIBUTES)
+                continue;
+
+            const wchar_t* paths[] = { binPath.c_str() };
+            NVPW_SetLibraryLoadPathsW_Params params = { NVPW_SetLibraryLoadPathsW_Params_STRUCT_SIZE };
+            params.numPaths = 1;
+            params.ppwPaths = paths;
+            if (NVPW_SetLibraryLoadPathsW(&params) == NVPA_STATUS_SUCCESS)
+                return true;
+        }
+        return true;
+    }
+
+    static void HudPrintCapture(const char* format, va_list list)
+    {
+        if (!gHudTextCapture)
+            return;
+        char buffer[512];
+        const int written = vsnprintf(buffer, sizeof(buffer), format, list);
+        if (written > 0)
+            gHudTextCapture->capturedHudText.append(buffer, static_cast<size_t>(written));
+    }
+
+    static bool IsTimestampTableHeader(const std::string& line)
+    {
+        return line.find("Timestamp") != std::string::npos && line.find('|') != std::string::npos;
+    }
+
+    static bool IsTimestampTableDataRow(const std::string& line)
+    {
+        if (line.empty())
+            return false;
+        if (line.find("===") != std::string::npos)
+            return false;
+        if (line.find("Timestamp") != std::string::npos)
+            return false;
+        if (line.find('|') == std::string::npos)
+            return false;
+        if (line.find("---") != std::string::npos)
+            return false;
+        return true;
+    }
+
+    static void KeepOnlyLatestTimestampRows(std::string& text)
+    {
+        std::vector<std::string> lines;
+        size_t lineStart = 0;
+        for (size_t i = 0; i <= text.size(); ++i)
+        {
+            if (i == text.size() || text[i] == '\n')
+            {
+                lines.push_back(text.substr(lineStart, i - lineStart));
+                lineStart = i + 1;
+            }
+        }
+
+        std::string filtered;
+        filtered.reserve(text.size());
+        std::string latestDataRow;
+        bool inTimestampTable = false;
+
+        auto flushLatestRow = [&]() {
+            if (!latestDataRow.empty())
+            {
+                filtered.append(latestDataRow);
+                filtered.push_back('\n');
+                latestDataRow.clear();
+            }
+        };
+
+        for (const std::string& line : lines)
+        {
+            if (IsTimestampTableHeader(line))
+            {
+                if (inTimestampTable)
+                    flushLatestRow();
+                inTimestampTable = true;
+                filtered.append(line);
+                filtered.push_back('\n');
+                continue;
+            }
+            if (inTimestampTable && IsTimestampTableDataRow(line))
+            {
+                latestDataRow = line;
+                continue;
+            }
+            if (inTimestampTable)
+            {
+                flushLatestRow();
+                inTimestampTable = false;
+            }
+            if (!line.empty() || !filtered.empty())
+            {
+                filtered.append(line);
+                filtered.push_back('\n');
+            }
+        }
+        if (inTimestampTable)
+            flushLatestRow();
+        while (!filtered.empty() && filtered.back() == '\n')
+            filtered.pop_back();
+        text.swap(filtered);
+    }
+
+    static void RenderHudText(PerfSdkHudImpl& impl)
+    {
+        impl.capturedHudText.clear();
+        impl.hudTextRenderer.Render();
+        KeepOnlyLatestTimestampRows(impl.capturedHudText);
+    }
+
+    static bool TryGetLatestHudMetricValueInPanel(nv::perf::hud::HudDataModel& model, const char* panelName, const char* signalLabel, float& outValue)
+    {
+        if (!signalLabel)
+            return false;
+
+        for (const nv::perf::hud::HudConfiguration& configuration : model.GetConfigurations())
+        {
+            for (const nv::perf::hud::Panel& panel : configuration.panels)
+            {
+                if (panelName && panel.name != panelName)
+                    continue;
+
+                for (const std::unique_ptr<nv::perf::hud::Widget>& widget : panel.widgets)
+                {
+                    if (!widget)
+                        continue;
+
+                    if (widget->type == nv::perf::hud::Widget::Type::ScalarText)
+                    {
+                        nv::perf::hud::ScalarText& scalar = *static_cast<nv::perf::hud::ScalarText*>(widget.get());
+                        if (scalar.label.text != signalLabel || scalar.signal.valBuffer.Size() == 0)
+                            continue;
+                        outValue = static_cast<float>(scalar.signal.valBuffer.Back());
+                        return true;
+                    }
+
+                    if (widget->type == nv::perf::hud::Widget::Type::TimePlot)
+                    {
+                        nv::perf::hud::TimePlot& plot = *static_cast<nv::perf::hud::TimePlot*>(widget.get());
+                        for (nv::perf::hud::MetricSignal& signal : plot.signals)
+                        {
+                            if (signal.label.text != signalLabel || signal.valBuffer.Size() == 0)
+                                continue;
+                            outValue = static_cast<float>(signal.valBuffer.Back());
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryGetLatestHudMetricValue(nv::perf::hud::HudDataModel& model, const char* signalLabel, float& outValue)
+    {
+        return TryGetLatestHudMetricValueInPanel(model, nullptr, signalLabel, outValue);
+    }
+
+    static float NormalizeDesignerMetricValue(float value)
+    {
+        if (std::isnan(value) || std::isinf(value))
+            return 0.0f;
+        return static_cast<float>(Math::Clamp(value, 0.0f, 100.0f));
+    }
+
+    enum class ChipMetricFormat
+    {
+        Percent,
+        Warps,
+        Pixels,
+        Bandwidth,
+    };
+
+    struct ChipAreaDefinition
+    {
+        const Char* GroupName;
+        const Char* AreaName;
+        const char* PanelName;
+        const char* HudLabel;
+        const Char* MetricLabel;
+        ChipMetricFormat Format;
+        float BarScale;
+        bool HigherIsBetter;
+    };
+
+    static const ChipAreaDefinition gChipAreaDefinitions[] =
+    {
+        // GPU Engines
+        { TEXT("GPU Engines"), TEXT("3D Engine"), "Frame Level Stats", "GR Active", TEXT("GR Active"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("GPU Engines"), TEXT("Copy Engine"), "Engine Active (%)", "Sync CE", TEXT("Sync Copy Engine"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("GPU Engines"), TEXT("Compute"), "Warp Occupancy (warps)", "Compute", TEXT("Compute Warps"), ChipMetricFormat::Warps, 24.0f, false },
+        { TEXT("GPU Engines"), TEXT("Fill Rate"), "ROP Throughput (%)", "CROP Write", TEXT("CROP Write"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("GPU Engines"), TEXT("Depth Output"), "ROP Throughput (%)", "ZROP Write", TEXT("ZROP Write"), ChipMetricFormat::Percent, 100.0f, false },
+
+        // Shaders
+        { TEXT("Shaders"), TEXT("Shader Load"), "Frame Level Stats", "SM Active", TEXT("SM Active"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("Shaders"), TEXT("Complexity"), "Shader Activity (%)", "Instructions", TEXT("Instructions"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("Shaders"), TEXT("Heavy Math (FMA)"), "Shader Activity (%)", "FMA-Heavy Instructions", TEXT("FMA-Heavy"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("Shaders"), TEXT("ALU Instructions"), "Shader Activity (%)", "ALU Instructions", TEXT("ALU Instructions"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("Shaders"), TEXT("Pixel Shaders"), "Warp Occupancy (warps)", "Pixel", TEXT("Pixel Warps"), ChipMetricFormat::Warps, 24.0f, false },
+        { TEXT("Shaders"), TEXT("Vertex Shaders"), "Warp Occupancy (warps)", "Vertex/Tess/Geometry", TEXT("VTG Warps"), ChipMetricFormat::Warps, 24.0f, false },
+        { TEXT("Shaders"), TEXT("GPU Headroom"), "Warp Occupancy (warps)", "Unused, SM Active", TEXT("Idle Warps"), ChipMetricFormat::Warps, 24.0f, true },
+
+        // VRAM
+        { TEXT("VRAM"), TEXT("Memory Throughput"), "Frame Level Stats", "VRAM Throughput", TEXT("VRAM Throughput"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("VRAM"), TEXT("Read"), "VRAM Throughput (%)", "Read", TEXT("VRAM Read"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("VRAM"), TEXT("Write"), "VRAM Throughput (%)", "Write", TEXT("VRAM Write"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("VRAM"), TEXT("System RAM (PCI)"), "Frame Level Stats", "PCI Throughput", TEXT("PCI Throughput"), ChipMetricFormat::Percent, 100.0f, false },
+        { TEXT("VRAM"), TEXT("PCI Read"), "PCI Bandwidth (GB/s)", "Read", TEXT("PCI Read"), ChipMetricFormat::Bandwidth, 64.0f, false },
+        { TEXT("VRAM"), TEXT("PCI Write"), "PCI Bandwidth (GB/s)", "Write", TEXT("PCI Write"), ChipMetricFormat::Bandwidth, 64.0f, false },
+
+        // Caches
+        { TEXT("Caches"), TEXT("L2 Cache"), "L2 Hit-Rates (%)", "Total", TEXT("L2 Hit Rate"), ChipMetricFormat::Percent, 100.0f, true },
+        { TEXT("Caches"), TEXT("Texture L2"), "L2 Hit-Rates (%)", "Tex", TEXT("Texture L2 Hit"), ChipMetricFormat::Percent, 100.0f, true },
+        { TEXT("Caches"), TEXT("TRAM Stalls"), "TRAM Allocation Stalls (%)", "TRAM Allocation Stalls", TEXT("TRAM Stalls"), ChipMetricFormat::Percent, 100.0f, false },
+    };
+
+    static const Char* gChipAreaGroupOrder[] =
+    {
+        TEXT("GPU Engines"),
+        TEXT("Shaders"),
+        TEXT("VRAM"),
+        TEXT("Caches"),
+    };
+
+    static float ComputeBarValue(const ChipAreaDefinition& def, float rawValue)
+    {
+        if (def.Format == ChipMetricFormat::Percent)
+            return NormalizeDesignerMetricValue(rawValue);
+
+        if (def.BarScale <= 0.0f)
+            return 0.0f;
+
+        return NormalizeDesignerMetricValue(rawValue / def.BarScale * 100.0f);
+    }
+
+    static String FormatChipMetricDetail(const ChipAreaDefinition& def, float rawValue)
+    {
+        switch (def.Format)
+        {
+        case ChipMetricFormat::Percent:
+            return String::Format(TEXT("{0}: {1:.1f}%"), def.MetricLabel, rawValue);
+        case ChipMetricFormat::Warps:
+            return String::Format(TEXT("{0}: {1:.1f} warps"), def.MetricLabel, rawValue);
+        case ChipMetricFormat::Pixels:
+            return String::Format(TEXT("{0}: {1:.0f}"), def.MetricLabel, rawValue);
+        case ChipMetricFormat::Bandwidth:
+            return String::Format(TEXT("{0}: {1:.2f} GB/s"), def.MetricLabel, rawValue);
+        default:
+            return String::Format(TEXT("{0}: {1:.1f}"), def.MetricLabel, rawValue);
+        }
+    }
+
+    static bool TryGetChipMetricValue(PerfSdkHudImpl& impl, const ChipAreaDefinition& def, float& rawValue)
+    {
+        return TryGetLatestHudMetricValueInPanel(impl.hudDataModel, def.PanelName, def.HudLabel, rawValue);
+    }
+
+    static void AppendChipAreaRows(StringBuilder& sb, PerfSdkHudImpl& impl)
+    {
+        for (const Char* groupName : gChipAreaGroupOrder)
+        {
+            sb.AppendFormat(TEXT("#GROUP\t{0}\n"), groupName);
+
+            for (const ChipAreaDefinition& def : gChipAreaDefinitions)
+            {
+                if (String(def.GroupName) != groupName)
+                    continue;
+
+                float rawValue = 0.0f;
+                const bool hasData = TryGetChipMetricValue(impl, def, rawValue);
+                const float throughput = hasData ? ComputeBarValue(def, rawValue) : 0.0f;
+                const String detail = hasData ? FormatChipMetricDetail(def, rawValue) : TEXT("Collecting samples...");
+                sb.AppendFormat(TEXT("{0}\t{1:.1f}\t{2}\t{3}\n"),
+                                def.AreaName,
+                                throughput,
+                                detail,
+                                def.HigherIsBetter ? 1 : 0);
+            }
+        }
+    }
+
+    static bool InitHudDataModel(PerfSdkHudImpl& impl, const char* chipName, String& statusText)
+    {
+        if (!chipName)
+        {
+            statusText = TEXT("Nsight Perf: unknown GPU chip.");
+            return false;
+        }
+
+        impl.hudPresets.Initialize(chipName);
+        const char* hudConfigurationName = "Graphics General Triage";
+        impl.hudDataModel.Load(impl.hudPresets.GetPreset(hudConfigurationName));
+
+        nv::perf::MetricConfigObject metricConfigObject;
+        std::string metricConfigName;
+        if (nv::perf::MetricConfigurations::GetMetricConfigNameBasedOnHudConfigurationName(
+                metricConfigName, chipName, hudConfigurationName))
+        {
+            if (!nv::perf::MetricConfigurations::LoadMetricConfigObject(metricConfigObject, chipName, metricConfigName))
+            {
+                statusText = TEXT("Nsight Perf: metric config load failed.");
+                return false;
+            }
+        }
+
+        const double samplingPeriod = 1.0 / static_cast<double>(impl.samplingFrequencyHz);
+        if (!impl.hudDataModel.Initialize(samplingPeriod, 4.0, metricConfigObject))
+        {
+            statusText = TEXT("Nsight Perf: HudDataModel init failed.");
+            return false;
+        }
+
+        impl.hudTextRenderer.SetConsoleOutput([](const char* format, va_list list) {
+            HudPrintCapture(format, list);
+        });
+        impl.hudTextRenderer.SetColumnSeparator("|");
+        impl.hudTextRenderer.Initialize(impl.hudDataModel);
+        return true;
+    }
+
+    static bool CreateD3D11TimestampQueries(ID3D11Device* device, ComPtr<ID3D11Query>& disjointQuery, ComPtr<ID3D11Query>& timestampQuery)
+    {
+        D3D11_QUERY_DESC disjointDesc = {};
+        disjointDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+        if (FAILED(device->CreateQuery(&disjointDesc, &disjointQuery)))
+            return false;
+        D3D11_QUERY_DESC tsDesc = {};
+        tsDesc.Query = D3D11_QUERY_TIMESTAMP;
+        return SUCCEEDED(device->CreateQuery(&tsDesc, &timestampQuery));
+    }
+
+    static uint64_t ReadD3D11GpuTimestamp(ID3D11Device* device, ID3D11DeviceContext* context, ID3D11Query* disjointQuery, ID3D11Query* timestampQuery)
+    {
+        if (!device || !context || !timestampQuery)
+            return 0;
+        context->End(timestampQuery);
+        if (disjointQuery)
+            context->End(disjointQuery);
+        nv::perf::D3D11Finish(device, context);
+        if (disjointQuery)
+        {
+            D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
+            while (context->GetData(disjointQuery, &disjointData, sizeof(disjointData), 0) == S_FALSE)
+            {
+            }
+        }
+        uint64_t timestamp = 0;
+        while (context->GetData(timestampQuery, &timestamp, sizeof(timestamp), 0) == S_FALSE)
+        {
+        }
+        return timestamp;
+    }
+
+    static ID3D12CommandQueue* GetFlaxGraphicsCommandQueue(GPUDevice* gpuDevice)
+    {
+        if (!gpuDevice)
+            return nullptr;
+        return static_cast<ID3D12CommandQueue*>(gpuDevice->GetNativeCommandQueue());
+    }
+
+    static bool DecodeAndUpdateHudD3D11(PerfSdkHudImpl& impl)
+    {
+        nv::perf::sampler::GpuPeriodicSampler::GetRecordBufferStatusParams status = {};
+        status.queryOverflow = true;
+        status.queryNumUnreadBytes = true;
+        if (!impl.d3d11PeriodicSampler.GetRecordBufferStatus(status))
+            return false;
+        if (status.overflow)
+            return false;
+
+        if (status.numUnreadBytes > 0)
+        {
+            NVPW_GPU_PeriodicSampler_DecodeStopReason decodeStopReason = NVPW_GPU_PERIODIC_SAMPLER_DECODE_STOP_REASON_OTHER;
+            size_t numSamplesMerged = 0;
+            size_t numBytesConsumed = 0;
+            if (!impl.d3d11PeriodicSampler.DecodeCounters(
+                    impl.d3d11CounterData.GetCounterData(),
+                    status.numUnreadBytes,
+                    decodeStopReason,
+                    numSamplesMerged,
+                    numBytesConsumed))
+                return false;
+            if (!impl.d3d11PeriodicSampler.AcknowledgeRecordBuffer(numBytesConsumed))
+                return false;
+            if (!impl.d3d11CounterData.UpdatePut())
+                return false;
+        }
+
+        uint32_t numRangesConsumed = 0;
+        if (!impl.d3d11CounterData.ConsumeData([&](const uint8_t* pCounterDataImage, size_t counterDataImageSize, uint32_t rangeIndex, bool& stop) {
+                stop = false;
+                if (!impl.hudDataModel.AddSample(pCounterDataImage, counterDataImageSize, rangeIndex))
+                    return false;
+                ++numRangesConsumed;
+                return true;
+            }))
+            return false;
+
+        if (!impl.d3d11CounterData.UpdateGet(numRangesConsumed))
+            return false;
+
+        if (impl.d3d11PendingFrameEndTime != 0)
+            impl.hudDataModel.AddFrameDelimiter(impl.d3d11PendingFrameEndTime);
+
+        RenderHudText(impl);
+        return true;
+    }
+
+    template<typename TSampler>
+    static bool DecodeAndUpdateHudTimeHistory(TSampler& sampler, PerfSdkHudImpl& impl)
+    {
+        if (!sampler.DecodeCounters())
+            return false;
+
+        if (!sampler.ConsumeSamples([&](const uint8_t* pCounterDataImage, size_t counterDataImageSize, uint32_t rangeIndex, bool& stop) {
+                stop = false;
+                return impl.hudDataModel.AddSample(pCounterDataImage, counterDataImageSize, rangeIndex);
+            }))
+            return false;
+
+        for (const auto& frameDelimiter : sampler.GetFrameDelimiters())
+            impl.hudDataModel.AddFrameDelimiter(frameDelimiter.frameEndTime);
+
+        RenderHudText(impl);
+        return true;
+    }
+
+    static bool BeginGpuPeriodicSession(nv::perf::sampler::GpuPeriodicSampler& sampler, size_t deviceIndex, uint32_t maxTriggerLatency, uint32_t samplingIntervalNs)
+    {
+        const auto pulse = sampler.GetGpuPulseSamplingInterval(samplingIntervalNs);
+        size_t recordBufferSize = 0;
+        if (!nv::perf::sampler::GpuPeriodicSamplerCalculateRecordBufferSize(deviceIndex, std::vector<uint8_t>(), maxTriggerLatency, recordBufferSize))
+            return false;
+        return sampler.BeginSession(recordBufferSize, 1, { pulse.triggerSource }, pulse.samplingInterval);
+    }
+
+    static bool InitD3D11(PerfSdkHudImpl& impl, ID3D11Device* device, ID3D11DeviceContext* context, String& statusText)
+    {
+        if (!device || !context || context->GetType() != D3D11_DEVICE_CONTEXT_IMMEDIATE)
+        {
+            statusText = TEXT("Nsight Perf: D3D11 immediate context required.");
+            return false;
+        }
+        if (!nv::perf::D3D11LoadDriver())
+        {
+            statusText = TEXT("Nsight Perf: D3D11LoadDriver failed.");
+            return false;
+        }
+        if (!nv::perf::D3D11IsNvidiaDevice(device) || !nv::perf::profiler::D3D11IsGpuSupported(device))
+        {
+            statusText = TEXT("Nsight Perf: D3D11 NVIDIA GPU not supported.");
+            return false;
+        }
+
+        const size_t deviceIndex = nv::perf::D3D11GetNvperfDeviceIndex(device);
+        if (deviceIndex == size_t(~0))
+        {
+            statusText = TEXT("Nsight Perf: D3D11GetNvperfDeviceIndex failed.");
+            return false;
+        }
+
+        impl.d3d11Device = device;
+        impl.d3d11Context = context;
+        if (!CreateD3D11TimestampQueries(device, impl.d3d11TimestampDisjointQuery, impl.d3d11TimestampQuery))
+        {
+            statusText = TEXT("Nsight Perf: D3D11 timestamp queries failed.");
+            return false;
+        }
+        if (!impl.d3d11PeriodicSampler.Initialize(deviceIndex))
+        {
+            statusText = TEXT("Nsight Perf: GpuPeriodicSampler init failed.");
+            return false;
+        }
+
+        const char* chipName = impl.d3d11PeriodicSampler.GetDeviceIdentifiers().pChipName;
+        if (!InitHudDataModel(impl, chipName, statusText))
+            return false;
+
+        const uint32_t samplingIntervalNs = 1000u * 1000u * 1000u / impl.samplingFrequencyHz;
+        const uint32_t maxDecodeLatencyNs = 1000u * 1000u * 1000u;
+        impl.d3d11MaxTriggerLatency = maxDecodeLatencyNs / samplingIntervalNs;
+
+        if (!BeginGpuPeriodicSession(impl.d3d11PeriodicSampler, deviceIndex, impl.d3d11MaxTriggerLatency, samplingIntervalNs))
+        {
+            statusText = TEXT("Nsight Perf: D3D11 BeginSession failed.");
+            return false;
+        }
+        impl.d3d11InSession = true;
+
+        const auto& counterConfig = impl.hudDataModel.GetCounterConfiguration();
+        if (!impl.d3d11PeriodicSampler.SetConfig(counterConfig.configImage, 0))
+        {
+            statusText = TEXT("Nsight Perf: D3D11 SetConfig failed.");
+            return false;
+        }
+
+        if (!impl.d3d11CounterData.Initialize(impl.d3d11MaxTriggerLatency, false, [&](uint32_t maxSamples, NVPW_PeriodicSampler_CounterData_AppendMode appendMode, std::vector<uint8_t>& counterData) {
+                return nv::perf::sampler::GpuPeriodicSamplerCreateCounterData(
+                    deviceIndex,
+                    counterConfig.counterDataPrefix.data(),
+                    counterConfig.counterDataPrefix.size(),
+                    maxSamples,
+                    appendMode,
+                    counterData);
+            }))
+        {
+            statusText = TEXT("Nsight Perf: D3D11 counter data init failed.");
+            return false;
+        }
+
+        if (!impl.hudDataModel.PrepareSampleProcessing(impl.d3d11CounterData.GetCounterData()))
+        {
+            statusText = TEXT("Nsight Perf: PrepareSampleProcessing failed.");
+            return false;
+        }
+
+        if (!impl.d3d11PeriodicSampler.StartSampling())
+        {
+            statusText = TEXT("Nsight Perf: StartSampling failed.");
+            return false;
+        }
+        return true;
+    }
+
+    static bool InitD3D12(PerfSdkHudImpl& impl, GPUDevice* gpuDevice, String& statusText)
+    {
+        if (!gpuDevice)
+        {
+            statusText = TEXT("Nsight Perf: missing D3D12 device.");
+            return false;
+        }
+        auto* device = static_cast<ID3D12Device*>(gpuDevice->GetNativePtr());
+        if (!device)
+        {
+            statusText = TEXT("Nsight Perf: missing D3D12 native device.");
+            return false;
+        }
+        if (!nv::perf::D3D12LoadDriver())
+        {
+            statusText = TEXT("Nsight Perf: D3D12LoadDriver failed.");
+            return false;
+        }
+        if (!nv::perf::D3D12IsNvidiaDevice(device) || !nv::perf::profiler::D3D12IsGpuSupported(device))
+        {
+            statusText = TEXT("Nsight Perf: D3D12 NVIDIA GPU not supported.");
+            return false;
+        }
+
+        if (!impl.d3d12Sampler.Initialize(device))
+        {
+            statusText = TEXT("Nsight Perf: D3D12 sampler init failed.");
+            return false;
+        }
+
+        const char* chipName = impl.d3d12Sampler.GetGpuDeviceIdentifiers().pChipName;
+        if (!InitHudDataModel(impl, chipName, statusText))
+            return false;
+
+        ComPtr<ID3D12CommandQueue> queue;
+        ID3D12CommandQueue* flaxQueue = GetFlaxGraphicsCommandQueue(gpuDevice);
+        if (!flaxQueue)
+        {
+            statusText = TEXT("Nsight Perf: D3D12 graphics queue not found.");
+            return false;
+        }
+        queue = flaxQueue;
+        impl.d3d12Queue = queue;
+
+        const uint32_t samplingIntervalNs = 1000u * 1000u * 1000u / impl.samplingFrequencyHz;
+        const uint32_t maxDecodeLatencyNs = 1000u * 1000u * 1000u;
+        const size_t maxFrameLatency = 3;
+        if (!impl.d3d12Sampler.BeginSession(queue.Get(), samplingIntervalNs, maxDecodeLatencyNs, maxFrameLatency))
+        {
+            statusText = TEXT("Nsight Perf: D3D12 BeginSession failed.");
+            return false;
+        }
+
+        if (!impl.d3d12Sampler.SetConfig(&impl.hudDataModel.GetCounterConfiguration()))
+        {
+            statusText = TEXT("Nsight Perf: D3D12 SetConfig failed.");
+            return false;
+        }
+
+        if (!impl.hudDataModel.PrepareSampleProcessing(impl.d3d12Sampler.GetCounterData()))
+        {
+            statusText = TEXT("Nsight Perf: PrepareSampleProcessing failed.");
+            return false;
+        }
+        return true;
+    }
+
+    static bool InitVulkan(PerfSdkHudImpl& impl, GPUDevice* gpuDevice, GPUAdapter* adapter, String& statusText)
+    {
+        if (!gpuDevice || !adapter)
+        {
+            statusText = TEXT("Nsight Perf: missing Vulkan device or adapter.");
+            return false;
+        }
+
+        void** handles = static_cast<void**>(gpuDevice->GetNativePtr());
+        VkInstance instance = handles ? static_cast<VkInstance>(handles[0]) : VK_NULL_HANDLE;
+        VkDevice device = handles ? static_cast<VkDevice>(handles[1]) : VK_NULL_HANDLE;
+        VkPhysicalDevice physicalDevice = static_cast<VkPhysicalDevice>(adapter->GetNativePtr());
+        if (!instance || !physicalDevice || !device)
+        {
+            statusText = TEXT("Nsight Perf: missing Vulkan handles.");
+            return false;
+        }
+        if (!nv::perf::VulkanLoadDriver(instance))
+        {
+            statusText = TEXT("Nsight Perf: VulkanLoadDriver failed.");
+            return false;
+        }
+        if (!adapter->IsNVIDIA())
+        {
+            statusText = TEXT("Nsight Perf: Vulkan NVIDIA GPU not supported.");
+            return false;
+        }
+
+        if (!impl.vkSampler.Initialize(instance, physicalDevice, device, vkGetInstanceProcAddr, vkGetDeviceProcAddr))
+        {
+            statusText = TEXT("Nsight Perf: Vulkan sampler init failed.");
+            return false;
+        }
+
+        const char* chipName = impl.vkSampler.GetGpuDeviceIdentifiers().pChipName;
+        if (!InitHudDataModel(impl, chipName, statusText))
+            return false;
+
+        VkQueue queue = static_cast<VkQueue>(gpuDevice->GetNativeCommandQueue());
+        const uint32_t queueFamilyIndex = gpuDevice->GetNativeCommandQueueFamilyIndex();
+        if (!queue)
+        {
+            statusText = TEXT("Nsight Perf: Vulkan graphics queue not found.");
+            return false;
+        }
+
+        const uint32_t samplingIntervalNs = 1000u * 1000u * 1000u / impl.samplingFrequencyHz;
+        const uint32_t maxDecodeLatencyNs = 1000u * 1000u * 1000u;
+        const size_t maxFrameLatency = 3;
+        if (!impl.vkSampler.BeginSession(queue, queueFamilyIndex, samplingIntervalNs, maxDecodeLatencyNs, maxFrameLatency))
+        {
+            statusText = TEXT("Nsight Perf: Vulkan BeginSession failed. Fully restart the editor after rebuilding so PerfSDK Vulkan features/extensions are applied at device creation.");
+            return false;
+        }
+
+        if (!impl.vkSampler.SetConfig(&impl.hudDataModel.GetCounterConfiguration()))
+        {
+            statusText = TEXT("Nsight Perf: Vulkan SetConfig failed.");
+            return false;
+        }
+
+        if (!impl.hudDataModel.PrepareSampleProcessing(impl.vkSampler.GetCounterData()))
+        {
+            statusText = TEXT("Nsight Perf: PrepareSampleProcessing failed.");
+            return false;
+        }
+        return true;
+    }
+}
+
+bool PerfSdkHud::TryInitialize(GPUDevice* device, GPUAdapter* adapter, GPUContext* context)
+{
+    Shutdown();
+
+    if (!device || !context)
+    {
+        _statusText = TEXT("Nsight Perf: missing GPU device or context.");
+        return false;
+    }
+
+    const RendererType rendererType = device->GetRendererType();
+    _graphicsApiName = RendererTypeToDisplayName(rendererType);
+
+    if (rendererType != RendererType::DirectX11 &&
+        rendererType != RendererType::DirectX12 &&
+        rendererType != RendererType::Vulkan)
+    {
+        _statusText = String::Format(TEXT("Nsight Perf: unsupported graphics API ({0}). Use D3D11, D3D12, or Vulkan."), _graphicsApiName);
+        return false;
+    }
+
+    TrySetNvPerfLibraryPath();
+    if (!nv::perf::InitializeNvPerf())
+    {
+        _statusText = TEXT("Nsight Perf: NVPW_InitializeHost/Target failed.");
+        return false;
+    }
+
+    auto impl = std::make_unique<PerfSdkHudImpl>();
+    bool initOk = false;
+
+    switch (rendererType)
+    {
+    case RendererType::DirectX11:
+    {
+        impl->backend = PerfSdkBackend::D3D11;
+        auto* d3dContext = static_cast<ID3D11DeviceContext*>(context->GetNativePtr());
+        ComPtr<ID3D11Device> d3dDevice;
+        if (d3dContext)
+            d3dContext->GetDevice(&d3dDevice);
+        initOk = InitD3D11(*impl, d3dDevice.Get(), d3dContext, _statusText);
+        break;
+    }
+    case RendererType::DirectX12:
+    {
+        impl->backend = PerfSdkBackend::D3D12;
+        initOk = InitD3D12(*impl, device, _statusText);
+        break;
+    }
+    case RendererType::Vulkan:
+    {
+        impl->backend = PerfSdkBackend::Vulkan;
+        initOk = InitVulkan(*impl, device, adapter, _statusText);
+        break;
+    }
+    default:
+        break;
+    }
+
+    if (!initOk)
+        return false;
+
+    gHudTextCapture = impl.get();
+    _impl = impl.release();
+    _active = true;
+
+    const char* chipName = nullptr;
+    switch (rendererType)
+    {
+    case RendererType::DirectX11:
+        chipName = static_cast<PerfSdkHudImpl*>(_impl)->d3d11PeriodicSampler.GetDeviceIdentifiers().pChipName;
+        break;
+    case RendererType::DirectX12:
+        chipName = static_cast<PerfSdkHudImpl*>(_impl)->d3d12Sampler.GetGpuDeviceIdentifiers().pChipName;
+        break;
+    case RendererType::Vulkan:
+        chipName = static_cast<PerfSdkHudImpl*>(_impl)->vkSampler.GetGpuDeviceIdentifiers().pChipName;
+        break;
+    default:
+        break;
+    }
+
+    _statusText = String::Format(
+        TEXT("Nsight Perf: {0} | {1} @ {2} Hz"),
+        _graphicsApiName,
+        chipName ? String(chipName) : String(TEXT("GPU")),
+        static_cast<PerfSdkHudImpl*>(_impl)->samplingFrequencyHz);
+    _overlayText = TEXT("Nsight Perf: warming up...");
+    return true;
+}
+
+void PerfSdkHud::Shutdown()
+{
+    gHudTextCapture = nullptr;
+    if (!_impl)
+        return;
+
+    auto* impl = static_cast<PerfSdkHudImpl*>(_impl);
+    switch (impl->backend)
+    {
+    case PerfSdkBackend::D3D11:
+        if (impl->d3d11InSession)
+        {
+            impl->d3d11PeriodicSampler.StopSampling();
+            impl->d3d11PeriodicSampler.EndSession();
+            impl->d3d11InSession = false;
+        }
+        impl->d3d11PeriodicSampler.Reset();
+        impl->d3d11CounterData.Reset();
+        break;
+    case PerfSdkBackend::D3D12:
+        impl->d3d12Sampler.EndSession();
+        impl->d3d12Sampler.Reset();
+        break;
+    case PerfSdkBackend::Vulkan:
+        impl->vkSampler.EndSession();
+        impl->vkSampler.Reset();
+        break;
+    }
+    delete impl;
+    _impl = nullptr;
+    _active = false;
+}
+
+void PerfSdkHud::OnRenderPassBegin(GPUContext* context)
+{
+    if (!_active || !_impl || !context)
+        return;
+
+    auto* impl = static_cast<PerfSdkHudImpl*>(_impl);
+    switch (impl->backend)
+    {
+    case PerfSdkBackend::D3D11:
+    {
+        auto* d3dContext = static_cast<ID3D11DeviceContext*>(context->GetNativePtr());
+        if (impl->d3d11TimestampDisjointQuery && d3dContext)
+            d3dContext->Begin(impl->d3d11TimestampDisjointQuery.Get());
+        DecodeAndUpdateHudD3D11(*impl);
+        break;
+    }
+    case PerfSdkBackend::D3D12:
+        DecodeAndUpdateHudTimeHistory(impl->d3d12Sampler, *impl);
+        break;
+    case PerfSdkBackend::Vulkan:
+        DecodeAndUpdateHudTimeHistory(impl->vkSampler, *impl);
+        break;
+    }
+
+    if (!impl->capturedHudText.empty())
+        _overlayText = impl->capturedHudText.c_str();
+}
+
+void PerfSdkHud::OnRenderPassEnd(GPUContext* context)
+{
+    if (!_active || !_impl || !context)
+        return;
+
+    auto* impl = static_cast<PerfSdkHudImpl*>(_impl);
+    switch (impl->backend)
+    {
+    case PerfSdkBackend::D3D11:
+    {
+        auto* d3dContext = static_cast<ID3D11DeviceContext*>(context->GetNativePtr());
+        if (impl->d3d11Device && d3dContext)
+        {
+            impl->d3d11PendingFrameEndTime = ReadD3D11GpuTimestamp(
+                impl->d3d11Device.Get(),
+                d3dContext,
+                impl->d3d11TimestampDisjointQuery.Get(),
+                impl->d3d11TimestampQuery.Get());
+            if (impl->d3d11InSession)
+                impl->d3d11PeriodicSampler.StartSampling();
+        }
+        break;
+    }
+    case PerfSdkBackend::D3D12:
+        impl->d3d12Sampler.OnFrameEnd();
+        break;
+    case PerfSdkBackend::Vulkan:
+        if (!impl->vkSampler.OnFrameEnd())
+            _overlayText = TEXT("Nsight Perf: Vulkan frame marker failed.");
+        break;
+    }
+}
+
+void PerfSdkHud::GetDesignerMetrics(Array<RenderPerfTools::DesignerGpuMetric, InlinedAllocation<32>>& metrics) const
+{
+    metrics.Clear();
+    if (!_active || !_impl)
+        return;
+
+    auto* impl = static_cast<PerfSdkHudImpl*>(_impl);
+    for (const ChipAreaDefinition& def : gChipAreaDefinitions)
+    {
+        float rawValue = 0.0f;
+        if (!TryGetChipMetricValue(*impl, def, rawValue))
+            continue;
+
+        RenderPerfTools::DesignerGpuMetric metric;
+        metric.Title = def.AreaName;
+        metric.Hint = FormatChipMetricDetail(def, rawValue);
+        metric.Value = ComputeBarValue(def, rawValue);
+        metric.HigherIsBetter = def.HigherIsBetter;
+        metrics.Add(metric);
+    }
+}
+
+String PerfSdkHud::GetChipAreasText() const
+{
+    if (!_active || !_impl)
+        return String::Empty;
+
+    StringBuilder sb;
+    AppendChipAreaRows(sb, *static_cast<PerfSdkHudImpl*>(_impl));
+    return sb.ToString();
+}
+
+#else
+
+bool PerfSdkHud::TryInitialize(GPUDevice*, GPUAdapter*, GPUContext*)
+{
+    _graphicsApiName = TEXT("Unknown");
+    _statusText = TEXT("Nsight Perf: Windows + COMPILE_WITH_RENDER_PERF_NVPERF build required.");
+    return false;
+}
+
+void PerfSdkHud::Shutdown()
+{
+    _active = false;
+}
+
+void PerfSdkHud::OnRenderPassBegin(GPUContext*)
+{
+}
+
+void PerfSdkHud::OnRenderPassEnd(GPUContext*)
+{
+}
+
+void PerfSdkHud::GetDesignerMetrics(Array<RenderPerfTools::DesignerGpuMetric, InlinedAllocation<32>>& metrics) const
+{
+    metrics.Clear();
+}
+
+String PerfSdkHud::GetChipAreasText() const
+{
+    return String::Empty;
+}
+
+#endif

--- a/Source/Engine/RenderPerf/PerfSdkHud.h
+++ b/Source/Engine/RenderPerf/PerfSdkHud.h
@@ -1,0 +1,50 @@
+// Copyright (c) Flax Engine. Nsight Perf SDK HUD helper for RenderPerfSDK.
+
+#pragma once
+
+#if COMPILE_WITH_RENDER_PERF
+
+#include "Engine/Core/Collections/Array.h"
+#include "Engine/Core/Types/String.h"
+#include "Engine/RenderPerf/RenderPerfTools.h"
+
+class GPUAdapter;
+class GPUContext;
+class GPUDevice;
+
+/// <summary>
+/// Live PerfSDK metrics (GPU periodic sampler + HUD) for supported graphics APIs.
+/// </summary>
+class PerfSdkHud
+{
+public:
+    bool TryInitialize(GPUDevice* device, GPUAdapter* adapter, GPUContext* context);
+    void Shutdown();
+
+    void OnRenderPassBegin(GPUContext* context);
+    void OnRenderPassEnd(GPUContext* context);
+
+    bool IsActive() const { return _active; }
+    const String& GetGraphicsApiName() const { return _graphicsApiName; }
+    const String& GetOverlayText() const { return _overlayText; }
+    const String& GetStatusText() const { return _statusText; }
+
+    /// <summary>
+    /// Fills designer-friendly throughput metrics from the live HUD data model.
+    /// </summary>
+    void GetDesignerMetrics(Array<RenderPerfTools::DesignerGpuMetric, InlinedAllocation<32>>& metrics) const;
+
+    /// <summary>
+    /// Tab-separated chip area rows for the editor metrics table (Area, throughput %, detail, higher-is-better flag).
+    /// </summary>
+    String GetChipAreasText() const;
+
+private:
+    bool _active = false;
+    String _graphicsApiName;
+    String _overlayText;
+    String _statusText;
+    void* _impl = nullptr;
+};
+
+#endif

--- a/Source/Engine/RenderPerf/RenderPerf.Build.cs
+++ b/Source/Engine/RenderPerf/RenderPerf.Build.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using Flax.Build;
+using Flax.Build.NativeCpp;
+
+/// <summary>
+/// Optional NVIDIA Nsight Perf SDK integration for GPU region profiling.
+/// </summary>
+public class RenderPerf : EngineModule
+{
+    /// <summary>
+    /// Determinates whenever the RenderPerf module should be built for a given target.
+    /// </summary>
+    public static bool Use(BuildOptions options)
+    {
+        return options.Platform.Target == TargetPlatform.Windows;
+    }
+
+    /// <inheritdoc />
+    public override void Setup(BuildOptions options)
+    {
+        base.Setup(options);
+
+        options.PublicDefinitions.Add("COMPILE_WITH_RENDER_PERF");
+
+        string perfSdk = Environment.GetEnvironmentVariable("NVPERF_SDK_PATH");
+        if (string.IsNullOrEmpty(perfSdk))
+            perfSdk = @"C:\Users\nproc\Downloads\PerfSDK_2025_5";
+
+        string perfInclude = Path.Combine(perfSdk, "redist", "include");
+        if (!Directory.Exists(perfInclude))
+            return;
+
+        string perfIncludeOs = Path.Combine(perfInclude, "windows-desktop-x64");
+        string perfUtility = Path.Combine(perfSdk, "redist", "NvPerfUtility", "include");
+        string perfRyml = Path.Combine(perfSdk, "Samples", "NvPerfUtility", "imports", "rapidyaml-0.4.0");
+
+        options.PublicDefinitions.Add("COMPILE_WITH_RENDER_PERF_NVPERF=1");
+        options.PublicIncludePaths.Add(perfInclude);
+        options.PublicIncludePaths.Add(perfIncludeOs);
+        options.PublicIncludePaths.Add(perfUtility);
+        options.PrivateIncludePaths.Add(perfRyml);
+        options.PublicDefinitions.Add("NOMINMAX");
+
+        options.PrivateDependencies.Add("volk");
+
+        string perfBin = Path.Combine(perfSdk, "NvPerf", "bin", "x64");
+        if (Directory.Exists(perfBin))
+        {
+            foreach (string dll in Directory.GetFiles(perfBin, "nvperf*.dll"))
+                options.DependencyFiles.Add(dll);
+        }
+    }
+}

--- a/Source/Engine/RenderPerf/RenderPerfTools.cpp
+++ b/Source/Engine/RenderPerf/RenderPerfTools.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#if COMPILE_WITH_RENDER_PERF
+
+#include "RenderPerfTools.h"
+#include "Engine/Core/Types/StringBuilder.h"
+#include "Engine/Graphics/GPUAdapter.h"
+#include "Engine/Graphics/GPUContext.h"
+#include "Engine/Graphics/GPUDevice.h"
+#include "Engine/Graphics/Enums.h"
+
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+#include "PerfSdkHud.h"
+#endif
+
+namespace
+{
+    static bool SessionActive = false;
+    static String RegionName;
+    static String RegionSummary;
+    static String ErrorText;
+    static float RegionGpuTimeMs = 0.0f;
+    static int32 RegionDrawCalls = 0;
+    static int32 RegionTriangles = 0;
+    static int32 RegionVertices = 0;
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    static PerfSdkHud Hud;
+#endif
+}
+
+Array<RenderPerfTools::DesignerGpuMetric, InlinedAllocation<32>> RenderPerfTools::DesignerMetrics;
+
+bool RenderPerfTools::GetIsCompiled()
+{
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool RenderPerfTools::GetIsSessionActive()
+{
+    return SessionActive;
+}
+
+String RenderPerfTools::GetRegionName()
+{
+    return RegionName;
+}
+
+String RenderPerfTools::GetStatusText()
+{
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    if (Hud.IsActive())
+        return Hud.GetStatusText();
+#endif
+    return String::Empty;
+}
+
+String RenderPerfTools::GetMetricsText()
+{
+    StringBuilder sb;
+    if (!RegionSummary.IsEmpty())
+    {
+        sb.Append(RegionSummary);
+        sb.AppendLine();
+        sb.AppendLine();
+    }
+
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    if (Hud.IsActive())
+    {
+        if (!Hud.GetGraphicsApiName().IsEmpty())
+        {
+            sb.AppendFormat(TEXT("Graphics API: {0}"), Hud.GetGraphicsApiName());
+            sb.AppendLine();
+        }
+        if (!Hud.GetStatusText().IsEmpty())
+        {
+            sb.Append(Hud.GetStatusText());
+            sb.AppendLine();
+            sb.AppendLine();
+        }
+        if (!Hud.GetOverlayText().IsEmpty())
+            sb.Append(Hud.GetOverlayText());
+    }
+#endif
+
+    return sb.ToString();
+}
+
+String RenderPerfTools::GetChipAreasText()
+{
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    if (Hud.IsActive())
+        return Hud.GetChipAreasText();
+#endif
+    return String::Empty;
+}
+
+String RenderPerfTools::GetErrorText()
+{
+    return ErrorText;
+}
+
+float RenderPerfTools::GetRegionGpuTimeMs()
+{
+    return RegionGpuTimeMs;
+}
+
+int32 RenderPerfTools::GetRegionDrawCalls()
+{
+    return RegionDrawCalls;
+}
+
+int32 RenderPerfTools::GetRegionTriangles()
+{
+    return RegionTriangles;
+}
+
+int32 RenderPerfTools::GetRegionVertices()
+{
+    return RegionVertices;
+}
+
+bool RenderPerfTools::TryOpenRegionProfiler(const String& regionName, float gpuTimeMs, int32 drawCalls, int32 triangles, int32 vertices)
+{
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    ErrorText.Clear();
+    RegionName = regionName;
+    RegionGpuTimeMs = gpuTimeMs;
+    RegionDrawCalls = drawCalls;
+    RegionTriangles = triangles;
+    RegionVertices = vertices;
+    RegionSummary = String::Format(TEXT("GPU Profiler Region: {0}\r\nGPU Time: {1:.3f} ms\r\nDraw Calls: {2}\r\nTriangles: {3}\r\nVertices: {4}"),
+                                   regionName, gpuTimeMs, drawCalls, triangles, vertices);
+    DesignerMetrics.Clear();
+
+    GPUDevice* device = GPUDevice::Instance;
+    if (!device)
+    {
+        ErrorText = TEXT("GPU device is not available.");
+        SessionActive = false;
+        return false;
+    }
+
+    GPUAdapter* adapter = device->GetAdapter();
+    GPUContext* context = device->GetMainContext();
+    if (!adapter || !context)
+    {
+        ErrorText = TEXT("GPU adapter or context is not available.");
+        SessionActive = false;
+        return false;
+    }
+
+    if (!Hud.IsActive())
+    {
+        if (!Hud.TryInitialize(device, adapter, context))
+        {
+            ErrorText = Hud.GetStatusText();
+            if (ErrorText.IsEmpty())
+                ErrorText = TEXT("Failed to initialize NVIDIA Perf SDK.");
+            SessionActive = false;
+            return false;
+        }
+    }
+
+    SessionActive = true;
+    return true;
+#else
+    ErrorText = TEXT("Engine was built without NVIDIA Perf SDK support.");
+    SessionActive = false;
+    return false;
+#endif
+}
+
+void RenderPerfTools::CloseRegionProfiler()
+{
+    SessionActive = false;
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    Hud.Shutdown();
+#endif
+    RegionName.Clear();
+    RegionSummary.Clear();
+    ErrorText.Clear();
+    RegionGpuTimeMs = 0.0f;
+    RegionDrawCalls = 0;
+    RegionTriangles = 0;
+    RegionVertices = 0;
+    DesignerMetrics.Clear();
+}
+
+void RenderPerfTools::OnGpuFrameBegin(GPUContext* context)
+{
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    if (!SessionActive || !context || !Hud.IsActive())
+        return;
+
+    Hud.OnRenderPassBegin(context);
+#endif
+}
+
+void RenderPerfTools::OnGpuFrameEnd(GPUContext* context)
+{
+#if COMPILE_WITH_RENDER_PERF_NVPERF
+    if (!SessionActive || !context || !Hud.IsActive())
+        return;
+
+    Hud.OnRenderPassEnd(context);
+    Hud.GetDesignerMetrics(DesignerMetrics);
+#endif
+}
+
+#endif

--- a/Source/Engine/RenderPerf/RenderPerfTools.h
+++ b/Source/Engine/RenderPerf/RenderPerfTools.h
@@ -1,0 +1,131 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#if COMPILE_WITH_RENDER_PERF
+
+#include "Engine/Core/Collections/Array.h"
+#include "Engine/Core/Types/String.h"
+#include "Engine/Scripting/ScriptingType.h"
+
+class GPUContext;
+
+/// <summary>
+/// NVIDIA Nsight Perf SDK integration for GPU profiler region inspection.
+/// </summary>
+API_CLASS(Static) class FLAXENGINE_API RenderPerfTools
+{
+    DECLARE_SCRIPTING_TYPE_NO_SPAWN(RenderPerfTools);
+
+public:
+    /// <summary>
+    /// Game-designer friendly GPU throughput metric (0-100%).
+    /// </summary>
+    API_STRUCT(NoDefault) struct DesignerGpuMetric
+    {
+        DECLARE_SCRIPTING_TYPE_MINIMAL(DesignerGpuMetric);
+
+        /// <summary>
+        /// Short metric title for game developers.
+        /// </summary>
+        API_FIELD() String Title;
+
+        /// <summary>
+        /// Plain-language explanation and guidance.
+        /// </summary>
+        API_FIELD() String Hint;
+
+        /// <summary>
+        /// Normalized value in range [0, 100].
+        /// </summary>
+        API_FIELD() float Value;
+
+        /// <summary>
+        /// True if higher values are better (e.g. cache hit rate).
+        /// </summary>
+        API_FIELD() bool HigherIsBetter;
+    };
+
+    /// <summary>
+    /// True if engine was built with NVPerf SDK support (COMPILE_WITH_RENDER_PERF_NVPERF).
+    /// </summary>
+    API_PROPERTY() static bool GetIsCompiled();
+
+    /// <summary>
+    /// True if a region profiling session is active.
+    /// </summary>
+    API_PROPERTY() static bool GetIsSessionActive();
+
+    /// <summary>
+    /// The selected GPU profiler region name.
+    /// </summary>
+    API_PROPERTY() static String GetRegionName();
+
+    /// <summary>
+    /// Perf SDK status line (chip, API, sampling rate).
+    /// </summary>
+    API_PROPERTY() static String GetStatusText();
+
+    /// <summary>
+    /// Combined region summary and live Perf SDK HUD text.
+    /// </summary>
+    API_PROPERTY() static String GetMetricsText();
+
+    /// <summary>
+    /// Live chip-area rows for the editor metrics table. Each line: Area\tThroughput\tDetail\tHigherIsBetter.
+    /// </summary>
+    API_PROPERTY() static String GetChipAreasText();
+
+    /// <summary>
+    /// Game-designer friendly GPU throughput metrics (0-100%) updated while a session is active.
+    /// </summary>
+    API_FIELD(ReadOnly) static Array<DesignerGpuMetric, InlinedAllocation<32>> DesignerMetrics;
+
+    /// <summary>
+    /// GPU time in ms for the selected profiler region (from the click that opened this session).
+    /// </summary>
+    API_PROPERTY() static float GetRegionGpuTimeMs();
+
+    /// <summary>
+    /// Draw calls for the selected profiler region.
+    /// </summary>
+    API_PROPERTY() static int32 GetRegionDrawCalls();
+
+    /// <summary>
+    /// Triangles for the selected profiler region.
+    /// </summary>
+    API_PROPERTY() static int32 GetRegionTriangles();
+
+    /// <summary>
+    /// Vertices for the selected profiler region.
+    /// </summary>
+    API_PROPERTY() static int32 GetRegionVertices();
+
+    /// <summary>
+    /// Last error message from TryOpenRegionProfiler.
+    /// </summary>
+    API_PROPERTY() static String GetErrorText();
+
+    /// <summary>
+    /// Starts (or reuses) a Perf SDK sampling session for the selected GPU profiler region.
+    /// Returns false if Perf SDK is unavailable or initialization failed.
+    /// </summary>
+    API_FUNCTION() static bool TryOpenRegionProfiler(const String& regionName, float gpuTimeMs, int32 drawCalls, int32 triangles, int32 vertices);
+
+    /// <summary>
+    /// Stops the active Perf SDK sampling session.
+    /// </summary>
+    API_FUNCTION() static void CloseRegionProfiler();
+
+    /// <summary>
+    /// Called from the GPU frame before scene rendering to begin Perf SDK sampling for the frame.
+    /// </summary>
+    static void OnGpuFrameBegin(GPUContext* context);
+
+    /// <summary>
+    /// Called from the GPU frame after scene rendering to tick live Perf SDK sampling.
+    /// </summary>
+    static void OnGpuFrameEnd(GPUContext* context);
+};
+
+#endif


### PR DESCRIPTION
Another Niko PR that integrates NVIDIA PerfSDK into Flax Engine to provide access to GPU performance counters and profiling data on supported NVIDIA hardware.

The implementation introduces the required PerfSDK initialization and data collection workflow, enabling the engine to gather detailed GPU performance metrics during runtime and profiling sessions. The integration is designed to work alongside the existing profiling infrastructure while ensuring graceful fallback behavior when PerfSDK is unavailable or unsupported.

This addition improves performance analysis capabilities, helping developers identify GPU bottlenecks, optimize rendering workloads, and gain deeper insight into graphics performance directly within the engine.