### PR TITLE
Fix floating editor window ordering and focus restoration

### DIFF
--- a/Source/Engine/Platform/Mac/MacWindow.cpp
+++ b/Source/Engine/Platform/Mac/MacWindow.cpp
@@ -39,6 +39,62 @@ inline bool IsWindowInvalid(Window* win)
     return !hasWindow || !win;
 }
 
+inline Window* GetEngineWindow(NSWindow* nativeWindow)
+{
+    WindowsManager::WindowsLocker.Lock();
+    for (auto* window : WindowsManager::Windows)
+    {
+        if (window && window->GetNativePtr() == nativeWindow)
+        {
+            WindowsManager::WindowsLocker.Unlock();
+            return window;
+        }
+    }
+    WindowsManager::WindowsLocker.Unlock();
+    return nullptr;
+}
+
+inline bool ShouldAttachToParent(const CreateWindowSettings& settings)
+{
+    // Cocoa child windows inherit parent z-order and minimize behavior.
+    // Minimizable regular windows need independent top-level window semantics.
+    return settings.Parent && (settings.Type != WindowType::Regular || !settings.AllowMinimize);
+}
+
+inline bool CanMakeKeyWindow(NSWindow* window)
+{
+    return window && [window isVisible] && ![window isMiniaturized] && [window canBecomeKeyWindow];
+}
+
+inline bool IsRegularWindowWithParent(Window* window, Window* parent)
+{
+    return window &&
+           !window->IsClosed() &&
+           window->GetSettings().Type == WindowType::Regular &&
+           window->GetSettings().Parent == parent;
+}
+
+inline void MakeNextParentedWindowKey(NSWindow* hiddenWindow, Window* fallbackParent)
+{
+    if (!fallbackParent || IsWindowInvalid(fallbackParent))
+        return;
+
+    for (NSWindow* candidate in [NSApp orderedWindows])
+    {
+        if (candidate == hiddenWindow || !CanMakeKeyWindow(candidate))
+            continue;
+        Window* candidateWindow = GetEngineWindow(candidate);
+        if (!IsRegularWindowWithParent(candidateWindow, fallbackParent))
+            continue;
+        [candidate makeKeyAndOrderFront:nil];
+        return;
+    }
+
+    NSWindow* parent = (NSWindow*)fallbackParent->GetNativePtr();
+    if (parent != hiddenWindow && CanMakeKeyWindow(parent))
+        [parent makeKeyAndOrderFront:nil];
+}
+
 KeyboardKeys GetKey(NSEvent* event)
 {
     switch ([event keyCode])
@@ -963,7 +1019,7 @@ void MacWindow::Show()
 
         // Show
         NSWindow* window = (NSWindow*)_window;
-        if (_settings.Parent)
+        if (ShouldAttachToParent(_settings))
         {
             NSWindow* parent = (NSWindow*)_settings.Parent->GetNativePtr();
             [parent addChildWindow:window ordered:NSWindowAbove];
@@ -989,18 +1045,17 @@ void MacWindow::Hide()
 
         // Hide (order out doesn't work for miniaturized windows)
         NSWindow* window = (NSWindow*)_window;
-        const BOOL wasKey = [window isKeyWindow];
+        const BOOL wasKey = [window isKeyWindow] || [NSApp keyWindow] == window;
         if ([window isMiniaturized])
             [window close];
         else
             [window orderOut:nil];
-
-        // Transfer focus back to the parent when hiding popup
-        if (_settings.Parent && wasKey && _settings.Type != WindowType::Popup && _settings.Type != WindowType::Tooltip)
-        {
-            NSWindow* parent = (NSWindow*)_settings.Parent->GetNativePtr();
-            [parent makeKeyAndOrderFront:nil];
-        }
+        const bool shouldRestoreFocus = _settings.Parent &&
+                                        _settings.Type == WindowType::Regular &&
+                                        [NSApp isActive] &&
+                                        (wasKey || [NSApp keyWindow] == nil);
+        if (!IsClosed() && shouldRestoreFocus)
+            MakeNextParentedWindowKey(window, _settings.Parent);
 
         // Base
         WindowBase::Hide();
@@ -1009,23 +1064,27 @@ void MacWindow::Hide()
 
 void MacWindow::Close(ClosingReason reason)
 {
-    const BOOL wasKey = _window && [(NSWindow*)_window isKeyWindow];
+    NSWindow* window = (NSWindow*)_window;
+    const BOOL shouldRestoreFocus = window &&
+                                    _settings.Parent &&
+                                    _settings.Type == WindowType::Regular &&
+                                    [NSApp isActive] &&
+                                    ([window isKeyWindow] || [NSApp keyWindow] == window);
+
     WindowBase::Close(reason);
 
     // Closing can be cancelled by managed Window.Closing handlers.
     if (!IsClosed())
         return;
     
-    if (NSWindow* window = (NSWindow*)_window)
-    {
+    if (window)
         [window close];
-    }
-    
-    if (_settings.Parent && wasKey && _settings.Type != WindowType::Popup && _settings.Type != WindowType::Tooltip)
-    {
-        NSWindow* parent = (NSWindow*)_settings.Parent->GetNativePtr();
-        [parent makeKeyAndOrderFront:nil];
-    }
+    const bool hasNoKeyWindow = _settings.Parent &&
+                                _settings.Type == WindowType::Regular &&
+                                [NSApp isActive] &&
+                                [NSApp keyWindow] == nil;
+    if (shouldRestoreFocus || hasNoKeyWindow)
+        MakeNextParentedWindowKey(window, _settings.Parent);
 }
 
 void MacWindow::Minimize()

--- a/Source/Engine/Platform/Windows/WindowsWindow.cpp
+++ b/Source/Engine/Platform/Windows/WindowsWindow.cpp
@@ -362,6 +362,13 @@ void WindowsWindow::BringToFront(bool force)
 {
     ASSERT(HasHWND());
 
+    HWND hWndInsertAfter = HWND_TOP;
+    uint32 flags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER;
+    if (_settings.IsTopmost)
+    {
+        hWndInsertAfter = HWND_TOPMOST;
+    }
+
     if (_settings.Type == WindowType::Regular)
     {
         if (IsIconic(_handle))
@@ -372,20 +379,13 @@ void WindowsWindow::BringToFront(bool force)
         {
             SetActiveWindow(_handle);
         }
+        SetWindowPos(_handle, hWndInsertAfter, 0, 0, 0, 0, flags);
     }
     else
     {
-        HWND hWndInsertAfter = HWND_TOP;
-        uint32 flags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER;
-
         if (!force)
         {
             flags |= SWP_NOACTIVATE;
-        }
-
-        if (_settings.IsTopmost)
-        {
-            hWndInsertAfter = HWND_TOPMOST;
         }
 
         SetWindowPos(_handle, hWndInsertAfter, 0, 0, 0, 0, flags);
@@ -614,6 +614,7 @@ void WindowsWindow::SetOpacity(const float opacity)
 void WindowsWindow::Focus()
 {
     ASSERT(HasHWND());
+    BringToFront();
     if (GetFocus() != _handle)
     {
         SetFocus(_handle);
@@ -1129,6 +1130,10 @@ LRESULT WindowsWindow::WndProc(UINT msg, WPARAM wParam, LPARAM lParam)
                 return 0;
             }
         }
+        break;
+    case WM_MOUSEACTIVATE:
+        if (_settings.Type == WindowType::Regular)
+            BringToFront();
         break;
     case WM_CREATE:
         return 0;


### PR DESCRIPTION
## Summary

This change fixes platform window ordering and focus behavior for parented floating editor windows.

On macOS, minimizable `Regular` windows with a logical parent are now kept as independent top-level Cocoa windows instead of native child windows. This prevents AppKit child-window side effects such as parent/sibling minimization, incorrect z-ordering, and floating windows being pushed behind their parent. Popup, tooltip, utility, and non-minimizable regular windows continue to use native parent attachment where that behavior is expected.

The macOS backend also restores focus after hiding or closing a parented regular window by selecting another visible Flax regular sibling window with the same parent, falling back to the parent only when no sibling is available. This keeps input working after closing a floating window without blindly raising the parent above the remaining floating windows.

On Windows, regular windows are explicitly moved to the top of the z-order when focused or mouse-activated, which makes clicking between multiple floating windows bring the selected window forward consistently.

## Changes

- Keep minimizable macOS `Regular` windows as top-level `NSWindow` instances while preserving their logical `Parent` in `CreateWindowSettings`.
- Continue using Cocoa native parent/child behavior for transient or non-minimizable windows where parent ordering is expected.
- Restore macOS focus after hide/close to another visible parented regular Flax window before falling back to the parent window.
- Avoid selecting arbitrary AppKit windows during focus restoration by mapping `NSWindow` instances back to Flax `Window` objects.
- Update Windows `BringToFront()` so regular windows also receive an explicit `SetWindowPos()` z-order update.
- Call `BringToFront()` from Windows `Focus()`.
- Handle `WM_MOUSEACTIVATE` for Windows regular windows to bring clicked floating windows forward.

## Motivation

Floating editor windows created with client-side decorations can be regular, minimizable windows with a logical parent. Treating those windows as native child windows on macOS gives AppKit too much control over z-order and minimization behavior. As a result, selecting, minimizing, or closing one floating window can affect the parent window or sibling floating windows incorrectly.

The fix separates logical parenting from native platform parenting for the affected window class. This keeps parent-relative behavior available to the engine while avoiding AppKit child-window behavior that is not appropriate for independent floating editor windows.
