### PR TITLE
Adds debug draw point

### DIFF
--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -1526,6 +1526,45 @@ void DebugDraw::DrawCircle(const Vector3& position, const Float3& normal, float 
     }
 }
 
+void DebugDraw::DrawPoint(const Vector3& position, float radius, const Color& color, float duration, bool depthTest)
+{
+    Float3 normal = (Float3)(Context->LastViewPosition - position);
+    if (normal.Length() < ZeroTolerance)
+        normal = Float3::Up;
+    normal.Normalize();
+    
+    // Create matrix transform for unit circle points
+    Matrix world, scale, matrix;
+    Float3 right, up;
+    if (Float3::Dot(normal, Float3::Up) > 0.99f)
+        right = Float3::Right;
+    else if (Float3::Dot(normal, Float3::Down) > 0.99f)
+        right = Float3::Left;
+    else
+        Float3::Cross(normal, Float3::Up, right);
+    Float3::Cross(right, normal, up);
+    Matrix::Scaling(radius, scale);
+    const Float3 positionF = position - Context->Origin;
+    Matrix::CreateWorld(positionF, normal, up, world);
+    Matrix::Multiply(scale, world, matrix);
+
+    // Draw lines of the unit circle after linear transform
+    PROFILE_MEM(EngineDebug);
+    Float3 prev = Float3::Transform(CircleCache[0], matrix);
+    for (int32 i = 1; i < DEBUG_DRAW_CIRCLE_VERTICES;)
+    {
+        Float3 cur = Float3::Transform(CircleCache[i++], matrix);
+        DebugTriangle t;
+        t.Color = Color32(color);
+        t.TimeLeft = duration;
+        t.V0 = positionF;
+        t.V1 = prev;
+        t.V2 = cur;
+        (depthTest ? Context->DebugDrawDepthTest : Context->DebugDrawDefault).Add(t);
+        prev = cur;
+    }
+}
+
 void DebugDraw::DrawWireTriangle(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Color& color, float duration, bool depthTest)
 {
     DrawLine(v0, v1, color, duration, depthTest);

--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -1550,18 +1550,15 @@ void DebugDraw::DrawPoint(const Vector3& position, float radius, const Color& co
 
     // Build a filled disc as a triangle fan from the center over the transformed unit circle points
     PROFILE_MEM(EngineDebug);
-    Float3 prev = Float3::Transform(CircleCache[0], matrix);
-    for (int32 i = 1; i < DEBUG_DRAW_CIRCLE_VERTICES;)
+    for (int32 i = 0; i < DEBUG_DRAW_CIRCLE_VERTICES; i += 2)
     {
-        Float3 cur = Float3::Transform(CircleCache[i++], matrix);
         DebugTriangle t;
         t.Color = Color32(color);
         t.TimeLeft = duration;
         t.V0 = positionF;
-        t.V1 = prev;
-        t.V2 = cur;
+        t.V1 = Float3::Transform(CircleCache[i], matrix);
+        t.V2 = Float3::Transform(CircleCache[i + 1], matrix);
         (depthTest ? Context->DebugDrawDepthTest : Context->DebugDrawDefault).Add(t);
-        prev = cur;
     }
 }
 

--- a/Source/Engine/Debug/DebugDraw.cpp
+++ b/Source/Engine/Debug/DebugDraw.cpp
@@ -1548,7 +1548,7 @@ void DebugDraw::DrawPoint(const Vector3& position, float radius, const Color& co
     Matrix::CreateWorld(positionF, normal, up, world);
     Matrix::Multiply(scale, world, matrix);
 
-    // Draw lines of the unit circle after linear transform
+    // Build a filled disc as a triangle fan from the center over the transformed unit circle points
     PROFILE_MEM(EngineDebug);
     Float3 prev = Float3::Transform(CircleCache[0], matrix);
     for (int32 i = 1; i < DEBUG_DRAW_CIRCLE_VERTICES;)

--- a/Source/Engine/Debug/DebugDraw.h
+++ b/Source/Engine/Debug/DebugDraw.h
@@ -267,6 +267,16 @@ API_CLASS(Static) class FLAXENGINE_API DebugDraw
     /// <param name="duration">The duration (in seconds). Use 0 to draw it only once.</param>
     /// <param name="depthTest">If set to <c>true</c> depth test will be performed, otherwise depth will be ignored.</param>
     API_FUNCTION() static void DrawCircle(const Vector3& position, const Float3& normal, float radius, const Color& color = Color::White, float duration = 0.0f, bool depthTest = true);
+    
+    /// <summary>
+    /// Draws the point facing camera.
+    /// </summary>
+    /// <param name="position">The center position.</param>
+    /// <param name="radius">The radius.</param>
+    /// <param name="color">The color.</param>
+    /// <param name="duration">The duration (in seconds). Use 0 to draw it only once.</param>
+    /// <param name="depthTest">If set to <c>true</c> depth test will be performed, otherwise depth will be ignored.</param>
+    API_FUNCTION() static void DrawPoint(const Vector3& position, float radius, const Color& color = Color::White, float duration = 0.0f, bool depthTest = true);
 
     /// <summary>
     /// Draws the wireframe triangle.
@@ -780,6 +790,7 @@ API_CLASS(Static) class FLAXENGINE_API DebugDraw
 #define DEBUG_DRAW_LINES(lines, transform, color, duration, depthTest)                                      DebugDraw::DrawLines(lines, transform, color, duration, depthTest)
 #define DEBUG_DRAW_BEZIER(p1, p2, p3, p4, color, duration, depthTest)                                       DebugDraw::DrawBezier(p1, p2, p3, p4, color, duration, depthTest)
 #define DEBUG_DRAW_CIRCLE(position, normal, radius, color, duration, depthTest)                             DebugDraw::DrawCircle(position, normal, radius, color, duration, depthTest)
+#define DEBUG_DRAW_POINT(position, radius, color, duration, depthTest)                                      DebugDraw::DrawPoint(position, radius, color, duration, depthTest)
 #define DEBUG_DRAW_TRIANGLE(v0, v1, v2, color, duration, depthTest)                                         DebugDraw::DrawTriangle(v0, v1, v2, color, duration, depthTest)
 #define DEBUG_DRAW_TRIANGLES(vertices, color, duration, depthTest)                                          DebugDraw::DrawTriangles(vertices, color, duration, depthTest)
 #define DEBUG_DRAW_TRIANGLES_EX(vertices, indices, color, duration, depthTest)                              DebugDraw::DrawTriangles(vertices, indices, color, duration, depthTest)


### PR DESCRIPTION
## Problem
closes https://github.com/FlaxEngine/FlaxEngine/issues/4133
"[Request]: DebugDraw.DrawPoint() method to draw a point in 3D space"
See that post for more info.

## Solution
Copies `DebugDraw::DrawCircle` 
Removes normal param and uses a normal calculated from the cameras `LastViewPosition`
Builds a filled disc as a triangle fan from the center over the transformed unit circle points

## Testing
- Built the editor (Linux x64, Development).
- Edited cpp scipt in one of my projects to use both the `Debug::DrawPoint` and macro `DEBUG_DRAW_POINT`
```cpp
DebugDraw::DrawPoint(TurretBase->GetPosition(), 15.f, Color::Red, 0, false);
DEBUG_DRAW_POINT(TurretBase->GetPosition() + (Vector3::Up * 20.f), 25.f, Color::Green, 0.1f, true);
```
- Used multiple colors, radiuses, durations, and depth option
- Confirmed the rendering looked correct from all angels.

<img width="988" height="700" alt="image" src="https://github.com/user-attachments/assets/6226146e-27ae-458d-98a2-17310208b546" />

