### PR TITLE
Expose Actor debug draw callbacks in game builds

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -1496,23 +1496,23 @@ void Actor::Draw(RenderContextBatch& renderContextBatch)
         Draw(renderContext);
 }
 
-#if USE_EDITOR
-
 void Actor::OnDebugDraw()
 {
+#if USE_EDITOR
     for (auto* script : Scripts)
         if (script->GetEnabled())
             script->OnDebugDraw();
+#endif
 }
 
 void Actor::OnDebugDrawSelected()
 {
+#if USE_EDITOR
     for (auto* script : Scripts)
         if (script->GetEnabled())
             script->OnDebugDrawSelected();
-}
-
 #endif
+}
 
 void Actor::ChangeScriptOrder(Script* script, int32 newIndex)
 {

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -748,7 +748,6 @@ public:
     /// <param name="renderContextBatch">The rendering context batch (eg, main view and shadow projections).</param>
     virtual void Draw(RenderContextBatch& renderContextBatch);
 
-#if USE_EDITOR
     /// <summary>
     /// Draws debug shapes for the actor and all child scripts.
     /// </summary>
@@ -758,7 +757,6 @@ public:
     /// Draws debug shapes for the selected actor and all child scripts.
     /// </summary>
     API_FUNCTION() virtual void OnDebugDrawSelected();
-#endif
 
 public:
     /// <summary>


### PR DESCRIPTION
Fixes #4138.

## Cause
`Actor.OnDebugDraw()` and `Actor.OnDebugDrawSelected()` were only declared under `USE_EDITOR`, so release game builds generated `Actor` without those virtual methods. User actors that override them then fail to compile during Release cooking with CS0115.

## Changes
- Keep the two Actor debug draw callbacks in the scripting API for game builds.
- Preserve the existing editor behavior by only forwarding to script debug draw callbacks when `USE_EDITOR` is enabled.
- Make the callbacks no-ops in non-editor native builds.

## Validation
- `git diff --check -- Source\Engine\Level\Actor.cpp Source\Engine\Level\Actor.h`
- `.\Development\Scripts\Windows\CallBuildTool.bat -build -log -dotnet=9 -arch=x64 -platform=Windows -configuration=Release -buildtargets=FlaxGame`
- Compiled a minimal `Actor` subclass overriding `OnDebugDraw()` and `OnDebugDrawSelected()` against the generated Release `FlaxEngine.CSharp.dll`.
- `.\Development\Scripts\Windows\CallBuildTool.bat -build -log -dotnet=9 -arch=x64 -platform=Windows -configuration=Development -buildtargets=FlaxTestsTarget`
- `.\Binaries\Editor\Win64\Development\FlaxTests.exe -headless`

`FlaxTests.exe -headless` passed with 377,575 assertions in 25 test cases.