### PR TITLE
Preload assembly for dynamic support in editor

### DIFF
--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -1007,15 +1007,13 @@ namespace FlaxEngine.Interop
 
             scriptingAssemblyLoadContext = new AssemblyLoadContext("Flax", isCollectible: true);
             scriptingAssemblyLoadContext.Resolving += OnScriptingAssemblyLoadContextResolving;
+            
+            // Load Microsoft.CSharp assembly into collectible ALC for dynamic binder support
+            scriptingAssemblyLoadContext.LoadFromAssemblyPath(typeof(Microsoft.CSharp.RuntimeBinder.Binder).Assembly.Location);
 #else
             scriptingAssemblyLoadContext = new AssemblyLoadContext("Flax", isCollectible: false);
 #endif
             DelegateHelpers.InitMethods();
-            
-#if FLAX_EDITOR
-            // Load Microsoft.CSharp assembly into collectible ALC for dynamic binder support
-            scriptingAssemblyLoadContext.LoadFromAssemblyPath(typeof(Microsoft.CSharp.RuntimeBinder.Binder).Assembly.Location);
-#endif
         }
 
         [UnmanagedCallersOnly]

--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -1011,6 +1011,11 @@ namespace FlaxEngine.Interop
             scriptingAssemblyLoadContext = new AssemblyLoadContext("Flax", isCollectible: false);
 #endif
             DelegateHelpers.InitMethods();
+            
+#if FLAX_EDITOR
+            // Load Microsoft.CSharp assembly into collectible ALC for dynamic binder support
+            scriptingAssemblyLoadContext.LoadFromAssemblyPath(typeof(Microsoft.CSharp.RuntimeBinder.Binder).Assembly.Location);
+#endif
         }
 
         [UnmanagedCallersOnly]

--- a/Source/Engine/Engine/NativeInterop.cs
+++ b/Source/Engine/Engine/NativeInterop.cs
@@ -1758,9 +1758,6 @@ namespace FlaxEngine.Interop
                 assembly.GetType("System.Linq.Expressions.Compiler.DelegateHelpers")
                         .GetMethod("MakeNewCustomDelegate", BindingFlags.NonPublic | BindingFlags.Static).CreateDelegate<Func<Type[], Type>>();
 
-                // Load Microsoft.CSharp assembly into collectible ALC for dynamic binder support
-                scriptingAssemblyLoadContext.LoadFromAssemblyPath(typeof(Microsoft.CSharp.RuntimeBinder.Binder).Assembly.Location);
-
                 // Create dummy delegates to force the dynamic Snippets assembly to be loaded in correcet ALCs
                 MakeNewCustomDelegateFunc(new[] { typeof(void) });
                 {

--- a/Source/Engine/Engine/NativeInterop.cs
+++ b/Source/Engine/Engine/NativeInterop.cs
@@ -1758,6 +1758,9 @@ namespace FlaxEngine.Interop
                 assembly.GetType("System.Linq.Expressions.Compiler.DelegateHelpers")
                         .GetMethod("MakeNewCustomDelegate", BindingFlags.NonPublic | BindingFlags.Static).CreateDelegate<Func<Type[], Type>>();
 
+                // Load Microsoft.CSharp assembly into collectible ALC for dynamic binder support
+                scriptingAssemblyLoadContext.LoadFromAssemblyPath(typeof(Microsoft.CSharp.RuntimeBinder.Binder).Assembly.Location);
+
                 // Create dummy delegates to force the dynamic Snippets assembly to be loaded in correcet ALCs
                 MakeNewCustomDelegateFunc(new[] { typeof(void) });
                 {


### PR DESCRIPTION
Fixes <https://discord.com/channels/437989205315158016/1531529970810097754>

Seems to be since the editor assemblies are collectable, that is issue exists. dynamic works fine in a built game. I am not sure if this is the best spot to put this loading in the interop section, so if there is a better spot, let me know.