### PR TITLE
Resolves undefined behavior when passing in a non locked mutex into `pthread_cond_wait`

### DIFF
--- a/Source/Editor/Cooker/GameCooker.cpp
+++ b/Source/Editor/Cooker/GameCooker.cpp
@@ -795,16 +795,17 @@ int32 GameCookerImpl::ThreadFunction()
     IsThreadRunning = true;
 
     CriticalSection mutex;
+    mutex.Lock();
     while (Platform::AtomicRead(&CancelThreadFlag) == 0)
     {
         if (IsRunning)
         {
             Build();
         }
-
         ThreadCond.Wait(mutex);
     }
 
+    mutex.Unlock();
     IsThreadRunning = false;
     return 0;
 }


### PR DESCRIPTION
## Problem
Closes #4170

After a build the cooker thread is kept alive and parks in `GameCookerImpl::ThreadFunction`'s loop calling `ThreadCond.Wait(mutex)` on a `mutex` that is never locked
POSIX requires `pthread_cond_wait` to be called with the mutex locked by the caller
https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cond_wait.html
On glibc it returns `EPERM` immediately instead of blocking, so the idle thread busy-loops

## Solution
Lock the mutex before the loop so it is held whenever `Wait` is called (`Wait` releases and re-acquires it internally)
The idle thread now sleeps and is woken by `NotifyOne` for the next build

## Testing
- Built the editor (Linux x64, Development)
- Ran Cook and Run, let it finish, left the editor idle
- Confirmed the Game Cooker thread no longer pins a core at ~100% (`top -H`) and CPU returns to idle
- Reran a build afterwards to confirm the thread still wakes and cooks normally
- Had AI write a minimal repro (glibc 2.43) since Flax's `Wait` wrapper is `void` and discards `pthread_cond_wait`'s return code, so the error is invisible in-engine. The repro confirms: waiting on an unlocked recursive mutex returns EPERM ~11.8M times/sec on my machine instead of blocking. Locking first makes it block.

## Note

I am on vacation RN and do not have access to a Windows system to test this change on