### PR TITLE
Fix macOS window input, sizing, and rendering issues on mixed-DPI multi-monitor setups.

### DIFF
--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -702,10 +702,11 @@ namespace FlaxEditor.Modules
             {
                 // Check if there is a floating window that has the same size
                 var dpi = (float)Platform.Dpi / 96.0f;
+                var dpiScale = Platform.CustomDpiScale;
 #if PLATFORM_MAC && !PLATFORM_SDL
                 dpi = 1.0f; // TODO: refactor DPI support on macOS to skip such hacks
+                dpiScale = MainWindow?.DpiScale ?? Platform.DpiScale;
 #endif
-                var dpiScale = Platform.CustomDpiScale;
                 var defaultSize = window.DefaultSize * dpi;
                 for (var i = 0; i < Editor.UI.MasterPanel.FloatingPanels.Count; i++)
                 {

--- a/Source/Editor/Windows/SplashScreen.cpp
+++ b/Source/Editor/Windows/SplashScreen.cpp
@@ -141,6 +141,12 @@ const Char* SplashScreenQuotes[] =
     TEXT("We do this not because it is easy,\nbut because we thought it would be easy"),
 };
 
+namespace
+{
+    constexpr float SplashScreenWidth = 500.0f;
+    constexpr float SplashScreenHeight = 170.0f;
+}
+
 SplashScreen::~SplashScreen()
 {
     // Ensure to be closed
@@ -159,8 +165,8 @@ void SplashScreen::Show()
     const float dpiScale = Platform::GetDpiScale();
     CreateWindowSettings settings;
     settings.Title = TEXT("Flax Editor");
-    settings.Size.X = 500 * dpiScale;
-    settings.Size.Y = 170 * dpiScale;
+    settings.Size.X = SplashScreenWidth * dpiScale;
+    settings.Size.Y = SplashScreenHeight * dpiScale;
     settings.HasBorder = false;
     settings.AllowInput = true;
     settings.AllowMinimize = false;
@@ -191,7 +197,9 @@ void SplashScreen::Show()
 
     // Setup
     _dpiScale = dpiScale;
-    _size = settings.Size;
+    UpdateLayoutScale(true);
+    UpdateTargetMonitorBounds();
+    CenterWindow();
     _startTime = DateTime::NowUTC();
     auto str = Globals::ProjectFolder;
 #if PLATFORM_WIN32
@@ -203,17 +211,17 @@ void SplashScreen::Show()
     _quote = SplashScreenQuotes[rand() % ARRAY_COUNT(SplashScreenQuotes)];
 
     // Load font
-    auto font = Content::LoadAsyncInternal<FontAsset>(TEXT("Editor/Fonts/Roboto-Regular"));
-    if (font == nullptr)
+    _fontAsset = Content::LoadAsyncInternal<FontAsset>(TEXT("Editor/Fonts/Roboto-Regular"));
+    if (_fontAsset == nullptr)
     {
         LOG(Fatal, "Cannot load GUI primary font.");
     }
     else
     {
-        if (font->IsLoaded())
-            OnFontLoaded(font);
+        if (_fontAsset->IsLoaded())
+            OnFontLoaded(_fontAsset.Get());
         else
-            font->OnLoaded.Bind<SplashScreen, &SplashScreen::OnFontLoaded>(this);
+            _fontAsset->OnLoaded.Bind<SplashScreen, &SplashScreen::OnFontLoaded>(this);
     }
 
     // Load custom image
@@ -238,7 +246,63 @@ void SplashScreen::Close()
 
     _titleFont = nullptr;
     _subtitleFont = nullptr;
+    _fontAsset = nullptr;
     _splashTexture = nullptr;
+}
+
+void SplashScreen::UpdateLayoutScale(bool resizeWindow)
+{
+    if (!_window)
+        return;
+
+    const float oldDpiScale = _dpiScale;
+    _dpiScale = _window->GetDpiScale();
+    _size = Float2(SplashScreenWidth, SplashScreenHeight) * _dpiScale;
+    if (resizeWindow)
+    {
+        if (!Float2::NearEqual(_window->GetClientSize(), _size))
+            _window->SetClientSize(_size);
+    }
+    else
+    {
+        _size = _window->GetClientSize();
+    }
+
+    if (!Math::NearEqual(oldDpiScale, _dpiScale) && _fontAsset && _fontAsset->IsLoaded())
+        CreateFonts();
+}
+
+void SplashScreen::CreateFonts()
+{
+    if (!_fontAsset)
+        return;
+
+    const float s = _dpiScale;
+    _titleFont = _fontAsset->CreateFont(35 * s);
+    _subtitleFont = _fontAsset->CreateFont(9 * s);
+}
+
+void SplashScreen::UpdateTargetMonitorBounds()
+{
+    if (!_window)
+        return;
+
+#if PLATFORM_MAC && !PLATFORM_SDL
+    const auto monitorPoint = Platform::GetMousePosition();
+#else
+    const auto monitorPoint = _window->GetPosition() + _window->GetSize() * 0.5f;
+#endif
+    _targetMonitorBounds = Platform::GetMonitorBounds(monitorPoint);
+}
+
+void SplashScreen::CenterWindow()
+{
+    if (!_window)
+        return;
+
+    if (_targetMonitorBounds.Size.IsZero())
+        UpdateTargetMonitorBounds();
+    _window->SetPosition(_targetMonitorBounds.Location + (_targetMonitorBounds.Size - _window->GetSize()) * 0.5f);
 }
 
 void SplashScreen::OnShown()
@@ -250,6 +314,8 @@ void SplashScreen::OnShown()
 
 void SplashScreen::OnDraw()
 {
+    UpdateLayoutScale(false);
+
     const float s = _dpiScale;
     const float width = _size.X;
     const float height = _size.Y;
@@ -335,23 +401,26 @@ bool SplashScreen::HasLoadedFonts() const
 void SplashScreen::OnFontLoaded(Asset* asset)
 {
     ASSERT(asset && asset->IsLoaded());
-    auto font = (FontAsset*)asset;
+    _fontAsset = (FontAsset*)asset;
 
-    font->OnLoaded.Unbind<SplashScreen, &SplashScreen::OnFontLoaded>(this);
-
-    // Create fonts
-    const float s = _dpiScale;
-    _titleFont = font->CreateFont(35 * s);
-    _subtitleFont = font->CreateFont(9 * s);
+    _fontAsset->OnLoaded.Unbind<SplashScreen, &SplashScreen::OnFontLoaded>(this);
+    CreateFonts();
 }
 
 void SplashScreen::OnSplashLoaded()
 {
     // Resize window to be larger if texture is being used
-    auto desktopSize = Platform::GetDesktopSize();
-    auto xSize = (desktopSize.X / (600.0f * 3.0f)) * 600.0f;
-    auto ySize = (desktopSize.Y / (200.0f * 3.0f)) * 200.0f;
+    if (_targetMonitorBounds.Size.IsZero())
+        UpdateTargetMonitorBounds();
+    auto clientDesktopSize = _targetMonitorBounds.Size;
+#if PLATFORM_MAC && !PLATFORM_SDL
+    // macOS monitor bounds are stored in the global virtual screen scale.
+    // Convert them to the splash window backing-pixel scale before using them as a client size.
+    clientDesktopSize *= _window->GetDpiScale() / Platform::CustomDpiScale;
+#endif
+    auto xSize = (clientDesktopSize.X / (600.0f * 3.0f)) * 600.0f;
+    auto ySize = (clientDesktopSize.Y / (200.0f * 3.0f)) * 200.0f;
     _window->SetClientSize(Float2(xSize, ySize));
-    _size = _window->GetSize();
-    _window->SetPosition((desktopSize - _size) * 0.5f);
+    _size = _window->GetClientSize();
+    CenterWindow();
 }

--- a/Source/Editor/Windows/SplashScreen.h
+++ b/Source/Editor/Windows/SplashScreen.h
@@ -4,11 +4,13 @@
 
 #include "Engine/Content/Assets/Texture.h"
 #include "Engine/Content/AssetReference.h"
+#include "Engine/Core/Math/Rectangle.h"
 #include "Engine/Core/Types/DateTime.h"
 #include "Engine/Platform/Window.h"
 
 class Asset;
 class Font;
+class FontAsset;
 
 /// <summary>
 /// Splash Screen popup
@@ -18,6 +20,7 @@ class SplashScreen
 private:
 
     Window* _window = nullptr;
+    AssetReference<FontAsset> _fontAsset;
     Font* _titleFont = nullptr;
     Font* _subtitleFont = nullptr;
     AssetReference<Texture> _splashTexture;
@@ -26,6 +29,7 @@ private:
     String _infoText;
     float _dpiScale;
     Float2 _size;
+    Rectangle _targetMonitorBounds = Rectangle(Float2::Zero, Float2::Zero);
     StringView _quote;
 
 public:
@@ -78,6 +82,10 @@ public:
 
 private:
 
+    void UpdateLayoutScale(bool resizeWindow);
+    void UpdateTargetMonitorBounds();
+    void CreateFonts();
+    void CenterWindow();
     void OnShown();
     void OnDraw();
     bool HasLoadedFonts() const;

--- a/Source/Engine/Platform/Mac/MacPlatform.cpp
+++ b/Source/Engine/Platform/Mac/MacPlatform.cpp
@@ -181,6 +181,52 @@ Float2 AppleUtils::GetScreensOrigin()
     return result;
 }
 
+CGPoint CocoaPointToCGDisplayPoint(NSPoint point)
+{
+    NSScreen* targetScreen = nil;
+    CGFloat closestDistance = MAXFLOAT;
+    NSArray* screenArray = [NSScreen screens];
+    for (NSScreen* screen in screenArray)
+    {
+        NSRect frame = [screen frame];
+        if (NSPointInRect(point, frame))
+        {
+            targetScreen = screen;
+            break;
+        }
+
+        const CGFloat dx = point.x < NSMinX(frame) ? NSMinX(frame) - point.x : (point.x > NSMaxX(frame) ? point.x - NSMaxX(frame) : 0.0f);
+        const CGFloat dy = point.y < NSMinY(frame) ? NSMinY(frame) - point.y : (point.y > NSMaxY(frame) ? point.y - NSMaxY(frame) : 0.0f);
+        const CGFloat distance = dx * dx + dy * dy;
+        if (distance < closestDistance)
+        {
+            closestDistance = distance;
+            targetScreen = screen;
+        }
+    }
+
+    if (!targetScreen)
+        targetScreen = [NSScreen mainScreen];
+    if (!targetScreen)
+        return CGPointMake(point.x, point.y);
+
+    NSNumber* screenNumber = [[targetScreen deviceDescription] objectForKey:@"NSScreenNumber"];
+    const CGDirectDisplayID display = (CGDirectDisplayID)[screenNumber unsignedIntValue];
+    const CGRect displayBounds = CGDisplayBounds(display);
+    const NSRect screenFrame = [targetScreen frame];
+    return CGPointMake(
+        displayBounds.origin.x + point.x - screenFrame.origin.x,
+        displayBounds.origin.y + NSMaxY(screenFrame) - point.y);
+}
+
+Rectangle GetScreenBounds(NSScreen* screen)
+{
+    const float screenScale = ApplePlatform::ScreenScale;
+    const NSRect frame = [screen frame];
+    const Float2 topLeft = AppleUtils::CocaToPos(Float2((float)frame.origin.x, (float)NSMaxY(frame)) * screenScale);
+    return Rectangle(topLeft.X, topLeft.Y, (float)frame.size.width * screenScale, (float)frame.size.height * screenScale);
+}
+
 void MacClipboard::Clear()
 {
     NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
@@ -363,57 +409,50 @@ String MacPlatform::GetComputerName()
 
 Float2 MacPlatform::GetMousePosition()
 {
-    CGEventRef event = CGEventCreate(nullptr);
-    CGPoint cursor = CGEventGetLocation(event);
-    CFRelease(event);
-    return Float2((float)cursor.x, (float)cursor.y) * MacPlatform::ScreenScale;
+    NSPoint cursor = [NSEvent mouseLocation];
+    return AppleUtils::CocaToPos(Float2((float)cursor.x, (float)cursor.y) * MacPlatform::ScreenScale);
 }
 
 void MacPlatform::SetMousePosition(const Float2& pos)
 {
-    CGPoint cursor;
-    cursor.x = (CGFloat)(pos.X / MacPlatform::ScreenScale);
-    cursor.y = (CGFloat)(pos.Y / MacPlatform::ScreenScale);
+    const Float2 cocoaPos = AppleUtils::PosToCoca(pos) / MacPlatform::ScreenScale;
+    const CGPoint cursor = CocoaPointToCGDisplayPoint(NSMakePoint((CGFloat)cocoaPos.X, (CGFloat)cocoaPos.Y));
     CGWarpMouseCursorPosition(cursor);
     CGAssociateMouseAndMouseCursorPosition(true);
 }
 
 Float2 MacPlatform::GetDesktopSize()
 {
-    CGDirectDisplayID mainDisplay = CGMainDisplayID();
-    return Float2((float)CGDisplayPixelsWide(mainDisplay) * ScreenScale, (float)CGDisplayPixelsHigh(mainDisplay) * ScreenScale);
-}
-
-Rectangle GetDisplayBounds(CGDirectDisplayID display)
-{
-    CGRect rect = CGDisplayBounds(display);
-    float screnScale = ApplePlatform::ScreenScale;
-    return Rectangle(rect.origin.x * screnScale, rect.origin.y * screnScale, rect.size.width * screnScale, rect.size.height * screnScale);
+    NSScreen* screen = [NSScreen mainScreen];
+    if (!screen)
+        screen = [[NSScreen screens] firstObject];
+    if (!screen)
+        return Float2::Zero;
+    const NSRect frame = [screen frame];
+    return Float2((float)frame.size.width * ScreenScale, (float)frame.size.height * ScreenScale);
 }
 
 Rectangle MacPlatform::GetMonitorBounds(const Float2& screenPos)
 {
-    CGPoint point;
-    point.x = screenPos.X;
-    point.y = screenPos.Y;
-    CGDirectDisplayID display;
-    uint32_t count = 0;
-    CGGetDisplaysWithPoint(point, 1, &display, &count);
-    if (count == 1)
-        return GetDisplayBounds(display);
+    const Float2 cocoaPos = AppleUtils::PosToCoca(screenPos) / ScreenScale;
+    const NSPoint point = NSMakePoint((CGFloat)cocoaPos.X, (CGFloat)cocoaPos.Y);
+    NSArray* screenArray = [NSScreen screens];
+    for (NSScreen* screen in screenArray)
+    {
+        if (NSPointInRect(point, [screen frame]))
+            return GetScreenBounds(screen);
+    }
 	return Rectangle(Float2::Zero, GetDesktopSize());
 }
 
 Rectangle MacPlatform::GetVirtualDesktopBounds()
 {
-    CGDirectDisplayID displays[16];
-    uint32_t count = 0;
-    CGGetOnlineDisplayList(ARRAY_COUNT(displays), displays, &count);
-    if (count == 0)
+    NSArray* screenArray = [NSScreen screens];
+    if ([screenArray count] == 0)
 	    return Rectangle(Float2::Zero, GetDesktopSize());
-    Rectangle result = GetDisplayBounds(displays[0]);
-    for (uint32_t i = 1; i < count; i++)
-        result = Rectangle::Union(result, GetDisplayBounds(displays[i]));
+    Rectangle result = GetScreenBounds([screenArray objectAtIndex:0]);
+    for (NSUInteger i = 1; i < [screenArray count]; i++)
+        result = Rectangle::Union(result, GetScreenBounds([screenArray objectAtIndex:i]));
     return result;
 }
 

--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -184,35 +184,156 @@ KeyboardKeys GetKey(NSEvent* event)
     }
 }
 
-Float2 GetWindowTitleSize(const MacWindow* window)
+float GetScreenBackingScale(NSScreen* screen)
 {
-    Float2 size = Float2::Zero;
-    if (window->GetSettings().HasBorder)
+    if (MacPlatform::ScreenScale <= 1.0f)
+        return 1.0f;
+    if (screen && [screen respondsToSelector:@selector(backingScaleFactor)])
     {
-        NSRect frameStart = [(NSWindow*)window->GetNativePtr() frameRectForContentRect:NSMakeRect(0, 0, 0, 0)];
-        size.Y = frameStart.size.height;
+        const CGFloat backingScale = [screen backingScaleFactor];
+        if (backingScale > 0.0f)
+            return (float)backingScale;
     }
-    return size * MacPlatform::ScreenScale;
+    return MacPlatform::ScreenScale;
+}
+
+float GetBackingScaleForScreenPoint(const Float2& screenPos)
+{
+    const Float2 cocoaPos = AppleUtils::PosToCoca(screenPos) / MacPlatform::ScreenScale;
+    const NSPoint point = NSMakePoint((CGFloat)cocoaPos.X, (CGFloat)cocoaPos.Y);
+    NSArray* screenArray = [NSScreen screens];
+    for (NSScreen* screen in screenArray)
+    {
+        if (NSPointInRect(point, [screen frame]))
+            return GetScreenBackingScale(screen);
+    }
+    return GetScreenBackingScale([NSScreen mainScreen]);
+}
+
+Float2 ScreenSizeToClientSize(const Float2& screenSize, float backingScale)
+{
+    return screenSize * (backingScale / MacPlatform::ScreenScale);
+}
+
+bool IsSameRect(const Rectangle& a, const Rectangle& b)
+{
+    return Float2::NearEqual(a.Location, b.Location, 1.0f) && Float2::NearEqual(a.Size, b.Size, 1.0f);
+}
+
+bool IsSameSize(const Float2& a, const Float2& b)
+{
+    return Float2::NearEqual(a, b, 1.0f);
+}
+
+bool IsCenteredInBounds(const Rectangle& rect, const Rectangle& bounds)
+{
+    const Float2 expectedLocation = bounds.Location + (bounds.Size - rect.Size) * 0.5f;
+    return Float2::NearEqual(rect.Location, expectedLocation, 1.0f);
+}
+
+bool IsDesktopSize(const Float2& size)
+{
+    return IsSameSize(size, Platform::GetDesktopSize());
+}
+
+bool UsesScreenCoordinateInitialSize(const CreateWindowSettings& settings)
+{
+    const Rectangle windowBounds(settings.Position, settings.Size);
+    const Rectangle monitorBounds = Platform::GetMonitorBounds(settings.Position + settings.Size * 0.5f);
+
+    // Platform desktop/monitor bounds use the global macOS screen coordinate scale. Most windows
+    // pass client backing-pixel sizes, so convert only the legacy desktop-relative layouts here.
+    if (settings.Fullscreen || IsDesktopSize(settings.Size) || IsSameRect(windowBounds, monitorBounds))
+        return true;
+
+    if (settings.StartPosition != WindowStartPosition::CenterScreen ||
+        settings.Parent != nullptr ||
+        settings.Type != WindowType::Regular ||
+        !settings.ShowInTaskbar ||
+        !IsCenteredInBounds(windowBounds, monitorBounds))
+        return false;
+
+    const Float2 halfMonitorSize = monitorBounds.Size * 0.5f;
+    const bool fitsMonitor = settings.Size.X <= monitorBounds.Size.X + 1.0f && settings.Size.Y <= monitorBounds.Size.Y + 1.0f;
+    const bool isDesktopRelativeSize = settings.Size.X >= halfMonitorSize.X && settings.Size.Y >= halfMonitorSize.Y;
+    return fitsMonitor && isDesktopRelativeSize;
+}
+
+Float2 GetInitialClientSize(const CreateWindowSettings& settings, float backingScale)
+{
+    if (UsesScreenCoordinateInitialSize(settings))
+        return ScreenSizeToClientSize(settings.Size, backingScale);
+
+    return settings.Size;
+}
+
+Float2 GetClientSizeForBounds(const Rectangle& clientArea, float backingScale)
+{
+    const Rectangle monitorBounds = Platform::GetMonitorBounds(clientArea.Location);
+    if (IsSameRect(clientArea, monitorBounds))
+        return ScreenSizeToClientSize(clientArea.Size, backingScale);
+    return clientArea.Size;
+}
+
+float GetWindowBackingScale(const MacWindow* window)
+{
+    if (MacPlatform::ScreenScale <= 1.0f)
+        return 1.0f;
+    NSWindow* nativeWindow = (NSWindow*)window->GetNativePtr();
+    if (!nativeWindow)
+        return MacPlatform::ScreenScale;
+    const CGFloat backingScale = [nativeWindow backingScaleFactor];
+    return backingScale > 0.0f ? (float)backingScale : GetScreenBackingScale([nativeWindow screen]);
+}
+
+void UpdateLayerScale(NSView* view, float backingScale)
+{
+    CALayer* layer = [view layer];
+    if (!layer)
+        return;
+    layer.contentsScale = backingScale;
+    if ([layer isKindOfClass:[CAMetalLayer class]])
+    {
+        NSRect bounds = [view bounds];
+        ((CAMetalLayer*)layer).drawableSize = CGSizeMake(bounds.size.width * backingScale, bounds.size.height * backingScale);
+    }
+}
+
+void UpdateWindowSizeLimits(NSWindow* window, const CreateWindowSettings& settings, float backingScale)
+{
+    [window setMinSize:NSMakeSize(settings.MinimumSize.X / backingScale, settings.MinimumSize.Y / backingScale)];
+    if (settings.MaximumSize.SumValues() > 0)
+        [window setMaxSize:NSMakeSize(settings.MaximumSize.X / backingScale, settings.MaximumSize.Y / backingScale)];
+}
+
+Float2 ConvertWindowPointToClient(const MacWindow* window, NSPoint point)
+{
+    NSView* view = [(NSWindow*)window->GetNativePtr() contentView];
+    if (!view)
+        return Float2((float)point.x, (float)point.y) * MacPlatform::ScreenScale;
+    const float backingScale = GetWindowBackingScale(window);
+    NSPoint viewPoint = [view convertPoint:point fromView:nil];
+    NSRect bounds = [view bounds];
+    return Float2((float)viewPoint.x, (float)(bounds.size.height - viewPoint.y)) * backingScale;
 }
 
 Float2 GetMousePosition(MacWindow* window, NSEvent* event)
 {
-    NSRect frame = [(NSWindow*)window->GetNativePtr() frame];
-    NSPoint point = [event locationInWindow];
-    return Float2(point.x, frame.size.height - point.y) * MacPlatform::ScreenScale - GetWindowTitleSize(window);
+    return ConvertWindowPointToClient(window, [event locationInWindow]);
 }
 
-NSRect GetFrameRectForClientBounds(MacWindow* macWindow, NSWindow* window, const Rectangle& clientArea)
+NSRect GetFrameRectForClientBounds(NSWindow* window, const Rectangle& clientArea)
 {
     const float screenScale = MacPlatform::ScreenScale;
-    NSRect rect = NSMakeRect(0, 0, clientArea.Size.X / screenScale, clientArea.Size.Y / screenScale);
-    rect = [window frameRectForContentRect:rect];
-
-    Float2 pos = AppleUtils::PosToCoca(clientArea.Location) / screenScale;
-    Float2 titleSize = GetWindowTitleSize(macWindow);
-    rect.origin.x = pos.X + titleSize.X;
-    rect.origin.y = pos.Y - rect.size.height + titleSize.Y;
-    return rect;
+    const float backingScale = GetBackingScaleForScreenPoint(clientArea.Location);
+    const Float2 clientSize = GetClientSizeForBounds(clientArea, backingScale);
+    const Float2 pos = AppleUtils::PosToCoca(clientArea.Location) / screenScale;
+    NSRect contentRect = NSMakeRect(
+        pos.X,
+        pos.Y - clientSize.Y / backingScale,
+        clientSize.X / backingScale,
+        clientSize.Y / backingScale);
+    return [window frameRectForContentRect:contentRect];
 }
 
 class MacDropData : public IGuiData
@@ -238,9 +359,8 @@ public:
 
 void GetDragDropData(const MacWindow* window, id<NSDraggingInfo> sender, Float2& mousePos, MacDropData& dropData)
 {
-    NSRect frame = [(NSWindow*)window->GetNativePtr() frame];
     NSPoint point = [sender draggingLocation];
-    mousePos = Float2(point.x, frame.size.height - point.y) * MacPlatform::ScreenScale - GetWindowTitleSize(window);
+    mousePos = ConvertWindowPointToClient(window, point);
     NSPasteboard* pasteboard = [sender draggingPasteboard];
     if ([[pasteboard types] containsObject:NSPasteboardTypeString])
     {
@@ -329,6 +449,7 @@ NSDragOperation GetDragDropOperation(DragDropEffect dragDropEffect)
 {
     if (IsWindowInvalid(Window)) return;
     Window->SyncWindowState();
+    Window->SyncBackingScale();
 }
 
 - (void)windowWillClose:(NSNotification*)notification
@@ -338,26 +459,16 @@ NSDragOperation GetDragDropOperation(DragDropEffect dragDropEffect)
     Window->Close(ClosingReason::User);
 }
 
-static void ConvertNSRect(NSScreen *screen, NSRect *r)
-{
-    r->origin.y = CGDisplayPixelsHigh(kCGDirectMainDisplay) - r->origin.y - r->size.height;
-}
-
 - (void)windowDidResize:(NSNotification*)notification
 {
-    NSView* view = [self contentView];
-    const float screenScale = MacPlatform::ScreenScale;
-    NSWindow* nswindow = (NSWindow*)Window->GetNativePtr();
-    NSRect rect = [nswindow contentRectForFrameRect:[nswindow frame]];
-    ConvertNSRect([nswindow screen], &rect);
+    if (IsWindowInvalid(Window)) return;
+    Window->SyncBackingScale();
+}
 
-    // Rescale contents
-	CALayer* layer = [view layer];
-	if (layer)
-		layer.contentsScale = screenScale;
-
-    // Resize window
-    Window->CheckForResize((float)rect.size.width * screenScale, (float)rect.size.height * screenScale);
+- (void)windowDidChangeBackingProperties:(NSNotification*)notification
+{
+    if (IsWindowInvalid(Window)) return;
+    Window->SyncBackingScale();
 }
 
 - (void)setWindow:(MacWindow*)window
@@ -798,9 +909,12 @@ MacWindow::MacWindow(const CreateWindowSettings& settings)
     : WindowBase(settings)
 {
     // Setup size and styles
-    _clientSize = Float2(settings.Size.X, settings.Size.Y);
-    Float2 pos = AppleUtils::PosToCoca(settings.Position);
-    NSRect frame = NSMakeRect(pos.X, pos.Y - settings.Size.Y, settings.Size.X, settings.Size.Y);
+    const float screenScale = MacPlatform::ScreenScale;
+    const float backingScale = GetBackingScaleForScreenPoint(settings.Position);
+    const Float2 clientSize = GetInitialClientSize(settings, backingScale);
+    _clientSize = clientSize;
+    Float2 pos = AppleUtils::PosToCoca(settings.Position) / screenScale;
+    NSRect frame = NSMakeRect(pos.X, pos.Y - clientSize.Y / backingScale, clientSize.X / backingScale, clientSize.Y / backingScale);
     NSUInteger styleMask = NSWindowStyleMaskClosable;
     if (settings.Type == WindowType::Regular)
     {
@@ -827,12 +941,6 @@ MacWindow::MacWindow(const CreateWindowSettings& settings)
         styleMask &= ~NSWindowStyleMaskTitled;
     }
 
-    const float screenScale = MacPlatform::ScreenScale;
-    frame.origin.x /= screenScale;
-    frame.origin.y /= screenScale;
-    frame.size.width /= screenScale;
-    frame.size.height /= screenScale;
-
     // Create window
     MacWindowImpl* window = [[MacWindowImpl alloc] initWithContentRect:frame
         styleMask:(styleMask)
@@ -845,9 +953,7 @@ MacWindow::MacWindow(const CreateWindowSettings& settings)
     window.releasedWhenClosed = NO;
     [window setWindow:this];
     [window setReleasedWhenClosed:NO];
-    [window setMinSize:NSMakeSize(settings.MinimumSize.X, settings.MinimumSize.Y)];
-    if (settings.MaximumSize.SumValues() > 0)
-        [window setMaxSize:NSMakeSize(settings.MaximumSize.X, settings.MaximumSize.Y)];
+    UpdateWindowSizeLimits(window, settings, backingScale);
     [window setOpaque:!settings.SupportsTransparency];
     [window setContentView:view];
     if (settings.AllowInput)
@@ -870,10 +976,7 @@ MacWindow::MacWindow(const CreateWindowSettings& settings)
     [superview setNextResponder:responder];
 #endif
 
-    // Rescale contents
-	CALayer* layer = [view layer];
-	if (layer)
-		layer.contentsScale = screenScale;
+    SyncBackingScale();
 }
 
 MacWindow::~MacWindow()
@@ -895,6 +998,23 @@ void MacWindow::SyncWindowState()
         _minimized = window.miniaturized;
         _maximized = window.zoomed;
     }
+}
+
+void MacWindow::SyncBackingScale()
+{
+    NSWindow* window = (NSWindow*)_window;
+    NSView* view = (NSView*)_view;
+    if (!window || !view)
+        return;
+
+    const float backingScale = GetWindowBackingScale(this);
+    _dpi = (int)(backingScale * 96.0f + 0.5f);
+    _dpiScale = backingScale / MacPlatform::ScreenScale;
+    UpdateWindowSizeLimits(window, _settings, backingScale);
+    UpdateLayerScale(view, backingScale);
+
+    NSRect rect = [view bounds];
+    CheckForResize((float)rect.size.width * backingScale, (float)rect.size.height * backingScale);
 }
 
 void MacWindow::CheckForResize(float width, float height)
@@ -939,6 +1059,36 @@ void MacWindow::OnUpdate(float dt)
     {
         // Keep sending mouse movement events no matter if window has focus
         Float2 mousePos = Platform::GetMousePosition();
+        if (_isUsingMouseOffset)
+        {
+            Float2 desktopLocation = _mouseOffsetScreenSize.Location;
+            Float2 desktopSize = _mouseOffsetScreenSize.GetBottomRight();
+            Float2 newMousePosition = mousePos;
+            _isHorizontalFlippingMouse = mousePos.X <= desktopLocation.X + 2;
+            if (_isHorizontalFlippingMouse)
+                newMousePosition.X = desktopSize.X - 3;
+            else
+            {
+                _isHorizontalFlippingMouse = mousePos.X >= desktopSize.X - 1;
+                if (_isHorizontalFlippingMouse)
+                    newMousePosition.X = desktopLocation.X + 3;
+            }
+            _isVerticalFlippingMouse = mousePos.Y <= desktopLocation.Y + 2;
+            if (_isVerticalFlippingMouse)
+                newMousePosition.Y = desktopSize.Y - 3;
+            else
+            {
+                _isVerticalFlippingMouse = mousePos.Y >= desktopSize.Y - 1;
+                if (_isVerticalFlippingMouse)
+                    newMousePosition.Y = desktopLocation.Y + 3;
+            }
+            if (!Float2::NearEqual(mousePos, newMousePosition))
+            {
+                _trackingMouseOffset -= newMousePosition - mousePos;
+                Platform::SetMousePosition(newMousePosition);
+                mousePos = newMousePosition;
+            }
+        }
         if (_mouseTrackPos != mousePos)
         {
             _mouseTrackPos = mousePos;
@@ -1072,7 +1222,7 @@ void MacWindow::Restore()
     {
         const Rectangle restoreClientBounds = _restoreClientBounds;
         _hasRestoreClientBounds = false;
-        NSRect restoreFrame = GetFrameRectForClientBounds(this, window, restoreClientBounds);
+        NSRect restoreFrame = GetFrameRectForClientBounds(window, restoreClientBounds);
         [window setFrame:restoreFrame display:YES animate:YES];
         _maximized = false;
     }
@@ -1104,7 +1254,7 @@ void MacWindow::SetClientBounds(const Rectangle& clientArea)
     NSWindow* window = (NSWindow*)_window;
     if (!window)
         return;
-    NSRect newRect = GetFrameRectForClientBounds(this, window, clientArea);
+    NSRect newRect = GetFrameRectForClientBounds(window, clientArea);
     [window setFrame:newRect display:YES];
 }
 
@@ -1146,8 +1296,16 @@ Float2 MacWindow::ScreenToClient(const Float2& screenPos) const
     NSWindow* window = (NSWindow*)_window;
     if (!window)
         return screenPos;
-    Float2 titleSize = GetWindowTitleSize(this);
-    return screenPos - GetPosition() - titleSize;
+    NSView* view = (NSView*)_view;
+    if (!view)
+        return screenPos;
+    const float screenScale = MacPlatform::ScreenScale;
+    const float backingScale = GetWindowBackingScale(this);
+    const Float2 cocoaPos = AppleUtils::PosToCoca(screenPos) / screenScale;
+    NSPoint windowPoint = [window convertPointFromScreen:NSMakePoint((CGFloat)cocoaPos.X, (CGFloat)cocoaPos.Y)];
+    NSPoint viewPoint = [view convertPoint:windowPoint fromView:nil];
+    NSRect bounds = [view bounds];
+    return Float2((float)viewPoint.x, (float)(bounds.size.height - viewPoint.y)) * backingScale;
 }
 
 Float2 MacWindow::ClientToScreen(const Float2& clientPos) const
@@ -1155,8 +1313,16 @@ Float2 MacWindow::ClientToScreen(const Float2& clientPos) const
     NSWindow* window = (NSWindow*)_window;
     if (!window)
         return clientPos;
-    Float2 titleSize = GetWindowTitleSize(this);
-    return GetPosition() + titleSize + clientPos;
+    NSView* view = (NSView*)_view;
+    if (!view)
+        return clientPos;
+    const float screenScale = MacPlatform::ScreenScale;
+    const float backingScale = GetWindowBackingScale(this);
+    NSRect bounds = [view bounds];
+    NSPoint viewPoint = NSMakePoint((CGFloat)(clientPos.X / backingScale), (CGFloat)(bounds.size.height - clientPos.Y / backingScale));
+    NSPoint windowPoint = [view convertPoint:viewPoint toView:nil];
+    NSPoint screenPoint = [window convertPointToScreen:windowPoint];
+    return AppleUtils::CocaToPos(Float2((float)screenPoint.x, (float)screenPoint.y) * screenScale);
 }
 
 void MacWindow::FlashWindow()
@@ -1243,6 +1409,9 @@ void MacWindow::StartTrackingMouse(bool useMouseScreenOffset)
     _isTrackingMouse = true;
     _trackingMouseOffset = Float2::Zero;
     _isUsingMouseOffset = useMouseScreenOffset;
+    _isHorizontalFlippingMouse = false;
+    _isVerticalFlippingMouse = false;
+    _mouseOffsetScreenSize = Platform::GetVirtualDesktopBounds();
     _mouseTrackPos = Float2::Minimum;
 }
 

--- a/Source/Engine/Platform/Mac/MacWindow.h
+++ b/Source/Engine/Platform/Mac/MacWindow.h
@@ -27,6 +27,7 @@ public:
 	~MacWindow() override;
 
     void SyncWindowState();
+    void SyncBackingScale();
     void CheckForResize(float width, float height);
     void SetIsMouseOver(bool value);
     const String& GetDragText() const


### PR DESCRIPTION
## Summary

Fixes macOS window input, sizing, and rendering issues on mixed-DPI multi-monitor setups.

- Uses Cocoa/NSScreen coordinates for macOS mouse position, cursor warping, monitor bounds, and virtual desktop bounds.
- Tracks the actual per-window backing scale and updates DPI, layer scale, drawable size, and min/max constraints when a window moves between displays.
- Converts only desktop/monitor-derived window sizes from global screen coordinates to the target display backing scale, instead of treating every `CenterScreen` window as screen-sized.
- Makes the editor splash screen use the actual window DPI scale, keeps it centered on a stable target monitor, and sizes custom splash images against that monitor.
- Uses the editor main window DPI scale for macOS floating editor windows so secondary windows do not open oversized on low-DPI displays.

## Why

The old macOS path mixed CoreGraphics display pixels, Cocoa screen points, and Flax's global `ScreenScale`. That works on simple single-DPI setups, but breaks down with displays such as a 1x monitor next to a 2x Retina monitor: mouse input can be offset, text can render at the wrong scale, windows can open too large, and splash windows can appear off-center.

This change aligns macOS window geometry with AppKit's per-screen backing scale model while keeping the existing Flax client-size contract for normal windows.
