### PR TITLE
Fix model material access with empty entries

### DIFF
--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -1317,8 +1317,8 @@ MaterialBase* AnimatedModel::GetMaterial(int32 entryIndex)
         SkinnedModel->WaitForLoaded();
     else
         return nullptr;
-    CHECK_RETURN(entryIndex >= 0 && entryIndex < Entries.Count(), nullptr);
-    MaterialBase* material = Entries[entryIndex].Material.Get();
+    CHECK_RETURN(entryIndex >= 0 && entryIndex < SkinnedModel->MaterialSlots.Count(), nullptr);
+    MaterialBase* material = entryIndex < Entries.Count() ? Entries[entryIndex].Material.Get() : nullptr;
     if (!material)
     {
         material = SkinnedModel->MaterialSlots[entryIndex].Material.Get();

--- a/Source/Engine/Level/Actors/ModelInstanceActor.cpp
+++ b/Source/Engine/Level/Actors/ModelInstanceActor.cpp
@@ -39,6 +39,9 @@ void ModelInstanceActor::SetMaterial(int32 entryIndex, MaterialBase* material)
     WaitForModelLoad();
     if (Entries.Count() == 0 && !material)
         return;
+    const int32 slotsCount = GetMaterialSlots().Length();
+    if (Entries.Count() != slotsCount)
+        Entries.Setup(slotsCount);
     CHECK(entryIndex >= 0 && entryIndex < Entries.Count());
     if (Entries[entryIndex].Material == material)
         return;
@@ -50,6 +53,10 @@ void ModelInstanceActor::SetMaterial(int32 entryIndex, MaterialBase* material)
 MaterialInstance* ModelInstanceActor::CreateAndSetVirtualMaterialInstance(int32 entryIndex)
 {
     WaitForModelLoad();
+    const int32 slotsCount = GetMaterialSlots().Length();
+    CHECK_RETURN(entryIndex >= 0 && entryIndex < slotsCount, nullptr);
+    if (Entries.Count() != slotsCount)
+        Entries.Setup(slotsCount);
     MaterialBase* material = GetMaterial(entryIndex);
     CHECK_RETURN(material && !material->WaitForLoaded(), nullptr);
     MaterialInstance* result = material->CreateVirtualInstance();

--- a/Source/Engine/Level/Actors/SplineModel.cpp
+++ b/Source/Engine/Level/Actors/SplineModel.cpp
@@ -356,8 +356,8 @@ MaterialBase* SplineModel::GetMaterial(int32 entryIndex)
         Model->WaitForLoaded();
     else
         return nullptr;
-    CHECK_RETURN(entryIndex >= 0 && entryIndex < Entries.Count(), nullptr);
-    MaterialBase* material = Entries[entryIndex].Material.Get();
+    CHECK_RETURN(entryIndex >= 0 && entryIndex < Model->MaterialSlots.Count(), nullptr);
+    MaterialBase* material = entryIndex < Entries.Count() ? Entries[entryIndex].Material.Get() : nullptr;
     if (!material)
     {
         material = Model->MaterialSlots[entryIndex].Material.Get();

--- a/Source/Engine/Level/Actors/StaticModel.cpp
+++ b/Source/Engine/Level/Actors/StaticModel.cpp
@@ -128,7 +128,7 @@ MaterialBase* StaticModel::GetMaterial(int32 meshIndex, int32 lodIndex) const
         Math::IsInRange(meshIndex, 0, model->LODs[lodIndex].Meshes.Count()));
     const auto& mesh = model->LODs[lodIndex].Meshes[meshIndex];
     const auto materialSlotIndex = mesh.GetMaterialSlotIndex();
-    MaterialBase* material = Entries[materialSlotIndex].Material.Get();
+    MaterialBase* material = materialSlotIndex < Entries.Count() ? Entries[materialSlotIndex].Material.Get() : nullptr;
     return material ? material : model->MaterialSlots[materialSlotIndex].Material.Get();
 }
 
@@ -586,9 +586,9 @@ MaterialBase* StaticModel::GetMaterial(int32 entryIndex)
 {
     if (!Model || Model->WaitForLoaded())
         return nullptr;
-    CHECK_RETURN(entryIndex >= 0 && entryIndex < Entries.Count(), nullptr);
-    MaterialBase* material = Entries[entryIndex].Material.Get();
-    if (!material && entryIndex < Model->MaterialSlots.Count())
+    CHECK_RETURN(entryIndex >= 0 && entryIndex < Model->MaterialSlots.Count(), nullptr);
+    MaterialBase* material = entryIndex < Entries.Count() ? Entries[entryIndex].Material.Get() : nullptr;
+    if (!material)
     {
         material = Model->MaterialSlots[entryIndex].Material.Get();
         if (!material)


### PR DESCRIPTION
Fixes #3801.

## Cause
Model instance material APIs assumed `Entries` was already initialized to match the model material slots. Newly imported prefab model instances can have valid asset material slots while their per-instance `Entries` array is still empty, so `GetMaterial(0)` and `SetMaterial(0, material)` could assert before the prefab was saved once.

## Changes
- Let `StaticModel`, `AnimatedModel`, and `SplineModel` material getters fall back to asset material slots when `Entries` is missing an override entry.
- Lazily initialize `Entries` from material slots before writing material overrides.
- Apply the same initialization before creating virtual material instances.

## Validation
- `git diff --check -- Source\\Engine\\Level\\Actors\\ModelInstanceActor.cpp Source\\Engine\\Level\\Actors\\StaticModel.cpp Source\\Engine\\Level\\Actors\\AnimatedModel.cpp Source\\Engine\\Level\\Actors\\SplineModel.cpp`
- `.\\Development\\Scripts\\Windows\\CallBuildTool.bat -build -log -dotnet=9 -arch=x64 -platform=Windows -configuration=Development -buildtargets=FlaxEditor`
- `.\\Development\\Scripts\\Windows\\CallBuildTool.bat -build -log -dotnet=9 -arch=x64 -platform=Windows -configuration=Development -buildtargets=FlaxTestsTarget`
- `.\\Binaries\\Editor\\Win64\\Development\\FlaxTests.exe -headless`

`FlaxTests.exe -headless` passed with 377,575 assertions in 25 test cases.