### PR TITLE
Allow more than 1 skinned mesh imported LOD

### DIFF
--- a/Source/Engine/Tools/ModelTool/ModelTool.cpp
+++ b/Source/Engine/Tools/ModelTool/ModelTool.cpp
@@ -1318,10 +1318,10 @@ bool ModelTool::ImportModel(const String& path, ModelData& data, Options& option
         }
         break;
     case ModelType::SkinnedModel:
-        if (data.LODs.Count() > 1)
+        if (data.LODs.IsEmpty() || data.LODs[0].Meshes.IsEmpty())
         {
-            LOG(Warning, "Imported skinned model has more than one LOD. Removing the lower LODs. Only single one is supported.");
-            data.LODs.Resize(1);
+            errorMsg = TEXT("Imported skinned model has no valid geometry.");
+            return true;
         }
         break;
     case ModelType::Animation:


### PR DESCRIPTION
Closes #4191 

I did not see a reason why only 1 was supported. the code seems the same for models and skinned models in this regard. Is it because of specific functionality like blend shapes or something? If as, this won't fix the issue fully.