### PR TITLE
Added colors for Debug.log

### DIFF
--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -70,22 +70,61 @@ namespace FlaxEditor.Windows
 
         private class LogEntry : Control
         {
+            /// <summary>
+            /// Text block with only color available, no other styling.
+            /// </summary>
             private struct TextColorBlock
             {
+                /// <summary>
+                /// Color of this block.
+                /// </summary>
                 public Color TextColor;
+
+                /// <summary>
+                /// Range of the text.
+                /// </summary>
                 public TextRange Range;
-                public Float2 Location;
-                public Float2 Size;
+
+                /// <summary>
+                /// The text location and size.
+                /// </summary>
+                public Rectangle Bounds;
             }
 
+            /// <summary>
+            /// Rich text parsing context.
+            /// </summary>
             private struct ColorParseContext
             {
+                /// <summary>
+                /// LogEntry control.
+                /// </summary>
                 public LogEntry Control;
+
+                /// <summary>
+                /// Caret location for the next text block.
+                /// </summary>
                 public Float2 Caret;
+
+                /// <summary>
+                /// Current parsed color.
+                /// </summary>
                 public Color CurrentColor;
+
+                /// <summary>
+                /// Default color, for reverting color on closing tags.
+                /// </summary>
                 public Color DefaultColor;
+
+                /// <summary>
+                /// Current text font for text processing.
+                /// </summary>
                 public Font TextFont;
 
+                /// <summary>
+                /// Add text block to the control.
+                /// </summary>
+                /// <param name="block">The text block to add.</param>
                 public void AddBlock(ref TextColorBlock block)
                 {
                     Control._textBlocks.Add(block);
@@ -163,18 +202,27 @@ namespace FlaxEditor.Windows
                     }
                 }
 
+                // Processing leftover text
                 ProcessTextBlock(ref context, pointerPos, Desc.Title.Length);
             }
 
+            /// <summary>
+            /// Processing the text block within given range and adding it to the list.
+            /// </summary>
+            /// <param name="context">The parsing context.</param>
+            /// <param name="startPos">Start of the range.(Character index)</param>
+            /// <param name="endPos">End of the range.(Character index)</param>
             private void ProcessTextBlock(ref ColorParseContext context, int startPos, int endPos)
             {
+                // Text block preset
                 var textBlock = new TextColorBlock()
                 {
                     TextColor = context.CurrentColor,
                     Range = new TextRange(startPos, endPos),
-                    Location = context.Caret
+                    Bounds = new Rectangle(context.Caret, Float2.Zero)
                 };
 
+                // Processing the text with selected font. (Handle newlines, text offsets)
                 var lines = context.TextFont.ProcessText(Desc.Title, ref textBlock.Range);
 
                 if (lines == null || lines.Length == 0)
@@ -190,18 +238,20 @@ namespace FlaxEditor.Windows
                         EndIndex = startPos + line.LastCharIndex + 1
                     };
 
+                    // Move to the next line
                     if (i != 0)
                     {
                         context.Caret.Y += line.Size.Y;
-                        textBlock.Location.X = 0;
-                        textBlock.Location.Y += line.Size.Y;
+                        textBlock.Bounds.X = 0;
+                        textBlock.Bounds.Y += line.Size.Y;
                     }
 
-                    textBlock.Location.X += line.Location.X;
-                    textBlock.Size = line.Size;
+                    textBlock.Bounds.X += line.Location.X;
+                    textBlock.Bounds.Size = line.Size;
                     context.AddBlock(ref textBlock);
                 }
 
+                // Caret location for the next text block
                 var lastLine = lines[lines.Length - 1];
                 if (lines.Length == 1)
                 {
@@ -213,20 +263,31 @@ namespace FlaxEditor.Windows
                 }
             }
 
+            /// <summary>
+            /// Parse color info from the tag and handle closing tags.
+            /// </summary>
+            /// <param name="context">The parsing context.</param>
+            /// <param name="tag">Tag to process.</param>
             private static void ProcessColorTag(ref ColorParseContext context, ref HtmlTag tag)
             {
+                // Closing tag
                 if (tag.IsSlash)
                 {
                     context.CurrentColor = context.DefaultColor;
                 }
                 else
                 {
+                    // Parse color
                     if (tag.Attributes.TryGetValue(string.Empty, out string colorText))
                     {
                         if (Color.TryParse(colorText, out Color colorVal))
                         {
                             context.CurrentColor = colorVal;
                         }
+                    }
+                    else
+                    {
+                        context.CurrentColor = context.DefaultColor;
                     }
                 }
             }
@@ -265,25 +326,27 @@ namespace FlaxEditor.Windows
                 Render2D.DrawSprite(Icon, new Rectangle(8, 0, 32, 32), color);
 
                 // Title
-                var textRect = new Rectangle(43, 2, clientRect.Width - 40, clientRect.Height - 10);
+                var textLocation = new Float2(43, 2);
                 Render2D.PushClip(ref clientRect);
                 bool coloredText = _window._colorDebugLogText;
 
+                // Render text blocks with their colors
                 for (int i = 0; i < _textBlocks.Count; i++)
                 {
                     TextColorBlock block = _textBlocks[i];
                     Render2D.DrawText(style.FontMedium, Desc.Title, ref block.Range,
-                        coloredText ? block.TextColor : style.Foreground, textRect.TopLeft + block.Location);
+                        coloredText ? block.TextColor : style.Foreground, textLocation + block.Bounds.Location);
                 }
 
+                // Adding log counter for collapsed logs
                 if (LogCount > 1)
                 {
-                    Float2 numberLocation = textRect.TopLeft;
+                    Float2 numberLocation = textLocation;
                     if (_textBlocks.Count > 0)
                     {
                         TextColorBlock block = _textBlocks[_textBlocks.Count - 1];
-                        numberLocation += block.Location;
-                        numberLocation.X += block.Size.X;
+                        numberLocation += block.Bounds.Location;
+                        numberLocation.X += block.Bounds.Size.X;
                     }
 
                     Render2D.DrawText(style.FontMedium, $" ({LogCount})", color, numberLocation);

--- a/Source/Editor/Windows/DebugLogWindow.cs
+++ b/Source/Editor/Windows/DebugLogWindow.cs
@@ -13,6 +13,7 @@ using FlaxEditor.Options;
 using FlaxEngine;
 using FlaxEngine.Assertions;
 using FlaxEngine.GUI;
+using FlaxEngine.Utilities;
 using Object = FlaxEngine.Object;
 
 namespace FlaxEditor.Windows
@@ -69,6 +70,28 @@ namespace FlaxEditor.Windows
 
         private class LogEntry : Control
         {
+            private struct TextColorBlock
+            {
+                public Color TextColor;
+                public TextRange Range;
+                public Float2 Location;
+                public Float2 Size;
+            }
+
+            private struct ColorParseContext
+            {
+                public LogEntry Control;
+                public Float2 Caret;
+                public Color CurrentColor;
+                public Color DefaultColor;
+                public Font TextFont;
+
+                public void AddBlock(ref TextColorBlock block)
+                {
+                    Control._textBlocks.Add(block);
+                }
+            }
+
             private bool _isRightMouseDown;
 
             /// <summary>
@@ -81,6 +104,8 @@ namespace FlaxEditor.Windows
             public LogEntryDescription Desc;
             public SpriteHandle Icon;
             public int LogCount = 1;
+
+            private readonly List<TextColorBlock> _textBlocks = new List<TextColorBlock>();
 
             public LogEntry(DebugLogWindow window, ref LogEntryDescription desc)
             : base(0, 0, 120, DefaultHeight)
@@ -105,6 +130,104 @@ namespace FlaxEditor.Windows
                     Group = LogGroup.Error;
                     Icon = _window._iconError;
                     break;
+                }
+
+                // Color parsing
+                var style = Style.Current;
+                var color = Group == LogGroup.Error ? _window._colorError : (Group == LogGroup.Warning ? _window._colorWarning : _window._colorInfo);
+
+                HtmlParser parser = new();
+
+                parser.Reset(Desc.Title);
+
+                var context = new ColorParseContext
+                {
+                    Control = this,
+                    Caret = Float2.Zero,
+                    CurrentColor = color,
+                    DefaultColor = color,
+                    TextFont = style.FontMedium,
+                };
+
+                int pointerPos = 0;
+
+                while (parser.ParseNext(out var tag))
+                {
+                    if (tag.Name.ToLower() == "color")
+                    {
+                        ProcessTextBlock(ref context, pointerPos, tag.StartPosition);
+
+                        pointerPos = tag.EndPosition;
+
+                        ProcessColorTag(ref context, ref tag);
+                    }
+                }
+
+                ProcessTextBlock(ref context, pointerPos, Desc.Title.Length);
+            }
+
+            private void ProcessTextBlock(ref ColorParseContext context, int startPos, int endPos)
+            {
+                var textBlock = new TextColorBlock()
+                {
+                    TextColor = context.CurrentColor,
+                    Range = new TextRange(startPos, endPos),
+                    Location = context.Caret
+                };
+
+                var lines = context.TextFont.ProcessText(Desc.Title, ref textBlock.Range);
+
+                if (lines == null || lines.Length == 0)
+                {
+                    return;
+                }
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    ref var line = ref lines[i];
+                    textBlock.Range = new TextRange
+                    {
+                        StartIndex = startPos + line.FirstCharIndex,
+                        EndIndex = startPos + line.LastCharIndex + 1
+                    };
+
+                    if (i != 0)
+                    {
+                        context.Caret.Y += line.Size.Y;
+                        textBlock.Location.X = 0;
+                        textBlock.Location.Y += line.Size.Y;
+                    }
+
+                    textBlock.Location.X += line.Location.X;
+                    textBlock.Size = line.Size;
+                    context.AddBlock(ref textBlock);
+                }
+
+                var lastLine = lines[lines.Length - 1];
+                if (lines.Length == 1)
+                {
+                    context.Caret.X += lastLine.Size.X;
+                }
+                else
+                {
+                    context.Caret.X = lastLine.Size.X;
+                }
+            }
+
+            private static void ProcessColorTag(ref ColorParseContext context, ref HtmlTag tag)
+            {
+                if (tag.IsSlash)
+                {
+                    context.CurrentColor = context.DefaultColor;
+                }
+                else
+                {
+                    if (tag.Attributes.TryGetValue(string.Empty, out string colorText))
+                    {
+                        if (Color.TryParse(colorText, out Color colorVal))
+                        {
+                            context.CurrentColor = colorVal;
+                        }
+                    }
                 }
             }
 
@@ -145,13 +268,25 @@ namespace FlaxEditor.Windows
                 var textRect = new Rectangle(43, 2, clientRect.Width - 40, clientRect.Height - 10);
                 Render2D.PushClip(ref clientRect);
                 bool coloredText = _window._colorDebugLogText;
-                if (LogCount == 1)
+
+                for (int i = 0; i < _textBlocks.Count; i++)
                 {
-                    Render2D.DrawText(style.FontMedium, Desc.Title, textRect, coloredText ? color : style.Foreground);
+                    TextColorBlock block = _textBlocks[i];
+                    Render2D.DrawText(style.FontMedium, Desc.Title, ref block.Range,
+                        coloredText ? block.TextColor : style.Foreground, textRect.TopLeft + block.Location);
                 }
-                else if (LogCount > 1)
+
+                if (LogCount > 1)
                 {
-                    Render2D.DrawText(style.FontMedium, $"{Desc.Title} ({LogCount})", textRect, coloredText ? color : style.Foreground);
+                    Float2 numberLocation = textRect.TopLeft;
+                    if (_textBlocks.Count > 0)
+                    {
+                        TextColorBlock block = _textBlocks[_textBlocks.Count - 1];
+                        numberLocation += block.Location;
+                        numberLocation.X += block.Size.X;
+                    }
+
+                    Render2D.DrawText(style.FontMedium, $" ({LogCount})", color, numberLocation);
                 }
                 Render2D.PopClip();
             }


### PR DESCRIPTION
Added color formatting in Debug.Log, as requested in #294 

The implementation is based on RichTextBox. And has the same syntax.
Formatting is only added on the LogEntry and is not applied to the expanded log info on the bottom of the window when log is selected. Let me know if it is needed there.

Some maybe important quirks:
- The formatting is implemented directly inside the LogEntry. There is no ability to disable it. I don't think anyone will need to have text: <color> in their logs. But if that's a concern let me know.
- Any other tags beside color are left in.
- The implementation ended up being a simpler version of the RichTextBox. So there is some duplicate code. If this is an issue, let me know how it should be resolved.
- Performance is worse. I'm not sure by how much. On my Windows machine I didn't feel any difference.


Tested on Windows11 machine.