### PR TITLE
Fix ProgressBar fill with large margins

### DIFF
--- a/Source/Engine/UI/GUI/Common/ProgressBar.cs
+++ b/Source/Engine/UI/GUI/Common/ProgressBar.cs
@@ -228,19 +228,27 @@ namespace FlaxEngine.GUI
             float progressNormalized = Mathf.InverseLerp(_minimum, _maximum, _current);
             if (progressNormalized > 0.001f)
             {
-                Rectangle barRect = new Rectangle(0, 0, Width * progressNormalized, Height);
+                Rectangle rect = new Rectangle(0, 0, Width, Height);
+                BarMargin.ShrinkRectangle(ref rect);
+                if (rect.Width <= 0.0f || rect.Height <= 0.0f)
+                    return;
+
+                Rectangle barRect = rect;
                 switch (Origin)
                 {
                 case BarOrigin.HorizontalLeft:
+                    barRect.Width *= progressNormalized;
                     break;
                 case BarOrigin.HorizontalRight:
-                    barRect = new Rectangle(Width - Width * progressNormalized, 0, Width * progressNormalized, Height);
+                    barRect.Width *= progressNormalized;
+                    barRect.X = rect.Right - barRect.Width;
                     break;
                 case BarOrigin.VerticalTop:
-                    barRect = new Rectangle(0, 0, Width, Height * progressNormalized);
+                    barRect.Height *= progressNormalized;
                     break;
                 case BarOrigin.VerticalBottom:
-                    barRect = new Rectangle(0, Height - Height * progressNormalized, Width, Height * progressNormalized);
+                    barRect.Height *= progressNormalized;
+                    barRect.Y = rect.Bottom - barRect.Height;
                     break;
                 default: break;
                 }
@@ -248,15 +256,12 @@ namespace FlaxEngine.GUI
                 switch (Method)
                 {
                 case BarMethod.Stretch:
-                    BarMargin.ShrinkRectangle(ref barRect);
                     if (BarBrush != null)
                         BarBrush.Draw(barRect, BarColor);
                     else
                         Render2D.FillRectangle(barRect, BarColor);
                     break;
                 case BarMethod.Clip:
-                    var rect = new Rectangle(0, 0, Width, Height);
-                    BarMargin.ShrinkRectangle(ref rect);
                     Render2D.PushClip(ref barRect);
                     if (BarBrush != null)
                         BarBrush.Draw(rect, BarColor);


### PR DESCRIPTION
Fixes #4076.

## Cause
ProgressBar applied BarMargin after scaling the bar rectangle by progress. When progress was low and the scaled rectangle was smaller than the horizontal or vertical margins, ShrinkRectangle produced a negative size, making the fill appear to move backwards.

## Changes
- Apply BarMargin to the full control bounds before calculating progress fill.
- Scale and clip within the inner bar area.
- Skip drawing if margins leave no drawable area.

## Validation
- `git diff --check -- Source\\Engine\\UI\\GUI\\Common\\ProgressBar.cs`
- Numeric check for width 100 / margin 10 showing old widths go negative and new widths stay positive.
- `.\\Development\\Scripts\\Windows\\CallBuildTool.bat -build -log -dotnet=9 -arch=x64 -platform=Windows -configuration=Development -buildtargets=FlaxEditor`
- `.\\Development\\Scripts\\Windows\\CallBuildTool.bat -build -log -dotnet=9 -arch=x64 -platform=Windows -configuration=Development -buildtargets=FlaxTestsTarget`
- `.\\Binaries\\Editor\\Win64\\Development\\FlaxTests.exe -headless`

`FlaxTests.exe -headless` passed with 377,575 assertions in 25 test cases.