### PR TITLE
Adds editor option for default prefabe folder

### DIFF
--- a/Source/Editor/Modules/PrefabsModule.cs
+++ b/Source/Editor/Modules/PrefabsModule.cs
@@ -50,6 +50,9 @@ namespace FlaxEditor.Modules
         /// </remarks>
         public void CreatePrefab()
         {
+            var folder = GetDefaultPrefabFolder();
+            if (folder != null)
+                Editor.Windows.ContentWin.Navigate(folder.Node);
             CreatePrefab(Editor.SceneEditing.Selection);
         }
 
@@ -103,6 +106,19 @@ namespace FlaxEditor.Modules
 
             var proxy = Editor.ContentDatabase.GetProxy<Prefab>();
             Editor.Windows.ContentWin.NewItem(proxy, actor, contentItem => OnPrefabCreated(contentItem, actor, prefabWindow), actor.Name, rename);
+        }
+
+        internal ContentFolder GetDefaultPrefabFolder()
+        {
+            var relativePath = Editor.Options.Options.Interface.DefaultPrefabFolder;
+            if (string.IsNullOrWhiteSpace(relativePath))
+                return null;
+
+            var absolutePath = StringUtils.ConvertRelativePathToAbsolute(Globals.ProjectContentFolder,
+                                                                         StringUtils.NormalizePath(relativePath));
+            return Editor.ContentDatabase.Find(absolutePath) is ContentFolder folder && folder.CanHaveAssets
+                   ? folder
+                   : null;
         }
 
         /// <summary>

--- a/Source/Editor/Modules/PrefabsModule.cs
+++ b/Source/Editor/Modules/PrefabsModule.cs
@@ -50,9 +50,6 @@ namespace FlaxEditor.Modules
         /// </remarks>
         public void CreatePrefab()
         {
-            var folder = GetDefaultPrefabFolder();
-            if (folder != null)
-                Editor.Windows.ContentWin.Navigate(folder.Node);
             CreatePrefab(Editor.SceneEditing.Selection);
         }
 
@@ -70,6 +67,9 @@ namespace FlaxEditor.Modules
                 selection = Editor.SceneEditing.Selection;
             if (selection.Count == 1 && selection[0] is ActorNode actorNode && actorNode.CanCreatePrefab)
             {
+                var folder = GetDefaultPrefabFolder();
+                if (folder != null)
+                    Editor.Windows.ContentWin.Navigate(folder.Node);
                 CreatePrefab(actorNode.Actor, true, prefabWindow);
             }
         }

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -313,6 +313,14 @@ namespace FlaxEditor.Options
         [EditorDisplay("Interface"), EditorOrder(322)]
         public bool ScrollToScriptOnAdd { get; set; } = true;
 
+        /// <summary>
+        /// If set, prefabs created from the scene tree are placed in this folder instead of the current content folder.
+        /// (Relative to the project's Content folder)
+        /// </summary>
+        [DefaultValue(null)]
+        [EditorDisplay("Interface"), EditorOrder(323)]
+        public string DefaultPrefabFolder { get; set; }
+
 #if PLATFORM_SDL || PLATFORM_MAC
         /// <summary>
         /// Gets or sets a value indicating whether use native window title bar decorations in child windows. Editor restart required.

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -320,10 +320,13 @@ namespace FlaxEditor.Windows.Assets
 
             contextMenu.AddSeparator();
 
+            // Skip if we cannot create assets in the given location
+            // Or DefaultPrefabFolder setting is invalid
             b = contextMenu.AddButton("Create Prefab", () => Editor.Prefabs.CreatePrefab(Selection, this));
             b.Enabled = isSingleActorSelected &&
                         (Selection[0] as ActorNode).CanCreatePrefab &&
-                        Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets;
+                        (Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets 
+                            || Editor.Prefabs.GetDefaultPrefabFolder() != null);
 
             b = contextMenu.AddButton("Select Prefab", Editor.Prefabs.SelectPrefab);
             b.Enabled = hasPrefabLink;

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -139,7 +139,7 @@ namespace FlaxEditor.Windows
 
             b = contextMenu.AddButton("Create Prefab", Editor.Prefabs.CreatePrefab);
             // Skip if we cannot create assets in the given location
-            // Or DefualtPrefabFolder setting is invalid
+            // Or DefaultPrefabFolder setting is invalid
             b.Enabled = isSingleActorSelected &&
                         (firstSelection != null ? firstSelection.CanCreatePrefab : false) &&
                         (Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -138,9 +138,12 @@ namespace FlaxEditor.Windows
             b.Enabled = canEditScene && hasSthSelected && firstSelection?.Actor is not Scene;
 
             b = contextMenu.AddButton("Create Prefab", Editor.Prefabs.CreatePrefab);
+            // Skip if we cannot create assets in the given location
+            // Or DefualtPrefabFolder setting is invalid
             b.Enabled = isSingleActorSelected &&
                         (firstSelection != null ? firstSelection.CanCreatePrefab : false) &&
-                        Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets;
+                        (Editor.Windows.ContentWin.CurrentViewFolder.CanHaveAssets
+                            || Editor.Prefabs.GetDefaultPrefabFolder() != null);
 
             bool hasPrefabLink = canEditScene && isSingleActorSelected && (firstSelection != null ? firstSelection.HasPrefabLink : false);
             if (hasPrefabLink)


### PR DESCRIPTION
## Problem

Creating a prefab from the scene tree's or prefabs tree's "Create Prefab" context menu always places the new asset in the currently viewed content folder. Projects that keep prefabs in a dedicated folder have to manually navigate the Content window there first every time, or move the asset afterwards.

## Solution

Add a `Default Prefab Folder` editor option. When set, prefabs created from the scene tree or prefab tree are placed in that folder instead of the current one.

- Add `DefaultPrefabFolder` to `InterfaceOptions` a path relative to the project's `Content` folder (e.g. `Prefabs` or `Characters/Enemies`). Empty by default, which preserves the existing "use current folder" behavior.

- Add `PrefabsModule.GetDefaultPrefabFolder()` which resolves the option to a valid `ContentFolder`, or `null` when unset or not a usable content folder.

- `PrefabsModule.CreatePrefab(List<SceneGraphNode> selection, Window.Assets.PrefabWindow prefabWindow = null)` navigates the Content window to that folder before creating, when configured. Dragging an actor into a content folder is unchanged.

- Update the scene tree and prefab window "Create Prefab" enabled check to also accept a valid configured folder, so the action isn't disabled just because the current view folder can't hold assets.

## Usage

`Editor Options -> Interface -> Default Prefab Folder`. Leave empty for the previous behavior.

Willing to move this somewhere else y'all think is more appropriate

<img width="1404" height="618" alt="image" src="https://github.com/user-attachments/assets/0cfcd8b0-4220-4472-9c01-f5e746bb3b67" />


## Testing

- Built the editor (Linux x64, Development).

- With the option empty: (unchanged behavior).
Prefab creation places the asset in the current folder
The "Create Prefab" button still enables/disables based on the current folder.

- With the option set to a valid content folder: 
Creating a prefab from the scene tree and prefab window places it there regardless of the current view folder. 
The "Create Prefab" button is enabled regardless of current view folder.

- With an invalid/non-existent path: falls back to the current folder
The "Create Prefab" button still enables/disables based on the current folder.

- Drag actor from scene tree and prefab window to content browser still creates prefab in the dragged to folder