### PR TITLE
Neural Rendering 2027+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,126 @@
+# AGENTS.md
+
+## Repo Purpose
+
+Flax Engine is a modern 3D game engine written in C++ and C#.
+This repository contains the engine, editor, tooling, shaders, tests, assets, and platform-specific sources, excluding NDA-protected platform support.
+
+## High-Level Structure
+
+- `Source/Engine/`: engine runtime code and managed/runtime integration.
+- `Source/Editor/`: editor code in both C++ and C#.
+- `Source/Tools/`: build system and developer tooling, including `Flax.Build`.
+- `Source/Platforms/`: platform-specific code, dependencies, and binaries.
+- `Source/ThirdParty/`: vendored third-party code. Avoid changes here unless the task explicitly requires it.
+- `Source/Engine/Tests/`: native and managed engine tests.
+- `Source/Tools/Flax.Build.Tests/`: .NET tests for the build tool.
+- `Content/`: engine/editor assets.
+- `Development/Scripts/`: helper scripts for project generation and builds.
+
+## Working Assumptions
+
+- Generated solutions and project files are not committed. On a clean clone, generate them first.
+- Git LFS is required. The Windows build scripts explicitly check for LFS-populated files.
+- On Windows, the main entry points are `GenerateProjectFiles.bat` and `Development\Scripts\Windows\CallBuildTool.bat`.
+- Prefer edits in `Source/Engine`, `Source/Editor`, `Source/Tools`, or docs. Do not modify `Binaries/`, `Cache/`, or generated project files unless the task explicitly targets generated output.
+
+## Windows Setup And Build
+
+Use these commands from the repo root.
+
+Generate project files:
+
+```powershell
+.\GenerateProjectFiles.bat -vs2022 -log -verbose -printSDKs -dotnet=8
+```
+
+Alternative default generation:
+
+```powershell
+.\GenerateProjectFiles.bat
+```
+
+Build the editor target:
+
+```powershell
+.\Development\Scripts\Windows\CallBuildTool.bat -build -log -dotnet=8 -arch=x64 -platform=Windows -configuration=Development -buildtargets=FlaxEditor
+```
+
+Run the editor:
+
+```powershell
+.\Binaries\Editor\Win64\Development\FlaxEditor.exe
+```
+
+Visual Studio workflow after generation:
+
+- Open `Flax.sln`.
+- Use solution configuration `Editor.Development` and platform `Win64`.
+- Set `Flax` or `FlaxEngine` as the startup project.
+
+## Tests And Validation
+
+The checked-in CI workflow in `.github/workflows/tests.yml` is the most reliable source for current validation commands.
+
+Build native tests:
+
+```powershell
+.\Development\Scripts\Windows\CallBuildTool.bat -build -log -dotnet=8 -arch=x64 -platform=Windows -configuration=Development -buildtargets=FlaxTestsTarget
+```
+
+Run native tests:
+
+```powershell
+.\Binaries\Editor\Win64\Development\FlaxTests.exe -headless
+```
+
+Build Flax.Build tests:
+
+```powershell
+dotnet msbuild Source\Tools\Flax.Build.Tests\Flax.Build.Tests.csproj /m /t:Restore,Build /p:Configuration=Debug /p:Platform=AnyCPU /nologo
+```
+
+Run Flax.Build tests:
+
+```powershell
+dotnet test -f net8.0 Binaries\Tests\Flax.Build.Tests.dll
+```
+
+Run managed engine tests after copying runtime dependencies:
+
+```powershell
+xcopy /y Binaries\Editor\Win64\Development\FlaxEngine.CSharp.dll Binaries\Tests
+xcopy /y Binaries\Editor\Win64\Development\FlaxEngine.CSharp.runtimeconfig.json Binaries\Tests
+xcopy /y Binaries\Editor\Win64\Development\Newtonsoft.Json.dll Binaries\Tests
+dotnet test -f net8.0 Binaries\Tests\FlaxEngine.CSharp.dll
+```
+
+If a change is localized, prefer the narrowest possible target build and only run the relevant tests for that area.
+
+## Style And Conventions
+
+- The root `Source/.editorconfig` sets CRLF line endings, UTF-8, final newline, and spaces for indentation.
+- Use 4 spaces for C++, C#, shaders, and Python. Use 2 spaces for XAML and MSBuild files.
+- Keep the existing copyright header in source files.
+- Public APIs in both C++ headers and C# commonly use XML-style documentation comments such as `/// <summary>`.
+- Preserve local file style instead of mass-normalizing. The C# codebase mixes block namespaces and file-scoped namespaces.
+- Follow existing naming patterns: PascalCase for types and public members; private C# fields often use `_camelCase`.
+- In C++ headers, prefer forward declarations where practical and keep includes minimal.
+
+## Build System Notes
+
+- `FlaxEditor` is the main standalone editor target.
+- `FlaxGame` is the standalone game target.
+- `FlaxTestsTarget` builds the native test executable.
+- `Flax.Build` supports project generation switches such as `-vs2022`, `-vs2026`, `-vscode`, and `-rider`.
+- `GenerateProjectFiles.bat` also builds C# bindings for `FlaxEditor` on Windows.
+
+## Agent Guidance
+
+- Treat `.github/workflows/tests.yml` as the source of truth for CI-backed validation.
+- Do not assume generated artifacts already exist in the repo.
+- Avoid broad style-only rewrites.
+- Avoid touching `Source/ThirdParty/` unless explicitly requested.
+- If a change affects developer workflow or build/test steps, update the relevant root docs as part of the task.
+- No dedicated repo-wide formatter or linter command is checked in. Prefer build and test validation over inventing formatting steps.
+- PVS-Studio is mentioned in `README.md`, but it is not wired here as a standard local validation command.

--- a/Source/Editor/Cooker/GameCooker.cpp
+++ b/Source/Editor/Cooker/GameCooker.cpp
@@ -239,7 +239,7 @@ String CookingData::GetGameBinariesPath() const
         archDir = TEXT("ARM64");
         break;
     default:
-    CRASH;
+        CRASH;
         return String::Empty;
     }
 

--- a/Source/Editor/Cooker/Steps/ValidateStep.cpp
+++ b/Source/Editor/Cooker/Steps/ValidateStep.cpp
@@ -69,8 +69,6 @@ bool ValidateStep::Perform(CookingData& data)
             return true;
         }
 
-        // TODO: validate version
-
         AssetInfo info;
         if (!Content::GetAssetInfo(gameSettings->FirstScene, info))
         {
@@ -78,10 +76,6 @@ bool ValidateStep::Perform(CookingData& data)
             return true;
         }
     }
-
-    // TODO: validate more game config
-
-    // TODO: validate all input scenes?
 
     return false;
 }

--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -654,7 +654,7 @@ Window* Editor::CreateMainWindow()
     PROFILE_MEM(Editor);
     Window* window = Managed->GetMainWindow();
 
-#if PLATFORM_LINUX || (PLATFORM_MAC && PLATFORM_SDL)
+#if PLATFORM_LINUX || PLATFORM_MAC
     // Set window icon
     const String iconPath = Globals::BinariesFolder / TEXT("Logo.png");
     if (FileSystem::FileExists(iconPath))

--- a/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuBase.cs
@@ -1,8 +1,8 @@
-#if PLATFORM_WINDOWS || PLATFORM_SDL
+#if PLATFORM_WINDOWS || PLATFORM_SDL || PLATFORM_MAC
 #define USE_IS_FOREGROUND
 #else
 #endif
-#if PLATFORM_SDL
+#if PLATFORM_SDL || PLATFORM_MAC
 #define USE_SDL_WORKAROUNDS
 #endif
 // Copyright (c) Wojciech Figat. All rights reserved.

--- a/Source/Editor/GUI/Timeline/Tracks/ScriptTrack.cs
+++ b/Source/Editor/GUI/Timeline/Tracks/ScriptTrack.cs
@@ -52,8 +52,67 @@ namespace FlaxEditor.GUI.Timeline.Tracks
         /// </summary>
         public Script Script
         {
-            get => FlaxEngine.Object.TryFind<Script>(ref ScriptID);
-            set => ScriptID = value?.ID ?? Guid.Empty;
+            get
+            {
+                if (Flags.HasFlag(TrackFlags.PrefabObject))
+                {
+                    // TODO: reuse cached script to improve perf
+                    foreach (var window in Editor.Instance.Windows.Windows)
+                    {
+                        if (window is Windows.Assets.PrefabWindow prefabWindow && prefabWindow.Graph.MainActor)
+                        {
+                            var script = FindScriptWithPrefabObjectID(prefabWindow.Graph.MainActor, ref ScriptID);
+                            if (script != null)
+                                return script;
+                        }
+                    }
+                    return null;
+                }
+                return FlaxEngine.Object.TryFind<Script>(ref ScriptID);
+            }
+            set
+            {
+                if (value != null)
+                {
+                    if (value.HasPrefabLink && !value.HasScene)
+                    {
+                        // Track with prefab object reference assigned in Editor
+                        ScriptID = value.PrefabObjectID;
+                        Flags |= TrackFlags.PrefabObject;
+                    }
+                    else
+                    {
+                        ScriptID = value.ID;
+                        Flags &= ~TrackFlags.PrefabObject;
+                    }
+                }
+                else
+                {
+                    ScriptID = Guid.Empty;
+                    Flags &= ~TrackFlags.PrefabObject;
+                }
+            }
+        }
+
+        private static Script FindScriptWithPrefabObjectID(Actor actor, ref Guid id)
+        {
+            if (actor == null)
+                return null;
+
+            var scripts = actor.Scripts;
+            for (int i = 0; i < scripts.Length; i++)
+            {
+                var script = scripts[i];
+                if (script && script.PrefabObjectID == id)
+                    return script;
+            }
+            for (int i = 0; i < actor.ChildrenCount; i++)
+            {
+                var e = FindScriptWithPrefabObjectID(actor.GetChild(i), ref id);
+                if (e != null)
+                    return e;
+            }
+            return null;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Gizmo/GridGizmo.cs
+++ b/Source/Editor/Gizmo/GridGizmo.cs
@@ -113,7 +113,7 @@ namespace FlaxEditor.Gizmo
                 if (cb != IntPtr.Zero)
                 {
                     var data = new Data();
-                    var projection = renderContext.View.GetOverlayProjection();
+                    renderContext.View.GetOverlayProjection(out var projection);
                     Matrix.Multiply(ref renderContext.View.View, ref projection, out var viewProjection);
                     Matrix.Transpose(ref viewProjection, out data.ViewProjectionMatrix);
                     data.ViewPos = renderContext.View.WorldPosition;

--- a/Source/Editor/Gizmo/GridGizmo.cs
+++ b/Source/Editor/Gizmo/GridGizmo.cs
@@ -113,7 +113,8 @@ namespace FlaxEditor.Gizmo
                 if (cb != IntPtr.Zero)
                 {
                     var data = new Data();
-                    Matrix.Multiply(ref renderContext.View.View, ref renderContext.View.Projection, out var viewProjection);
+                    var projection = renderContext.View.GetOverlayProjection();
+                    Matrix.Multiply(ref renderContext.View.View, ref projection, out var viewProjection);
                     Matrix.Transpose(ref viewProjection, out data.ViewProjectionMatrix);
                     data.ViewPos = renderContext.View.WorldPosition;
                     data.GridColor = options.Viewport.ViewportGridColor;

--- a/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
+++ b/Source/Editor/Modules/SourceCodeEditing/CodeEditingModule.cs
@@ -532,6 +532,7 @@ namespace FlaxEditor.Modules.SourceCodeEditing
         {
             // Invalidate cached types
             All.ClearTypes();
+            AllWithStd.ClearTypes();
             VisualScriptPropertyTypes.ClearTypes();
             Actors.ClearTypes();
             Scripts.ClearTypes();

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -189,12 +189,18 @@ namespace FlaxEditor.Options
             /// <summary>
             /// Determined automatically based on the system and any known compatibility issues with native decorations.
             /// </summary>
+#if PLATFORM_MAC && !PLATFORM_SDL
+            [HideInEditor]
+#endif
             Auto,
 
             /// <summary>
             /// Automatically choose most compatible window decorations for child windows, prefer custom decorations on main window.
             /// </summary>
             [EditorDisplay(Name = "Auto (Child Only)")]
+#if PLATFORM_MAC && !PLATFORM_SDL
+            [HideInEditor]
+#endif
             AutoChildOnly,
 
             /// <summary>
@@ -307,7 +313,7 @@ namespace FlaxEditor.Options
         [EditorDisplay("Interface"), EditorOrder(322)]
         public bool ScrollToScriptOnAdd { get; set; } = true;
 
-#if PLATFORM_SDL
+#if PLATFORM_SDL || PLATFORM_MAC
         /// <summary>
         /// Gets or sets a value indicating whether use native window title bar decorations in child windows. Editor restart required.
         /// </summary>

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -317,14 +317,14 @@ namespace FlaxEditor.Options
         /// <summary>
         /// Gets or sets a value indicating whether use native window title bar decorations in child windows. Editor restart required.
         /// </summary>
-#if PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS || PLATFORM_MAC
         [DefaultValue(WindowDecorationsType.ClientSide)]
 #else
         [DefaultValue(WindowDecorationsType.AutoChildOnly)]
 #endif
         [EditorDisplay("Tabs & Windows"), EditorOrder(70), Tooltip("Determines whether use native window title bar decorations. Editor restart required.")]
         public WindowDecorationsType WindowDecorations { get; set; } =
-#if PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS || PLATFORM_MAC
             WindowDecorationsType.ClientSide;
 #else
             WindowDecorationsType.AutoChildOnly;

--- a/Source/Editor/Surface/Archetypes/Tools.cs
+++ b/Source/Editor/Surface/Archetypes/Tools.cs
@@ -651,10 +651,16 @@ namespace FlaxEditor.Surface.Archetypes
                     foreach (var e in values)
                     {
                         _combobox.AddItem(e.Key);
-                        tooltips[i++] = "Type: " + CustomEditorsUtil.GetTypeNameUI(e.Value.GetType()) + ", default value: " + e.Value;
+                        var value = e.Value;
+                        if (value == null)
+                        {
+                            tooltips[i++] = "null";
+                            continue;
+                        }
+                        tooltips[i++] = "Type: " + CustomEditorsUtil.GetTypeNameUI(value.GetType()) + ", default value: " + value;
                         if (toSelect == e.Key)
                         {
-                            type = e.Value.GetType();
+                            type = value.GetType();
                         }
                     }
                     _combobox.Tooltips = tooltips;

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -161,6 +161,7 @@ namespace FlaxEditor.Surface
                     if (noClampedSize.Y < minSize.Y && noClampedSize.Y < ResizableNode.Size.Y)
                         resizeAxisAbs.Y = resizeAxisPos.Y = resizeAxisNeg.Y = 0f;
 
+                    ResizableNode.Size += uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
                     ResizableNode.Location += uiControlDelta * resizeAxisNeg;
                     ResizableNode.SizeValue = ResizableNode.Size - emptySize;
 

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -1,19 +1,22 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
+using System;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
 namespace FlaxEditor.Surface
 {
     /// <summary>
-    /// Visject Surface node control that cna be resized.
+    /// Visject Surface node control that can be resized.
     /// </summary>
     /// <seealso cref="SurfaceNode" />
     [HideInEditor]
     public class ResizableSurfaceNode : SurfaceNode
     {
+        private Float2 _resizeWeight;
         private Float2 _startResizingSize;
-        private Float2 _startResizingCornerOffset;
+        private Float2 _surfaceMouseLocation;
+        private bool _isMouseOverResizeBorder;
 
         /// <summary>
         /// Indicates whether the node is currently being resized.
@@ -30,11 +33,6 @@ namespace FlaxEditor.Surface
         /// </summary>
         protected Float2 _sizeMin = new Float2(240, 160);
 
-        /// <summary>
-        /// Node resizing rectangle bounds.
-        /// </summary>
-        protected Rectangle _resizeButtonRect;
-
         private Float2 SizeValue
         {
             get => (Float2)Values[_sizeValueIndex];
@@ -50,7 +48,7 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool CanSelect(ref Float2 location)
         {
-            return base.CanSelect(ref location) && !_resizeButtonRect.MakeOffsetted(Location).Contains(ref location);
+            return base.CanSelect(ref location);// && !_resizeButtonRect.MakeOffsetted(Location).Contains(ref location);
         }
 
         /// <inheritdoc />
@@ -79,15 +77,9 @@ namespace FlaxEditor.Surface
         {
             base.Draw();
 
-            if (Surface.CanEdit)
+            if (Surface.CanEdit && (_isResizing || _isMouseOverResizeBorder))
             {
-                var style = Style.Current;
-                if (_isResizing)
-                {
-                    Render2D.FillRectangle(_resizeButtonRect, style.Selection);
-                    Render2D.DrawRectangle(_resizeButtonRect, style.SelectionBorder);
-                }
-                Render2D.DrawSprite(style.Scale, _resizeButtonRect, _resizeButtonRect.Contains(_mousePosition) ? style.Foreground : style.ForegroundGrey);
+                Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 2f);
             }
         }
 
@@ -109,24 +101,67 @@ namespace FlaxEditor.Surface
             base.OnEndMouseCapture();
         }
 
+        private bool UpdateIsOverResizeBorder(Float2 location)
+        {
+            const float ResizeBorderHalfWidth = 20f;
+            const float ResizeOnAxisThreshold = 0.85f;
+
+            var nodeRect = new Rectangle(Float2.Zero, Size);
+            bool onBorder = nodeRect.MakeExpanded(ResizeBorderHalfWidth).Contains(location);
+            var inNodeRect = nodeRect.MakeExpanded(-ResizeBorderHalfWidth);
+            bool inNode = inNodeRect.Contains(location);
+
+            Float2 rawResizeWeight = (location - nodeRect.Center) / (nodeRect.Size * 0.5f);
+            _resizeWeight = new Float2(Mathf.Abs(rawResizeWeight.X) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.X) : 0,
+                                    Mathf.Abs(rawResizeWeight.Y) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.Y) : 0);
+
+            _isMouseOverResizeBorder = onBorder && !inNode;
+            return onBorder && !inNode;
+        }
+
+        private CursorType ResizeWeightToCursorType()
+        {
+            if ((_resizeWeight.X == 1 && _resizeWeight.Y == 0) || (_resizeWeight.X == -1 && _resizeWeight.Y == 0))
+                return CursorType.SizeWE;
+            if ((_resizeWeight.X == 0 && _resizeWeight.Y == 1) || (_resizeWeight.X == 0 && _resizeWeight.Y == -1))
+                return CursorType.SizeNS;
+            if ((_resizeWeight.X == -1 && _resizeWeight.Y == -1) || (_resizeWeight.X == 1 && _resizeWeight.Y == 1))
+                return CursorType.SizeNWSE;
+            if ((_resizeWeight.X == 1 && _resizeWeight.Y == -1) || (_resizeWeight.X == -1 && _resizeWeight.Y == 1))
+                return CursorType.SizeNESW;
+            return CursorType.Default;
+        }
+
         /// <inheritdoc />
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
             if (base.OnMouseDown(location, button))
                 return true;
 
-            if (button == MouseButton.Left && _resizeButtonRect.Contains(ref location) && Surface.CanEdit)
+            if (button == MouseButton.Left && UpdateIsOverResizeBorder(location))
             {
                 // Start resizing
+                UpdateSurfaceMouseLocation();
                 _isResizing = true;
                 _startResizingSize = Size;
-                _startResizingCornerOffset = Size - location;
                 StartMouseCapture();
-                Cursor = CursorType.SizeNWSE;
                 return true;
             }
 
             return false;
+        }
+
+        private Float2 GetControlDelta(Control control, ref Float2 start, ref Float2 end)
+        {
+            var pointOrigin = control.Parent ?? control;
+            var startPos = pointOrigin.PointFromParent(this, start);
+            var endPos = pointOrigin.PointFromParent(this, end);
+            return endPos - startPos;
+        }
+
+        private void UpdateSurfaceMouseLocation()
+        {
+            _surfaceMouseLocation = Surface.PointFromScreen(Input.MouseScreenPosition);
         }
 
         /// <inheritdoc />
@@ -134,14 +169,44 @@ namespace FlaxEditor.Surface
         {
             if (_isResizing)
             {
+                var resizeAxisAbs = _resizeWeight.Absolute;
+                var resizeAxisPos = Float2.Clamp(_resizeWeight, Float2.Zero, Float2.One);
+                var resizeAxisNeg = Float2.Clamp(-_resizeWeight, Float2.Zero, Float2.One);
+
+                var delta = PointToParent(Surface, location) - _surfaceMouseLocation;
+                // TODO: scale/size snapping?
+                delta *= resizeAxisAbs;
+
+                var moveLocation = _surfaceMouseLocation + delta;
+
+                // TODO: Do I need GetControlDelta?
+                var uiControlDelta = GetControlDelta(this, ref _surfaceMouseLocation, ref moveLocation);
                 var emptySize = CalculateNodeSize(0, 0);
-                var size = Float2.Max(location - emptySize + _startResizingCornerOffset, _sizeMin);
-                Resize(size.X, size.Y);
+                Location += uiControlDelta * resizeAxisNeg;
+                Size += uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
+                Size = new Float2(Mathf.Max(Size.X, _sizeMin.X), Mathf.Max(Size.Y, _sizeMin.Y));
+                SizeValue = Size - emptySize;
+                SizeValue = new Float2(Mathf.Max(SizeValue.X, _sizeMin.X), Mathf.Max(SizeValue.Y, _sizeMin.Y));
+                CalculateNodeSize(Size.X, Size.Y);
+                UpdateSurfaceMouseLocation();
+            }
+            else if (UpdateIsOverResizeBorder(location))
+            {
+                Cursor = ResizeWeightToCursorType();
             }
             else
             {
+                Cursor = CursorType.Default;
                 base.OnMouseMove(location);
             }
+        }
+
+        /// <inheritdoc />
+        public override void OnMouseLeave()
+        {
+            Cursor = CursorType.Default;
+            _isMouseOverResizeBorder = false;
+            base.OnMouseLeave();
         }
 
         /// <inheritdoc />
@@ -149,6 +214,7 @@ namespace FlaxEditor.Surface
         {
             if (button == MouseButton.Left && _isResizing)
             {
+                Cursor = CursorType.Default;
                 EndResizing();
                 return true;
             }
@@ -156,19 +222,8 @@ namespace FlaxEditor.Surface
             return base.OnMouseUp(location, button);
         }
 
-        /// <inheritdoc />
-        protected override void UpdateRectangles()
-        {
-            base.UpdateRectangles();
-
-            const float buttonMargin = Constants.NodeCloseButtonMargin;
-            const float buttonSize = Constants.NodeCloseButtonSize;
-            _resizeButtonRect = new Rectangle(_closeButtonRect.Left, Height - buttonSize - buttonMargin - 4, buttonSize, buttonSize);
-        }
-
         private void EndResizing()
         {
-            Cursor = CursorType.Default;
             EndMouseCapture();
             _isResizing = false;
             if (_startResizingSize != Size)

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -248,12 +248,6 @@ namespace FlaxEditor.Surface
 
                 base.OnEndMouseCapture();
             }
-
-            /// <inheritdoc />
-            public override void Draw()
-            {
-                Render2D.DrawRectangle(Bounds with { Location = Float2.Zero }, Color.Green, 1f);
-            }
         }
 
         /// <summary>

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -13,15 +13,204 @@ namespace FlaxEditor.Surface
     [HideInEditor]
     public class ResizableSurfaceNode : SurfaceNode
     {
-        private Float2 _resizeWeight;
-        private Float2 _startResizingSize;
-        private Float2 _surfaceMouseLocation;
-        private bool _isMouseOverResizeBorder;
+        private class ResizeBorder : Control
+        {
+            private const float BorderWidth = 15f;
+            private const float ResizeOnAxisThreshold = 0.85f;
 
-        /// <summary>
-        /// Indicates whether the node is currently being resized.
-        /// </summary>
-        protected bool _isResizing;
+            public VisjectSurface Surface;
+            public ResizableSurfaceNode ResizeableNode;
+
+            private Float2 _surfaceMouseLocation;
+            private Float2 startResizingSize;
+
+            public bool IsMouseOverResizeBorder { get; private set; }
+            public bool IsResizing { get; private set; }
+
+            public Action StartResize;
+            public Action EndResize;
+
+            public Float2 ResizeWeight { get; private set; }
+            public CursorType CursorType
+            {
+                get
+                {
+                    if ((ResizeWeight.X == 1 && ResizeWeight.Y == 0) || (ResizeWeight.X == -1 && ResizeWeight.Y == 0))
+                        return CursorType.SizeWE;
+                    if ((ResizeWeight.X == 0 && ResizeWeight.Y == 1) || (ResizeWeight.X == 0 && ResizeWeight.Y == -1))
+                        return CursorType.SizeNS;
+                    if ((ResizeWeight.X == -1 && ResizeWeight.Y == -1) || (ResizeWeight.X == 1 && ResizeWeight.Y == 1))
+                        return CursorType.SizeNWSE;
+                    if ((ResizeWeight.X == 1 && ResizeWeight.Y == -1) || (ResizeWeight.X == -1 && ResizeWeight.Y == 1))
+                        return CursorType.SizeNESW;
+
+                    return CursorType.Default;
+                }
+            }
+            
+
+
+            public ResizeBorder(VisjectSurface surface, ResizableSurfaceNode resizeableNode)
+            {
+                Surface = surface;
+                ResizeableNode = resizeableNode;
+            }
+
+            /// <summary>
+            /// Updates location and size to match the resizeable node with the additional padding.
+            /// </summary>
+            /// <param name="nodeSize">The node size.</param>
+            /// <param name="nodeLocation">The node location.</param>
+            public void MatchResizeableNode(Float2 nodeSize, Float2 nodeLocation)
+            {
+                Size = nodeSize + new Float2(BorderWidth);
+                Location = nodeLocation - new Float2(BorderWidth * 0.5f);
+            }
+
+            private void UpdateSurfaceMouseLocation()
+            {
+                _surfaceMouseLocation = Surface.PointFromScreen(Input.MouseScreenPosition);
+            }
+
+            private void UpdateResizeFlags(Float2 location)
+            {
+                var borderRect = Bounds with { Location = Float2.Zero };
+                bool onBorder = borderRect.Contains(location);
+
+                Float2 rawResizeWeight = (location - borderRect.Center) / (borderRect.Size * 0.5f);
+                ResizeWeight = new Float2(Mathf.Abs(rawResizeWeight.X) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.X) : 0,
+                                        Mathf.Abs(rawResizeWeight.Y) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.Y) : 0);
+
+                IsMouseOverResizeBorder = onBorder && !ResizeableNode.IsMouseOver;
+            }
+
+            private Float2 GetControlDelta(Control control, ref Float2 start, ref Float2 end)
+            {
+                var pointOrigin = control.Parent ?? control;
+                var startPos = pointOrigin.PointFromParent(ResizeableNode, start);
+                var endPos = pointOrigin.PointFromParent(ResizeableNode, end);
+                return endPos - startPos;
+            }
+
+            private void EndResizing()
+            {
+                EndMouseCapture();
+                IsResizing = false;
+                if (startResizingSize != ResizeableNode.Size)
+                {
+                    var emptySize = ResizeableNode.CalculateNodeSize(0, 0);
+                    ResizeableNode.SizeValue = ResizeableNode.Size - emptySize;
+                    Surface.MarkAsEdited(false);
+                }
+            }
+
+            public override void OnMouseLeave()
+            {
+                Cursor = CursorType.Default;
+                IsMouseOverResizeBorder = false;
+                base.OnMouseLeave();
+            }
+
+            /// <inheritdoc />
+            public override void OnMouseMove(Float2 location)
+            {
+                if (!IsResizing)
+                {
+                    UpdateResizeFlags(location);
+                }
+                else
+                {
+                    var resizeAxisAbs = ResizeWeight.Absolute;
+                    var resizeAxisPos = Float2.Clamp(ResizeWeight, Float2.Zero, Float2.One);
+                    var resizeAxisNeg = Float2.Clamp(-ResizeWeight, Float2.Zero, Float2.One);
+
+                    var currentSurfaceMouse = Surface.PointFromScreen(Input.MouseScreenPosition);
+                    var delta = currentSurfaceMouse - _surfaceMouseLocation;
+                    // TODO: scale/size snapping?
+                    delta *= resizeAxisAbs;
+
+                    var moveLocation = _surfaceMouseLocation + delta;
+
+                    // TODO: Do I need GetControlDelta?
+                    var uiControlDelta = GetControlDelta(this, ref _surfaceMouseLocation, ref moveLocation);
+                    var emptySize = ResizeableNode.CalculateNodeSize(0, 0);
+                    ResizeableNode.Size += uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
+                    Float2 oldSize = ResizeableNode.Size;
+                    ResizeableNode.Size = new Float2(Mathf.Max(ResizeableNode.Size.X, ResizeableNode.sizeMin.X), Mathf.Max(ResizeableNode.Size.Y, ResizeableNode.sizeMin.Y));
+                    if (oldSize == ResizeableNode.Size) // Only move if size wasn't clamped
+                    {
+                        ResizeableNode.Location += uiControlDelta * resizeAxisNeg;
+                    }
+                    ResizeableNode.SizeValue = ResizeableNode.Size - emptySize;
+                    ResizeableNode.SizeValue = new Float2(Mathf.Max(ResizeableNode.SizeValue.X, ResizeableNode.sizeMin.X), Mathf.Max(ResizeableNode.SizeValue.Y, ResizeableNode.sizeMin.Y));
+                    ResizeableNode.CalculateNodeSize(ResizeableNode.Size.X, ResizeableNode.Size.Y);
+                    UpdateSurfaceMouseLocation();
+                    MatchResizeableNode(ResizeableNode.Size, ResizeableNode.Location);
+                }
+
+                if (IsMouseOverResizeBorder)
+                    Cursor = CursorType;
+                else
+                    Cursor = CursorType.Default;
+                
+
+
+                base.OnMouseMove(location);
+            }
+
+            public override bool OnMouseDown(Float2 location, MouseButton button)
+            {
+                if (button == MouseButton.Left && IsMouseOverResizeBorder && !IsResizing)
+                {
+                    // Start resizing
+                    UpdateSurfaceMouseLocation();
+                    IsResizing = true;
+                    startResizingSize = ResizeableNode.Size;
+                    StartMouseCapture();
+                    return true;
+                }
+
+                return base.OnMouseDown(location, button);
+            }
+
+            public override bool OnMouseUp(Float2 location, MouseButton button)
+            {
+                if (button == MouseButton.Left && IsResizing)
+                {
+                    Cursor = CursorType.Default;
+                    EndResizing();
+                    return true;
+                }
+
+                return base.OnMouseUp(location, button);
+            }
+
+            /// <inheritdoc />
+            public override void OnLostFocus()
+            {
+                if (IsResizing)
+                    EndResizing();
+
+                base.OnLostFocus();
+            }
+
+            /// <inheritdoc />
+            public override void OnEndMouseCapture()
+            {
+                if (IsResizing)
+                    EndResizing();
+
+                base.OnEndMouseCapture();
+            }
+
+            //public override void Draw()
+            //{
+            //    Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Color.Blue, 1f);
+            //}
+        }
+
+
+        private ResizeBorder resizeBorder;
 
         /// <summary>
         /// Index of the Float2 value in the node values list to store node size.
@@ -31,7 +220,7 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// Minimum node size.
         /// </summary>
-        protected Float2 _sizeMin = new Float2(240, 160);
+        protected Float2 sizeMin = new Float2(240, 160);
 
         private Float2 SizeValue
         {
@@ -43,12 +232,27 @@ namespace FlaxEditor.Surface
         public ResizableSurfaceNode(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
         : base(id, context, nodeArch, groupArch)
         {
+            CullChildren = false;
+            ClipChildren = false;
+            resizeBorder = new ResizeBorder(Surface, this)
+            {
+                Parent = Surface.SurfaceRoot,
+            };
+
+            resizeBorder.MatchResizeableNode(Size, Location);
+        }
+
+        /// <inheritdoc />
+        protected override void OnLocationChanged()
+        {
+            resizeBorder.MatchResizeableNode(Size, Location);
+            base.OnLocationChanged();
         }
 
         /// <inheritdoc />
         public override bool CanSelect(ref Float2 location)
         {
-            return base.CanSelect(ref location);// && !_resizeButtonRect.MakeOffsetted(Location).Contains(ref location);
+            return base.CanSelect(ref location);
         }
 
         /// <inheritdoc />
@@ -59,6 +263,7 @@ namespace FlaxEditor.Surface
             if (Surface != null && Surface.GridSnappingEnabled)
                 size = Surface.SnapToGrid(size, true);
             Resize(size.X, size.Y);
+            resizeBorder.MatchResizeableNode(Size, Location);
 
             base.OnSurfaceLoaded(action);
         }
@@ -77,160 +282,9 @@ namespace FlaxEditor.Surface
         {
             base.Draw();
 
-            if (Surface.CanEdit && (_isResizing || _isMouseOverResizeBorder))
+            if (Surface.CanEdit && (resizeBorder.IsResizing || resizeBorder.IsMouseOverResizeBorder))
             {
                 Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 2f);
-            }
-        }
-
-        /// <inheritdoc />
-        public override void OnLostFocus()
-        {
-            if (_isResizing)
-                EndResizing();
-
-            base.OnLostFocus();
-        }
-
-        /// <inheritdoc />
-        public override void OnEndMouseCapture()
-        {
-            if (_isResizing)
-                EndResizing();
-
-            base.OnEndMouseCapture();
-        }
-
-        private bool UpdateIsOverResizeBorder(Float2 location)
-        {
-            const float ResizeBorderHalfWidth = 20f;
-            const float ResizeOnAxisThreshold = 0.85f;
-
-            var nodeRect = new Rectangle(Float2.Zero, Size);
-            bool onBorder = nodeRect.MakeExpanded(ResizeBorderHalfWidth).Contains(location);
-            var inNodeRect = nodeRect.MakeExpanded(-ResizeBorderHalfWidth);
-            bool inNode = inNodeRect.Contains(location);
-
-            Float2 rawResizeWeight = (location - nodeRect.Center) / (nodeRect.Size * 0.5f);
-            _resizeWeight = new Float2(Mathf.Abs(rawResizeWeight.X) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.X) : 0,
-                                    Mathf.Abs(rawResizeWeight.Y) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.Y) : 0);
-
-            _isMouseOverResizeBorder = onBorder && !inNode;
-            return onBorder && !inNode;
-        }
-
-        private CursorType ResizeWeightToCursorType()
-        {
-            if ((_resizeWeight.X == 1 && _resizeWeight.Y == 0) || (_resizeWeight.X == -1 && _resizeWeight.Y == 0))
-                return CursorType.SizeWE;
-            if ((_resizeWeight.X == 0 && _resizeWeight.Y == 1) || (_resizeWeight.X == 0 && _resizeWeight.Y == -1))
-                return CursorType.SizeNS;
-            if ((_resizeWeight.X == -1 && _resizeWeight.Y == -1) || (_resizeWeight.X == 1 && _resizeWeight.Y == 1))
-                return CursorType.SizeNWSE;
-            if ((_resizeWeight.X == 1 && _resizeWeight.Y == -1) || (_resizeWeight.X == -1 && _resizeWeight.Y == 1))
-                return CursorType.SizeNESW;
-            return CursorType.Default;
-        }
-
-        /// <inheritdoc />
-        public override bool OnMouseDown(Float2 location, MouseButton button)
-        {
-            if (base.OnMouseDown(location, button))
-                return true;
-
-            if (button == MouseButton.Left && UpdateIsOverResizeBorder(location))
-            {
-                // Start resizing
-                UpdateSurfaceMouseLocation();
-                _isResizing = true;
-                _startResizingSize = Size;
-                StartMouseCapture();
-                return true;
-            }
-
-            return false;
-        }
-
-        private Float2 GetControlDelta(Control control, ref Float2 start, ref Float2 end)
-        {
-            var pointOrigin = control.Parent ?? control;
-            var startPos = pointOrigin.PointFromParent(this, start);
-            var endPos = pointOrigin.PointFromParent(this, end);
-            return endPos - startPos;
-        }
-
-        private void UpdateSurfaceMouseLocation()
-        {
-            _surfaceMouseLocation = Surface.PointFromScreen(Input.MouseScreenPosition);
-        }
-
-        /// <inheritdoc />
-        public override void OnMouseMove(Float2 location)
-        {
-            if (_isResizing)
-            {
-                var resizeAxisAbs = _resizeWeight.Absolute;
-                var resizeAxisPos = Float2.Clamp(_resizeWeight, Float2.Zero, Float2.One);
-                var resizeAxisNeg = Float2.Clamp(-_resizeWeight, Float2.Zero, Float2.One);
-
-                var delta = PointToParent(Surface, location) - _surfaceMouseLocation;
-                // TODO: scale/size snapping?
-                delta *= resizeAxisAbs;
-
-                var moveLocation = _surfaceMouseLocation + delta;
-
-                // TODO: Do I need GetControlDelta?
-                var uiControlDelta = GetControlDelta(this, ref _surfaceMouseLocation, ref moveLocation);
-                var emptySize = CalculateNodeSize(0, 0);
-                Location += uiControlDelta * resizeAxisNeg;
-                Size += uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
-                Size = new Float2(Mathf.Max(Size.X, _sizeMin.X), Mathf.Max(Size.Y, _sizeMin.Y));
-                SizeValue = Size - emptySize;
-                SizeValue = new Float2(Mathf.Max(SizeValue.X, _sizeMin.X), Mathf.Max(SizeValue.Y, _sizeMin.Y));
-                CalculateNodeSize(Size.X, Size.Y);
-                UpdateSurfaceMouseLocation();
-            }
-            else if (UpdateIsOverResizeBorder(location))
-            {
-                Cursor = ResizeWeightToCursorType();
-            }
-            else
-            {
-                Cursor = CursorType.Default;
-                base.OnMouseMove(location);
-            }
-        }
-
-        /// <inheritdoc />
-        public override void OnMouseLeave()
-        {
-            Cursor = CursorType.Default;
-            _isMouseOverResizeBorder = false;
-            base.OnMouseLeave();
-        }
-
-        /// <inheritdoc />
-        public override bool OnMouseUp(Float2 location, MouseButton button)
-        {
-            if (button == MouseButton.Left && _isResizing)
-            {
-                Cursor = CursorType.Default;
-                EndResizing();
-                return true;
-            }
-
-            return base.OnMouseUp(location, button);
-        }
-
-        private void EndResizing()
-        {
-            EndMouseCapture();
-            _isResizing = false;
-            if (_startResizingSize != Size)
-            {
-                var emptySize = CalculateNodeSize(0, 0);
-                SizeValue = Size - emptySize;
-                Surface.MarkAsEdited(false);
             }
         }
     }

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -16,7 +16,7 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// Helper class for <see cref="ResizableSurfaceNode"/> that handles mouse interactions resizing the node itself.
         /// </summary>
-        protected class ResizeBorder : Control
+        public class ResizeBorder : ContainerControl
         {
             /// <summary>
             /// Distance to each of the 4 node edges that the cursor has to be so the user can resize along the direction of the edge.
@@ -24,9 +24,13 @@ namespace FlaxEditor.Surface
             private const float BorderWidth = 15f;
 
             private readonly VisjectSurface Surface;
-            private readonly ResizableSurfaceNode ResizableNode;
             private Float2 _surfaceMouseLocation;
             private Float2 startResizingSize;
+
+            /// <summary>
+            /// The resizable node that this <see cref="ResizeBorder"/> controls.
+            /// </summary>
+            public readonly ResizableSurfaceNode ResizableNode;
 
             /// <summary>
             /// True if the mouse is at the border of the resizable node and not further away from the border than <see cref="BorderWidth"/>.
@@ -62,7 +66,6 @@ namespace FlaxEditor.Surface
                     return CursorType.Default;
                 }
             }
-
 
             /// <inheritdoc />
             public ResizeBorder(VisjectSurface surface, ResizableSurfaceNode resizableNode)
@@ -100,7 +103,7 @@ namespace FlaxEditor.Surface
                 ResizeDirection = new Float2(Mathf.Abs(rawResizeDirection.X) >= nodeHalfSizeNoBorder.X ? Mathf.Sign(rawResizeDirection.X) : 0,
                                              Mathf.Abs(rawResizeDirection.Y) >= nodeHalfSizeNoBorder.Y ? Mathf.Sign(rawResizeDirection.Y) : 0);
 
-                IsMouseOverResizeBorder = false;// onBorder && !inNode;
+                IsMouseOverResizeBorder = onBorder && !inNode;
             }
 
             private Float2 GetControlDelta(Control control, ref Float2 start, ref Float2 end)
@@ -187,6 +190,13 @@ namespace FlaxEditor.Surface
             }
 
             /// <inheritdoc />
+            public override void OnMouseEnter(Float2 location)
+            {
+                Cursor = CursorType.Default;
+                base.OnMouseEnter(location);
+            }
+
+            /// <inheritdoc />
             public override bool OnMouseDown(Float2 location, MouseButton button)
             {
                 if (button == MouseButton.Left && IsMouseOverResizeBorder && !IsResizing)
@@ -243,7 +253,7 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// Represents the border control used for resizing the associated element.
         /// </summary>
-        protected ResizeBorder ResizeBorderControl;
+        public ResizeBorder ResizeBorderControl;
 
         /// <summary>
         /// Index of the Float2 value in the node values list to store node size.
@@ -270,6 +280,7 @@ namespace FlaxEditor.Surface
                 Parent = Surface.SurfaceRoot,
             };
 
+            Parent = ResizeBorderControl;
             ResizeBorderControl.MatchResizableNode(Size, Location);
         }
 
@@ -280,13 +291,7 @@ namespace FlaxEditor.Surface
             base.OnLocationChanged();
         }
 
-        ///// <inheritdoc />
-        //public override bool CanSelect(ref Float2 location)
-        //{
-        //    return base.CanSelect(ref location);
-        //}
-
-        /// <inheritdoc />
+         /// <inheritdoc />
         public override void OnSurfaceLoaded(SurfaceNodeActions action)
         {
             // Reapply the curve node size
@@ -314,9 +319,14 @@ namespace FlaxEditor.Surface
             base.Draw();
 
             if (Surface.CanEdit && (ResizeBorderControl.IsResizing || ResizeBorderControl.IsMouseOverResizeBorder))
-            {
                 Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 0.5f);
-            }
+        }
+
+        /// <inheritdoc />
+        public override void OnDestroy()
+        {
+            ResizeBorderControl.Parent = null;
+            base.OnDestroy();
         }
     }
 }

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -24,11 +24,12 @@ namespace FlaxEditor.Surface
             private const float BorderWidth = 15f;
 
             private readonly VisjectSurface _surface;
-            private Float2 _surfaceMouseLocation;
+            private Float2 _lastSurfaceMouseLoc;
             private Float2 startResizingSize;
+            private Float2 noClampedSize;
 
             /// <summary>
-            /// Wether to ignore the surface index in parent when updating the cursor type. Set to <code>false</code> for nodes that have order like <see cref="SurfaceComment"/>.
+            /// Whether to ignore the surface index in parent when updating the cursor type. Set to <code>false</code> for nodes that have order like <see cref="SurfaceComment"/>.
             /// </summary>
             internal bool IgnoreSurfaceIndex = true;
 
@@ -94,16 +95,11 @@ namespace FlaxEditor.Surface
                 Location = nodeLocation - new Float2(BorderWidth);
             }
 
-            private void UpdateSurfaceMouseLocation()
-            {
-                _surfaceMouseLocation = _surface.PointFromScreen(Input.MouseScreenPosition);
-            }
-
             private void UpdateResizeFlags(Float2 mouseLocation)
             {
                 var borderRect = Bounds with { Location = Float2.Zero };
                 bool onBorder = borderRect.Contains(mouseLocation);
-                // Check this the way we do because some resizeable nodes (like comments) have an implementation of `Control.ContainsPoint`
+                // Check this the way we do because some resizable nodes (like comments) have an implementation of `Control.ContainsPoint`
                 // that does not check for the size you would think they have based on their visual appearance
                 bool inNode = borderRect.MakeExpanded(-BorderWidth * 2f).Contains(mouseLocation);
 
@@ -115,7 +111,7 @@ namespace FlaxEditor.Surface
                 IsMouseOverResizeBorder = onBorder && !inNode;
             }
 
-            private Float2 GetControlDelta(Control control, ref Float2 start, ref Float2 end)
+            private Float2 GetControlDelta(Control control, Float2 start, Float2 end)
             {
                 var pointOrigin = control.Parent ?? control;
                 var startPos = pointOrigin.PointFromParent(ResizableNode, start);
@@ -148,32 +144,30 @@ namespace FlaxEditor.Surface
                     var resizeAxisPos = Float2.Clamp(ResizeDirection, Float2.Zero, Float2.One);
                     var resizeAxisNeg = Float2.Clamp(-ResizeDirection, Float2.Zero, Float2.One);
 
-                    var currentSurfaceMouse = _surface.PointFromScreen(Input.MouseScreenPosition);
-                    var delta = currentSurfaceMouse - _surfaceMouseLocation;
+                    var currentSurfaceMouseLoc = _surface.PointFromScreen(Input.MouseScreenPosition);
+                    var delta = currentSurfaceMouseLoc - _lastSurfaceMouseLoc;
 
-                    // TODO: scale/size snapping?
+                    // TODO: Snapping
                     delta *= resizeAxisAbs;
+                    var moveLocation = currentSurfaceMouseLoc;
+                    var uiControlDelta = GetControlDelta(this, _lastSurfaceMouseLoc, moveLocation);
 
-                    var moveLocation = _surfaceMouseLocation + delta;
-
-                    var uiControlDelta = GetControlDelta(this, ref _surfaceMouseLocation, ref moveLocation);
+                    // This ensures that the node is not resized below min size, but also keeps the resize behavior like expected (which just Max() -ing the value does not)
                     var emptySize = ResizableNode.CalculateNodeSize(0, 0);
+                    var minSize = ResizableNode.sizeMin;
+                    noClampedSize = noClampedSize + uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
+                    if (noClampedSize.X < minSize.X && noClampedSize.X < ResizableNode.Size.X)
+                        resizeAxisAbs.X = resizeAxisPos.X = resizeAxisNeg.X = 0f;
+                    if (noClampedSize.Y < minSize.Y && noClampedSize.Y < ResizableNode.Size.Y)
+                        resizeAxisAbs.Y = resizeAxisPos.Y = resizeAxisNeg.Y = 0f;
 
-
-                    // TODO: If resize is blocked by min size and the user tries to increase the size again, wait until !blocked by min size to apply delta again
-                    // To do this, just record pos when starting to block by min size and if (cursorLocation > min) { ResizeAgain() }
-
-                    ResizableNode.Size += uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
-                    ResizableNode.Size = new Float2(Mathf.Max(ResizableNode.Size.X, ResizableNode.sizeMin.X), Mathf.Max(ResizableNode.Size.Y, ResizableNode.sizeMin.Y));
                     ResizableNode.Location += uiControlDelta * resizeAxisNeg;
-
                     ResizableNode.SizeValue = ResizableNode.Size - emptySize;
-                    ResizableNode.SizeValue = new Float2(Mathf.Max(ResizableNode.SizeValue.X, ResizableNode.sizeMin.X), Mathf.Max(ResizableNode.SizeValue.Y, ResizableNode.sizeMin.Y));
 
                     ResizableNode.CalculateNodeSize(ResizableNode.Size.X, ResizableNode.Size.Y);
-
-                    UpdateSurfaceMouseLocation();
                     MatchResizableNode(ResizableNode.Size, ResizableNode.Location);
+
+                    _lastSurfaceMouseLoc = currentSurfaceMouseLoc;
                 }
 
                 // Update the cursor shape
@@ -213,7 +207,8 @@ namespace FlaxEditor.Surface
                 if (button == MouseButton.Left && IsMouseOverResizeBorder && !IsResizing)
                 {
                     // Start resizing
-                    UpdateSurfaceMouseLocation();
+                    _lastSurfaceMouseLoc = _surface.PointFromScreen(Input.MouseScreenPosition);
+                    noClampedSize = ResizableNode.Size;
                     IsResizing = true;
                     startResizingSize = ResizableNode.Size;
                     StartMouseCapture();

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -13,58 +13,73 @@ namespace FlaxEditor.Surface
     [HideInEditor]
     public class ResizableSurfaceNode : SurfaceNode
     {
-        private class ResizeBorder : Control
+        /// <summary>
+        /// Helper class for <see cref="ResizableSurfaceNode"/> that handles mouse interactions resizing the node itself.
+        /// </summary>
+        protected class ResizeBorder : Control
         {
+            /// <summary>
+            /// Distance to each of the 4 node edges that the cursor has to be so the user can resize along the direction of the edge.
+            /// </summary>
             private const float BorderWidth = 15f;
-            private const float ResizeOnAxisThreshold = 0.85f;
 
-            public VisjectSurface Surface;
-            public ResizableSurfaceNode ResizeableNode;
-
+            private readonly VisjectSurface Surface;
+            private readonly ResizableSurfaceNode ResizableNode;
             private Float2 _surfaceMouseLocation;
             private Float2 startResizingSize;
 
+            /// <summary>
+            /// True if the mouse is at the border of the resizable node and not further away from the border than <see cref="BorderWidth"/>.
+            /// </summary>
             public bool IsMouseOverResizeBorder { get; private set; }
+
+            /// <summary>
+            /// True if <see cref="ResizableNode"/> is being resized.
+            /// </summary>
             public bool IsResizing { get; private set; }
 
-            public Action StartResize;
-            public Action EndResize;
+            /// <summary>
+            /// The direction in which to resize the node. Should be either -1, 0 or 1 on both axes.
+            /// </summary>
+            public Float2 ResizeDirection { get; private set; }
 
-            public Float2 ResizeWeight { get; private set; }
+            /// <summary>
+            /// The type of cursor to show to hint to the user that they can resize the node in a given direction.
+            /// </summary>
             public CursorType CursorType
             {
                 get
                 {
-                    if ((ResizeWeight.X == 1 && ResizeWeight.Y == 0) || (ResizeWeight.X == -1 && ResizeWeight.Y == 0))
+                    if ((ResizeDirection.X == 1 && ResizeDirection.Y == 0) || (ResizeDirection.X == -1 && ResizeDirection.Y == 0))
                         return CursorType.SizeWE;
-                    if ((ResizeWeight.X == 0 && ResizeWeight.Y == 1) || (ResizeWeight.X == 0 && ResizeWeight.Y == -1))
+                    if ((ResizeDirection.X == 0 && ResizeDirection.Y == 1) || (ResizeDirection.X == 0 && ResizeDirection.Y == -1))
                         return CursorType.SizeNS;
-                    if ((ResizeWeight.X == -1 && ResizeWeight.Y == -1) || (ResizeWeight.X == 1 && ResizeWeight.Y == 1))
+                    if ((ResizeDirection.X == -1 && ResizeDirection.Y == -1) || (ResizeDirection.X == 1 && ResizeDirection.Y == 1))
                         return CursorType.SizeNWSE;
-                    if ((ResizeWeight.X == 1 && ResizeWeight.Y == -1) || (ResizeWeight.X == -1 && ResizeWeight.Y == 1))
+                    if ((ResizeDirection.X == 1 && ResizeDirection.Y == -1) || (ResizeDirection.X == -1 && ResizeDirection.Y == 1))
                         return CursorType.SizeNESW;
 
                     return CursorType.Default;
                 }
             }
-            
 
 
-            public ResizeBorder(VisjectSurface surface, ResizableSurfaceNode resizeableNode)
+            /// <inheritdoc />
+            public ResizeBorder(VisjectSurface surface, ResizableSurfaceNode resizableNode)
             {
                 Surface = surface;
-                ResizeableNode = resizeableNode;
+                ResizableNode = resizableNode;
             }
 
             /// <summary>
-            /// Updates location and size to match the resizeable node with the additional padding.
+            /// Updates location and size to match the resizable node with the additional padding.
             /// </summary>
             /// <param name="nodeSize">The node size.</param>
             /// <param name="nodeLocation">The node location.</param>
-            public void MatchResizeableNode(Float2 nodeSize, Float2 nodeLocation)
+            public void MatchResizableNode(Float2 nodeSize, Float2 nodeLocation)
             {
-                Size = nodeSize + new Float2(BorderWidth);
-                Location = nodeLocation - new Float2(BorderWidth * 0.5f);
+                Size = nodeSize + new Float2(BorderWidth * 2);
+                Location = nodeLocation - new Float2(BorderWidth);
             }
 
             private void UpdateSurfaceMouseLocation()
@@ -72,23 +87,27 @@ namespace FlaxEditor.Surface
                 _surfaceMouseLocation = Surface.PointFromScreen(Input.MouseScreenPosition);
             }
 
-            private void UpdateResizeFlags(Float2 location)
+            private void UpdateResizeFlags(Float2 mouseLocation)
             {
                 var borderRect = Bounds with { Location = Float2.Zero };
-                bool onBorder = borderRect.Contains(location);
+                bool onBorder = borderRect.Contains(mouseLocation);
+                // Check this the way we do because some resizeable nodes (like comments) have an implementation of `Control.ContainsPoint`
+                // that does not check for the size you would think they have based on their visual appearance
+                bool inNode = borderRect.MakeExpanded(-BorderWidth * 2f).Contains(mouseLocation);
 
-                Float2 rawResizeWeight = (location - borderRect.Center) / (borderRect.Size * 0.5f);
-                ResizeWeight = new Float2(Mathf.Abs(rawResizeWeight.X) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.X) : 0,
-                                        Mathf.Abs(rawResizeWeight.Y) >= ResizeOnAxisThreshold ? Mathf.Sign(rawResizeWeight.Y) : 0);
+                Float2 rawResizeDirection = (mouseLocation - borderRect.Center);
+                var nodeHalfSizeNoBorder = ResizableNode.Size * 0.5f - BorderWidth;
+                ResizeDirection = new Float2(Mathf.Abs(rawResizeDirection.X) >= nodeHalfSizeNoBorder.X ? Mathf.Sign(rawResizeDirection.X) : 0,
+                                             Mathf.Abs(rawResizeDirection.Y) >= nodeHalfSizeNoBorder.Y ? Mathf.Sign(rawResizeDirection.Y) : 0);
 
-                IsMouseOverResizeBorder = onBorder && !ResizeableNode.IsMouseOver;
+                IsMouseOverResizeBorder = false;// onBorder && !inNode;
             }
 
             private Float2 GetControlDelta(Control control, ref Float2 start, ref Float2 end)
             {
                 var pointOrigin = control.Parent ?? control;
-                var startPos = pointOrigin.PointFromParent(ResizeableNode, start);
-                var endPos = pointOrigin.PointFromParent(ResizeableNode, end);
+                var startPos = pointOrigin.PointFromParent(ResizableNode, start);
+                var endPos = pointOrigin.PointFromParent(ResizableNode, end);
                 return endPos - startPos;
             }
 
@@ -96,14 +115,15 @@ namespace FlaxEditor.Surface
             {
                 EndMouseCapture();
                 IsResizing = false;
-                if (startResizingSize != ResizeableNode.Size)
+                if (startResizingSize != ResizableNode.Size)
                 {
-                    var emptySize = ResizeableNode.CalculateNodeSize(0, 0);
-                    ResizeableNode.SizeValue = ResizeableNode.Size - emptySize;
+                    var emptySize = ResizableNode.CalculateNodeSize(0, 0);
+                    ResizableNode.SizeValue = ResizableNode.Size - emptySize;
                     Surface.MarkAsEdited(false);
                 }
             }
 
+            /// <inheritdoc />
             public override void OnMouseLeave()
             {
                 Cursor = CursorType.Default;
@@ -120,44 +140,53 @@ namespace FlaxEditor.Surface
                 }
                 else
                 {
-                    var resizeAxisAbs = ResizeWeight.Absolute;
-                    var resizeAxisPos = Float2.Clamp(ResizeWeight, Float2.Zero, Float2.One);
-                    var resizeAxisNeg = Float2.Clamp(-ResizeWeight, Float2.Zero, Float2.One);
+                    var resizeAxisAbs = ResizeDirection.Absolute;
+                    var resizeAxisPos = Float2.Clamp(ResizeDirection, Float2.Zero, Float2.One);
+                    var resizeAxisNeg = Float2.Clamp(-ResizeDirection, Float2.Zero, Float2.One);
 
                     var currentSurfaceMouse = Surface.PointFromScreen(Input.MouseScreenPosition);
                     var delta = currentSurfaceMouse - _surfaceMouseLocation;
+
                     // TODO: scale/size snapping?
                     delta *= resizeAxisAbs;
 
                     var moveLocation = _surfaceMouseLocation + delta;
 
-                    // TODO: Do I need GetControlDelta?
                     var uiControlDelta = GetControlDelta(this, ref _surfaceMouseLocation, ref moveLocation);
-                    var emptySize = ResizeableNode.CalculateNodeSize(0, 0);
-                    ResizeableNode.Size += uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
-                    Float2 oldSize = ResizeableNode.Size;
-                    ResizeableNode.Size = new Float2(Mathf.Max(ResizeableNode.Size.X, ResizeableNode.sizeMin.X), Mathf.Max(ResizeableNode.Size.Y, ResizeableNode.sizeMin.Y));
-                    if (oldSize == ResizeableNode.Size) // Only move if size wasn't clamped
-                    {
-                        ResizeableNode.Location += uiControlDelta * resizeAxisNeg;
-                    }
-                    ResizeableNode.SizeValue = ResizeableNode.Size - emptySize;
-                    ResizeableNode.SizeValue = new Float2(Mathf.Max(ResizeableNode.SizeValue.X, ResizeableNode.sizeMin.X), Mathf.Max(ResizeableNode.SizeValue.Y, ResizeableNode.sizeMin.Y));
-                    ResizeableNode.CalculateNodeSize(ResizeableNode.Size.X, ResizeableNode.Size.Y);
+                    var emptySize = ResizableNode.CalculateNodeSize(0, 0);
+
+
+                    // TODO: Fix: Can't move comments anymore
+
+                    // TODO: If resize is blocked by min size and the user tries to increase the size again, wait until !blocked by min size to apply delta again
+                    // To do this, just record pos when starting to block by min size and if (cursorLocation > min) { ResizeAgain() }
+
+                    ResizableNode.Size += uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
+                    ResizableNode.Size = new Float2(Mathf.Max(ResizableNode.Size.X, ResizableNode.sizeMin.X), Mathf.Max(ResizableNode.Size.Y, ResizableNode.sizeMin.Y));
+                    ResizableNode.Location += uiControlDelta * resizeAxisNeg;
+
+                    // Only move if size wasn't clamped
+
+
+                    //Debug.Log($"OLD: {oldSize} NEW: {ResizableNode.Size}");
+
+                    ResizableNode.SizeValue = ResizableNode.Size - emptySize;
+                    ResizableNode.SizeValue = new Float2(Mathf.Max(ResizableNode.SizeValue.X, ResizableNode.sizeMin.X), Mathf.Max(ResizableNode.SizeValue.Y, ResizableNode.sizeMin.Y));
+                    ResizableNode.CalculateNodeSize(ResizableNode.Size.X, ResizableNode.Size.Y);
+
                     UpdateSurfaceMouseLocation();
-                    MatchResizeableNode(ResizeableNode.Size, ResizeableNode.Location);
+                    MatchResizableNode(ResizableNode.Size, ResizableNode.Location);
                 }
 
                 if (IsMouseOverResizeBorder)
                     Cursor = CursorType;
                 else
                     Cursor = CursorType.Default;
-                
-
 
                 base.OnMouseMove(location);
             }
 
+            /// <inheritdoc />
             public override bool OnMouseDown(Float2 location, MouseButton button)
             {
                 if (button == MouseButton.Left && IsMouseOverResizeBorder && !IsResizing)
@@ -165,7 +194,7 @@ namespace FlaxEditor.Surface
                     // Start resizing
                     UpdateSurfaceMouseLocation();
                     IsResizing = true;
-                    startResizingSize = ResizeableNode.Size;
+                    startResizingSize = ResizableNode.Size;
                     StartMouseCapture();
                     return true;
                 }
@@ -173,6 +202,7 @@ namespace FlaxEditor.Surface
                 return base.OnMouseDown(location, button);
             }
 
+            /// <inheritdoc />
             public override bool OnMouseUp(Float2 location, MouseButton button)
             {
                 if (button == MouseButton.Left && IsResizing)
@@ -203,14 +233,17 @@ namespace FlaxEditor.Surface
                 base.OnEndMouseCapture();
             }
 
-            //public override void Draw()
-            //{
-            //    Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Color.Blue, 1f);
-            //}
+            /// <inheritdoc />
+            public override void Draw()
+            {
+                Render2D.DrawRectangle(Bounds with { Location = Float2.Zero }, Color.Green, 1f);
+            }
         }
 
-
-        private ResizeBorder resizeBorder;
+        /// <summary>
+        /// Represents the border control used for resizing the associated element.
+        /// </summary>
+        protected ResizeBorder ResizeBorderControl;
 
         /// <summary>
         /// Index of the Float2 value in the node values list to store node size.
@@ -232,28 +265,26 @@ namespace FlaxEditor.Surface
         public ResizableSurfaceNode(uint id, VisjectSurfaceContext context, NodeArchetype nodeArch, GroupArchetype groupArch)
         : base(id, context, nodeArch, groupArch)
         {
-            CullChildren = false;
-            ClipChildren = false;
-            resizeBorder = new ResizeBorder(Surface, this)
+            ResizeBorderControl = new ResizeBorder(Surface, this)
             {
                 Parent = Surface.SurfaceRoot,
             };
 
-            resizeBorder.MatchResizeableNode(Size, Location);
+            ResizeBorderControl.MatchResizableNode(Size, Location);
         }
 
         /// <inheritdoc />
         protected override void OnLocationChanged()
         {
-            resizeBorder.MatchResizeableNode(Size, Location);
+            ResizeBorderControl.MatchResizableNode(Size, Location);
             base.OnLocationChanged();
         }
 
-        /// <inheritdoc />
-        public override bool CanSelect(ref Float2 location)
-        {
-            return base.CanSelect(ref location);
-        }
+        ///// <inheritdoc />
+        //public override bool CanSelect(ref Float2 location)
+        //{
+        //    return base.CanSelect(ref location);
+        //}
 
         /// <inheritdoc />
         public override void OnSurfaceLoaded(SurfaceNodeActions action)
@@ -263,7 +294,7 @@ namespace FlaxEditor.Surface
             if (Surface != null && Surface.GridSnappingEnabled)
                 size = Surface.SnapToGrid(size, true);
             Resize(size.X, size.Y);
-            resizeBorder.MatchResizeableNode(Size, Location);
+            ResizeBorderControl.MatchResizableNode(Size, Location);
 
             base.OnSurfaceLoaded(action);
         }
@@ -282,9 +313,9 @@ namespace FlaxEditor.Surface
         {
             base.Draw();
 
-            if (Surface.CanEdit && (resizeBorder.IsResizing || resizeBorder.IsMouseOverResizeBorder))
+            if (Surface.CanEdit && (ResizeBorderControl.IsResizing || ResizeBorderControl.IsMouseOverResizeBorder))
             {
-                Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 2f);
+                Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 0.5f);
             }
         }
     }

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -23,9 +23,14 @@ namespace FlaxEditor.Surface
             /// </summary>
             private const float BorderWidth = 15f;
 
-            private readonly VisjectSurface Surface;
+            private readonly VisjectSurface _surface;
             private Float2 _surfaceMouseLocation;
             private Float2 startResizingSize;
+
+            /// <summary>
+            /// Wether to ignore the surface index in parent when updating the cursor type. Set to <code>false</code> for nodes that have order like <see cref="SurfaceComment"/>.
+            /// </summary>
+            internal bool IgnoreSurfaceIndex = true;
 
             /// <summary>
             /// The resizable node that this <see cref="ResizeBorder"/> controls.
@@ -67,10 +72,14 @@ namespace FlaxEditor.Surface
                 }
             }
 
-            /// <inheritdoc />
+            /// <summary>
+            /// Creates a new instance of <see cref="ResizeBorder"/>.
+            /// </summary>
+            /// <param name="surface">The surface.</param>
+            /// <param name="resizableNode">The <see cref="ResizableSurfaceNode "/> this controls.</param>
             public ResizeBorder(VisjectSurface surface, ResizableSurfaceNode resizableNode)
             {
-                Surface = surface;
+                _surface = surface;
                 ResizableNode = resizableNode;
             }
 
@@ -87,7 +96,7 @@ namespace FlaxEditor.Surface
 
             private void UpdateSurfaceMouseLocation()
             {
-                _surfaceMouseLocation = Surface.PointFromScreen(Input.MouseScreenPosition);
+                _surfaceMouseLocation = _surface.PointFromScreen(Input.MouseScreenPosition);
             }
 
             private void UpdateResizeFlags(Float2 mouseLocation)
@@ -122,16 +131,8 @@ namespace FlaxEditor.Surface
                 {
                     var emptySize = ResizableNode.CalculateNodeSize(0, 0);
                     ResizableNode.SizeValue = ResizableNode.Size - emptySize;
-                    Surface.MarkAsEdited(false);
+                    _surface.MarkAsEdited(false);
                 }
-            }
-
-            /// <inheritdoc />
-            public override void OnMouseLeave()
-            {
-                Cursor = CursorType.Default;
-                IsMouseOverResizeBorder = false;
-                base.OnMouseLeave();
             }
 
             /// <inheritdoc />
@@ -147,7 +148,7 @@ namespace FlaxEditor.Surface
                     var resizeAxisPos = Float2.Clamp(ResizeDirection, Float2.Zero, Float2.One);
                     var resizeAxisNeg = Float2.Clamp(-ResizeDirection, Float2.Zero, Float2.One);
 
-                    var currentSurfaceMouse = Surface.PointFromScreen(Input.MouseScreenPosition);
+                    var currentSurfaceMouse = _surface.PointFromScreen(Input.MouseScreenPosition);
                     var delta = currentSurfaceMouse - _surfaceMouseLocation;
 
                     // TODO: scale/size snapping?
@@ -159,8 +160,6 @@ namespace FlaxEditor.Surface
                     var emptySize = ResizableNode.CalculateNodeSize(0, 0);
 
 
-                    // TODO: Fix: Can't move comments anymore
-
                     // TODO: If resize is blocked by min size and the user tries to increase the size again, wait until !blocked by min size to apply delta again
                     // To do this, just record pos when starting to block by min size and if (cursorLocation > min) { ResizeAgain() }
 
@@ -168,23 +167,26 @@ namespace FlaxEditor.Surface
                     ResizableNode.Size = new Float2(Mathf.Max(ResizableNode.Size.X, ResizableNode.sizeMin.X), Mathf.Max(ResizableNode.Size.Y, ResizableNode.sizeMin.Y));
                     ResizableNode.Location += uiControlDelta * resizeAxisNeg;
 
-                    // Only move if size wasn't clamped
-
-
-                    //Debug.Log($"OLD: {oldSize} NEW: {ResizableNode.Size}");
-
                     ResizableNode.SizeValue = ResizableNode.Size - emptySize;
                     ResizableNode.SizeValue = new Float2(Mathf.Max(ResizableNode.SizeValue.X, ResizableNode.sizeMin.X), Mathf.Max(ResizableNode.SizeValue.Y, ResizableNode.sizeMin.Y));
+
                     ResizableNode.CalculateNodeSize(ResizableNode.Size.X, ResizableNode.Size.Y);
 
                     UpdateSurfaceMouseLocation();
                     MatchResizableNode(ResizableNode.Size, ResizableNode.Location);
                 }
 
-                if (IsMouseOverResizeBorder)
-                    Cursor = CursorType;
-                else
-                    Cursor = CursorType.Default;
+                // Update the cursor shape
+                if (_surface.resizeableNodeIndexInParent <= IndexInParent || IgnoreSurfaceIndex)
+                {
+                    if (!IgnoreSurfaceIndex)
+                        _surface.resizeableNodeIndexInParent = IndexInParent;
+
+                    if (IsMouseOverResizeBorder)
+                        Cursor = CursorType;
+                    else
+                        Cursor = CursorType.Default;
+                }
 
                 base.OnMouseMove(location);
             }
@@ -194,6 +196,15 @@ namespace FlaxEditor.Surface
             {
                 Cursor = CursorType.Default;
                 base.OnMouseEnter(location);
+            }
+
+            /// <inheritdoc />
+            public override void OnMouseLeave()
+            {
+                Cursor = CursorType.Default;
+                IsMouseOverResizeBorder = false;
+                _surface.resizeableNodeIndexInParent = -1; // Will get updated by MouseMove again to match current index
+                base.OnMouseLeave();
             }
 
             /// <inheritdoc />
@@ -291,10 +302,10 @@ namespace FlaxEditor.Surface
             base.OnLocationChanged();
         }
 
-         /// <inheritdoc />
+        /// <inheritdoc />
         public override void OnSurfaceLoaded(SurfaceNodeActions action)
         {
-            // Reapply the curve node size
+            // Reapply the node size
             var size = SizeValue;
             if (Surface != null && Surface.GridSnappingEnabled)
                 size = Surface.SnapToGrid(size, true);

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -177,7 +177,7 @@ namespace FlaxEditor.Surface
                 }
 
                 // Update the cursor shape
-                if (_surface.resizeableNodeIndexInParent <= IndexInParent || IgnoreSurfaceIndex)
+                if ((_surface.resizeableNodeIndexInParent <= IndexInParent || IgnoreSurfaceIndex) && !_surface.IsConnecting)
                 {
                     if (!IgnoreSurfaceIndex)
                         _surface.resizeableNodeIndexInParent = IndexInParent;
@@ -329,7 +329,7 @@ namespace FlaxEditor.Surface
         {
             base.Draw();
 
-            if (Surface.CanEdit && (ResizeBorderControl.IsResizing || ResizeBorderControl.IsMouseOverResizeBorder))
+            if (Surface.CanEdit && !Surface.IsConnecting && (ResizeBorderControl.IsResizing || ResizeBorderControl.IsMouseOverResizeBorder))
                 Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 0.5f);
         }
 

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -138,7 +138,7 @@ namespace FlaxEditor.Surface
                 {
                     UpdateResizeFlags(location);
                 }
-                else
+                else if (_surface.CanEdit)
                 {
                     var resizeAxisAbs = ResizeDirection.Absolute;
                     var resizeAxisPos = Float2.Clamp(ResizeDirection, Float2.Zero, Float2.One);
@@ -172,7 +172,7 @@ namespace FlaxEditor.Surface
                 }
 
                 // Update the cursor shape
-                if ((_surface.resizeableNodeIndexInParent <= IndexInParent || IgnoreSurfaceIndex) && !_surface.IsConnecting)
+                if ((_surface.resizeableNodeIndexInParent <= IndexInParent || IgnoreSurfaceIndex) && !_surface.IsConnecting && _surface.CanEdit)
                 {
                     if (!IgnoreSurfaceIndex)
                         _surface.resizeableNodeIndexInParent = IndexInParent;

--- a/Source/Editor/Surface/ResizableSurfaceNode.cs
+++ b/Source/Editor/Surface/ResizableSurfaceNode.cs
@@ -154,7 +154,7 @@ namespace FlaxEditor.Surface
 
                     // This ensures that the node is not resized below min size, but also keeps the resize behavior like expected (which just Max() -ing the value does not)
                     var emptySize = ResizableNode.CalculateNodeSize(0, 0);
-                    var minSize = ResizableNode.sizeMin;
+                    var minSize = ResizableNode._sizeMin;
                     noClampedSize = noClampedSize + uiControlDelta * resizeAxisPos - uiControlDelta * resizeAxisNeg;
                     if (noClampedSize.X < minSize.X && noClampedSize.X < ResizableNode.Size.X)
                         resizeAxisAbs.X = resizeAxisPos.X = resizeAxisNeg.X = 0f;
@@ -264,7 +264,7 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// Minimum node size.
         /// </summary>
-        protected Float2 sizeMin = new Float2(240, 160);
+        protected Float2 _sizeMin = new Float2(240, 160);
 
         private Float2 SizeValue
         {

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -130,7 +130,6 @@ namespace FlaxEditor.Surface
             _headerRect = new Rectangle(0, 0, Width, headerSize);
             _closeButtonRect = new Rectangle(Width - buttonSize - buttonMargin, buttonMargin, buttonSize, buttonSize);
             _colorButtonRect = new Rectangle(_closeButtonRect.Left - buttonSize - buttonMargin, buttonMargin, buttonSize, buttonSize);
-            //_resizeButtonRect = new Rectangle(_closeButtonRect.Left, Height - buttonSize - buttonMargin, buttonSize, buttonSize);
             _renameTextBox.Width = Width;
             _renameTextBox.Height = headerSize;
         }
@@ -188,13 +187,9 @@ namespace FlaxEditor.Surface
                 // Color button
                 Render2D.DrawSprite(style.Settings, _colorButtonRect, _colorButtonRect.Contains(_mousePosition) && Surface.CanEdit ? style.Foreground : style.ForegroundGrey);
 
-                // Resize button
-                //if (_isResizing)
-                //{
-                //    Render2D.FillRectangle(_resizeButtonRect, style.Selection);
-                //    Render2D.DrawRectangle(_resizeButtonRect, style.SelectionBorder);
-                //}
-                //Render2D.DrawSprite(style.Scale, _resizeButtonRect, _resizeButtonRect.Contains(_mousePosition) ? style.Foreground : style.ForegroundGrey);
+                // Resize 
+                if (ResizeBorderControl.IsResizing || ResizeBorderControl.IsMouseOverResizeBorder)
+                    Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 0.5f);
             }
 
             // Selection outline
@@ -229,7 +224,7 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool ContainsPoint(ref Float2 location, bool precise)
         {
-            return _headerRect.Contains(ref location);// || _resizeButtonRect.Contains(ref location);
+            return _headerRect.Contains(ref location);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -56,7 +56,7 @@ namespace FlaxEditor.Surface
         : base(id, context, nodeArch, groupArch)
         {
             _sizeValueIndex = 2; // Index of the Size stored in Values array
-            _sizeMin = new Float2(140.0f, Constants.NodeHeaderSize);
+            sizeMin = new Float2(140.0f, Constants.NodeHeaderSize);
             _renameTextBox = new TextBox(false, 0, 0, Width)
             {
                 Height = Constants.NodeHeaderSize,

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -130,7 +130,7 @@ namespace FlaxEditor.Surface
             _headerRect = new Rectangle(0, 0, Width, headerSize);
             _closeButtonRect = new Rectangle(Width - buttonSize - buttonMargin, buttonMargin, buttonSize, buttonSize);
             _colorButtonRect = new Rectangle(_closeButtonRect.Left - buttonSize - buttonMargin, buttonMargin, buttonSize, buttonSize);
-            _resizeButtonRect = new Rectangle(_closeButtonRect.Left, Height - buttonSize - buttonMargin, buttonSize, buttonSize);
+            //_resizeButtonRect = new Rectangle(_closeButtonRect.Left, Height - buttonSize - buttonMargin, buttonSize, buttonSize);
             _renameTextBox.Width = Width;
             _renameTextBox.Height = headerSize;
         }
@@ -189,12 +189,12 @@ namespace FlaxEditor.Surface
                 Render2D.DrawSprite(style.Settings, _colorButtonRect, _colorButtonRect.Contains(_mousePosition) && Surface.CanEdit ? style.Foreground : style.ForegroundGrey);
 
                 // Resize button
-                if (_isResizing)
-                {
-                    Render2D.FillRectangle(_resizeButtonRect, style.Selection);
-                    Render2D.DrawRectangle(_resizeButtonRect, style.SelectionBorder);
-                }
-                Render2D.DrawSprite(style.Scale, _resizeButtonRect, _resizeButtonRect.Contains(_mousePosition) ? style.Foreground : style.ForegroundGrey);
+                //if (_isResizing)
+                //{
+                //    Render2D.FillRectangle(_resizeButtonRect, style.Selection);
+                //    Render2D.DrawRectangle(_resizeButtonRect, style.SelectionBorder);
+                //}
+                //Render2D.DrawSprite(style.Scale, _resizeButtonRect, _resizeButtonRect.Contains(_mousePosition) ? style.Foreground : style.ForegroundGrey);
             }
 
             // Selection outline
@@ -229,7 +229,7 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool ContainsPoint(ref Float2 location, bool precise)
         {
-            return _headerRect.Contains(ref location) || _resizeButtonRect.Contains(ref location);
+            return _headerRect.Contains(ref location);// || _resizeButtonRect.Contains(ref location);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -81,12 +81,16 @@ namespace FlaxEditor.Surface
             if (Values.Length < 4)
             {
                 if (IndexInParent > 0)
+                {
                     IndexInParent = 0;
+                    ResizeBorderControl.IndexInParent = - 1;
+                }
                 OrderValue = IndexInParent;
             }
             else if (OrderValue != -1)
             {
                 IndexInParent = OrderValue;
+                ResizeBorderControl.IndexInParent = OrderValue - 1;
             }
         }
 

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -81,16 +81,12 @@ namespace FlaxEditor.Surface
             if (Values.Length < 4)
             {
                 if (IndexInParent > 0)
-                {
                     IndexInParent = 0;
-                    ResizeBorderControl.IndexInParent = - 1;
-                }
                 OrderValue = IndexInParent;
             }
             else if (OrderValue != -1)
             {
-                IndexInParent = OrderValue;
-                ResizeBorderControl.IndexInParent = OrderValue - 1;
+                ResizeBorderControl.IndexInParent = OrderValue;
             }
         }
 
@@ -103,8 +99,8 @@ namespace FlaxEditor.Surface
             Color = ColorValue = Color.FromHSV(new Random().NextFloat(0, 360), 0.7f, 0.25f, 0.8f);
 
             if (OrderValue == -1)
-                OrderValue = Context.CommentCount - 1;
-            IndexInParent = OrderValue;
+                OrderValue = Context.CommentCount;
+            ResizeBorderControl.IndexInParent = OrderValue;
         }
 
         /// <inheritdoc />
@@ -333,25 +329,25 @@ namespace FlaxEditor.Surface
             {
                 cmOrder.ContextMenu.AddButton("Bring Forward", () =>
                 {
-                    if (IndexInParent < Context.CommentCount - 1)
-                        IndexInParent++;
-                    OrderValue = IndexInParent;
+                    if (ResizeBorderControl.IndexInParent < Context.CommentCount - 1)
+                        ResizeBorderControl.IndexInParent++;
+                    OrderValue = ResizeBorderControl.IndexInParent;
                 });
                 cmOrder.ContextMenu.AddButton("Bring to Front", () =>
                 {
-                    IndexInParent = Context.CommentCount - 1;
-                    OrderValue = IndexInParent;
+                    ResizeBorderControl.IndexInParent = Context.CommentCount - 1;
+                    OrderValue = ResizeBorderControl.IndexInParent;
                 });
                 cmOrder.ContextMenu.AddButton("Send Backward", () =>
                 {
-                    if (IndexInParent > 0)
-                        IndexInParent--;
-                    OrderValue = IndexInParent;
+                    if (ResizeBorderControl.IndexInParent > 0)
+                        ResizeBorderControl.IndexInParent--;
+                    OrderValue = ResizeBorderControl.IndexInParent;
                 });
                 cmOrder.ContextMenu.AddButton("Send to Back", () =>
                 {
-                    IndexInParent = 0;
-                    OrderValue = IndexInParent;
+                    ResizeBorderControl.IndexInParent = 0;
+                    OrderValue = ResizeBorderControl.IndexInParent;
                 });
             }
         }

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -190,7 +190,7 @@ namespace FlaxEditor.Surface
                 Render2D.DrawSprite(style.Settings, _colorButtonRect, _colorButtonRect.Contains(_mousePosition) && Surface.CanEdit ? style.Foreground : style.ForegroundGrey);
 
                 // Resize 
-                if (ResizeBorderControl.IsResizing || ResizeBorderControl.IsMouseOverResizeBorder)
+                if ((ResizeBorderControl.IsResizing || ResizeBorderControl.IsMouseOverResizeBorder) && !Surface.IsConnecting)
                     Render2D.DrawRectangle(new Rectangle(Float2.Zero, Size), Style.Current.Foreground, 0.5f);
             }
 

--- a/Source/Editor/Surface/SurfaceComment.cs
+++ b/Source/Editor/Surface/SurfaceComment.cs
@@ -65,6 +65,8 @@ namespace FlaxEditor.Surface
                 EndEditOnClick = false, // We have to handle this ourselves, otherwise the textbox instantly loses focus when double-clicking the header
                 HorizontalAlignment = TextAlignment.Center,
             };
+
+            ResizeBorderControl.IgnoreSurfaceIndex = false;
         }
 
         /// <inheritdoc />

--- a/Source/Editor/Surface/SurfaceRootControl.cs
+++ b/Source/Editor/Surface/SurfaceRootControl.cs
@@ -46,10 +46,10 @@ namespace FlaxEditor.Surface
             {
                 var child = _children[i];
 
-                if (child is SurfaceComment && child.Visible)
+                if (child is ResizableSurfaceNode.ResizeBorder border && border.ResizableNode is SurfaceComment comment2 && comment2.Visible)
                 {
-                    Render2D.PushTransform(ref child._cachedTransform);
-                    child.Draw();
+                    Render2D.PushTransform(ref comment2._cachedTransform);
+                    comment2.Draw();
                     Render2D.PopTransform();
                 }
             }

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -183,6 +183,9 @@ namespace FlaxEditor.Surface
                 {
                     _cache.Clear();
                     _version++;
+
+                    // Mark type list as dirty to rebuild it next use.
+                    Editor.Instance.CodeEditing.AllWithStd.ClearTypes();
                 }
 
                 Editor.Instance.CodeEditing.TypesCleared -= OnCodeEditingTypesCleared;

--- a/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
+++ b/Source/Editor/Surface/VisjectSurface.ContextMenu.cs
@@ -183,9 +183,6 @@ namespace FlaxEditor.Surface
                 {
                     _cache.Clear();
                     _version++;
-
-                    // Mark type list as dirty to rebuild it next use.
-                    Editor.Instance.CodeEditing.AllWithStd.ClearTypes();
                 }
 
                 Editor.Instance.CodeEditing.TypesCleared -= OnCodeEditingTypesCleared;

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -810,10 +810,11 @@ namespace FlaxEditor.Surface
             int lowestCommentOrder = int.MaxValue;
             for (int i = 0; i < selection.Count; i++)
             {
-                if (selection[i] is not SurfaceComment || selection[i].IndexInParent >= lowestCommentOrder)
-                    continue;
-                hasCommentsSelected = true;
-                lowestCommentOrder = selection[i].IndexInParent;
+                if (selection[i] is ResizableSurfaceNode node && node is SurfaceComment && node.ResizeBorderControl.IndexInParent < lowestCommentOrder)
+                {
+                    hasCommentsSelected = true;
+                    lowestCommentOrder = node.ResizeBorderControl.IndexInParent;
+                }
             }
 
             return _context.CreateComment(ref surfaceArea, string.IsNullOrEmpty(text) ? "Comment" : text, new Color(1.0f, 1.0f, 1.0f, 0.2f), hasCommentsSelected ? lowestCommentOrder : -1);

--- a/Source/Editor/Surface/VisjectSurface.cs
+++ b/Source/Editor/Surface/VisjectSurface.cs
@@ -62,6 +62,7 @@ namespace FlaxEditor.Surface
         private int _selectedConnectionIndex;
 
         internal int _isUpdatingBoxTypes;
+        internal int resizeableNodeIndexInParent = -1;
 
         /// <summary>
         /// True if surface supports implicit casting of the FlaxEngine.Object types into Boolean value (as simple validate check).

--- a/Source/Editor/Surface/VisjectSurfaceContext.cs
+++ b/Source/Editor/Surface/VisjectSurfaceContext.cs
@@ -80,8 +80,9 @@ namespace FlaxEditor.Surface
                 var result = new List<SurfaceComment>();
                 for (int i = 0; i < RootControl.Children.Count; i++)
                 {
-                    if (RootControl.Children[i] is SurfaceComment comment)
-                        result.Add(comment);
+                    var child = RootControl.Children[i];
+                    if (child is ResizableSurfaceNode.ResizeBorder border && border.ResizableNode is SurfaceComment comment2)
+                        result.Add(comment2);
                 }
                 return result;
             }
@@ -101,7 +102,8 @@ namespace FlaxEditor.Surface
                 int count = 0;
                 for (int i = 0; i < RootControl.Children.Count; i++)
                 {
-                    if (RootControl.Children[i] is SurfaceComment)
+                    var child = RootControl.Children[i];
+                    if (child is ResizableSurfaceNode.ResizeBorder border && border.ResizableNode is SurfaceComment)
                         count++;
                 }
                 return count;

--- a/Source/Editor/Utilities/Utils.cs
+++ b/Source/Editor/Utilities/Utils.cs
@@ -1293,6 +1293,12 @@ namespace FlaxEditor.Utilities
             };
 #elif PLATFORM_WINDOWS
             return !Editor.Instance.Options.Options.Interface.UseNativeWindowSystem;
+#elif PLATFORM_MAC
+            return Editor.Instance.Options.Options.Interface.WindowDecorations switch
+            {
+                Options.InterfaceOptions.WindowDecorationsType.ClientSide => true,
+                _ => false
+            };
 #else
             return false;
 #endif

--- a/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
+++ b/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
@@ -272,7 +272,6 @@ namespace FlaxEditor.Windows.Assets
                     {
                         var name = e.Key;
                         var value = _proxy.Asset.GetValue(name);
-                        var valueContainer = new VariableValueContainer(_proxy, name, value, false);
                         var propertyLabel = new PropertyNameLabel(name)
                         {
                             Tag = name,
@@ -280,7 +279,15 @@ namespace FlaxEditor.Windows.Assets
                         string tooltip = null;
                         if (_proxy.DefaultValues.TryGetValue(name, out var defaultValue))
                             tooltip = "Default value: " + defaultValue;
-                        layout.Object(propertyLabel, valueContainer, null, tooltip);
+                        var property = layout.AddPropertyItem(propertyLabel, tooltip);
+                        if (value == null)
+                        {
+                            property.Label("null");
+                            continue;
+                        }
+                        var valueContainer = new VariableValueContainer(_proxy, name, value, false);
+                        valueContainer.SetDefaultValue(defaultValue);
+                        property.Object(valueContainer);
                     }
                 }
                 else
@@ -289,19 +296,37 @@ namespace FlaxEditor.Windows.Assets
                     {
                         var name = e.Key;
                         var value = e.Value;
-                        var valueContainer = new VariableValueContainer(_proxy, name, value, true);
                         var propertyLabel = new ClickablePropertyNameLabel(name)
                         {
                             Tag = name,
                         };
                         propertyLabel.MouseLeftDoubleClick += (label, location) => StartParameterRenaming(name, label);
                         propertyLabel.SetupContextMenu += OnPropertyLabelSetupContextMenu;
-                        layout.Object(propertyLabel, valueContainer, null, "Type: " + CustomEditorsUtil.GetTypeNameUI(value.GetType()));
+                        var tooltip = value != null ? "Type: " + CustomEditorsUtil.GetTypeNameUI(value.GetType()) : string.Empty;
+                        var property = layout.AddPropertyItem(propertyLabel, tooltip);
+                        if (value == null)
+                        {
+                            property.Label("null");
+                            continue;
+                        }
+                        var valueContainer = new VariableValueContainer(_proxy, name, value, true);
+                        property.Object(valueContainer);
+                    }
+                    if (_proxy.DefaultValues.Count == 0)
+                    {
+                        var emptyLabel = layout.Label("Empty", TextAlignment.Center).Label;
+                        emptyLabel.TextColor = emptyLabel.TextColorHighlighted = FlaxEngine.GUI.Style.Current.ForegroundDisabled;
                     }
 
-                    // TODO: improve the UI
                     layout.Space(40);
-                    var addParamType = layout.ComboBox().ComboBox;
+                    var addPanel = layout.HorizontalPanel();
+                    addPanel.Panel.Size = new Float2(0, TextBox.DefaultHeight);
+                    addPanel.Panel.Margin = Margin.Zero;
+                    addPanel.Panel.Spacing = Utilities.Constants.UIMargin;
+
+                    addPanel.Label("New value type:");
+
+                    var addParamType = addPanel.ComboBox().ComboBox;
                     object lastValue = null;
                     foreach (var e in _proxy.DefaultValues)
                         lastValue = e.Value;
@@ -314,7 +339,7 @@ namespace FlaxEditor.Windows.Assets
                     addParamType.Items = allowedTypes;
                     addParamType.SelectedIndex = index;
                     _addParamType = addParamType;
-                    var addParamButton = layout.Button("Add").Button;
+                    var addParamButton = addPanel.Button("Add").Button;
                     addParamButton.Clicked += OnAddParamButtonClicked;
                 }
             }

--- a/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
+++ b/Source/Editor/Windows/Assets/GameplayGlobalsWindow.cs
@@ -157,6 +157,7 @@ namespace FlaxEditor.Windows.Assets
 
             private void Setter(object instance, int index, object value)
             {
+                CheckForNullValue(ref value, _proxy.DefaultValues[_name].GetType());
                 if (_isDefault)
                     _proxy.DefaultValues[_name] = value;
                 else
@@ -251,6 +252,8 @@ namespace FlaxEditor.Windows.Assets
                 typeof(Rectangle),
                 typeof(Matrix),
                 typeof(string),
+                typeof(Texture),
+                typeof(CubeTexture),
             };
 
             public override void Initialize(LayoutElementsContainer layout)
@@ -282,7 +285,7 @@ namespace FlaxEditor.Windows.Assets
                         var property = layout.AddPropertyItem(propertyLabel, tooltip);
                         if (value == null)
                         {
-                            property.Label("null");
+                            property.Label("null").Label.TextColor = Color.Red;
                             continue;
                         }
                         var valueContainer = new VariableValueContainer(_proxy, name, value, false);
@@ -306,7 +309,7 @@ namespace FlaxEditor.Windows.Assets
                         var property = layout.AddPropertyItem(propertyLabel, tooltip);
                         if (value == null)
                         {
-                            property.Label("null");
+                            property.Label("null").Label.TextColor = Color.Red;
                             continue;
                         }
                         var valueContainer = new VariableValueContainer(_proxy, name, value, true);
@@ -369,6 +372,7 @@ namespace FlaxEditor.Windows.Assets
                     Name = Utilities.Utils.IncrementNameNumber("New parameter", x => OnParameterRenameValidate(null, x)),
                     DefaultValue = TypeUtils.GetDefaultValue(new ScriptType(type)),
                 };
+                CheckForNullValue(ref action.DefaultValue, type);
                 _proxy.Window.Undo.AddAction(action);
                 action.Do();
             }
@@ -409,6 +413,26 @@ namespace FlaxEditor.Windows.Assets
                 };
                 _proxy.Window.Undo.AddAction(action);
                 action.Do();
+            }
+        }
+
+        private static void CheckForNullValue(ref object value, Type type)
+        {
+            if (value == null)
+            {
+                // Default values are invalid as Variant type is used in C++ to properly bind the value
+                if (typeof(CubeTexture).IsAssignableFrom(type))
+                {
+                    // Default cube texture
+                    value = FlaxEngine.Content.LoadAsyncInternal<CubeTexture>(EditorAssets.DefaultSkyCubeTexture);
+                }
+                else if (typeof(Texture).IsAssignableFrom(type))
+                {
+                    // Default texture
+                    value = FlaxEngine.Content.LoadAsyncInternal<Texture>("Engine/Textures/BlackTexture");
+                }
+                else
+                    throw new Exception("Null values are not allowed in Gameplay Globals");
             }
         }
 

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -821,7 +821,8 @@ namespace FlaxEditor.Windows
         {
             base.Draw();
 
-            if (Camera.MainCamera == null)
+            var mainRenderTask = MainRenderTask.Instance;
+            if (Camera.MainCamera == null && (mainRenderTask == null || !mainRenderTask.IsCustomRendering))
             {
                 var style = Style.Current;
                 Render2D.DrawText(style.FontLarge, "No camera", new Rectangle(Float2.Zero, Size), style.ForegroundDisabled, TextAlignment.Center, TextAlignment.Center);

--- a/Source/Engine/ContentImporters/ImportAudio.cpp
+++ b/Source/Engine/ContentImporters/ImportAudio.cpp
@@ -85,21 +85,31 @@ CreateAssetResult ImportAudio::Import(CreateAssetContext& context, AudioDecoder&
     LOG(Info, "Audio: {0}kHz, channels: {1}, Bit depth: {2}, Length: {3}s", info.SampleRate / 1000.0f, info.NumChannels, info.BitDepth, info.GetLength());
 
     // Load the whole audio data
-    uint32 bytesPerSample = info.BitDepth / 8;
-    uint32 bufferSize = info.NumSamples * bytesPerSample;
     DataContainer<byte> sampleBuffer;
-    sampleBuffer.Link(audioData.Get());
+    sampleBuffer.Link(audioData.Get(), info.NumSamples * (info.BitDepth / 8));
+
+    if (!Math::IsOne(options.Volume))
+    {
+        // Scale PCM signal
+        Array<float> pcm;
+        pcm.Resize(info.NumSamples);
+        AudioTool::ConvertToFloat(sampleBuffer.Get(), info.BitDepth, pcm.Get(), info.NumSamples);
+        for (float& e : pcm)
+            e *= options.Volume;
+        sampleBuffer.Allocate(info.NumSamples * sizeof(int32));
+        AudioTool::ConvertFromFloat(pcm.Get(), (int32*)sampleBuffer.Get(), info.NumSamples);
+        info.BitDepth = 32;
+    }
 
     // Convert bit depth if need to
     uint32 outputBitDepth = (uint32)options.BitDepth;
     if (outputBitDepth != info.BitDepth)
     {
+        DataContainer<byte> sampleBufferPrev = MoveTemp(sampleBuffer);
         const uint32 outBufferSize = info.NumSamples * (outputBitDepth / 8);
         sampleBuffer.Allocate(outBufferSize);
-        AudioTool::ConvertBitDepth(audioData.Get(), info.BitDepth, sampleBuffer.Get(), outputBitDepth, info.NumSamples);
+        AudioTool::ConvertBitDepth(sampleBufferPrev.Get(), info.BitDepth, sampleBuffer.Get(), outputBitDepth, info.NumSamples);
         info.BitDepth = outputBitDepth;
-        bytesPerSample = info.BitDepth / 8;
-        bufferSize = outBufferSize;
     }
 
     // Base
@@ -157,13 +167,14 @@ CreateAssetResult ImportAudio::Import(CreateAssetContext& context, AudioDecoder&
         if (context.AllocateChunk(0))
             return CreateAssetResult::CannotAllocateChunk;
 
-        WRITE_DATA(0, sampleBuffer.Get(), bufferSize);
+        WRITE_DATA(0, sampleBuffer.Get(), sampleBuffer.Length());
     }
     else
     {
         // Split audio data into a several chunks (uniform data spread)
         const uint32 minChunkSize = 1 * 1024 * 1024; // 1 MB
-        const uint32 dataAlignment = info.NumChannels * bytesPerSample * ASSET_FILE_DATA_CHUNKS; // Ensure to never split samples in-between (eg. 24-bit that uses 3 bytes)
+        const uint32 bufferSize = sampleBuffer.Length();
+        const uint32 dataAlignment = info.NumChannels * (info.BitDepth / 8) * ASSET_FILE_DATA_CHUNKS; // Ensure to never split samples in-between (eg. 24-bit that uses 3 bytes)
         const uint32 chunkSize = Math::AlignUp(Math::Max(minChunkSize, bufferSize / ASSET_FILE_DATA_CHUNKS), dataAlignment);
         const int32 chunksCount = Math::CeilToInt((float)bufferSize / (float)chunkSize);
         ASSERT(chunksCount > 0 && chunksCount <= ASSET_FILE_DATA_CHUNKS);

--- a/Source/Engine/Core/Math/BoundingFrustum.cs
+++ b/Source/Engine/Core/Math/BoundingFrustum.cs
@@ -264,7 +264,7 @@ namespace FlaxEngine
         /// <param name="cameraPos">The camera pos.</param>
         /// <param name="lookDir">The look dir.</param>
         /// <param name="upDir">Up dir.</param>
-        /// <param name="fov">The fov.</param>
+        /// <param name="fov">The fov in radians.</param>
         /// <param name="znear">The Z near.</param>
         /// <param name="zfar">The Z far.</param>
         /// <param name="aspect">The aspect.</param>

--- a/Source/Engine/Core/Math/BoundingFrustum.cs
+++ b/Source/Engine/Core/Math/BoundingFrustum.cs
@@ -259,29 +259,29 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Creates a new frustum relaying on perspective camera parameters
+        /// Creates a new frustum based on a perspective camera parameters.
         /// </summary>
-        /// <param name="cameraPos">The camera pos.</param>
-        /// <param name="lookDir">The look dir.</param>
-        /// <param name="upDir">Up dir.</param>
+        /// <param name="cameraPos">The camera position.</param>
+        /// <param name="lookDir">The look direction.</param>
+        /// <param name="upDir">Up direction.</param>
         /// <param name="fov">The fov in radians.</param>
-        /// <param name="znear">The Z near.</param>
-        /// <param name="zfar">The Z far.</param>
-        /// <param name="aspect">The aspect.</param>
-        /// <returns>The bounding frustum calculated from perspective camera</returns>
-        public static BoundingFrustum FromCamera(Vector3 cameraPos, Vector3 lookDir, Vector3 upDir, float fov, float znear, float zfar, float aspect)
+        /// <param name="zNear">The Z near plane.</param>
+        /// <param name="zFar">The Z far plane.</param>
+        /// <param name="aspectRatio">The aspect ratio.</param>
+        /// <returns>The bounding frustum calculated from the perspective camera</returns>
+        public static BoundingFrustum FromCamera(Vector3 cameraPos, Vector3 lookDir, Vector3 upDir, float fov, float zNear, float zFar, float aspectRatio)
         {
             //http://knol.google.com/k/view-frustum
 
             lookDir = Vector3.Normalize(lookDir);
             upDir = Vector3.Normalize(upDir);
 
-            Vector3 nearCenter = cameraPos + lookDir * znear;
-            Vector3 farCenter = cameraPos + lookDir * zfar;
-            var nearHalfHeight = (float)(znear * Math.Tan(fov / 2f));
-            var farHalfHeight = (float)(zfar * Math.Tan(fov / 2f));
-            float nearHalfWidth = nearHalfHeight * aspect;
-            float farHalfWidth = farHalfHeight * aspect;
+            Vector3 nearCenter = cameraPos + lookDir * zNear;
+            Vector3 farCenter = cameraPos + lookDir * zFar;
+            var nearHalfHeight = (float)(zNear * Math.Tan(fov / 2f));
+            var farHalfHeight = (float)(zFar * Math.Tan(fov / 2f));
+            float nearHalfWidth = nearHalfHeight * aspectRatio;
+            float farHalfWidth = farHalfHeight * aspectRatio;
 
             Vector3 rightDir = Vector3.Normalize(Vector3.Cross(upDir, lookDir));
             Vector3 near1 = nearCenter - nearHalfHeight * upDir + nearHalfWidth * rightDir;
@@ -310,20 +310,21 @@ namespace FlaxEngine
             result.pTop.Normalize();
             result.pBottom.Normalize();
 
-            result.pMatrix = Matrix.LookAt(cameraPos, cameraPos + lookDir * 10, upDir) * Matrix.PerspectiveFov(fov, aspect, znear, zfar);
+            result.pMatrix = Matrix.LookAt(cameraPos, cameraPos + lookDir * 10, upDir) * Matrix.PerspectiveFov(fov, aspectRatio, zNear, zFar);
 
             return result;
         }
 
         /// <summary>
-        /// Returns the 8 corners of the frustum, element0 is Near1 (near right down corner)
-        /// , element1 is Near2 (near right top corner)
-        /// , element2 is Near3 (near Left top corner)
-        /// , element3 is Near4 (near Left down corner)
-        /// , element4 is Far1 (far right down corner)
-        /// , element5 is Far2 (far right top corner)
-        /// , element6 is Far3 (far left top corner)
-        /// , element7 is Far4 (far left down corner)
+        /// Returns the 8 corners of the frustum:
+        /// <para>[0] is Near1 (Near right down corner)</para>
+        /// <para>[1] is Near2 (Near right top corner)</para>
+        /// <para>[2] is Near3 (Near left top corner)</para>
+        /// <para>[3] is Near4 (Near left down corner)</para>
+        /// <para>[4] is Far1 (Far right down corner)</para>
+        /// <para>[5] is Far2 (Far right top corner)</para>
+        /// <para>[6] is Far3 (Far left top corner)</para>
+        /// <para>[7] is Far4 (Far left down corner)</para>
         /// </summary>
         /// <returns>The 8 corners of the frustum</returns>
         public Vector3[] GetCorners()
@@ -334,16 +335,16 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Returns the 8 corners of the frustum, element0 is Near1 (near right down corner)
-        /// , element1 is Near2 (near right top corner)
-        /// , element2 is Near3 (near Left top corner)
-        /// , element3 is Near4 (near Left down corner)
-        /// , element4 is Far1 (far right down corner)
-        /// , element5 is Far2 (far right top corner)
-        /// , element6 is Far3 (far left top corner)
-        /// , element7 is Far4 (far left down corner)
+        /// Populates the array with the 8 corners of the frustum:
+        /// <para>[0] is Near1 (Near right down corner)</para>
+        /// <para>[1] is Near2 (Near right top corner)</para>
+        /// <para>[2] is Near3 (Near left top corner)</para>
+        /// <para>[3] is Near4 (Near left down corner)</para>
+        /// <para>[4] is Far1 (Far right down corner)</para>
+        /// <para>[5] is Far2 (Far right top corner)</para>
+        /// <para>[6] is Far3 (Far left top corner)</para>
+        /// <para>[7] is Far4 (Far left down corner)</para>
         /// </summary>
-        /// <returns>The 8 corners of the frustum</returns>
         public void GetCorners(Vector3[] corners)
         {
             corners[0] = Get3PlanesInterPoint(ref pNear, ref pBottom, ref pRight); //Near1
@@ -357,7 +358,7 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Checks whether a point lay inside, intersects or lay outside the frustum.
+        /// Checks whether a point lays inside, intersects or lays outside the frustum.
         /// </summary>
         /// <param name="point">The point.</param>
         /// <returns>Type of the containment</returns>
@@ -664,15 +665,15 @@ namespace FlaxEngine
         {
             if (Contains(ray.Position) != ContainmentType.Disjoint)
             {
-                Real nearstPlaneDistance = Real.MaxValue;
+                Real nearestPlaneDistance = Real.MaxValue;
                 for (var i = 0; i < 6; i++)
                 {
                     Plane plane = GetPlane(i);
-                    if (CollisionsHelper.RayIntersectsPlane(ref ray, ref plane, out Real distance) && (distance < nearstPlaneDistance))
-                        nearstPlaneDistance = distance;
+                    if (CollisionsHelper.RayIntersectsPlane(ref ray, ref plane, out Real distance) && (distance < nearestPlaneDistance))
+                        nearestPlaneDistance = distance;
                 }
 
-                inDistance = nearstPlaneDistance;
+                inDistance = nearestPlaneDistance;
                 outDistance = null;
                 return true;
             }
@@ -706,9 +707,9 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Get the distance which when added to camera position along the lookat direction will do the effect of zoom to extents (zoom to fit) operation, so all the passed points will fit in the current view.
-        /// if the returned value is positive, the camera will move toward the lookat direction (ZoomIn).
-        /// if the returned value is negative, the camera will move in the reverse direction of the lookat direction (ZoomOut).
+        /// Get the distance which when added to camera position along the look-at direction will do the effect of zoom to extents (zoom to fit) operation, so all the passed points will fit in the current view.
+        /// if the returned value is positive, the camera will move toward the look-at direction (ZoomIn).
+        /// if the returned value is negative, the camera will move in the reverse direction of the look-at direction (ZoomOut).
         /// </summary>
         /// <param name="points">The points.</param>
         /// <returns>The zoom to fit distance</returns>
@@ -735,9 +736,9 @@ namespace FlaxEngine
         }
 
         /// <summary>
-        /// Get the distance which when added to camera position along the lookat direction will do the effect of zoom to extents (zoom to fit) operation, so all the passed points will fit in the current view.
-        /// if the returned value is positive, the camera will move toward the lookat direction (ZoomIn).
-        /// if the returned value is negative, the camera will move in the reverse direction of the lookat direction (ZoomOut).
+        /// Get the distance which when added to camera position along the look-at direction will do the effect of zoom to extents (zoom to fit) operation, so all the passed points will fit in the current view.
+        /// if the returned value is positive, the camera will move toward the look-at direction (ZoomIn).
+        /// if the returned value is negative, the camera will move in the reverse direction of the look-at direction (ZoomOut).
         /// </summary>
         /// <param name="boundingBox">The bounding box.</param>
         /// <returns>The zoom to fit distance</returns>

--- a/Source/Engine/Core/Types/Variant.h
+++ b/Source/Engine/Core/Types/Variant.h
@@ -10,6 +10,7 @@ struct Transform;
 template<typename T>
 class AssetReference;
 struct ScriptingTypeHandle;
+template<typename Type> ScriptingTypeHandle StaticType();
 
 /// <summary>
 /// Represents an object type that can be interpreted as more than one type.

--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -357,7 +357,7 @@ struct DebugDrawContext
     Vector3 Origin = Vector3::Zero;
     DebugDrawData DebugDrawDefault;
     DebugDrawData DebugDrawDepthTest;
-    Float3 LastViewPos = Float3::Zero;
+    Vector3 LastViewPosition = Vector3::Zero;
     Matrix LastViewProjection = Matrix::Identity;
     BoundingFrustum LastViewFrustum;
 
@@ -790,9 +790,14 @@ bool DebugDraw::CanClear(void* context)
 
 #endif
 
-Vector3 DebugDraw::GetViewPos()
+Vector3 DebugDraw::GetViewPosition()
 {
-    return Context->LastViewPos;
+    return Context->LastViewPosition;
+}
+
+Vector3 DebugDraw::GetViewOrigin()
+{
+    return Context->Origin;
 }
 
 BoundingFrustum DebugDraw::GetViewFrustum()
@@ -802,7 +807,7 @@ BoundingFrustum DebugDraw::GetViewFrustum()
 
 void DebugDraw::SetView(const RenderView& view)
 {
-    Context->LastViewPos = view.Position;
+    Context->LastViewPosition = view.WorldPosition;
     Context->LastViewProjection = view.Projection;
     Context->LastViewFrustum = view.Frustum;
 }
@@ -1420,7 +1425,8 @@ void DebugDraw::DrawWireSphere(const BoundingSphere& sphere, const Color& color,
     int32 index;
     const Float3 centerF = sphere.Center - Context->Origin;
     const float radiusF = (float)sphere.Radius;
-    const float screenRadiusSquared = RenderTools::ComputeBoundsScreenRadiusSquared(centerF, radiusF, Context->LastViewPos, Context->LastViewProjection);
+    const Float3 drawPos = Context->LastViewPosition - Context->Origin;
+    const float screenRadiusSquared = RenderTools::ComputeBoundsScreenRadiusSquared(centerF, radiusF, drawPos, Context->LastViewProjection);
     if (screenRadiusSquared > DEBUG_DRAW_SPHERE_LOD0_SCREEN_SIZE * DEBUG_DRAW_SPHERE_LOD0_SCREEN_SIZE * 0.25f)
         index = 0;
     else if (screenRadiusSquared > DEBUG_DRAW_SPHERE_LOD1_SCREEN_SIZE * DEBUG_DRAW_SPHERE_LOD1_SCREEN_SIZE * 0.25f)

--- a/Source/Engine/Debug/DebugDraw.h
+++ b/Source/Engine/Debug/DebugDraw.h
@@ -74,8 +74,10 @@ API_CLASS(Static) class FLAXENGINE_API DebugDraw
     API_FUNCTION() static bool CanClear(void* context = nullptr);
 #endif
 
-    // Gets the last view position when rendering the current context. Can be used for custom culling or LODing when drawing more complex shapes.
-    static Vector3 GetViewPos();
+    // Gets the last view position (world-space) when rendering the current context. Can be used for custom culling or LODing when drawing more complex shapes.
+    static Vector3 GetViewPosition();
+    // Gets the last view origin (world-space) when rendering the current context. Can be used for custom culling or LODing when drawing more complex shapes.
+    static Vector3 GetViewOrigin();
     // Gets the last view frustum when rendering the current context. Can be used for custom culling or LODing when drawing more complex shapes.
     static BoundingFrustum GetViewFrustum();
 

--- a/Source/Engine/Engine/GameplayGlobals.cpp
+++ b/Source/Engine/Engine/GameplayGlobals.cpp
@@ -149,6 +149,18 @@ bool GameplayGlobals::Save(const StringView& path)
     return false;
 }
 
+void GameplayGlobals::GetReferences(Array<Guid>& assets, Array<String>& files) const
+{
+    BinaryAsset::GetReferences(assets, files);
+
+    for (auto& e : Variables)
+    {
+        auto asset = (Asset*)e.Value.DefaultValue;
+        if (asset)
+            assets.Add(asset->GetID());
+    }
+}
+
 #endif
 
 void GameplayGlobals::InitAsVirtual()

--- a/Source/Engine/Engine/GameplayGlobals.h
+++ b/Source/Engine/Engine/GameplayGlobals.h
@@ -85,6 +85,7 @@ public:
     void InitAsVirtual() override;
 #if USE_EDITOR
     bool Save(const StringView& path = StringView::Empty) override;
+    void GetReferences(Array<Guid>& assets, Array<String>& files) const override;
 #endif
 
 protected:

--- a/Source/Engine/Graphics/CooperativeVector.h
+++ b/Source/Engine/Graphics/CooperativeVector.h
@@ -1,0 +1,77 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+#pragma once
+
+#include "Engine/Core/Types/BaseTypes.h"
+
+class GPUBuffer;
+
+// Cooperative vectors (NVIDIA Neural Shading) public graphics API.
+//
+// Cooperative-vector matrix-vector ops (dx::linalg MatVecMulAdd / OuterProductAccumulate) read
+// matrices stored in hardware "optimal" layouts. Weights are authored row-major and converted to
+// the optimal layout on the GPU via GPUContext::ConvertCooperativeVectorMatrices. The required
+// destination byte size for a given layout/type is queried with GPUDevice::GetCooperativeVectorMatrixSize.
+//
+// Only available when GPUDevice::Limits.HasCooperativeVector is set (D3D12 with the Agility SDK
+// preview + a supporting driver). Values mirror the backend enums (D3D12 D3D12_LINEAR_ALGEBRA_*).
+
+/// <summary>
+/// Element data type of a cooperative-vector matrix or vector stored in memory.
+/// </summary>
+enum class CooperativeVectorDataType
+{
+    SInt16 = 2,
+    UInt16 = 3,
+    SInt32 = 4,
+    UInt32 = 5,
+    Float16 = 7,
+    Float32 = 8,
+    SInt8x4Packed = 16,
+    UInt8x4Packed = 17,
+    UInt8 = 18,
+    SInt8 = 19,
+    FloatE4M3 = 20,
+    FloatE5M2 = 21,
+};
+
+/// <summary>
+/// Physical layout of a cooperative-vector matrix in memory.
+/// </summary>
+enum class CooperativeVectorMatrixLayout
+{
+    // Row-major: elements stored row by row, Stride bytes between rows.
+    RowMajor = 0,
+    // Column-major: elements stored column by column, Stride bytes between columns.
+    ColumnMajor = 1,
+    // Hardware-optimal layout for matrix-vector multiply (inference). Stride must be 0.
+    MulOptimal = 2,
+    // Hardware-optimal layout for outer-product accumulation (training gradients). Stride must be 0.
+    OuterProductOptimal = 3,
+};
+
+/// <summary>
+/// Describes a single GPU cooperative-vector matrix layout/precision conversion.
+/// </summary>
+struct CooperativeVectorMatrixConvert
+{
+    // Source matrix.
+    GPUBuffer* SrcBuffer = nullptr;
+    uint32 SrcOffset = 0;
+    uint32 SrcSize = 0;
+    CooperativeVectorDataType SrcDataType = CooperativeVectorDataType::Float32;
+    CooperativeVectorMatrixLayout SrcLayout = CooperativeVectorMatrixLayout::RowMajor;
+    uint32 SrcStride = 0; // bytes between rows/columns for RowMajor/ColumnMajor, 0 for optimal layouts
+
+    // Destination matrix (DstSize must come from GPUDevice::GetCooperativeVectorMatrixSize).
+    GPUBuffer* DstBuffer = nullptr;
+    uint32 DstOffset = 0;
+    uint32 DstSize = 0;
+    CooperativeVectorDataType DstDataType = CooperativeVectorDataType::Float16;
+    CooperativeVectorMatrixLayout DstLayout = CooperativeVectorMatrixLayout::MulOptimal;
+    uint32 DstStride = 0;
+
+    // Matrix dimensions (rows = outputs, columns = inputs).
+    uint32 NumRows = 0;
+    uint32 NumColumns = 0;
+};

--- a/Source/Engine/Graphics/Enums.h
+++ b/Source/Engine/Graphics/Enums.h
@@ -1240,6 +1240,13 @@ enum class ShaderFlags : uint32
     /// Indicates that vertex shader function outputs data for the geometry shader.
     /// </summary>
     VertexToGeometryShader = 4,
+
+    /// <summary>
+    /// Compiles the shader with cooperative-vector support (NVIDIA Neural Shading). Bumps the compiled
+    /// profile to Shader Model 6.9 (preview) and enables native 16-bit types so the shader can use the
+    /// dx::linalg cooperative-vector intrinsics. Only honored on backends/devices that report support.
+    /// </summary>
+    CooperativeVector = 8,
 };
 
 DECLARE_ENUM_OPERATORS(ShaderFlags);

--- a/Source/Engine/Graphics/GPUContext.h
+++ b/Source/Engine/Graphics/GPUContext.h
@@ -7,6 +7,7 @@
 #include "Engine/Core/Math/Rectangle.h"
 #include "Engine/Core/Math/Viewport.h"
 #include "PixelFormat.h"
+#include "CooperativeVector.h"
 #include "Config.h"
 
 #if PLATFORM_WIN32
@@ -320,6 +321,17 @@ public:
     /// <param name="srcResource">The source resource.</param>
     /// <param name="srcSubresource">The source subresource index.</param>
     API_FUNCTION() virtual void CopySubresource(GPUResource* dstResource, uint32 dstSubresource, GPUResource* srcResource, uint32 srcSubresource) = 0;
+
+    /// <summary>
+    /// Records GPU cooperative-vector matrix layout/precision conversions (NVIDIA Neural Shading). Used to convert
+    /// row-major authored weights into the hardware-optimal layouts read by dx::linalg cooperative-vector ops.
+    /// No-op on backends/devices without cooperative-vector support (see GPUDevice::Limits.HasCooperativeVector).
+    /// </summary>
+    /// <param name="conversions">The array of matrix conversions to record.</param>
+    /// <param name="count">The number of conversions.</param>
+    virtual void ConvertCooperativeVectorMatrices(const CooperativeVectorMatrixConvert* conversions, int32 count)
+    {
+    }
 
 public:
     /// <summary>

--- a/Source/Engine/Graphics/GPUDevice.h
+++ b/Source/Engine/Graphics/GPUDevice.h
@@ -9,6 +9,7 @@
 #include "Engine/Scripting/ScriptingObject.h"
 #include "GPUAdapter.h"
 #include "GPULimits.h"
+#include "CooperativeVector.h"
 #include "Enums.h"
 #include "Config.h"
 
@@ -537,6 +538,16 @@ public:
     /// <param name="size">The buffer size (in bytes).</param>
     /// <returns>The constant buffer.</returns>
     virtual GPUConstantBuffer* CreateConstantBuffer(uint32 size, const StringView& name = StringView::Empty) = 0;
+
+    /// <summary>
+    /// Queries the required destination buffer size (in bytes) to hold a cooperative-vector matrix of the
+    /// given dimensions in the requested layout and element type. Only valid when Limits.HasCooperativeVector
+    /// is set; returns 0 if cooperative vectors are not supported.
+    /// </summary>
+    virtual uint32 GetCooperativeVectorMatrixSize(CooperativeVectorDataType dataType, CooperativeVectorMatrixLayout layout, uint32 numRows, uint32 numColumns, uint32 stride = 0)
+    {
+        return 0;
+    }
 
     /// <summary>
     /// Creates the GPU tasks context.

--- a/Source/Engine/Graphics/GPULimits.h
+++ b/Source/Engine/Graphics/GPULimits.h
@@ -333,6 +333,16 @@ API_STRUCT(NoDefault) struct GPULimits
     API_FIELD() bool HasTypedUAVLoad = false;
 
     /// <summary>
+    /// True if device supports cooperative vectors (neural shading matrix-vector ops). On DirectX 12 this requires Shader Model 6.9 preview + the cooperative vector experimental feature (tier 1.0+); on Vulkan it requires VK_NV_cooperative_vector. Enables MLP inference in shaders.
+    /// </summary>
+    API_FIELD() bool HasCooperativeVector = false;
+
+    /// <summary>
+    /// True if device supports cooperative vector training (outer-product and reduce-sum accumulate). On DirectX 12 this requires cooperative vector tier 1.1+; on Vulkan it requires the training-capable VK_NV_cooperative_vector path. Enables on-GPU MLP training.
+    /// </summary>
+    API_FIELD() bool HasCooperativeVectorTraining = false;
+
+    /// <summary>
     /// The maximum amount of texture mip levels.
     /// </summary>
     API_FIELD() int32 MaximumMipLevelsCount = 1;

--- a/Source/Engine/Graphics/Materials/MaterialParams.cpp
+++ b/Source/Engine/Graphics/Materials/MaterialParams.cpp
@@ -472,7 +472,17 @@ void MaterialParameter::Bind(BindMeta& meta) const
                     ASSERT_LOW_LAYER(meta.Constants.Get() && meta.Constants.Length() >= (int32)(_offset + sizeof(Int4)));
                     *((Int4*)(meta.Constants.Get() + _offset)) = (Int4)e->Value.AsInt4();
                     break;
-                default: ;
+                case VariantType::Asset:
+                {
+                    auto texture = Cast<TextureBase>(e->Value.AsAsset);
+                    meta.Context->BindSR(_registerIndex, texture ? texture->GetTexture() : nullptr);
+                    break;
+                }
+                default:
+#if !BUILD_RELEASE
+                    LOG(Warning, "Invalid Gameplay Global '{}' ({}) value type '{}' to bind to material", _name, _asAsset->GetPath(), e->Value.Type.ToString());
+#endif
+                    break;
                 }
             }
         }

--- a/Source/Engine/Graphics/RenderView.cs
+++ b/Source/Engine/Graphics/RenderView.cs
@@ -34,6 +34,14 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Gets projection matrix for overlay geometry rendered after temporal anti-aliasing has been resolved.
+        /// </summary>
+        public Matrix GetOverlayProjection()
+        {
+            return IsTaaResolved ? NonJitteredProjection : Projection;
+        }
+
+        /// <summary>
         /// Initializes render view data.
         /// </summary>
         /// <param name="view">The view.</param>

--- a/Source/Engine/Graphics/RenderView.cs
+++ b/Source/Engine/Graphics/RenderView.cs
@@ -36,9 +36,10 @@ namespace FlaxEngine
         /// <summary>
         /// Gets projection matrix for overlay geometry rendered after temporal anti-aliasing has been resolved.
         /// </summary>
-        public Matrix GetOverlayProjection()
+        /// <param name="projection">Projection matrix valid for rendering before or after (matches current TAA jitter stage).</param>
+        public void GetOverlayProjection(out Matrix projection)
         {
-            return IsTaaResolved ? NonJitteredProjection : Projection;
+            projection = IsTaaResolved ? NonJitteredProjection : Projection;
         }
 
         /// <summary>

--- a/Source/Engine/GraphicsDevice/DirectX/IncludeDirectXHeaders.h
+++ b/Source/Engine/GraphicsDevice/DirectX/IncludeDirectXHeaders.h
@@ -35,7 +35,15 @@ typedef IGraphicsUnknown IDXGISwapChain3;
 #else
 
 #if GRAPHICS_API_DIRECTX12
+#if GPU_ENABLE_COOPERATIVE_VECTOR
+// Use the vendored DirectX 12 Agility SDK preview header (Shader Model 6.9 + cooperative vectors).
+// The Windows SDK include paths precede module include paths, so a plain <D3D12.h> would resolve to the
+// system header (which lacks the preview interfaces). Include it explicitly by path; its include guard
+// (__d3d12_h__) prevents any later system <D3D12.h> from being pulled in.
+#include <ThirdParty/DirectX12Agility/d3d12.h>
+#else
 #include <D3D12.h>
+#endif
 #endif
 #include <d3dcommon.h>
 #if GRAPHICS_API_DIRECTX11

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUBufferVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUBufferVulkan.cpp
@@ -91,6 +91,16 @@ void GPUBufferVulkan::Unmap()
     vmaUnmapMemory(_device->Allocator, _allocation);
 }
 
+VkDeviceAddress GPUBufferVulkan::GetDeviceAddress() const
+{
+    if (_buffer == VK_NULL_HANDLE || !_device->BufferDeviceAddressEnabled)
+        return 0;
+    VkBufferDeviceAddressInfo info;
+    RenderToolsVulkan::ZeroStruct(info, VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO);
+    info.buffer = _buffer;
+    return vkGetBufferDeviceAddress(_device->Device, &info);
+}
+
 bool GPUBufferVulkan::OnInit()
 {
     const bool useSRV = IsShaderResource();
@@ -118,6 +128,9 @@ bool GPUBufferVulkan::OnInit()
         bufferInfo.usage |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     if (IsStaging() || EnumHasAnyFlags(_desc.Flags, GPUBufferFlags::UnorderedAccess))
         bufferInfo.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    // Storage buffers can be addressed by GPU virtual address (needed by cooperative-vector matrix conversion).
+    if (_device->BufferDeviceAddressEnabled && (useUAV || EnumHasAnyFlags(_desc.Flags, GPUBufferFlags::RawBuffer | GPUBufferFlags::Structured)))
+        bufferInfo.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
     // Create buffer
     VmaAllocationCreateInfo allocInfo = {};

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUBufferVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUBufferVulkan.h
@@ -91,6 +91,12 @@ public:
     }
 
     /// <summary>
+    /// Gets the buffer GPU virtual address. Requires the buffer to be created with device-address usage
+    /// (only when GPUDeviceVulkan::BufferDeviceAddressEnabled). Returns 0 otherwise.
+    /// </summary>
+    VkDeviceAddress GetDeviceAddress() const;
+
+    /// <summary>
     /// The current buffer access flags.
     /// </summary>
     VkAccessFlags Access;

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
@@ -2057,6 +2057,66 @@ void GPUContextVulkan::Transition(GPUResource* resource, GPUResourceAccess acces
     }
 }
 
+void GPUContextVulkan::ConvertCooperativeVectorMatrices(const CooperativeVectorMatrixConvert* conversions, int32 count)
+{
+#if VK_NV_cooperative_vector
+    if (!conversions || count <= 0 || !_device->CoopVecCmdConvert)
+        return;
+    const auto cmdBuffer = _cmdBufferManager->GetCmdBuffer();
+
+    // The conversion command must run outside a render pass; flush any pending barriers first.
+    if (cmdBuffer->IsInsideRenderPass())
+        EndRenderPass();
+    FlushBarriers();
+
+    // Ensure prior writes to the source matrices (eg. an fp16 packing compute dispatch) are visible to the convert.
+    {
+        VkMemoryBarrier preBarrier;
+        RenderToolsVulkan::ZeroStruct(preBarrier, VK_STRUCTURE_TYPE_MEMORY_BARRIER);
+        preBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+        preBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        vkCmdPipelineBarrier(cmdBuffer->GetHandle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 1, &preBarrier, 0, nullptr, 0, nullptr);
+    }
+
+    Array<VkConvertCooperativeVectorMatrixInfoNV> infos;
+    Array<size_t> dstSizes;
+    infos.Resize(count);
+    dstSizes.Resize(count);
+    for (int32 i = 0; i < count; i++)
+    {
+        const CooperativeVectorMatrixConvert& c = conversions[i];
+        auto src = static_cast<GPUBufferVulkan*>(c.SrcBuffer);
+        auto dst = static_cast<GPUBufferVulkan*>(c.DstBuffer);
+        dstSizes[i] = c.DstSize;
+
+        VkConvertCooperativeVectorMatrixInfoNV& info = infos[i];
+        RenderToolsVulkan::ZeroStruct(info, VK_STRUCTURE_TYPE_CONVERT_COOPERATIVE_VECTOR_MATRIX_INFO_NV);
+        info.numRows = c.NumRows;
+        info.numColumns = c.NumColumns;
+        info.srcComponentType = CooperativeVectorDataTypeToVk(c.SrcDataType);
+        info.dstComponentType = CooperativeVectorDataTypeToVk(c.DstDataType);
+        info.srcLayout = CooperativeVectorLayoutToVk(c.SrcLayout);
+        info.srcStride = c.SrcStride;
+        info.dstLayout = CooperativeVectorLayoutToVk(c.DstLayout);
+        info.dstStride = c.DstStride;
+        info.srcSize = c.SrcSize;
+        info.pDstSize = &dstSizes[i];
+        info.srcData.deviceAddress = src->GetDeviceAddress() + c.SrcOffset;
+        info.dstData.deviceAddress = dst->GetDeviceAddress() + c.DstOffset;
+    }
+    _device->CoopVecCmdConvert(cmdBuffer->GetHandle(), (uint32)count, infos.Get());
+
+    // Make the converted matrices visible to subsequent shader reads (inference).
+    {
+        VkMemoryBarrier postBarrier;
+        RenderToolsVulkan::ZeroStruct(postBarrier, VK_STRUCTURE_TYPE_MEMORY_BARRIER);
+        postBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        postBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        vkCmdPipelineBarrier(cmdBuffer->GetHandle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 1, &postBarrier, 0, nullptr, 0, nullptr);
+    }
+#endif
+}
+
 void GPUContextVulkan::MemoryBarrier()
 {
     AddMemoryBarrier();

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.h
@@ -227,6 +227,7 @@ public:
     void CopyResource(GPUResource* dstResource, GPUResource* srcResource) override;
     void CopySubresource(GPUResource* dstResource, uint32 dstSubresource, GPUResource* srcResource, uint32 srcSubresource) override;
     void Transition(GPUResource* resource, GPUResourceAccess access) override;
+    void ConvertCooperativeVectorMatrices(const CooperativeVectorMatrixConvert* conversions, int32 count) override;
     void MemoryBarrier() override;
     void OverlapUA(bool end) override;
     void BeginDrawPass(GPUDrawPass& pass) override;

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.Layers.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.Layers.cpp
@@ -68,6 +68,9 @@ static const char* GDeviceExtensions[] =
 #if VK_KHR_sampler_mirror_clamp_to_edge
     VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME,
 #endif
+#if VK_NV_cooperative_vector
+    VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME, // NVIDIA Neural Shading: cooperative-vector matrix-vector ops
+#endif
 #if VULKAN_USE_TRACY_GPU && VK_EXT_calibrated_timestamps && VK_EXT_host_query_reset
     VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
     VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
@@ -778,6 +781,9 @@ void GPUDeviceVulkan::ParseOptionalDeviceExtensions(const Array<const char*>& de
     OptionalDeviceExtensions.HasMirrorClampToEdge = RenderToolsVulkan::HasExtension(deviceExtensions, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
 #if VULKAN_USE_VALIDATION_CACHE
     OptionalDeviceExtensions.HasEXTValidationCache = RenderToolsVulkan::HasExtension(deviceExtensions, VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
+#endif
+#if VK_NV_cooperative_vector
+    OptionalDeviceExtensions.HasNVCooperativeVector = RenderToolsVulkan::HasExtension(deviceExtensions, VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME);
 #endif
 }
 

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.cpp
@@ -1654,6 +1654,22 @@ bool GPUDeviceVulkan::Init()
     GetDeviceExtensions(gpu, deviceExtensions);
     ParseOptionalDeviceExtensions(deviceExtensions);
 
+#if VK_NV_cooperative_vector
+    // Cooperative vectors (NVIDIA Neural Shading) require VK_NV_cooperative_vector and the matching feature,
+    // plus bufferDeviceAddress (the conversion command reads/writes matrices through GPU virtual addresses).
+    VkPhysicalDeviceCooperativeVectorFeaturesNV coopVecFeatures;
+    RenderToolsVulkan::ZeroStruct(coopVecFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV);
+    bool coopVecSupported = false;
+    if (OptionalDeviceExtensions.HasNVCooperativeVector && vkGetPhysicalDeviceFeatures2 && PhysicalDeviceFeatures12.bufferDeviceAddress)
+    {
+        VkPhysicalDeviceFeatures2 coopVecQuery;
+        RenderToolsVulkan::ZeroStruct(coopVecQuery, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2);
+        coopVecQuery.pNext = &coopVecFeatures;
+        vkGetPhysicalDeviceFeatures2(gpu, &coopVecQuery);
+        coopVecSupported = coopVecFeatures.cooperativeVector == VK_TRUE;
+    }
+#endif
+
     // Setup device info
     VkDeviceCreateInfo deviceInfo;
     RenderToolsVulkan::ZeroStruct(deviceInfo, VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO);
@@ -1774,6 +1790,31 @@ bool GPUDeviceVulkan::Init()
         PerfSDKInitDeviceInfo(deviceInfo, deviceExtensions, enabledFeatures2Ptr);
 #endif
 
+#if VK_NV_cooperative_vector
+    // Enable bufferDeviceAddress + cooperativeVector at device creation by prepending the feature structs to the
+    // pNext chain (preserves any chain set up above). Kept in function scope so they outlive vkCreateDevice.
+    VkPhysicalDeviceVulkan12Features coopVecEnable12;
+    VkPhysicalDeviceCooperativeVectorFeaturesNV coopVecEnable;
+    if (coopVecSupported)
+    {
+        RenderToolsVulkan::ZeroStruct(coopVecEnable12, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES);
+        coopVecEnable12.bufferDeviceAddress = VK_TRUE;
+        // The SPIR-V CooperativeVectorNV capability requires the Vulkan memory model to be enabled.
+        // Device-scope is needed for the training (OuterProductAccumulate/ReduceSumAccumulate) atomics.
+        coopVecEnable12.vulkanMemoryModel = PhysicalDeviceFeatures12.vulkanMemoryModel;
+        coopVecEnable12.vulkanMemoryModelDeviceScope = PhysicalDeviceFeatures12.vulkanMemoryModelDeviceScope;
+        coopVecEnable12.pNext = (void*)deviceInfo.pNext;
+
+        RenderToolsVulkan::ZeroStruct(coopVecEnable, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV);
+        coopVecEnable.cooperativeVector = VK_TRUE;
+        coopVecEnable.cooperativeVectorTraining = coopVecFeatures.cooperativeVectorTraining;
+        coopVecEnable.pNext = &coopVecEnable12;
+
+        deviceInfo.pNext = &coopVecEnable;
+        BufferDeviceAddressEnabled = true;
+    }
+#endif
+
     // Create the device
     VALIDATE_VULKAN_RESULT(vkCreateDevice(gpu, &deviceInfo, nullptr, &Device));
     PhysicalDeviceFeatures12.pNext = nullptr;
@@ -1781,6 +1822,22 @@ bool GPUDeviceVulkan::Init()
 #if !PLATFORM_SWITCH
     // Optimize bindings
     volkLoadDevice(Device);
+#endif
+
+#if VK_NV_cooperative_vector
+    // Load cooperative-vector entry points manually (vendored volk predates the extension).
+    if (coopVecSupported)
+    {
+        CoopVecConvert = (PFN_vkConvertCooperativeVectorMatrixNV)vkGetDeviceProcAddr(Device, "vkConvertCooperativeVectorMatrixNV");
+        CoopVecCmdConvert = (PFN_vkCmdConvertCooperativeVectorMatrixNV)vkGetDeviceProcAddr(Device, "vkCmdConvertCooperativeVectorMatrixNV");
+        if (!CoopVecConvert || !CoopVecCmdConvert)
+        {
+            LOG(Warning, "Failed to load VK_NV_cooperative_vector entry points; cooperative vectors disabled.");
+            CoopVecConvert = nullptr;
+            CoopVecCmdConvert = nullptr;
+            coopVecSupported = false;
+        }
+    }
 #endif
 
     // Create queues
@@ -1819,6 +1876,12 @@ bool GPUDeviceVulkan::Init()
         limits.HasInstancing = true;
         limits.HasVolumeTextureRendering = true;
         limits.HasDrawIndirect = PhysicalDeviceLimits.maxDrawIndirectCount >= 1;
+#if VK_NV_cooperative_vector
+        limits.HasCooperativeVector = coopVecSupported;
+        limits.HasCooperativeVectorTraining = coopVecSupported && coopVecFeatures.cooperativeVectorTraining == VK_TRUE;
+        if (coopVecSupported)
+            LOG(Info, "Cooperative Vector supported (VK_NV_cooperative_vector, inference: 1, training: {0})", limits.HasCooperativeVectorTraining ? 1 : 0);
+#endif
         limits.HasAppendConsumeBuffers = false;
         limits.HasDepthClip = PhysicalDeviceFeatures.depthClamp;
         limits.HasDepthBounds = PhysicalDeviceFeatures.depthBounds;
@@ -1975,6 +2038,12 @@ bool GPUDeviceVulkan::Init()
         allocatorInfo.instance = Instance;
         allocatorInfo.device = Device;
         allocatorInfo.pVulkanFunctions = &vulkanFunctions;
+        if (BufferDeviceAddressEnabled)
+        {
+            // Required so VMA-created buffers may use VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT (cooperative vectors).
+            // VMA adds VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT to allocations; the address itself is fetched by the engine.
+            allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+        }
         VALIDATE_VULKAN_RESULT(vmaCreateAllocator(&allocatorInfo, &Allocator));
     }
 
@@ -2285,6 +2354,89 @@ GPUConstantBuffer* GPUDeviceVulkan::CreateConstantBuffer(uint32 size, const Stri
 {
     PROFILE_MEM(GraphicsShaders);
     return New<GPUConstantBufferVulkan>(this, size);
+}
+
+#if VK_NV_cooperative_vector
+
+// Maps the backend-agnostic cooperative-vector element type to the Vulkan component type.
+VkComponentTypeKHR CooperativeVectorDataTypeToVk(CooperativeVectorDataType type)
+{
+    switch (type)
+    {
+    case CooperativeVectorDataType::SInt16: return VK_COMPONENT_TYPE_SINT16_KHR;
+    case CooperativeVectorDataType::UInt16: return VK_COMPONENT_TYPE_UINT16_KHR;
+    case CooperativeVectorDataType::SInt32: return VK_COMPONENT_TYPE_SINT32_KHR;
+    case CooperativeVectorDataType::UInt32: return VK_COMPONENT_TYPE_UINT32_KHR;
+    case CooperativeVectorDataType::Float16: return VK_COMPONENT_TYPE_FLOAT16_KHR;
+    case CooperativeVectorDataType::Float32: return VK_COMPONENT_TYPE_FLOAT32_KHR;
+    case CooperativeVectorDataType::SInt8x4Packed: return VK_COMPONENT_TYPE_SINT8_PACKED_NV;
+    case CooperativeVectorDataType::UInt8x4Packed: return VK_COMPONENT_TYPE_UINT8_PACKED_NV;
+    case CooperativeVectorDataType::UInt8: return VK_COMPONENT_TYPE_UINT8_KHR;
+    case CooperativeVectorDataType::SInt8: return VK_COMPONENT_TYPE_SINT8_KHR;
+    case CooperativeVectorDataType::FloatE4M3: return VK_COMPONENT_TYPE_FLOAT8_E4M3_EXT;
+    case CooperativeVectorDataType::FloatE5M2: return VK_COMPONENT_TYPE_FLOAT8_E5M2_EXT;
+    default: return VK_COMPONENT_TYPE_FLOAT16_KHR;
+    }
+}
+
+// Maps the backend-agnostic cooperative-vector matrix layout to the Vulkan layout (values match by design).
+VkCooperativeVectorMatrixLayoutNV CooperativeVectorLayoutToVk(CooperativeVectorMatrixLayout layout)
+{
+    switch (layout)
+    {
+    case CooperativeVectorMatrixLayout::RowMajor: return VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_ROW_MAJOR_NV;
+    case CooperativeVectorMatrixLayout::ColumnMajor: return VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_COLUMN_MAJOR_NV;
+    case CooperativeVectorMatrixLayout::MulOptimal: return VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_INFERENCING_OPTIMAL_NV;
+    case CooperativeVectorMatrixLayout::OuterProductOptimal: return VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_TRAINING_OPTIMAL_NV;
+    default: return VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_ROW_MAJOR_NV;
+    }
+}
+
+// Byte size of a single cooperative-vector matrix element (used for the row-major source stride).
+static uint32 CooperativeVectorDataTypeSize(CooperativeVectorDataType type)
+{
+    switch (type)
+    {
+    case CooperativeVectorDataType::SInt8:
+    case CooperativeVectorDataType::UInt8:
+    case CooperativeVectorDataType::SInt8x4Packed:
+    case CooperativeVectorDataType::UInt8x4Packed:
+    case CooperativeVectorDataType::FloatE4M3:
+    case CooperativeVectorDataType::FloatE5M2: return 1;
+    case CooperativeVectorDataType::SInt16:
+    case CooperativeVectorDataType::UInt16:
+    case CooperativeVectorDataType::Float16: return 2;
+    default: return 4;
+    }
+}
+#endif
+
+uint32 GPUDeviceVulkan::GetCooperativeVectorMatrixSize(CooperativeVectorDataType dataType, CooperativeVectorMatrixLayout layout, uint32 numRows, uint32 numColumns, uint32 stride)
+{
+#if VK_NV_cooperative_vector
+    if (CoopVecConvert)
+    {
+        // Query the destination byte size by running a host conversion with a null destination address.
+        size_t dstSize = 0;
+        VkConvertCooperativeVectorMatrixInfoNV info;
+        RenderToolsVulkan::ZeroStruct(info, VK_STRUCTURE_TYPE_CONVERT_COOPERATIVE_VECTOR_MATRIX_INFO_NV);
+        info.numRows = numRows;
+        info.numColumns = numColumns;
+        info.srcComponentType = CooperativeVectorDataTypeToVk(dataType);
+        info.dstComponentType = CooperativeVectorDataTypeToVk(dataType);
+        info.srcLayout = VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_ROW_MAJOR_NV;
+        info.srcStride = (size_t)numColumns * CooperativeVectorDataTypeSize(dataType);
+        info.dstLayout = CooperativeVectorLayoutToVk(layout);
+        info.dstStride = stride;
+        info.pDstSize = &dstSize;
+        info.srcData.hostAddress = nullptr;
+        info.dstData.hostAddress = nullptr;
+        info.srcSize = 0;
+        CoopVecConvert(Device, &info);
+        return (uint32)dstSize;
+    }
+#endif
+    return 0;
 }
 
 SemaphoreVulkan::SemaphoreVulkan(GPUDeviceVulkan* device)

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUDeviceVulkan.h
@@ -28,6 +28,12 @@ class GPUDeviceVulkan;
 class UniformBufferUploaderVulkan;
 class DescriptorPoolsManagerVulkan;
 
+#if VK_NV_cooperative_vector
+// Maps the backend-agnostic cooperative-vector enums to Vulkan (shared by device + context).
+VkComponentTypeKHR CooperativeVectorDataTypeToVk(CooperativeVectorDataType type);
+VkCooperativeVectorMatrixLayoutNV CooperativeVectorLayoutToVk(CooperativeVectorMatrixLayout layout);
+#endif
+
 /// <summary>
 /// GPU query ID packed into 64-bits.
 /// </summary>
@@ -390,6 +396,9 @@ public:
 #if VULKAN_USE_VALIDATION_CACHE
         uint32 HasEXTValidationCache : 1;
 #endif
+#if VK_NV_cooperative_vector
+        uint32 HasNVCooperativeVector : 1;
+#endif
     };
 
     static OptionalVulkanDeviceExtensions OptionalDeviceExtensions;
@@ -519,6 +528,21 @@ public:
     VkPhysicalDeviceFeatures PhysicalDeviceFeatures;
     VkPhysicalDeviceVulkan12Features PhysicalDeviceFeatures12;
 
+    /// <summary>
+    /// True if VK_KHR_buffer_device_address (Vulkan 1.2 bufferDeviceAddress) was enabled on the device.
+    /// Required by the cooperative-vector matrix conversion which reads/writes via GPU virtual addresses.
+    /// </summary>
+    bool BufferDeviceAddressEnabled = false;
+
+#if VK_NV_cooperative_vector
+    /// <summary>
+    /// Cooperative-vector (NVIDIA Neural Shading, VK_NV_cooperative_vector) entry points, loaded manually via
+    /// vkGetDeviceProcAddr because the vendored volk loader predates the extension. Null when unsupported.
+    /// </summary>
+    PFN_vkConvertCooperativeVectorMatrixNV CoopVecConvert = nullptr;
+    PFN_vkCmdConvertCooperativeVectorMatrixNV CoopVecCmdConvert = nullptr;
+#endif
+
     Array<BufferedQueryPoolVulkan*> QueryPools;
     Array<GPUQueryVulkan> QueriesToRelease;
 #if VULKAN_RESET_QUERY_POOLS
@@ -592,6 +616,7 @@ public:
     GPUVertexLayout* CreateVertexLayout(const VertexElements& elements, bool explicitOffsets) override;
     GPUSwapChain* CreateSwapChain(Window* window) override;
     GPUConstantBuffer* CreateConstantBuffer(uint32 size, const StringView& name) override;
+    uint32 GetCooperativeVectorMatrixSize(CooperativeVectorDataType dataType, CooperativeVectorMatrixLayout layout, uint32 numRows, uint32 numColumns, uint32 stride) override;
 };
 
 /// <summary>

--- a/Source/Engine/GraphicsDevice/Vulkan/Win32/Win32VulkanPlatform.h
+++ b/Source/Engine/GraphicsDevice/Vulkan/Win32/Win32VulkanPlatform.h
@@ -6,7 +6,9 @@
 
 #if GRAPHICS_API_VULKAN && PLATFORM_WIN32
 
-#define VULKAN_API_VERSION VK_API_VERSION_1_2
+// Vulkan 1.3 is required so the device accepts SPIR-V 1.6 modules used by the
+// NV cooperative-vector neural shading path (SPV_NV_cooperative_vector + VulkanMemoryModel).
+#define VULKAN_API_VERSION VK_API_VERSION_1_3
 #define VULKAN_USE_PLATFORM_WIN32_KHR 1
 #define VULKAN_USE_PLATFORM_WIN32_KHX 1
 #define VULKAN_USE_CREATE_WIN32_SURFACE 1

--- a/Source/Engine/Level/Actors/AnimatedModel.h
+++ b/Source/Engine/Level/Actors/AnimatedModel.h
@@ -489,7 +489,9 @@ public:
     ModelBase* GetModel() override;
     bool IntersectsEntry(int32 entryIndex, const Ray& ray, Real& distance, Vector3& normal) override;
     bool IntersectsEntry(const Ray& ray, Real& distance, Vector3& normal, int32& entryIndex) override;
+PRAGMA_DISABLE_DEPRECATION_WARNINGS;
     bool GetMeshData(const MeshReference& ref, MeshBufferType type, BytesContainer& result, int32& count, GPUVertexLayout** layout) const override;
+PRAGMA_ENABLE_DEPRECATION_WARNINGS;
     MeshBase* GetMesh(const MeshReference& ref) const override;
     void UpdateBounds() override;
     MeshDeformation* GetMeshDeformation() const override;

--- a/Source/Engine/Level/Actors/Spline.cpp
+++ b/Source/Engine/Level/Actors/Spline.cpp
@@ -496,7 +496,7 @@ namespace
     FORCE_INLINE float NodeSizeByDistance(const Vector3& nodePosition, bool scaleByDistance)
     {
         if (scaleByDistance)
-            return (float)(Vector3::Distance(DebugDraw::GetViewPos(), nodePosition) / 100);
+            return (float)(Vector3::Distance(DebugDraw::GetViewPosition(), nodePosition) / 100);
         return 5.0f;
     }
 
@@ -507,7 +507,7 @@ namespace
             return;
         Spline::Keyframe* prev = spline->Curve.GetKeyframes().Get();
         Vector3 prevPos = transform.LocalToWorld(prev->Value.Translation);
-        Real distance = Vector3::Distance(prevPos, DebugDraw::GetViewPos());
+        Real distance = Vector3::Distance(prevPos, DebugDraw::GetViewPosition());
         if (distance < METERS_TO_UNITS(800)) // 800m
         {
             // Bezier curve
@@ -540,7 +540,9 @@ namespace
 
 void Spline::OnDebugDraw()
 {
-    if (DebugDraw::GetViewFrustum().Intersects(_sphere))
+    BoundingSphere sphere(_sphere);
+    sphere.Center -= DebugDraw::GetViewOrigin();
+    if (DebugDraw::GetViewFrustum().Intersects(sphere))
         DrawSpline(this, GetSplineColor().AlphaMultiplied(0.7f), _transform, true);
 
     // Base

--- a/Source/Engine/Level/Actors/StaticModel.h
+++ b/Source/Engine/Level/Actors/StaticModel.h
@@ -181,7 +181,9 @@ public:
     ModelBase* GetModel() override;
     bool IntersectsEntry(int32 entryIndex, const Ray& ray, Real& distance, Vector3& normal) override;
     bool IntersectsEntry(const Ray& ray, Real& distance, Vector3& normal, int32& entryIndex) override;
+PRAGMA_DISABLE_DEPRECATION_WARNINGS;
     bool GetMeshData(const MeshReference& ref, MeshBufferType type, BytesContainer& result, int32& count, GPUVertexLayout** layout) const override;
+PRAGMA_ENABLE_DEPRECATION_WARNINGS;
     MeshBase* GetMesh(const MeshReference& ref) const override;
     MeshDeformation* GetMeshDeformation() const override;
     void UpdateBounds() override;

--- a/Source/Engine/Particles/Graph/GPU/ParticleEmitterGraph.GPU.Textures.cpp
+++ b/Source/Engine/Particles/Graph/GPU/ParticleEmitterGraph.GPU.Textures.cpp
@@ -5,7 +5,7 @@
 #include "ParticleEmitterGraph.GPU.h"
 #include "Engine/Graphics/Materials/MaterialInfo.h"
 
-bool ParticleEmitterGPUGenerator::loadTexture(Node* caller, Box* box, const SerializedMaterialParam& texture, Value& result)
+bool ParticleEmitterGPUGenerator::loadTexture(Node* caller, Box* box, const SerializedMaterialParam& texture, const Value& textureValue, Value& result)
 {
     ASSERT(caller && box && texture.ID.IsValid());
 
@@ -22,7 +22,8 @@ bool ParticleEmitterGPUGenerator::loadTexture(Node* caller, Box* box, const Seri
         && texture.Type != MaterialParameterType::GPUTextureVolume
         && texture.Type != MaterialParameterType::GPUTextureCube
         && texture.Type != MaterialParameterType::GPUTextureArray
-        && texture.Type != MaterialParameterType::CubeTexture)
+        && texture.Type != MaterialParameterType::CubeTexture
+        && textureValue.Type != VariantType::Object)
     {
         result = Value::Zero;
         OnError(caller, box, TEXT("No parameter for texture load or invalid type."));
@@ -41,7 +42,8 @@ bool ParticleEmitterGPUGenerator::loadTexture(Node* caller, Box* box, const Seri
 
     // Load texture
     const Char* format = TEXT("{0}.Load({1})");
-    const String sampledValue = String::Format(format, texture.ShaderName, location.Value);
+    auto& shaderName = textureValue.Type == VariantType::Object ? textureValue.Value : texture.ShaderName;
+    const String sampledValue = String::Format(format, shaderName, location.Value);
     result = writeLocal(VariantType::Float4, sampledValue, parent);
 
     return false;
@@ -300,7 +302,7 @@ void ParticleEmitterGPUGenerator::ProcessGroupTextures(Box* box, Node* node, Val
         const auto copy = *textureParam;
 
         // Load texture
-        loadTexture(node, box, copy, value);
+        loadTexture(node, box, copy, texture, value);
         break;
     }
     // Sample Global SDF

--- a/Source/Engine/Particles/Graph/GPU/ParticleEmitterGraph.GPU.h
+++ b/Source/Engine/Particles/Graph/GPU/ParticleEmitterGraph.GPU.h
@@ -127,7 +127,7 @@ private:
 
     Parameter* findGraphParam(const Guid& id);
     bool sampleSceneTexture(Node* caller, Box* box, const SerializedMaterialParam& texture, Value& result);
-    bool loadTexture(Node* caller, Box* box, const SerializedMaterialParam& texture, Value& result);
+    bool loadTexture(Node* caller, Box* box, const SerializedMaterialParam& texture, const Value& textureValue, Value& result);
     void sampleSceneDepth(Node* caller, Value& value, Box* box);
     void linearizeSceneDepth(Node* caller, const Value& depth, Value& value);
 

--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -15,6 +15,7 @@
 #include "Engine/Input/Mouse.h"
 #include "Engine/Input/Keyboard.h"
 #include "Engine/Graphics/RenderTask.h"
+#include "Engine/Graphics/Textures/TextureData.h"
 #include <Cocoa/Cocoa.h>
 #include <AppKit/AppKit.h>
 #include <QuartzCore/CAMetalLayer.h>
@@ -1300,6 +1301,39 @@ void MacWindow::SetCursor(CursorType type)
         }
         [cursor set];
     }
+}
+
+void MacWindow::SetIcon(TextureData& icon)
+{
+    // Get pixels
+    Array<Color32> colorData;
+    icon.GetPixels(colorData);
+
+    // Convert to Cocoa image
+    NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(icon.Width, icon.Height)];
+    if (image == nil)
+        return;
+    NSBitmapImageRep* rep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:NULL
+        pixelsWide:icon.Width
+        pixelsHigh:icon.Height
+        bitsPerSample:8
+        samplesPerPixel:4
+        hasAlpha:YES
+        isPlanar:NO
+        colorSpaceName:NSDeviceRGBColorSpace
+        bytesPerRow:icon.Width * 4
+        bitsPerPixel:32];
+    if (rep == nil)
+        return;
+
+    // Copy the pixels
+    Platform::MemoryCopy([rep bitmapData], colorData.Get(), colorData.Count() * sizeof(Color32));
+
+    // Add the image representation
+    [image addRepresentation:rep];
+
+    // Set app icon
+    [NSApp setApplicationIconImage:image];
 }
 
 #endif

--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -1009,6 +1009,10 @@ void MacWindow::Close(ClosingReason reason)
 {
     const BOOL wasKey = _window && [(NSWindow*)_window isKeyWindow];
     WindowBase::Close(reason);
+
+    // Closing can be cancelled by managed Window.Closing handlers.
+    if (!IsClosed())
+        return;
     
     if (NSWindow* window = (NSWindow*)_window)
     {

--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -200,6 +200,19 @@ Float2 GetMousePosition(MacWindow* window, NSEvent* event)
     return Float2(point.x, frame.size.height - point.y) * MacPlatform::ScreenScale - GetWindowTitleSize(window);
 }
 
+NSRect GetFrameRectForClientBounds(MacWindow* macWindow, NSWindow* window, const Rectangle& clientArea)
+{
+    const float screenScale = MacPlatform::ScreenScale;
+    NSRect rect = NSMakeRect(0, 0, clientArea.Size.X / screenScale, clientArea.Size.Y / screenScale);
+    rect = [window frameRectForContentRect:rect];
+
+    Float2 pos = AppleUtils::PosToCoca(clientArea.Location) / screenScale;
+    Float2 titleSize = GetWindowTitleSize(macWindow);
+    rect.origin.x = pos.X + titleSize.X;
+    rect.origin.y = pos.Y - rect.size.height + titleSize.Y;
+    return rect;
+}
+
 class MacDropData : public IGuiData
 {
 public:
@@ -308,6 +321,12 @@ NSDragOperation GetDragDropOperation(DragDropEffect dragDropEffect)
 {
     if (IsWindowInvalid(Window)) return;
     Window->OnLostFocus();
+}
+
+- (void)windowDidMove:(NSNotification*)notification
+{
+    if (IsWindowInvalid(Window)) return;
+    Window->SyncWindowState();
 }
 
 - (void)windowWillClose:(NSNotification*)notification
@@ -518,6 +537,28 @@ static void ConvertNSRect(NSScreen *screen, NSRect *r)
     if (IsWindowInvalid(Window)) return;
 	Float2 mousePos = GetMousePosition(Window, event);
     mousePos = Window->ClientToScreen(mousePos);
+
+    if ([event clickCount] == 1 && !Input::Mouse->IsRelative())
+    {
+        WindowHitCodes hit = WindowHitCodes::Client;
+        bool handled = false;
+        Window->OnHitTest(mousePos, hit, handled);
+
+        if (hit == WindowHitCodes::Caption)
+        {
+            bool consumed = false;
+            Window->OnLeftButtonHit(hit, consumed);
+
+            if (!consumed)
+            {
+                [(NSWindow*)Window->GetNativePtr() performWindowDragWithEvent:event];
+                Window->SyncWindowState();
+            }
+
+            return;
+        }
+    }
+
     MouseButton mouseButton = MouseButton::Left;
     if ([event clickCount] == 2 && !Input::Mouse->IsRelative())
         Input::Mouse->OnMouseDoubleClick(mousePos, mouseButton, Window);
@@ -835,15 +876,28 @@ MacWindow::MacWindow(const CreateWindowSettings& settings)
 
 MacWindow::~MacWindow()
 {
-    NSWindow* window = (NSWindow*)_window;
-    [window close];
-    [window release];
+    if (NSWindow* window = (NSWindow*)_window)
+    {
+        [window close];
+        [window release];
+    }
     _window = nullptr;
     _view = nullptr;
 }
 
+void MacWindow::SyncWindowState()
+{
+    NSWindow* window = (NSWindow*)_window;
+    if (window)
+    {
+        _minimized = window.miniaturized;
+        _maximized = window.zoomed;
+    }
+}
+
 void MacWindow::CheckForResize(float width, float height)
 {
+    SyncWindowState();
     const Float2 clientSize(width, height);
 	if (clientSize != _clientSize)
 	{
@@ -940,7 +994,7 @@ void MacWindow::Hide()
             [window orderOut:nil];
 
         // Transfer focus back to the parent when hiding popup
-        if (_settings.Parent && wasKey)
+        if (_settings.Parent && wasKey && _settings.Type != WindowType::Popup && _settings.Type != WindowType::Tooltip)
         {
             NSWindow* parent = (NSWindow*)_settings.Parent->GetNativePtr();
             [parent makeKeyAndOrderFront:nil];
@@ -948,6 +1002,23 @@ void MacWindow::Hide()
 
         // Base
         WindowBase::Hide();
+    }
+}
+
+void MacWindow::Close(ClosingReason reason)
+{
+    const BOOL wasKey = _window && [(NSWindow*)_window isKeyWindow];
+    WindowBase::Close(reason);
+    
+    if (NSWindow* window = (NSWindow*)_window)
+    {
+        [window close];
+    }
+    
+    if (_settings.Parent && wasKey && _settings.Type != WindowType::Popup && _settings.Type != WindowType::Tooltip)
+    {
+        NSWindow* parent = (NSWindow*)_settings.Parent->GetNativePtr();
+        [parent makeKeyAndOrderFront:nil];
     }
 }
 
@@ -967,17 +1038,43 @@ void MacWindow::Maximize()
     if (!_settings.AllowMaximize)
         return;
     NSWindow* window = (NSWindow*)_window;
+    if (!window)
+        return;
     if (!window.zoomed)
+    {
+        if (!_maximized)
+        {
+            _restoreClientBounds = GetClientBounds();
+            _hasRestoreClientBounds = true;
+        }
         [window zoom:nil];
+    }
+    SyncWindowState();
 }
 
 void MacWindow::Restore()
 {
     NSWindow* window = (NSWindow*)_window;
+    if (!window)
+        return;
     if (window.miniaturized)
+    {
         [window deminiaturize:nil];
+        SyncWindowState();
+    }
+    else if (_maximized && _hasRestoreClientBounds)
+    {
+        const Rectangle restoreClientBounds = _restoreClientBounds;
+        _hasRestoreClientBounds = false;
+        NSRect restoreFrame = GetFrameRectForClientBounds(this, window, restoreClientBounds);
+        [window setFrame:restoreFrame display:YES animate:YES];
+        _maximized = false;
+    }
     else if (window.zoomed)
+    {
         [window zoom:nil];
+        SyncWindowState();
+    }
 }
 
 bool MacWindow::IsForegroundWindow() const
@@ -1001,17 +1098,7 @@ void MacWindow::SetClientBounds(const Rectangle& clientArea)
     NSWindow* window = (NSWindow*)_window;
     if (!window)
         return;
-    const float screenScale = MacPlatform::ScreenScale;
-
-    NSRect oldRect = [window frame];
-    NSRect newRect = NSMakeRect(0, 0, clientArea.Size.X / screenScale, clientArea.Size.Y / screenScale);
-    newRect = [window frameRectForContentRect:newRect];
-
-    Float2 pos = AppleUtils::PosToCoca(clientArea.Location) / screenScale;
-    Float2 titleSize = GetWindowTitleSize(this);
-    newRect.origin.x = pos.X + titleSize.X;
-    newRect.origin.y = pos.Y - newRect.size.height + titleSize.Y;
-
+    NSRect newRect = GetFrameRectForClientBounds(this, window, clientArea);
     [window setFrame:newRect display:YES];
 }
 

--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -11,6 +11,7 @@
 #include "Engine/Platform/Base/DragDropHelper.h"
 #endif
 #include "Engine/Core/Log.h"
+#include "Engine/Core/Math/Color32.h"
 #include "Engine/Input/Input.h"
 #include "Engine/Input/Mouse.h"
 #include "Engine/Input/Keyboard.h"

--- a/Source/Engine/Platform/Mac/MacWindow.h
+++ b/Source/Engine/Platform/Mac/MacWindow.h
@@ -63,6 +63,7 @@ public:
     void StartTrackingMouse(bool useMouseScreenOffset) override;
     void EndTrackingMouse() override;
 	void SetCursor(CursorType type) override;
+    void SetIcon(TextureData& icon) override;
 };
 
 #endif

--- a/Source/Engine/Platform/Mac/MacWindow.h
+++ b/Source/Engine/Platform/Mac/MacWindow.h
@@ -17,13 +17,16 @@ private:
     void* _window = nullptr;
     void* _view = nullptr;
     bool _isMouseOver = false;
+    bool _hasRestoreClientBounds = false;
+    Rectangle _restoreClientBounds;
     Float2 _mouseTrackPos = Float2::Minimum;
     String _dragText;
 
 public:
 	MacWindow(const CreateWindowSettings& settings);
-	~MacWindow();
+	~MacWindow() override;
 
+    void SyncWindowState();
     void CheckForResize(float width, float height);
     void SetIsMouseOver(bool value);
     const String& GetDragText() const
@@ -37,6 +40,7 @@ public:
     void OnUpdate(float dt) override;
     void Show() override;
     void Hide() override;
+    void Close(ClosingReason reason) override;
     void Minimize() override;
     void Maximize() override;
     void Restore() override;

--- a/Source/Engine/Platform/Platform.Build.cs
+++ b/Source/Engine/Platform/Platform.Build.cs
@@ -36,7 +36,7 @@ public class Platform : EngineModule
             {
                 options.OutputFiles.Add("dbghelp.lib");
                 options.DelayLoadLibraries.Add("dbghelp.dll");
-                options.DependencyFiles.Add(Path.Combine(options.DepsFolder, "dbghelp.dll"));
+                options.OptionalDependencyFiles.Add(Path.Combine(options.DepsFolder, "dbghelp.dll"));
             }
             if (options.Target.IsEditor)
             {

--- a/Source/Engine/ShadersCompilation/DirectX/ShaderCompilerDX.cpp
+++ b/Source/Engine/ShadersCompilation/DirectX/ShaderCompilerDX.cpp
@@ -128,6 +128,12 @@ bool ShaderCompilerDX::CompileShader(ShaderFunctionMeta& meta, WritePermutationD
     auto containerReflection = (IDxcContainerReflection*)_containerReflection;
     auto type = meta.GetStage();
     IncludeDX include(_context, library);
+
+    // Cooperative-vector shaders (NVIDIA Neural Shading) require Shader Model 6.9 preview and the
+    // dx::linalg intrinsics. They are opted-in per shader function with META_FLAG(CooperativeVector)
+    // and are supported for compute (cs_6_9) and pixel (ps_6_9) shaders in this engine.
+    const bool useCoopVec = EnumHasAnyFlags(meta.Flags, ShaderFlags::CooperativeVector) && (type == ShaderStage::Compute || type == ShaderStage::Pixel);
+
     const Char* targetProfile;
     switch (type)
     {
@@ -144,10 +150,10 @@ bool ShaderCompilerDX::CompileShader(ShaderFunctionMeta& meta, WritePermutationD
         targetProfile = TEXT("gs_6_0");
         break;
     case ShaderStage::Pixel:
-        targetProfile = TEXT("ps_6_0");
+        targetProfile = useCoopVec ? TEXT("ps_6_9") : TEXT("ps_6_0");
         break;
     case ShaderStage::Compute:
-        targetProfile = TEXT("cs_6_0");
+        targetProfile = useCoopVec ? TEXT("cs_6_9") : TEXT("cs_6_0");
         break;
     default:
         return true;
@@ -170,6 +176,14 @@ bool ShaderCompilerDX::CompileShader(ShaderFunctionMeta& meta, WritePermutationD
         args.Add(DXC_ARG_WARNINGS_ARE_ERRORS);
     if (_context->Options->GenerateDebugData)
         args.Add(DXC_ARG_DEBUG);
+    if (useCoopVec)
+    {
+        // Cooperative vectors operate on native 16-bit types and target a preview shader model that the
+        // external DXIL validator does not recognize, so emit unvalidated DXIL (the device opts into
+        // experimental shader models at creation time to run it).
+        args.Add(TEXT("-enable-16bit-types"));
+        args.Add(DXC_ARG_SKIP_VALIDATION); // -Vd
+    }
     args.Add(TEXT("-T"));
     args.Add(targetProfile);
     args.Add(TEXT("-E"));

--- a/Source/Engine/ShadersCompilation/Parser/ShaderProcessing.Parse.cpp
+++ b/Source/Engine/ShadersCompilation/Parser/ShaderProcessing.Parse.cpp
@@ -146,8 +146,9 @@ ShaderFlags ShaderProcessing::ParseShaderFlags(const Token& token)
         _PARSE_ENTRY(Hidden),
         _PARSE_ENTRY(NoFastMath),
         _PARSE_ENTRY(VertexToGeometryShader),
+        _PARSE_ENTRY(CooperativeVector),
     };
-    static_assert(ARRAY_COUNT(data) == 4, "Invalid amount of Shader Flag data entries.");
+    static_assert(ARRAY_COUNT(data) == 5, "Invalid amount of Shader Flag data entries.");
 #undef _PARSE_ENTRY
 
     for (int32 i = 0; i < ARRAY_COUNT(data); i++)

--- a/Source/Engine/ShadersCompilation/Vulkan/ShaderCompilerVulkan.cpp
+++ b/Source/Engine/ShadersCompilation/Vulkan/ShaderCompilerVulkan.cpp
@@ -23,6 +23,20 @@
 #include <ThirdParty/glslang/SPIRV/GlslangToSpv.h>
 #include <ThirdParty/spirv-tools/libspirv.hpp>
 
+#if PLATFORM_WINDOWS
+// Cooperative-vector shaders are compiled with DXC (HLSL dx::linalg -> SPV_NV_cooperative_vector).
+#include "Engine/Core/Types/StringView.h"
+#include "Engine/Utilities/StringConverter.h"
+#include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
+// COM base types required by dxcapi.h (IncludeWindowsHeaders.h uses WIN32_LEAN_AND_MEAN which omits them).
+#include <unknwn.h>     // IUnknown
+#include <oaidl.h>      // BSTR
+#include <objidl.h>     // IStream
+#include <combaseapi.h> // IID_PPV_ARGS
+#include "Engine/Platform/Windows/ComPtr.h"
+#include <ThirdParty/DirectXShaderCompiler/dxcapi.h>
+#endif
+
 #define PRINT_UNIFORMS 0
 #define PRINT_DESCRIPTORS 0
 
@@ -87,6 +101,14 @@ ShaderCompilerVulkan::ShaderCompilerVulkan(ShaderProfile profile)
 ShaderCompilerVulkan::~ShaderCompilerVulkan()
 {
     ScopeLock lock(CompileShaderVulkanLocker);
+#if PLATFORM_WINDOWS
+    if (_dxcCompiler)
+        ((IUnknown*)_dxcCompiler)->Release();
+    if (_dxcLibrary)
+        ((IUnknown*)_dxcLibrary)->Release();
+    if (_dxcModule)
+        Platform::FreeLibrary(_dxcModule);
+#endif
     CompileShaderVulkanInstances--;
     if (CompileShaderVulkanInstances == 0)
     {
@@ -581,6 +603,650 @@ public:
     }
 };
 
+#if PLATFORM_WINDOWS
+
+// ---------------------------------------------------------------------------
+// Cooperative-vector (NVIDIA Neural Shading) shaders are compiled with DXC to SPIR-V because glslang
+// cannot translate the dx::linalg intrinsics. DXC emits resources in descriptor set 0 with bindings
+// derived from the HLSL register (offset by the -fvk-*-shift values below). We reflect the module to
+// build Flax's SpirvShaderDescriptorInfo and rewrite each resource decoration to the engine convention
+// (set = pipeline stage set, binding = sequential index), matching what the glslang path produces.
+// ---------------------------------------------------------------------------
+
+namespace SpvConst
+{
+    enum { MagicNumber = 0x07230203, HeaderWords = 5 };
+    enum Op
+    {
+        OpName = 5,
+        OpMemoryModel = 14,
+        OpTypeImage = 25,
+        OpTypeSampler = 26,
+        OpTypeArray = 28,
+        OpTypeRuntimeArray = 29,
+        OpTypeStruct = 30,
+        OpTypePointer = 32,
+        OpConstant = 43,
+        OpVariable = 59,
+        OpDecorate = 71,
+    };
+    enum Decoration
+    {
+        DecorationBlock = 2,
+        DecorationBufferBlock = 3,
+        DecorationLocation = 30,
+        DecorationBinding = 33,
+        DecorationDescriptorSet = 34,
+    };
+    enum StorageClass
+    {
+        StorageClassUniformConstant = 0,
+        StorageClassInput = 1,
+        StorageClassUniform = 2,
+        StorageClassOutput = 3,
+        StorageClassStorageBuffer = 12,
+    };
+    enum Dim
+    {
+        Dim1D = 0,
+        Dim3D = 2,
+        DimCube = 3,
+        DimBuffer = 5,
+    };
+}
+
+struct SpvIdInfo
+{
+    uint16 Op = 0;
+    int32 Set = -1;
+    int32 Binding = -1;
+    int32 SetWordIndex = -1;
+    int32 BindingWordIndex = -1;
+    uint32 StorageClass = 0xFFFFFFFF;
+    uint32 TypeRef = 0;
+    uint32 ElementType = 0;
+    uint32 ArrayLen = 1;
+    uint32 ConstValue = 0;
+    uint32 ImgDim = 0;
+    uint32 ImgSampled = 0;
+    bool HasLocation = false;
+    bool IsStruct = false;
+    bool IsImage = false;
+    bool IsSampler = false;
+    bool IsArray = false;
+    bool IsRuntimeArray = false;
+    bool IsBlock = false;
+    bool IsBufferBlock = false;
+};
+
+// The SPIR-V CooperativeVectorNV capability requires the Vulkan memory model, which in turn
+// requires OpMemoryModel to select the Vulkan memory model (DXC emits GLSL450 by default).
+// Patch the memory-model operand in place (the addressing model is left untouched).
+static void PatchSpirvVulkanMemoryModel(std::vector<unsigned>& spirv)
+{
+    using namespace SpvConst;
+    if (spirv.size() < HeaderWords || spirv[0] != MagicNumber)
+        return;
+    enum { MemoryModelVulkan = 3 };
+    size_t i = HeaderWords;
+    while (i < spirv.size())
+    {
+        const uint32 word0 = spirv[i];
+        const uint16 op = (uint16)(word0 & 0xFFFFu);
+        const uint16 wordCount = (uint16)(word0 >> 16);
+        if (wordCount == 0 || i + wordCount > spirv.size())
+            return;
+        if (op == OpMemoryModel && wordCount >= 3)
+        {
+            spirv[i + 2] = MemoryModelVulkan;
+            return;
+        }
+        i += wordCount;
+    }
+}
+
+static bool ReflectAndRemapCoopVecSpirv(std::vector<unsigned>& spirv, int32 stageSet, SpirvShaderHeader& header, ShaderBindings& bindings)
+{
+    using namespace SpvConst;
+    if (spirv.size() < HeaderWords || spirv[0] != MagicNumber)
+    {
+        LOG(Warning, "CoopVec reflect: bad SPIR-V header (size={0} words, magic=0x{1:x}).", (int32)spirv.size(), spirv.empty() ? 0u : spirv[0]);
+        return false;
+    }
+    const uint32 bound = spirv[3]; // SPIR-V header: [0]=magic [1]=version [2]=generator [3]=bound [4]=schema
+    if (bound == 0)
+    {
+        LOG(Warning, "CoopVec reflect: SPIR-V id bound is 0.");
+        return false;
+    }
+    std::vector<SpvIdInfo> ids((size_t)bound);
+
+    // Pass 1: scan the module
+    size_t i = HeaderWords;
+    while (i < spirv.size())
+    {
+        const uint32 word0 = spirv[i];
+        const uint16 op = (uint16)(word0 & 0xFFFFu);
+        const uint16 wordCount = (uint16)(word0 >> 16);
+        if (wordCount == 0 || i + wordCount > spirv.size())
+        {
+            LOG(Warning, "CoopVec reflect: malformed instruction at word {0} (op={1}, wordCount={2}, total={3}).", (int32)i, (int32)op, (int32)wordCount, (int32)spirv.size());
+            return false;
+        }
+        switch (op)
+        {
+        case OpDecorate:
+            if (wordCount >= 3)
+            {
+                const uint32 target = spirv[i + 1];
+                const uint32 deco = spirv[i + 2];
+                if (target < bound)
+                {
+                    auto& d = ids[(int32)target];
+                    if (deco == DecorationBinding && wordCount >= 4)
+                    {
+                        d.Binding = (int32)spirv[i + 3];
+                        d.BindingWordIndex = (int32)(i + 3);
+                    }
+                    else if (deco == DecorationDescriptorSet && wordCount >= 4)
+                    {
+                        d.Set = (int32)spirv[i + 3];
+                        d.SetWordIndex = (int32)(i + 3);
+                    }
+                    else if (deco == DecorationLocation)
+                        d.HasLocation = true;
+                    else if (deco == DecorationBlock)
+                        d.IsBlock = true;
+                    else if (deco == DecorationBufferBlock)
+                        d.IsBufferBlock = true;
+                }
+            }
+            break;
+        case OpTypePointer:
+            if (wordCount >= 4)
+            {
+                const uint32 res = spirv[i + 1];
+                if (res < bound)
+                {
+                    auto& d = ids[(int32)res];
+                    d.Op = OpTypePointer;
+                    d.StorageClass = spirv[i + 2];
+                    d.TypeRef = spirv[i + 3];
+                }
+            }
+            break;
+        case OpTypeStruct:
+            if (wordCount >= 2)
+            {
+                const uint32 res = spirv[i + 1];
+                if (res < bound)
+                    ids[(int32)res].IsStruct = true;
+            }
+            break;
+        case OpTypeImage:
+            if (wordCount >= 8)
+            {
+                const uint32 res = spirv[i + 1];
+                if (res < bound)
+                {
+                    auto& d = ids[(int32)res];
+                    d.IsImage = true;
+                    d.ImgDim = spirv[i + 3];
+                    d.ImgSampled = spirv[i + 7];
+                }
+            }
+            break;
+        case OpTypeSampler:
+            if (wordCount >= 2)
+            {
+                const uint32 res = spirv[i + 1];
+                if (res < bound)
+                    ids[(int32)res].IsSampler = true;
+            }
+            break;
+        case OpTypeArray:
+            if (wordCount >= 4)
+            {
+                const uint32 res = spirv[i + 1];
+                if (res < bound)
+                {
+                    auto& d = ids[(int32)res];
+                    d.IsArray = true;
+                    d.ElementType = spirv[i + 2];
+                    const uint32 lenId = spirv[i + 3];
+                    d.ArrayLen = (lenId < bound && ids[(int32)lenId].ConstValue > 0) ? ids[(int32)lenId].ConstValue : 1;
+                }
+            }
+            break;
+        case OpTypeRuntimeArray:
+            if (wordCount >= 3)
+            {
+                const uint32 res = spirv[i + 1];
+                if (res < bound)
+                {
+                    auto& d = ids[(int32)res];
+                    d.IsRuntimeArray = true;
+                    d.ElementType = spirv[i + 2];
+                }
+            }
+            break;
+        case OpConstant:
+            if (wordCount >= 4)
+            {
+                const uint32 res = spirv[i + 2];
+                if (res < bound)
+                    ids[(int32)res].ConstValue = spirv[i + 3];
+            }
+            break;
+        case OpVariable:
+            if (wordCount >= 4)
+            {
+                const uint32 res = spirv[i + 2];
+                if (res < bound)
+                {
+                    auto& d = ids[(int32)res];
+                    d.Op = OpVariable;
+                    d.TypeRef = spirv[i + 1];
+                    d.StorageClass = spirv[i + 3];
+                }
+            }
+            break;
+        default:
+            break;
+        }
+        i += wordCount;
+    }
+
+    // Pass 2: build descriptors and rewrite bindings
+    auto& info = header.DescriptorInfo;
+    int32 inputs = 0, outputs = 0;
+    for (uint32 id = 0; id < bound; id++)
+    {
+        const SpvIdInfo& v = ids[(int32)id];
+        if (v.Op != OpVariable)
+            continue;
+        if (v.StorageClass == StorageClassInput)
+        {
+            if (v.HasLocation)
+                inputs++;
+            continue;
+        }
+        if (v.StorageClass == StorageClassOutput)
+        {
+            if (v.HasLocation)
+                outputs++;
+            continue;
+        }
+        if (v.StorageClass != StorageClassUniform && v.StorageClass != StorageClassStorageBuffer && v.StorageClass != StorageClassUniformConstant)
+            continue;
+        if (v.Binding < 0 || v.BindingWordIndex < 0 || v.TypeRef >= bound)
+            continue;
+
+        // Resolve the variable's pointee type, unwrapping resource arrays
+        uint32 baseId = ids[(int32)v.TypeRef].TypeRef;
+        uint32 count = 1;
+        while (baseId < bound && (ids[(int32)baseId].IsArray || ids[(int32)baseId].IsRuntimeArray))
+        {
+            const SpvIdInfo& a = ids[(int32)baseId];
+            if (a.IsArray)
+                count *= a.ArrayLen;
+            baseId = a.ElementType;
+        }
+        if (baseId >= bound)
+            continue;
+        const SpvIdInfo& base = ids[(int32)baseId];
+
+        const int32 btype = v.Binding / 100; // 0=b,1=t,2=u,3=s (from -fvk-*-shift)
+        const int32 reg = v.Binding % 100;
+
+        SpirvShaderResourceBindingType bindingType = SpirvShaderResourceBindingType::INVALID;
+        VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+        SpirvShaderResourceType resourceType = SpirvShaderResourceType::Unknown;
+        if (base.IsStruct)
+        {
+            if (v.StorageClass == StorageClassUniform && base.IsBlock && !base.IsBufferBlock)
+            {
+                bindingType = SpirvShaderResourceBindingType::CB;
+                descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+                resourceType = SpirvShaderResourceType::ConstantBuffer;
+            }
+            else
+            {
+                bindingType = (btype == 2) ? SpirvShaderResourceBindingType::UAV : SpirvShaderResourceBindingType::SRV;
+                descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                resourceType = SpirvShaderResourceType::Buffer;
+            }
+        }
+        else if (base.IsImage)
+        {
+            const bool isStorage = base.ImgSampled == 2 || btype == 2;
+            bindingType = isStorage ? SpirvShaderResourceBindingType::UAV : SpirvShaderResourceBindingType::SRV;
+            if (base.ImgDim == DimBuffer)
+            {
+                resourceType = SpirvShaderResourceType::Buffer;
+                descriptorType = isStorage ? VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER : VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+            }
+            else
+            {
+                descriptorType = isStorage ? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE : VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+                switch (base.ImgDim)
+                {
+                case Dim1D: resourceType = SpirvShaderResourceType::Texture1D; break;
+                case Dim3D: resourceType = SpirvShaderResourceType::Texture3D; break;
+                case DimCube: resourceType = SpirvShaderResourceType::TextureCube; break;
+                default: resourceType = SpirvShaderResourceType::Texture2D; break;
+                }
+            }
+        }
+        else if (base.IsSampler)
+        {
+            bindingType = SpirvShaderResourceBindingType::SAMPLER;
+            descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+            resourceType = SpirvShaderResourceType::Sampler;
+        }
+        else
+        {
+            continue;
+        }
+
+        if (info.DescriptorTypesCount >= SpirvShaderDescriptorInfo::MaxDescriptors)
+        {
+            LOG(Warning, "Too many descriptors in cooperative-vector shader.");
+            return false;
+        }
+        const int32 newBinding = (int32)info.DescriptorTypesCount;
+        auto& d = info.DescriptorTypes[info.DescriptorTypesCount++];
+        d.Binding = (byte)newBinding;
+        d.Set = (byte)stageSet;
+        d.Slot = (byte)reg;
+        d.BindingType = bindingType;
+        d.DescriptorType = descriptorType;
+        d.ResourceType = resourceType;
+        d.ResourceFormat = PixelFormat::Unknown;
+        d.Count = count;
+
+        // Rewrite SPIR-V decorations to match the engine convention
+        spirv[v.BindingWordIndex] = (uint32)newBinding;
+        if (v.SetWordIndex >= 0)
+            spirv[v.SetWordIndex] = (uint32)stageSet;
+
+        switch (descriptorType)
+        {
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            info.ImageInfosCount += (uint16)count;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            info.BufferInfosCount += (uint16)count;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            info.TexelBufferViewsCount += count;
+            break;
+        default:
+            break;
+        }
+        switch (bindingType)
+        {
+        case SpirvShaderResourceBindingType::SAMPLER: bindings.UsedSamplersMask |= 1 << reg; break;
+        case SpirvShaderResourceBindingType::CB: bindings.UsedCBsMask |= 1 << reg; break;
+        case SpirvShaderResourceBindingType::SRV: bindings.UsedSRsMask |= 1 << reg; break;
+        case SpirvShaderResourceBindingType::UAV: bindings.UsedUAsMask |= 1 << reg; break;
+        default: break;
+        }
+    }
+
+    bindings.InputsCount = inputs;
+    bindings.OutputsCount = outputs;
+    return true;
+}
+
+// DXC include handler that resolves engine shader includes (mirrors the DirectX backend handler).
+class CoopVecIncludeDX : public IDxcIncludeHandler
+{
+private:
+    ShaderCompilationContext* _context;
+    IDxcLibrary* _library;
+
+public:
+    CoopVecIncludeDX(ShaderCompilationContext* context, IDxcLibrary* library)
+        : _context(context)
+        , _library(library)
+    {
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef() override { return 1; }
+    ULONG STDMETHODCALLTYPE Release() override { return 1; }
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override
+    {
+        if (riid == __uuidof(IDxcIncludeHandler) || riid == __uuidof(IUnknown))
+        {
+            AddRef();
+            *ppvObject = this;
+            return S_OK;
+        }
+        *ppvObject = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    HRESULT STDMETHODCALLTYPE LoadSource(LPCWSTR pFilename, IDxcBlob** ppIncludeSource) override
+    {
+        *ppIncludeSource = nullptr;
+        const char* source;
+        int32 sourceLength;
+        StringAnsi filename(pFilename);
+        filename.Replace('\\', '/');
+        if (ShaderCompiler::GetIncludedFileSource(_context, "", filename.Get(), source, sourceLength))
+            return E_FAIL;
+        IDxcBlobEncoding* textBlob;
+        if (FAILED(_library->CreateBlobWithEncodingFromPinned((LPBYTE)source, sourceLength, CP_UTF8, &textBlob)))
+            return E_FAIL;
+        *ppIncludeSource = textBlob;
+        return S_OK;
+    }
+};
+
+bool ShaderCompilerVulkan::InitDXC()
+{
+    if (_dxcInitDone)
+        return _dxcCompiler != nullptr && _dxcLibrary != nullptr;
+    _dxcInitDone = true;
+
+    // dxcompiler.dll is deployed next to the executable by the DirectX shader compiler module.
+    _dxcModule = (void*)LoadLibraryW(L"dxcompiler.dll");
+    if (!_dxcModule)
+    {
+        LOG(Warning, "Failed to load dxcompiler.dll for cooperative-vector SPIR-V compilation.");
+        return false;
+    }
+    const auto createInstance = (DxcCreateInstanceProc)Platform::GetProcAddress(_dxcModule, "DxcCreateInstance");
+    if (!createInstance)
+    {
+        LOG(Warning, "dxcompiler.dll is missing DxcCreateInstance.");
+        return false;
+    }
+    IDxcCompiler3* compiler = nullptr;
+    IDxcLibrary* library = nullptr;
+    if (FAILED(createInstance(CLSID_DxcCompiler, __uuidof(IDxcCompiler3), (void**)&compiler)) ||
+        FAILED(createInstance(CLSID_DxcLibrary, __uuidof(IDxcLibrary), (void**)&library)))
+    {
+        LOG(Warning, "DxcCreateInstance failed for cooperative-vector SPIR-V compilation.");
+        return false;
+    }
+    _dxcCompiler = compiler;
+    _dxcLibrary = library;
+    return true;
+}
+
+int32 ShaderCompilerVulkan::CompileShaderCoopVec(ShaderFunctionMeta& meta, WritePermutationData customDataWrite)
+{
+    auto options = _context->Options;
+    auto compiler = (IDxcCompiler3*)_dxcCompiler;
+    auto library = (IDxcLibrary*)_dxcLibrary;
+    const auto type = meta.GetStage();
+    CoopVecIncludeDX include(_context, library);
+
+    const Char* targetProfile = type == ShaderStage::Compute ? TEXT("cs_6_9") : TEXT("ps_6_9");
+    const int32 stageSet = type == ShaderStage::Compute ? 0 : 1;
+
+    ComPtr<IDxcBlobEncoding> textBlob;
+    if (FAILED(library->CreateBlobWithEncodingFromPinned((LPBYTE)options->Source, options->SourceLength, CP_UTF8, &textBlob)))
+        return 2;
+    DxcBuffer textBuffer;
+    textBuffer.Ptr = textBlob->GetBufferPointer();
+    textBuffer.Size = textBlob->GetBufferSize();
+    textBuffer.Encoding = DXC_CP_ACP;
+    const StringAsUTF16<> entryPoint(meta.Name.Get(), meta.Name.Length());
+    // Force the SPIR-V entry point name to match the engine convention (the Vulkan runtime binds the
+    // stage with pName = shader program name), as DXC may otherwise rename the entry to "main".
+    String entryNameArg(TEXT("-fspv-entrypoint-name="));
+    entryNameArg += entryPoint.Get();
+
+    // Phase 1: compile and reflect every permutation. This is all-or-nothing: if DXC cannot emit
+    // cooperative-vector SPIR-V (old compiler, unsupported intrinsics, ...), bail out before writing
+    // anything so the caller can fall back to the glslang fp32 path.
+    struct CompiledPermutation
+    {
+        std::vector<unsigned> Spirv;
+        SpirvShaderHeader Header;
+        ShaderBindings Bindings;
+    };
+    std::vector<CompiledPermutation> compiled((size_t)meta.Permutations.Count());
+    for (int32 permutationIndex = 0; permutationIndex < meta.Permutations.Count(); permutationIndex++)
+    {
+        _macros.Clear();
+        meta.GetDefinitionsForPermutation(permutationIndex, _macros);
+        GetDefineForFunction(meta, _macros);
+        _macros.Add(_context->Options->Macros);
+        _macros.Add(_globalMacros);
+
+        // Convert defines to "NAME[=VALUE]" UTF-16 strings
+        const int32 macrosCount = _macros.Count() - 1;
+        Array<String> definesStrings;
+        definesStrings.Resize(macrosCount);
+        for (int32 m = 0; m < macrosCount; m++)
+        {
+            auto& macro = _macros[m];
+            auto& define = definesStrings[m];
+            define = macro.Name;
+            if (macro.Definition && *macro.Definition)
+            {
+                define += TEXT("=");
+                define += macro.Definition;
+            }
+        }
+
+        // Build DXC arguments
+        Array<const Char*> args;
+        args.Add(options->NoOptimize ? DXC_ARG_SKIP_OPTIMIZATIONS : DXC_ARG_OPTIMIZATION_LEVEL3);
+        args.Add(TEXT("-enable-16bit-types"));
+        args.Add(TEXT("-spirv"));
+        // SPV_NV_cooperative_vector requires SPIR-V 1.6 (Vulkan 1.3) and the Vulkan memory model.
+        args.Add(TEXT("-fspv-target-env=vulkan1.3"));
+        // Skip DXC's bundled spirv-val: its SPV_NV_cooperative_vector support is incomplete and it
+        // rejects spec-legal constructs (e.g. single-scalar OpCompositeConstruct splat of a cooperative
+        // vector). The NVIDIA driver validates/compiles the cooperative-vector module at pipeline creation.
+        args.Add(TEXT("-Vd"));
+        // Do not pass -fspv-extension: that flag *restricts* the allowed extensions and some DXC builds
+        // do not recognize the 'SPV_NV_cooperative_vector' name even when their codegen can emit it.
+        // Omitting it lets DXC auto-enable whatever extensions the cooperative-vector lowering needs.
+        args.Add(TEXT("-fvk-use-dx-layout"));
+        // Map b/t/u/s register classes into disjoint binding ranges so the reflector can recover the
+        // HLSL register index from the SPIR-V binding (binding = register + 100 * classIndex).
+        args.Add(TEXT("-fvk-b-shift")); args.Add(TEXT("0")); args.Add(TEXT("0"));
+        args.Add(TEXT("-fvk-t-shift")); args.Add(TEXT("100")); args.Add(TEXT("0"));
+        args.Add(TEXT("-fvk-u-shift")); args.Add(TEXT("200")); args.Add(TEXT("0"));
+        args.Add(TEXT("-fvk-s-shift")); args.Add(TEXT("300")); args.Add(TEXT("0"));
+        args.Add(TEXT("-T")); args.Add(targetProfile);
+        args.Add(TEXT("-E")); args.Add(entryPoint.Get());
+        args.Add(*entryNameArg);
+        args.Add(options->TargetName.Get());
+        for (auto& define : definesStrings)
+        {
+            args.Add(TEXT("-D"));
+            args.Add(*define);
+        }
+
+        // Compile
+        ComPtr<IDxcResult> results;
+        HRESULT result = compiler->Compile(&textBuffer, (LPCWSTR*)args.Get(), args.Count(), &include, IID_PPV_ARGS(&results));
+        if (SUCCEEDED(result) && results)
+            results->GetStatus(&result);
+        if (FAILED(result))
+        {
+            if (results)
+            {
+                ComPtr<IDxcBlobEncoding> error;
+                results->GetErrorBuffer(&error);
+                if (error && error->GetBufferSize() > 0)
+                {
+                    ComPtr<IDxcBlobEncoding> errorUtf8;
+                    library->GetBlobAsUtf8(error, &errorUtf8);
+                    if (errorUtf8)
+                        LOG(Warning, "DXC cooperative-vector SPIR-V compile failed for '{0}': {1}", String(meta.Name), String((const char*)errorUtf8->GetBufferPointer()));
+                }
+            }
+            return 2;
+        }
+
+        // Get the SPIR-V output
+        ComPtr<IDxcBlob> shaderBuffer;
+        if (FAILED(results->GetResult(&shaderBuffer)) || !shaderBuffer || shaderBuffer->GetBufferSize() < SpvConst::HeaderWords * sizeof(unsigned))
+        {
+            LOG(Warning, "DXC produced no SPIR-V for cooperative-vector shader '{0}'.", String(meta.Name));
+            return 2;
+        }
+        CompiledPermutation& cp = compiled[permutationIndex];
+        const int32 spirvWords = (int32)(shaderBuffer->GetBufferSize() / sizeof(unsigned));
+        cp.Spirv.resize((size_t)spirvWords);
+        Platform::MemoryCopy(cp.Spirv.data(), shaderBuffer->GetBufferPointer(), (uint64)spirvWords * sizeof(unsigned));
+
+        // Cooperative vectors require the Vulkan memory model to be declared in the module.
+        PatchSpirvVulkanMemoryModel(cp.Spirv);
+
+        // Reflect and remap the bindings to the engine layout
+        Platform::MemoryClear(&cp.Header, sizeof(cp.Header));
+        cp.Bindings = {};
+        if (!ReflectAndRemapCoopVecSpirv(cp.Spirv, stageSet, cp.Header, cp.Bindings))
+        {
+            LOG(Warning, "Failed to reflect cooperative-vector SPIR-V for shader '{0}'.", String(meta.Name));
+            return 2;
+        }
+    }
+
+    // Phase 2: everything compiled - commit the results to the shader cache
+    for (int32 permutationIndex = 0; permutationIndex < (int32)compiled.size(); permutationIndex++)
+    {
+        CompiledPermutation& cp = compiled[(size_t)permutationIndex];
+        if (Write(_context, meta, permutationIndex, cp.Bindings, cp.Header, cp.Spirv))
+        {
+            LOG(Error, "Failed to write cooperative-vector shader '{0}'.", String(meta.Name));
+            return 1; // Hard failure mid-write; do not fall back (cache is already partially written)
+        }
+        if (customDataWrite)
+        {
+            // Rebuild the permutation macros for the custom data writer (matches the glslang path)
+            _macros.Clear();
+            meta.GetDefinitionsForPermutation(permutationIndex, _macros);
+            GetDefineForFunction(meta, _macros);
+            _macros.Add(_context->Options->Macros);
+            _macros.Add(_globalMacros);
+            if (customDataWrite(_context, meta, permutationIndex, _macros, nullptr))
+                return 1;
+        }
+    }
+
+    if (WriteShaderFunctionEnd(_context, meta))
+        return 1;
+    LOG(Info, "Compiled cooperative-vector SPIR-V (SPV_NV_cooperative_vector) for shader '{0}' via DXC.", String(meta.Name));
+    return 0;
+}
+
+#endif
+
 bool ShaderCompilerVulkan::CompileShader(ShaderFunctionMeta& meta, WritePermutationData customDataWrite)
 {
     // TODO: test without locking
@@ -591,6 +1257,26 @@ bool ShaderCompilerVulkan::CompileShader(ShaderFunctionMeta& meta, WritePermutat
     if (WriteShaderFunctionBegin(_context, meta))
         return true;
     auto type = meta.GetStage();
+
+#if PLATFORM_WINDOWS
+    // Cooperative-vector shaders (NVIDIA Neural Shading) use cooperative-vector intrinsics that glslang
+    // cannot translate, so they are routed through DXC to emit SPV_NV_cooperative_vector SPIR-V. There
+    // is no fp32 fallback: a coopvec-flagged shader requires DXC and must compile, otherwise it is a
+    // hard error (the HLSL has no non-coopvec body for glslang to compile).
+    if (EnumHasAnyFlags(meta.Flags, ShaderFlags::CooperativeVector) && (type == ShaderStage::Pixel || type == ShaderStage::Compute))
+    {
+        if (!InitDXC())
+        {
+            LOG(Error, "Cooperative-vector shader '{0}' requires DXC, but dxcompiler could not be initialized.", String(meta.Name));
+            return true;
+        }
+        const int32 r = CompileShaderCoopVec(meta, customDataWrite);
+        if (r == 0)
+            return false; // Compiled real cooperative-vector SPIR-V (success)
+        LOG(Error, "Cooperative-vector shader '{0}' failed to compile via DXC (no fp32 fallback).", String(meta.Name));
+        return true;
+    }
+#endif
 
     // Prepare
     EShLanguage lang = EShLanguage::EShLangCount;

--- a/Source/Engine/ShadersCompilation/Vulkan/ShaderCompilerVulkan.cpp
+++ b/Source/Engine/ShadersCompilation/Vulkan/ShaderCompilerVulkan.cpp
@@ -27,6 +27,8 @@
 // Cooperative-vector shaders are compiled with DXC (HLSL dx::linalg -> SPV_NV_cooperative_vector).
 #include "Engine/Core/Types/StringView.h"
 #include "Engine/Utilities/StringConverter.h"
+#include "Engine/Engine/Globals.h"
+#include "Engine/Platform/FileSystem.h"
 #include "Engine/Platform/Win32/IncludeWindowsHeaders.h"
 // COM base types required by dxcapi.h (IncludeWindowsHeaders.h uses WIN32_LEAN_AND_MEAN which omits them).
 #include <unknwn.h>     // IUnknown
@@ -1055,8 +1057,16 @@ bool ShaderCompilerVulkan::InitDXC()
         return _dxcCompiler != nullptr && _dxcLibrary != nullptr;
     _dxcInitDone = true;
 
-    // dxcompiler.dll is deployed next to the executable by the DirectX shader compiler module.
-    _dxcModule = (void*)LoadLibraryW(L"dxcompiler.dll");
+    // Cooperative vectors need a SPIR-V-enabled DXC. The stock dxcompiler.dll deployed next to the
+    // executable (from the Windows SDK) is built WITHOUT SPIR-V codegen and fails with
+    // "SPIR-V CodeGen not available", so prefer the SPIR-V-enabled build vendored in the engine's
+    // ThirdParty deps folder (where the README has the user drop the preview DXC). Platform::LoadLibrary
+    // also adds that folder to the DLL search path so the sibling dxil.dll resolves.
+    const String depsDxc = Globals::StartupFolder / TEXT("Source/Platforms/Windows/Binaries/ThirdParty/x64/dxcompiler.dll");
+    if (FileSystem::FileExists(depsDxc))
+        _dxcModule = Platform::LoadLibrary(depsDxc.Get());
+    if (!_dxcModule)
+        _dxcModule = (void*)LoadLibraryW(L"dxcompiler.dll"); // fall back to the copy next to the executable
     if (!_dxcModule)
     {
         LOG(Warning, "Failed to load dxcompiler.dll for cooperative-vector SPIR-V compilation.");

--- a/Source/Engine/ShadersCompilation/Vulkan/ShaderCompilerVulkan.h
+++ b/Source/Engine/ShadersCompilation/Vulkan/ShaderCompilerVulkan.h
@@ -20,6 +20,18 @@ class ShaderCompilerVulkan : public ShaderCompiler
 {
 private:
     Array<char> _funcNameDefineBuffer;
+#if PLATFORM_WINDOWS
+    // Cooperative-vector (NVIDIA Neural Shading) shaders cannot be translated by glslang, so they are
+    // routed through DXC to emit SPV_NV_cooperative_vector SPIR-V. DXC is loaded lazily on demand.
+    void* _dxcModule = nullptr;
+    void* _dxcCompiler = nullptr;
+    void* _dxcLibrary = nullptr;
+    bool _dxcInitDone = false;
+
+    bool InitDXC();
+    // Returns: 0 = compiled and written, 1 = hard error (may be partially written), 2 = not handled (nothing written, fall back to glslang).
+    int32 CompileShaderCoopVec(ShaderFunctionMeta& meta, WritePermutationData customDataWrite);
+#endif
 
 public:
     /// <summary>

--- a/Source/Engine/Tools/AudioTool/AudioTool.cpp
+++ b/Source/Engine/Tools/AudioTool/AudioTool.cpp
@@ -21,27 +21,7 @@
 
 String AudioTool::Options::ToString() const
 {
-    return String::Format(TEXT("Format:{}, DisableStreaming:{}, Is3D:{}, Quality:{}, BitDepth:{}"), ScriptingEnum::ToString(Format), DisableStreaming, Is3D, Quality, (int32)BitDepth);
-}
-
-void AudioTool::Options::Serialize(SerializeStream& stream, const void* otherObj)
-{
-    SERIALIZE_GET_OTHER_OBJ(AudioTool::Options);
-
-    SERIALIZE(Format);
-    SERIALIZE(DisableStreaming);
-    SERIALIZE(Is3D);
-    SERIALIZE(Quality);
-    SERIALIZE(BitDepth);
-}
-
-void AudioTool::Options::Deserialize(DeserializeStream& stream, ISerializeModifier* modifier)
-{
-    DESERIALIZE(Format);
-    DESERIALIZE(DisableStreaming);
-    DESERIALIZE(Is3D);
-    DESERIALIZE(Quality);
-    DESERIALIZE(BitDepth);
+    return String::Format(TEXT("Volume: {}, Format:{}, DisableStreaming:{}, Is3D:{}, Quality:{}, BitDepth:{}"), Volume, ScriptingEnum::ToString(Format), DisableStreaming, Is3D, Quality, (int32)BitDepth);
 }
 
 #endif

--- a/Source/Engine/Tools/AudioTool/AudioTool.h
+++ b/Source/Engine/Tools/AudioTool/AudioTool.h
@@ -42,6 +42,13 @@ public:
     API_STRUCT(Attributes="HideInEditor") struct FLAXENGINE_API Options : public ISerializable
     {
         DECLARE_SCRIPTING_TYPE_MINIMAL(Options);
+        API_AUTO_SERIALIZATION();
+
+        /// <summary>
+        /// The audio volume. Can be used to scale source audio data at import time.
+        /// </summary>
+        API_FIELD(Attributes="EditorOrder(5), Limit(0, 10, 0.01f)")
+        float Volume = 1;
 
         /// <summary>
         /// The audio data format to import the audio clip as.
@@ -74,10 +81,6 @@ public:
         BitDepth BitDepth = BitDepth::_16;
 
         String ToString() const;
-
-        // [ISerializable]
-        void Serialize(SerializeStream& stream, const void* otherObj) override;
-        void Deserialize(DeserializeStream& stream, ISerializeModifier* modifier) override;
     };
 #endif
 

--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -90,7 +90,7 @@ namespace FlaxEngine
             Matrix.Multiply(ref worldMatrix, ref renderContext.View.View, out Matrix viewMatrix);
             Matrix projectionMatrix = renderContext.View.Projection;
             if (worldSpace && (Canvas.RenderLocation == PostProcessEffectLocation.Default || Canvas.RenderLocation == PostProcessEffectLocation.AfterAntiAliasingPass))
-                projectionMatrix = renderContext.View.GetOverlayProjection(); // Fix TAA jittering when rendering UI in world after TAA resolve
+                renderContext.View.GetOverlayProjection(out projectionMatrix); // Fix TAA jittering when rendering UI in world after TAA resolve
             Matrix.Multiply(ref viewMatrix, ref projectionMatrix, out Matrix viewProjectionMatrix);
 
             // Pick a depth buffer

--- a/Source/Engine/UI/UICanvas.cs
+++ b/Source/Engine/UI/UICanvas.cs
@@ -90,7 +90,7 @@ namespace FlaxEngine
             Matrix.Multiply(ref worldMatrix, ref renderContext.View.View, out Matrix viewMatrix);
             Matrix projectionMatrix = renderContext.View.Projection;
             if (worldSpace && (Canvas.RenderLocation == PostProcessEffectLocation.Default || Canvas.RenderLocation == PostProcessEffectLocation.AfterAntiAliasingPass))
-                projectionMatrix = renderContext.View.NonJitteredProjection; // Fix TAA jittering when rendering UI in world after TAA resolve
+                projectionMatrix = renderContext.View.GetOverlayProjection(); // Fix TAA jittering when rendering UI in world after TAA resolve
             Matrix.Multiply(ref viewMatrix, ref projectionMatrix, out Matrix viewProjectionMatrix);
 
             // Pick a depth buffer

--- a/Source/Engine/Visject/ShaderGraph.cpp
+++ b/Source/Engine/Visject/ShaderGraph.cpp
@@ -5,6 +5,8 @@
 #include "ShaderGraph.h"
 #include "GraphUtilities.h"
 #include "ShaderGraphUtilities.h"
+#include "Engine/Content/Assets/Texture.h"
+#include "Engine/Content/Assets/CubeTexture.h"
 #include "Engine/Engine/GameplayGlobals.h"
 
 const Char* ShaderGenerator::_mathFunctions[] =
@@ -742,6 +744,37 @@ void ShaderGenerator::ProcessGroupTools(Box* box, Node* node, Value& value)
         // Get param value
         value.Type = variable.DefaultValue.Type.Type;
         value.Value = param->ShaderName;
+        switch (variable.DefaultValue.Type.Type)
+        {
+        case VariantType::Bool:
+        case VariantType::Int:
+        case VariantType::Uint:
+        case VariantType::Float:
+        case VariantType::Float2:
+        case VariantType::Float3:
+        case VariantType::Float4:
+        case VariantType::Color:
+        case VariantType::Double2:
+        case VariantType::Double3:
+        case VariantType::Double4:
+        case VariantType::Int2:
+        case VariantType::Int3:
+        case VariantType::Int4:
+            // POD value types
+            break;
+        case VariantType::Asset:
+            if (Texture::GetStaticType().Fullname == variable.DefaultValue.Type.TypeName || 
+                CubeTexture::GetStaticType().Fullname == variable.DefaultValue.Type.TypeName)
+            {
+                // Texture or Cube Texture
+                value.Type = VariantType::Object;
+                break;
+            }
+        default:
+            LOG(Warning, "Invalid Gameplay Global '{}' ({}) value type '{}' to bind to material", name, asset->GetPath(), variable.DefaultValue.Type.ToString());
+            value = Value::Zero;
+            break;
+        }
         break;
     }
     // Platform Switch

--- a/Source/Engine/Visject/ShaderGraphUtilities.cpp
+++ b/Source/Engine/Visject/ShaderGraphUtilities.cpp
@@ -7,6 +7,8 @@
 #include "Engine/Core/Types/StringBuilder.h"
 #include "Engine/Core/Math/Vector4.h"
 #include "Engine/Content/Content.h"
+#include "Engine/Content/Assets/Texture.h"
+#include "Engine/Content/Assets/CubeTexture.h"
 #include "Engine/Engine/GameplayGlobals.h"
 #include "Engine/Graphics/Config.h"
 #include "Engine/Renderer/GlobalSignDistanceFieldPass.h"
@@ -172,6 +174,26 @@ const Char* ShaderGraphUtilities::GenerateShaderResources(TextWriterUnicode& wri
         case MaterialParameterType::GPUTextureVolume:
             format = TEXT("Texture3D {0} : register(t{1});");
             break;
+        case MaterialParameterType::GameplayGlobal:
+        {
+            auto asset = Content::LoadAsync<GameplayGlobals>(param.AsGuid);
+            if (!asset || asset->WaitForLoaded())
+                break;
+            GameplayGlobals::Variable variable;
+            if (!asset->Variables.TryGet(param.Name, variable))
+                break;
+            if (Texture::GetStaticType().Fullname == variable.DefaultValue.Type.TypeName)
+            {
+                // Texture
+                format = TEXT("Texture2D {0} : register(t{1});");
+            }
+            else if (CubeTexture::GetStaticType().Fullname == variable.DefaultValue.Type.TypeName)
+            {
+                // Cube Texture
+                format = TEXT("TextureCube {0} : register(t{1});");
+            }
+            break;
+        }
         case MaterialParameterType::GlobalSDF:
             format = TEXT("Texture3D<snorm float> {0}_Tex : register(t{1});\nTexture3D<snorm float> {0}_Mip : register(t{2});");
             zeroOffset = false;

--- a/Source/FlaxEditor.Build.cs
+++ b/Source/FlaxEditor.Build.cs
@@ -71,8 +71,7 @@ public class FlaxEditor : EngineTarget
             break;
         case TargetPlatform.Mac:
             options.OutputFolder = Path.Combine(options.WorkingDirectory, "Binaries", "Editor", "Mac", options.Configuration.ToString());
-            if (EngineConfiguration.WithSDL(options))
-                options.DependencyFiles.Add(Path.Combine(Globals.EngineRoot, "Source", "Logo.png"));
+            options.DependencyFiles.Add(Path.Combine(Globals.EngineRoot, "Source", "Platforms", "Mac", "Logo.png"));
             break;
         default: throw new InvalidPlatformException(options.Platform.Target, "Not supported Editor platform.");
         }

--- a/Source/Platforms/Mac/Logo.png
+++ b/Source/Platforms/Mac/Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de813ad971bee3cffc5c0dcaffeed61ea56f97526d021e79f267db025f09414
+size 80147

--- a/Source/ThirdParty/fmt/format.h
+++ b/Source/ThirdParty/fmt/format.h
@@ -37,7 +37,6 @@
 #include <stdint.h>
 #include <limits>
 #include <initializer_list>
-#include <iterator>
 
 #include "core.h"
 
@@ -464,10 +463,12 @@ FMT_INLINE void assume(bool condition) {
 #endif
 }
 
+#if FMT_USE_ITERATOR
 // An approximation of iterator_t for pre-C++20 systems.
 template <typename T>
 using iterator_t = decltype(std::begin(std::declval<T&>()));
 template <typename T> using sentinel_t = decltype(std::end(std::declval<T&>()));
+#endif
 
 #if FMT_USE_STRING
 // A workaround for std::string not having mutable data() until C++17.
@@ -3407,6 +3408,7 @@ auto join(It begin, Sentinel end, string_view sep) -> join_view<It, Sentinel> {
   return {begin, end, sep};
 }
 
+#if FMT_USE_ITERATOR
 /**
   \rst
   Returns a view that formats `range` with elements separated by `sep`.
@@ -3428,6 +3430,7 @@ auto join(Range&& range, string_view sep)
     -> join_view<detail::iterator_t<Range>, detail::sentinel_t<Range>> {
   return join(std::begin(range), std::end(range), sep);
 }
+#endif
 
 #if FMT_USE_STRING
 /**

--- a/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
+++ b/Source/Tools/Flax.Build/Deploy/Deployment.Editor.cs
@@ -357,8 +357,7 @@ namespace Flax.Deploy
                     DeployFile(src, dst, "MoltenVK_icd.json");
                     DeployFiles(src, dst, "*.dll");
                     DeployFiles(src, dst, "*.dylib");
-                    if (EngineConfiguration.UseSDL && MacConfiguration.UseSDL)
-                        DeployFile(src, dst, "Logo.png");
+                    DeployFile(src, dst, "Logo.png");
 
                     // Optimize package size
                     Utilities.Run("strip", "FlaxEditor", null, dst, Utilities.RunOptions.None);

--- a/Source/Tools/Flax.Build/Deps/Dependencies/basis_universal.cs
+++ b/Source/Tools/Flax.Build/Deps/Dependencies/basis_universal.cs
@@ -134,6 +134,8 @@ namespace Flax.Deps.Dependencies
                     case TargetPlatform.Windows:
                     {
                         cmakeArgs = ".. -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL " + cmakeArgs;
+                        if (architecture == TargetArchitecture.ARM64)
+                            cmakeArgs += " -DBASISU_SSE=OFF";
                         RunCmake(buildDir, platform, architecture, cmakeArgs);
                         BuildCmake(buildDir, configuration, options:Utilities.RunOptions.ConsoleLogOutput);
                         CopyLib(platform, Path.Combine(buildDir, configuration), depsFolder, "basisu_encoder"); 

--- a/Source/Tools/Flax.Build/Deps/Dependencies/dbghelp.cs
+++ b/Source/Tools/Flax.Build/Deps/Dependencies/dbghelp.cs
@@ -49,6 +49,9 @@ namespace Flax.Deps.Dependencies
         }
 
         /// <inheritdoc />
+        public override bool BuildByDefault => false;
+
+        /// <inheritdoc />
         public override void Build(BuildOptions options)
         {
             foreach (var platform in options.Platforms)

--- a/Source/Tools/Flax.Build/Deps/Dependencies/glslang.cs
+++ b/Source/Tools/Flax.Build/Deps/Dependencies/glslang.cs
@@ -82,9 +82,19 @@ namespace Flax.Deps.Dependencies
             CloneGitRepoFast(root, "https://github.com/FlaxEngine/glslang.git");
 
             // Setup the external sources
-            // Requires distutils (pip install setuptools)
+            bool canRetry = true;
+            RETRY:
             if (Utilities.Run(BuildPlatform != TargetPlatform.Mac ? "python" : "python3", "update_glslang_sources.py", null, root, Utilities.RunOptions.ConsoleLogOutput) != 0)
+            {
+                if (canRetry)
+                {
+                    // Requires distutils (pip install setuptools)
+                    canRetry = false;
+                    Utilities.Run("pip", "install setuptools", null, root, Utilities.RunOptions.ConsoleLogOutput);
+                    goto RETRY;
+                }
                 throw new Exception("Failed to update glslang sources, make sure setuptools python package is installed.");
+            }
 
             foreach (var platform in options.Platforms)
             {


### PR DESCRIPTION
<img width="702" height="380" alt="image" src="https://github.com/user-attachments/assets/263712b1-f3f1-49b3-9cbc-6a15b27df3b6" />

Left Image: Original shader
Middle Image: Neural shader
Right Image: Difference amplified

Based on original sample by Nvidia
https://github.com/NVIDIA-RTX/RTXNS

New Flax Engine samples posted here
https://github.com/niko1point0/FlaxRenderSamples

===================================

No this is not DLSS 5 ai slop, this is AI accelerating the execution of graphics shader instructions, the result will look identical to the original graphics, just run faster

Results are not faster though:
Original shader: 0.047ms
Coop Vectors: 0.150ms
FP32 Vectors: 3.810ms

More research & development is needed, both in graphics hardware, drivers, shader compilers, and engine tech. This is a long-term goal

===================================

Requirments:
Vulkan SDK 1.4+
Nvidia public driver 590+
Nvidia RTX 2000+ hardware
Windows 11 in Developer Mode
Preview (unfinished) DXC compiler SM6.10
https://devblogs.microsoft.com/directx/shader-model-6-10-agilitysdk-720-preview/

Flax Engine does not support intended Vulkan Slang for Neural Shaders.
Preview DXC SM6.10 does not support SPIRV opcodes for Neural Shaders.
I had to create my own SPIRV opcode shader, for DXC to use manually.

D3D12 support requires preview Agility SDK (also unfinished).
In my testing it did not work at all. Will try again when SDK is finished.

===================================

This PR thread will be used to update progress.
Do not merge into the engine until we have proven performance boost.
