### PR TITLE
Fix NodesCache desync after hotreload

### DIFF
--- a/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
@@ -532,6 +532,7 @@ namespace FlaxEditor.Modules.SourceCodeEditing
         {
             // Invalidate cached types
             All.ClearTypes();
+            AllWithStd.ClearTypes();
             VisualScriptPropertyTypes.ClearTypes();
             Actors.ClearTypes();
             Scripts.ClearTypes();

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -183,6 +183,9 @@ namespace FlaxEditor.Surface
                 {
                     _cache.Clear();
                     _version++;
+
+                    // Mark type list as dirty to rebuild it next use.
+                    Editor.Instance.CodeEditing.AllWithStd.ClearTypes();
                 }
 
                 Editor.Instance.CodeEditing.TypesCleared -= OnCodeEditingTypesCleared;

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -183,9 +183,6 @@ namespace FlaxEditor.Surface
                 {
                     _cache.Clear();
                     _version++;
-
-                    // Mark type list as dirty to rebuild it next use.
-                    Editor.Instance.CodeEditing.AllWithStd.ClearTypes();
                 }
 
                 Editor.Instance.CodeEditing.TypesCleared -= OnCodeEditingTypesCleared;


### PR DESCRIPTION
Issue:
- Visject types popup context menu becomes desynchronized after multiple hotreloads (2)
- async cache not invalidated correctly when types are cleared

Fix:
- Clear cache 

Impact:
- No global system changes
- Only affects Visject NodesCache lifecycle