### PR TITLE
Adds auto-rename newly added Visject parameters

### DIFF
--- a/Source/Editor/Surface/VisjectSurfaceWindow.cs
+++ b/Source/Editor/Surface/VisjectSurfaceWindow.cs
@@ -43,6 +43,12 @@ namespace FlaxEditor.Surface
         IEnumerable<ScriptType> NewParameterTypes { get; }
 
         /// <summary>
+        /// Index of the parameter to start renaming once the properties panel is next rebuilt, or -1 if none.
+        /// Used to auto-start renaming of a freshly added parameter.
+        /// </summary>
+        int ParamToRename { get; set; }
+
+        /// <summary>
         /// Event called when surface gets loaded (eg. after opening the window).
         /// </summary>
         event Action SurfaceLoaded;
@@ -589,6 +595,7 @@ namespace FlaxEditor.Surface
             if (Utilities.Utils.OnAssetProperties(layout, asset))
                 return;
             var parameters = window.VisjectSurface.Parameters;
+            ParameterPropertyNameLabel labelToRename = null;
             CustomEditors.Editors.GenericEditor.OnGroupsBegin();
             for (int i = 0; i < parameters.Count; i++)
             {
@@ -643,6 +650,8 @@ namespace FlaxEditor.Surface
                     tooltipText += '\n' + tooltip.Text;
                 propertyLabel.MouseLeftDoubleClick += (label, location) => StartParameterRenaming(pIndex, label);
                 propertyLabel.SetupContextMenu += OnPropertyLabelSetupContextMenu;
+                if (pIndex == window.ParamToRename)
+                    labelToRename = propertyLabel;
                 var property = itemLayout.AddPropertyItem(propertyLabel, tooltipText);
                 property.Property("Value", propertyValue);
             }
@@ -656,6 +665,21 @@ namespace FlaxEditor.Surface
                 var newParam = layout.Button("Add parameter...");
                 newParam.Button.ButtonClicked += OnAddParameterButtonClicked;
                 layout.Space(10);
+            }
+            // Defer renaming a newly added param once its label is built and laid out
+            // Adding a param can rebuild the panel more than once (disposing earlier labels) 
+            // Because of this every rebuild recaptures the current label, only the surviving one actually calls StartParameterRenaming
+            if (labelToRename != null)
+            {
+                var index = window.ParamToRename;
+                var label = labelToRename;
+                FlaxEngine.Scripting.InvokeOnUpdate(() =>
+                {
+                    if (label.IsDisposing)
+                        return; // A latter rebuild replaced this label, its own callback will handle it
+                    window.ParamToRename = -1;
+                    StartParameterRenaming(index, label);
+                });
             }
         }
 
@@ -695,6 +719,7 @@ namespace FlaxEditor.Surface
             };
             window.VisjectSurface.Undo.AddAction(action);
             action.Do();
+            window.ParamToRename = action.Index;
         }
 
         private DragData OnDragParameter(DraggablePropertyNameLabel label)
@@ -1275,6 +1300,9 @@ namespace FlaxEditor.Surface
 
         /// <inheritdoc />
         public abstract IEnumerable<ScriptType> NewParameterTypes { get; }
+
+        /// <inheritdoc />
+        public int ParamToRename { get; set; } = -1;
 
         /// <inheritdoc />
         public event Action SurfaceLoaded;

--- a/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
+++ b/Source/Editor/Windows/Assets/BehaviorTreeWindow.cs
@@ -603,6 +603,9 @@ namespace FlaxEditor.Windows.Assets
         public IEnumerable<ScriptType> NewParameterTypes => Editor.CodeEditing.VisualScriptPropertyTypes.Get();
 
         /// <inheritdoc />
+        public int ParamToRename { get; set; } = -1;
+
+        /// <inheritdoc />
         public event Action SurfaceLoaded;
 
         /// <inheritdoc />

--- a/Source/Editor/Windows/Assets/VisualScriptWindow.cs
+++ b/Source/Editor/Windows/Assets/VisualScriptWindow.cs
@@ -1399,6 +1399,9 @@ namespace FlaxEditor.Windows.Assets
         public IEnumerable<ScriptType> NewParameterTypes => Editor.CodeEditing.VisualScriptPropertyTypes.Get();
 
         /// <inheritdoc />
+        public int ParamToRename { get; set; } = -1;
+
+        /// <inheritdoc />
         public event Action SurfaceLoaded;
 
         /// <inheritdoc />


### PR DESCRIPTION
# Problem
Closes #4127
"[Request]: Allow renaming parameters immediatly after adding them"
See that post for more info.

# Solution
Adding a parameter in a Visject surface editor now starts renaming it right away, this is consistent with creating items in the Content panel.
Previously you had to double click the new "New parameter" to rename it every time.

@xxSeys1 tried to set the the `StartParameterRenaming(index, label);` right after the param was added to the surface.
However the UI label only exists after the panel rebuilds itself.
Because of this I had to add the following
- Added `ParamToRename` member variable to `IVisjectSurfaceWindow`
- `OnAddParameterItemClicked` records the new parameter's index
- `ParametersEditor.Initialize` captures the matching label as it rebuilds then defers `StartParameterRenaming` until the panel UI is completed its rebuilding (by bailing out if IsDisposing is true so only the surviving label actually starts renaming)

# Testing
The following testing was done on a Material, Particle Emitter, and a Visual Script
I tried to test a Behavior Tree but I don't know how they work and didn't see a way to create params on them
- Built the editor (Linux x64, Development).
1. Opened Material, Particle Emitter, and a Visual Script
2. Clicked "Add parameter" and picked a type
3. Confirmed the new parameter immediately enters the renaming mode 
4. Typed and new name and hit enter
- Repeated steps 2-4 two more times