### PR TITLE
Adds Brightness, ResolusionScale, DebugView, and LayerMask to viewport persistence

### DIFF
--- a/Source/Editor/Options/ViewportOptions.cs
+++ b/Source/Editor/Options/ViewportOptions.cs
@@ -136,6 +136,13 @@ namespace FlaxEditor.Options
         [DefaultValue(50.0f), Limit(25.0f, 500.0f, 5.0f)]
         [EditorDisplay("Defaults"), EditorOrder(220), Tooltip("The default editor viewport grid scale.")]
         public float ViewportGridScale { get; set; } = 50.0f;
+        
+        /// <summary>
+        /// Gets or sets the use persistence over defaults setting
+        /// </summary>
+        [DefaultValue(true)]
+        [EditorDisplay("Defaults"), EditorOrder(230), Tooltip("Allow persistence setting from last session to override default settings")]
+        public bool UsePersistenceOverDefaults { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the view distance you can see the grid.

--- a/Source/Editor/Windows/EditGameWindow.cs
+++ b/Source/Editor/Windows/EditGameWindow.cs
@@ -450,6 +450,9 @@ namespace FlaxEditor.Windows
         /// <inheritdoc />
         public override void OnLayoutDeserialize(XmlElement node)
         {
+            if (!Editor.Options.Options.Viewport.UsePersistenceOverDefaults)
+                return;
+            
             if (bool.TryParse(node.GetAttribute("GridEnabled"), out bool value1))
                 Viewport.Grid.Enabled = value1;
             if (bool.TryParse(node.GetAttribute("ShowFpsCounter"), out value1))

--- a/Source/Editor/Windows/EditGameWindow.cs
+++ b/Source/Editor/Windows/EditGameWindow.cs
@@ -433,14 +433,18 @@ namespace FlaxEditor.Windows
             writer.WriteAttributeString("GridEnabled", Viewport.Grid.Enabled.ToString());
             writer.WriteAttributeString("ShowFpsCounter", Viewport.ShowFpsCounter.ToString());
             writer.WriteAttributeString("ShowNavigation", Viewport.ShowNavigation.ToString());
+            writer.WriteAttributeString("UseOrthographicProjection", Viewport.UseOrthographicProjection.ToString());
             writer.WriteAttributeString("NearPlane", Viewport.NearPlane.ToString());
             writer.WriteAttributeString("FarPlane", Viewport.FarPlane.ToString());
             writer.WriteAttributeString("FieldOfView", Viewport.FieldOfView.ToString());
             writer.WriteAttributeString("MovementSpeed", Viewport.MovementSpeed.ToString());
+            writer.WriteAttributeString("Brightness", Viewport.Brightness.ToString());
             writer.WriteAttributeString("ViewportIconsScale", ViewportIconsRenderer.Scale.ToString());
+            writer.WriteAttributeString("ResolutionScale", Viewport.ResolutionScale.ToString());
             writer.WriteAttributeString("OrthographicScale", Viewport.OrthographicScale.ToString());
-            writer.WriteAttributeString("UseOrthographicProjection", Viewport.UseOrthographicProjection.ToString());
             writer.WriteAttributeString("ViewFlags", ((ulong)Viewport.Task.View.Flags).ToString());
+            writer.WriteAttributeString("DebugView", ((int)Viewport.Task.ViewMode).ToString());
+            writer.WriteAttributeString("LayerMask", Viewport.Task.ViewLayersMask.Mask.ToString());
         }
 
         /// <inheritdoc />
@@ -452,6 +456,8 @@ namespace FlaxEditor.Windows
                 Viewport.ShowFpsCounter = value1;
             if (bool.TryParse(node.GetAttribute("ShowNavigation"), out value1))
                 Viewport.ShowNavigation = value1;
+            if (bool.TryParse(node.GetAttribute("UseOrthographicProjection"), out value1))
+                Viewport.UseOrthographicProjection = value1;
             if (float.TryParse(node.GetAttribute("NearPlane"), out float value2))
                 Viewport.NearPlane = value2;
             if (float.TryParse(node.GetAttribute("FarPlane"), out value2))
@@ -460,18 +466,28 @@ namespace FlaxEditor.Windows
                 Viewport.FieldOfView = value2;
             if (float.TryParse(node.GetAttribute("MovementSpeed"), out value2))
                 Viewport.MovementSpeed = value2;
+            if (float.TryParse(node.GetAttribute("Brightness"), out value2))
+                Viewport.Brightness = value2;
+            if (float.TryParse(node.GetAttribute("ResolutionScale"), out value2))
+                Viewport.ResolutionScale = value2;
             if (float.TryParse(node.GetAttribute("ViewportIconsScale"), out value2))
                 ViewportIconsRenderer.Scale = value2;
             if (float.TryParse(node.GetAttribute("OrthographicScale"), out value2))
                 Viewport.OrthographicScale = value2;
-            if (bool.TryParse(node.GetAttribute("UseOrthographicProjection"), out value1))
-                Viewport.UseOrthographicProjection = value1;
             if (ulong.TryParse(node.GetAttribute("ViewFlags"), out ulong value3))
                 Viewport.Task.ViewFlags = (ViewFlags)value3;
-
-            // Reset view flags if opening with different engine version (ViewFlags enum could be modified)
+            if (int.TryParse(node.GetAttribute("DebugView"), out int value4))
+                Viewport.Task.ViewMode = (ViewMode)value4;
+            if (uint.TryParse(node.GetAttribute("LayerMask"), out uint value5))
+                Viewport.Task.ViewLayersMask = new LayersMask(value5);
+            
+            // Reset view flags and view mode if opening with different engine version
+            // (ViewFlags and ViewMode enums could be modified)
             if (Editor.LastProjectOpenedEngineBuild != Globals.EngineBuildNumber)
+            {
                 Viewport.Task.ViewFlags = ViewFlags.DefaultEditor;
+                Viewport.Task.ViewMode = ViewMode.Default;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Problem
Closes #2932 
Viewport editor remembers some but not all settings between launches
Additionally, the default values are not used if any viewport setting has been changed in a previous session

## Solution
Adds Adds `Brightness`, `ResolusionScale`, `DebugView`, and `LayerMask` to viewport persistence
Also adds option in the viewport options to disable persistence settings on the view editor and always use defaults (Option default value is `true` to be consistent with how it worked before)

## Testing
- Built the editor (Linux x64, Development).
- Changed  `Brightness`, `ResolusionScale`, `DebugView`, and `LayerMask` in viewport
- Took screenshot of state <img width="1568" height="900" alt="image" src="https://github.com/user-attachments/assets/60681af6-9337-4990-95f3-3d2d2d65e123" />
- Restarted the editor and reloaded the project
- Confirmed all settings stayed the same between session <img width="1574" height="1046" alt="image" src="https://github.com/user-attachments/assets/cf1f6637-e1c1-4f6a-81d3-eaa2136631a7" />
- Toggled the new `Viewport` -> `Defaults` -> `Use Persistence Over Defaults` to false
- Reloaded the project and confirmed viewport settings used all the default options <img width="1572" height="1064" alt="image" src="https://github.com/user-attachments/assets/067e5e24-4787-4cfd-a793-6f827e0cfc7f" />
