### PR TITLE
Fix terrain resolution in editor.

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/TerrainEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/TerrainEditor.cs
@@ -29,8 +29,8 @@ namespace FlaxEditor.CustomEditors.Dedicated
                                             patchesCount,
                                             patchesCount * 16,
                                             chunkSize,
-                                            1.0f / (resolution.X + 1e-9f),
-                                            1.0f / (resolution.Z + 1e-9f),
+                                            Mathf.Abs(resolution.X),
+                                            Mathf.Abs(resolution.Z),
                                             totalSize.X / Units.Meters2Units * 0.001f,
                                             totalSize.Z / Units.Meters2Units * 0.001f
                 );


### PR DESCRIPTION
By default, the terrain resolution is 1m x 1m, after scaling it down by a factor of 10, I noticed the resolution increased instead of decreased and shown 10m x 10m instead of 0.1m x 0.1m. This PR fixes it, unless what I described was intended.

Before
<img width="590" height="601" alt="image" src="https://github.com/user-attachments/assets/80c0e26d-fccb-4a79-a860-d5331e7b30f5" />

After
<img width="593" height="605" alt="image" src="https://github.com/user-attachments/assets/195c7b36-4f3a-4fd5-b343-8d1b163e57b8" />

