### PR TITLE
Update various actor bounds method names.

### DIFF
--- a/Source/Engine/Level/Actor.cpp
+++ b/Source/Engine/Level/Actor.cpp
@@ -1429,9 +1429,14 @@ void Actor::OnLayerChanged()
 
 BoundingBox Actor::GetBoxWithChildren() const
 {
-    BoundingBox result = GetBox();
+    return GetBoundingBoxWithChildren();
+}
+
+BoundingBox Actor::GetBoundingBoxWithChildren() const
+{
+    BoundingBox result = GetBoundingBox();
     for (int32 i = 0; i < Children.Count(); i++)
-        BoundingBox::Merge(result, Children.Get()[i]->GetBoxWithChildren(), result);
+        BoundingBox::Merge(result, Children.Get()[i]->GetBoundingBoxWithChildren(), result);
     return result;
 }
 
@@ -1439,14 +1444,24 @@ BoundingBox Actor::GetBoxWithChildren() const
 
 BoundingBox Actor::GetEditorBox() const
 {
-    return GetBox();
+    return GetEditorBoundingBox();
+}
+
+BoundingBox Actor::GetEditorBoundingBox() const
+{
+    return GetBoundingBox();
 }
 
 BoundingBox Actor::GetEditorBoxChildren() const
 {
-    BoundingBox result = GetEditorBox();
+    return GetEditorBoundingBoxWithChildren();
+}
+
+BoundingBox Actor::GetEditorBoundingBoxWithChildren() const
+{
+    BoundingBox result = GetEditorBoundingBox();
     for (int32 i = 0; i < Children.Count(); i++)
-        BoundingBox::Merge(result, Children.Get()[i]->GetEditorBoxChildren(), result);
+        BoundingBox::Merge(result, Children.Get()[i]->GetEditorBoundingBoxWithChildren(), result);
     return result;
 }
 

--- a/Source/Engine/Level/Actor.h
+++ b/Source/Engine/Level/Actor.h
@@ -689,35 +689,71 @@ public:
 public:
     /// <summary>
     /// Gets actor bounding sphere that defines 3D space intersecting with the actor (for determination of the visibility for actor).
+    /// [DEPRECATED IN 1.13]
     /// </summary>
-    API_PROPERTY() FORCE_INLINE const BoundingSphere& GetSphere() const
+    API_PROPERTY() DEPRECATED("Use GetBoundingSphere instead.") FORCE_INLINE const BoundingSphere& GetSphere() const
+    {
+        return _sphere;
+    }
+    
+    /// <summary>
+    /// Gets actor bounding sphere that defines 3D space intersecting with the actor (for determination of the visibility for actor).
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE const BoundingSphere& GetBoundingSphere() const
     {
         return _sphere;
     }
 
     /// <summary>
     /// Gets actor bounding box that defines 3D space intersecting with the actor (for determination of the visibility for actor).
+    /// [DEPRECATED IN 1.13]
     /// </summary>
-    API_PROPERTY() FORCE_INLINE const BoundingBox& GetBox() const
+    API_PROPERTY() DEPRECATED("Use GetBoundingBox instead.") FORCE_INLINE const BoundingBox& GetBox() const
+    {
+        return _box;
+    }
+    
+    /// <summary>
+    /// Gets actor bounding box that defines 3D space intersecting with the actor (for determination of the visibility for actor).
+    /// </summary>
+    API_PROPERTY() FORCE_INLINE const BoundingBox& GetBoundingBox() const
     {
         return _box;
     }
 
     /// <summary>
     /// Gets actor bounding box of the actor including all child actors (children included in recursive way)
+    /// [DEPRECATED IN 1.13]
     /// </summary>
-    API_PROPERTY() BoundingBox GetBoxWithChildren() const;
+    API_PROPERTY() DEPRECATED("Use GetBoundingBoxWithChildren instead.") BoundingBox GetBoxWithChildren() const;
+    
+    /// <summary>
+    /// Gets actor bounding box of the actor including all child actors (children included in recursive way)
+    /// </summary>
+    API_PROPERTY() BoundingBox GetBoundingBoxWithChildren() const;
 
 #if USE_EDITOR
     /// <summary>
     /// Gets actor bounding box (single actor, no children included) for editor tools.
+    /// [DEPRECATED IN 1.13]
     /// </summary>
-    API_PROPERTY() virtual BoundingBox GetEditorBox() const;
+    API_PROPERTY() DEPRECATED("Use GetEditorBoundingBox instead.") virtual BoundingBox GetEditorBox() const;
+    
+    /// <summary>
+    /// Gets actor bounding box (single actor, no children included) for editor tools.
+    /// </summary>
+    API_PROPERTY() virtual BoundingBox GetEditorBoundingBox() const;
 
     /// <summary>
     /// Gets actor bounding box of the actor including all child actors for editor tools.
+    /// [DEPRECATED IN 1.13]
     /// </summary>
-    API_PROPERTY() BoundingBox GetEditorBoxChildren() const;
+    API_PROPERTY() DEPRECATED("Use GetEditorBoundingBoxWithChildren instead.") BoundingBox GetEditorBoxChildren() const;
+    
+    /// <summary>
+    /// Gets actor bounding box of the actor including all child actors for editor tools.
+    /// </summary>
+    API_PROPERTY() BoundingBox GetEditorBoundingBoxWithChildren() const;
 #endif
 
     /// <summary>


### PR DESCRIPTION
Was just looking through the actor file for something and noticed some more names that could be renamed to be more descriptive. This is for all of the actor bounding shapes.