### PR TITLE
Fix prefab Script track IDs for Scene Animation remapping

### DIFF
--- a/Source/Editor/GUI/Timeline/Tracks/ScriptTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/ScriptTrack.cs
@@ -52,8 +52,67 @@ namespace FlaxEditor.GUI.Timeline.Tracks
         /// </summary>
         public Script Script
         {
-            get => FlaxEngine.Object.TryFind<Script>(ref ScriptID);
-            set => ScriptID = value?.ID ?? Guid.Empty;
+            get
+            {
+                if (Flags.HasFlag(TrackFlags.PrefabObject))
+                {
+                    // TODO: reuse cached script to improve perf
+                    foreach (var window in Editor.Instance.Windows.Windows)
+                    {
+                        if (window is Windows.Assets.PrefabWindow prefabWindow && prefabWindow.Graph.MainActor)
+                        {
+                            var script = FindScriptWithPrefabObjectID(prefabWindow.Graph.MainActor, ref ScriptID);
+                            if (script != null)
+                                return script;
+                        }
+                    }
+                    return null;
+                }
+                return FlaxEngine.Object.TryFind<Script>(ref ScriptID);
+            }
+            set
+            {
+                if (value != null)
+                {
+                    if (value.HasPrefabLink && !value.HasScene)
+                    {
+                        // Track with prefab object reference assigned in Editor
+                        ScriptID = value.PrefabObjectID;
+                        Flags |= TrackFlags.PrefabObject;
+                    }
+                    else
+                    {
+                        ScriptID = value.ID;
+                        Flags &= ~TrackFlags.PrefabObject;
+                    }
+                }
+                else
+                {
+                    ScriptID = Guid.Empty;
+                    Flags &= ~TrackFlags.PrefabObject;
+                }
+            }
+        }
+
+        private static Script FindScriptWithPrefabObjectID(Actor actor, ref Guid id)
+        {
+            if (actor == null)
+                return null;
+
+            var scripts = actor.Scripts;
+            for (int i = 0; i < scripts.Length; i++)
+            {
+                var script = scripts[i];
+                if (script && script.PrefabObjectID == id)
+                    return script;
+            }
+            for (int i = 0; i < actor.ChildrenCount; i++)
+            {
+                var e = FindScriptWithPrefabObjectID(actor.GetChild(i), ref id);
+                if (e != null)
+                    return e;
+            }
+            return null;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

Fixes Scene Animation `Script` tracks created for prefab objects so they store the script `PrefabObjectID` instead of the runtime instance `ID`.

This allows `SceneAnimationPlayer.UsePrefabObjects` to remap prefab script tracks correctly when a scene animation is played on prefab instances.

## Why

`Actor` tracks already use prefab object IDs when authored from prefab assets, but `Script` tracks were still saving runtime script IDs. Because the player remaps only tracks marked with `PrefabObject`, script tracks could fail to resolve after prefab instancing.

## Changes

- Store `Script.PrefabObjectID` for prefab script tracks.
- Mark prefab script tracks with `TrackFlags.PrefabObject`.
- Resolve prefab script tracks in the editor by searching opened prefab roots by `PrefabObjectID`.

## Compatibility / Breaking Note

This changes the serialized meaning of `ScriptTrack.ScriptID` for prefab script tracks: new/updated prefab script tracks now store prefab object IDs instead of runtime object IDs.

There is no automatic migration in this PR. Existing Scene Animation assets that were already saved with incorrect script runtime IDs will not be fixed automatically and need to be re-authored or re-saved after retargeting the affected script tracks.