### PR TITLE
fix/interface-scaling

### DIFF
--- a/Source/Editor/Content/GUI/ContentNavigation.cs
+++ b/Source/Editor/Content/GUI/ContentNavigation.cs
@@ -163,7 +163,7 @@ namespace FlaxEditor.Content.GUI
             var rect = new Rectangle(Float2.Zero, Size);
             var color = IsDragOver ? Color.Transparent : (_mouseDown ? style.BackgroundSelected : (IsMouseOver ? style.BackgroundHighlighted : Color.Transparent));
             Render2D.FillRectangle(rect, color);
-            Render2D.DrawSprite(Editor.Instance.Icons.ArrowRight12, new Rectangle(rect.Location.X, rect.Y + rect.Size.Y * 0.25f, rect.Size.X, rect.Size.X), EnabledInHierarchy ? style.Foreground : style.ForegroundDisabled);
+            EditorGlyphs.DrawArrowRight(new Rectangle(rect.Location.X, rect.Y + rect.Size.Y * 0.25f, rect.Size.X, rect.Size.X), EnabledInHierarchy ? style.Foreground : style.ForegroundDisabled);
         }
 
         protected override void OnLayoutMenuButton(ContextMenuButton button, int index, bool construct = false)

--- a/Source/Editor/CustomEditors/Dedicated/MeshReferenceEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/MeshReferenceEditor.cs
@@ -113,7 +113,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
                     Render2D.PopClip();
 
                     // Draw deselect button
-                    Render2D.DrawSprite(style.Cross, button1Rect, isEnabled && button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                    EditorGlyphs.DrawCross(button1Rect, isEnabled && button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
                 }
                 else
                 {
@@ -123,7 +123,7 @@ namespace FlaxEditor.CustomEditors.Dedicated
 
                 // Draw picker button
                 var pickerRect = isSelected ? button2Rect : button1Rect;
-                Render2D.DrawSprite(style.ArrowDown, pickerRect, isEnabled && pickerRect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                EditorGlyphs.DrawArrowDown(pickerRect, isEnabled && pickerRect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
             }
 
             /// <inheritdoc />

--- a/Source/Editor/CustomEditors/Editors/AssetRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/AssetRefEditor.cs
@@ -179,7 +179,7 @@ namespace FlaxEditor.CustomEditors.Editors
 
                 var style = FlaxEngine.GUI.Style.Current;
                 var dropdownRect = DropdownRect;
-                Render2D.DrawSprite(style.ArrowDown, dropdownRect, Enabled ? (DropdownRect.Contains(PointFromWindow(RootWindow.MousePosition)) ? style.BorderSelected : style.Foreground) : style.ForegroundDisabled);
+                EditorGlyphs.DrawArrowDown(dropdownRect, Enabled ? (DropdownRect.Contains(PointFromWindow(RootWindow.MousePosition)) ? style.BorderSelected : style.Foreground) : style.ForegroundDisabled);
                 
                 // Check if drag is over
                 if (IsDragOver && _hasValidDragOver)

--- a/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
@@ -238,9 +238,8 @@ namespace FlaxEditor.CustomEditors.Editors
                 HeaderHeight = 18;
                 _canReorder = canReorder;
                 EnableDropDownIcon = true;
-                var icons = FlaxEditor.Editor.Instance.Icons;
-                ArrowImageClosed = new SpriteBrush(icons.ArrowRight12);
-                ArrowImageOpened = new SpriteBrush(icons.ArrowDown12);
+                ArrowImageClosed = new ArrowRightBrush();
+                ArrowImageOpened = new ArrowDownBrush();
                 HeaderText = $"Element {index}";
                 
                 string saveName = string.Empty;

--- a/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/CollectionEditor.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using FlaxEditor.CustomEditors.GUI;
+using FlaxEditor.GUI;
 using FlaxEditor.GUI.Input;
 using FlaxEditor.Content;
 using FlaxEditor.CustomEditors.Elements;

--- a/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/FlaxObjectRefEditor.cs
@@ -229,7 +229,7 @@ namespace FlaxEditor.CustomEditors.Editors
                 Render2D.PopClip();
 
                 // Draw deselect button
-                Render2D.DrawSprite(style.Cross, button1Rect, isEnabled && button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                EditorGlyphs.DrawCross(button1Rect, isEnabled && button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
             }
             else
             {
@@ -243,7 +243,7 @@ namespace FlaxEditor.CustomEditors.Editors
             if (_supportsPickDropDown && isEnabled)
             {
                 var pickerRect = isSelected ? button2Rect : button1Rect;
-                Render2D.DrawSprite(style.ArrowDown, pickerRect, isEnabled && pickerRect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                EditorGlyphs.DrawArrowDown(pickerRect, isEnabled && pickerRect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
             }
 
             // Check if drag is over

--- a/Source/Editor/CustomEditors/Editors/TypeEditor.cs
+++ b/Source/Editor/CustomEditors/Editors/TypeEditor.cs
@@ -156,7 +156,7 @@ namespace FlaxEditor.CustomEditors.Editors
             {
                 // Draw deselect button
                 if (_type == ScriptType.Null)
-                    Render2D.DrawSprite(style.Cross, button1Rect, button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                    EditorGlyphs.DrawCross(button1Rect, button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
 
                 // Draw name
                 Render2D.PushClip(nameRect);
@@ -171,7 +171,7 @@ namespace FlaxEditor.CustomEditors.Editors
 
             // Draw picker button
             var pickerRect = isSelected && _type == ScriptType.Null ? button2Rect : button1Rect;
-            Render2D.DrawSprite(style.ArrowDown, pickerRect, pickerRect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+            EditorGlyphs.DrawArrowDown(pickerRect, pickerRect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
 
             // Check if drag is over
             if (IsDragOver && _hasValidDragOver)

--- a/Source/Editor/GUI/AssetPicker.cs
+++ b/Source/Editor/GUI/AssetPicker.cs
@@ -119,7 +119,7 @@ namespace FlaxEditor.GUI
 
             // Draw asset picker button
             if (CanEdit)
-                Render2D.DrawSprite(style.ArrowDown, button1Rect, button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                EditorGlyphs.DrawArrowDown(button1Rect, button1Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
 
             if (DifferentValues)
             {
@@ -136,7 +136,7 @@ namespace FlaxEditor.GUI
                 if (CanEdit)
                 {
                     Render2D.DrawSprite(style.Search, button2Rect, button2Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
-                    Render2D.DrawSprite(style.Cross, button3Rect, button3Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                    EditorGlyphs.DrawCross(button3Rect, button3Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
                 }
                 else
                 {
@@ -167,7 +167,7 @@ namespace FlaxEditor.GUI
             else if (Validator.SelectedAsset)
             {
                 // Draw remove button
-                Render2D.DrawSprite(style.Cross, button3Rect, button3Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
+                EditorGlyphs.DrawCross(button3Rect, button3Rect.Contains(_mousePos) ? style.Foreground : style.ForegroundGrey);
 
                 // Draw name
                 float sizeForTextLeft = Width - button1Rect.Right;

--- a/Source/Editor/GUI/ComboBox.cs
+++ b/Source/Editor/GUI/ComboBox.cs
@@ -281,7 +281,7 @@ namespace FlaxEditor.GUI
             BorderColor = style.BorderNormal;
             BorderColorHighlighted = style.BorderSelected;
             BorderColorSelected = BorderColorHighlighted;
-            ArrowImage = new SpriteBrush(style.ArrowDown);
+            ArrowImage = new ArrowDownBrush();
             ArrowColor = style.Foreground * 0.6f;
             ArrowColorSelected = style.BackgroundSelected;
             ArrowColorHighlighted = style.Foreground;

--- a/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenuChildMenu.cs
@@ -53,7 +53,7 @@ namespace FlaxEditor.GUI.ContextMenu
 
             // Draw arrow
             if (ContextMenu.HasChildren)
-                Render2D.DrawSprite(style.ArrowRight, new Rectangle(Width - 15 + ExtraAdjustmentAmount, (Height - 12) / 2, 12, 12), Enabled ? isCMopened ? style.BackgroundSelected : style.Foreground : style.ForegroundDisabled);
+                EditorGlyphs.DrawArrowRight(new Rectangle(Width - 15 + ExtraAdjustmentAmount, (Height - 12) / 2, 12, 12), Enabled ? isCMopened ? style.BackgroundSelected : style.Foreground : style.ForegroundDisabled);
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Docking/DockPanelProxy.cs
+++ b/Source/Editor/GUI/Docking/DockPanelProxy.cs
@@ -277,7 +277,7 @@ namespace FlaxEditor.GUI.Docking
                     bool isMouseOverCross = isMouseOver && crossRect.Contains(MousePosition);
                     if (isMouseOverCross)
                         Render2D.FillRectangle(crossRect, (containsFocus ? style.BackgroundSelected : style.LightBackground) * 1.3f);
-                    Render2D.DrawSprite(style.Cross, crossRect, isMouseOverCross ? style.Foreground : style.ForegroundGrey);
+                    EditorGlyphs.DrawCross(crossRect, isMouseOverCross ? style.Foreground : style.ForegroundGrey);
                 }
             }
             else
@@ -347,7 +347,7 @@ namespace FlaxEditor.GUI.Docking
                         bool isMouseOverCross = isMouseOver && crossRect.Contains(MousePosition);
                         if (isMouseOverCross)
                             Render2D.FillRectangle(crossRect, tabColor * 1.3f);
-                        Render2D.DrawSprite(style.Cross, crossRect, isMouseOverCross ? style.Foreground : style.ForegroundGrey);
+                        EditorGlyphs.DrawCross(crossRect, isMouseOverCross ? style.Foreground : style.ForegroundGrey);
                     }
 
                     // Set the start position for the next tab

--- a/Source/Editor/GUI/EditorGlyphs.cs
+++ b/Source/Editor/GUI/EditorGlyphs.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Wojciech Figat. All rights reserved.
+
+using FlaxEngine;
+using FlaxEngine.GUI;
+
+namespace FlaxEditor.GUI
+{
+    /// <summary>
+    /// Draws small UI glyphs (cross, chevrons) using font rasterization instead of low-resolution
+    /// atlas sprites (Cross12, ArrowDown12, ArrowRight12). Because the font subsystem re-rasterizes
+    /// glyphs at the current interface DPI (see <c>Font.SetGlobalScale</c>), the resulting shapes
+    /// stay crisp at any Interface Scale, unlike the fixed 12-px sprites which become blurred (with
+    /// linear sampling) or blocky (with point sampling) when the UI is scaled up.
+    /// </summary>
+    [HideInEditor]
+    public static class EditorGlyphs
+    {
+        // Only the cross uses a font glyph (× / MULTIPLICATION SIGN) since it is present in every
+        // font we ship. The chevrons are drawn as filled triangles because the small-triangle
+        // Unicode codepoints (U+25BE / U+25B8) are outside the coverage of the default editor font
+        // and would render as tofu boxes.
+        private const string CrossChar = "\u00D7"; // ×
+
+        private static Font GetGlyphFont(float size)
+        {
+            var style = Style.Current;
+            var font = style?.FontMedium ?? style?.FontSmall;
+            if (font == null)
+                return null;
+            float targetSize = Mathf.Max(6.0f, size);
+            var asset = font.Asset;
+            return asset != null ? asset.CreateFont(targetSize) : font;
+        }
+
+        /// <summary>
+        /// Draws a crisp cross (×) glyph fitting the given rectangle.
+        /// </summary>
+        public static void DrawCross(Rectangle rect, Color color)
+        {
+            float size = Mathf.Min(rect.Width, rect.Height);
+            var font = GetGlyphFont(size * 1.3f);
+            if (font == null)
+                return;
+            Render2D.DrawText(font, CrossChar, rect, color, TextAlignment.Center, TextAlignment.Center);
+        }
+
+        /// <summary>
+        /// Draws a crisp down chevron glyph fitting the given rectangle.
+        /// </summary>
+        public static void DrawArrowDown(Rectangle rect, Color color)
+        {
+            float size = Mathf.Min(rect.Width, rect.Height) * 0.55f;
+            float cx = rect.Location.X + rect.Width * 0.5f;
+            float cy = rect.Location.Y + rect.Height * 0.5f;
+            float halfW = size * 0.5f;
+            float halfH = size * 0.4f;
+            var p0 = new Float2(cx - halfW, cy - halfH);
+            var p1 = new Float2(cx + halfW, cy - halfH);
+            var p2 = new Float2(cx, cy + halfH);
+            Render2D.FillTriangle(p0, p1, p2, color);
+        }
+
+        /// <summary>
+        /// Draws a crisp right chevron glyph fitting the given rectangle.
+        /// </summary>
+        public static void DrawArrowRight(Rectangle rect, Color color)
+        {
+            float size = Mathf.Min(rect.Width, rect.Height) * 0.55f;
+            float cx = rect.Location.X + rect.Width * 0.5f;
+            float cy = rect.Location.Y + rect.Height * 0.5f;
+            float halfW = size * 0.4f;
+            float halfH = size * 0.5f;
+            var p0 = new Float2(cx - halfW, cy - halfH);
+            var p1 = new Float2(cx - halfW, cy + halfH);
+            var p2 = new Float2(cx + halfW, cy);
+            Render2D.FillTriangle(p0, p1, p2, color);
+        }
+    }
+
+    /// <summary>
+    /// Brush that draws a cross (×) glyph using the editor font. Replacement for the low-resolution
+    /// Cross12 sprite brush so the glyph stays crisp at any Interface Scale.
+    /// </summary>
+    [HideInEditor]
+    public sealed class CrossBrush : IBrush
+    {
+        /// <inheritdoc />
+        public Float2 Size => new Float2(12.0f);
+
+        /// <inheritdoc />
+        public void Draw(Rectangle rect, Color color) => EditorGlyphs.DrawCross(rect, color);
+
+        /// <inheritdoc />
+        public int CompareTo(object obj) => obj is CrossBrush ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Brush that draws a down chevron (▾) glyph using the editor font. Replacement for the
+    /// low-resolution ArrowDown12 sprite brush so the glyph stays crisp at any Interface Scale.
+    /// </summary>
+    [HideInEditor]
+    public sealed class ArrowDownBrush : IBrush
+    {
+        /// <inheritdoc />
+        public Float2 Size => new Float2(12.0f);
+
+        /// <inheritdoc />
+        public void Draw(Rectangle rect, Color color) => EditorGlyphs.DrawArrowDown(rect, color);
+
+        /// <inheritdoc />
+        public int CompareTo(object obj) => obj is ArrowDownBrush ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Brush that draws a right chevron (▸) glyph using the editor font. Replacement for the
+    /// low-resolution ArrowRight12 sprite brush so the glyph stays crisp at any Interface Scale.
+    /// </summary>
+    [HideInEditor]
+    public sealed class ArrowRightBrush : IBrush
+    {
+        /// <inheritdoc />
+        public Float2 Size => new Float2(12.0f);
+
+        /// <inheritdoc />
+        public void Draw(Rectangle rect, Color color) => EditorGlyphs.DrawArrowRight(rect, color);
+
+        /// <inheritdoc />
+        public int CompareTo(object obj) => obj is ArrowRightBrush ? 0 : 1;
+    }
+}

--- a/Source/Editor/GUI/Input/SearchBox.cs
+++ b/Source/Editor/GUI/Input/SearchBox.cs
@@ -43,7 +43,7 @@ namespace FlaxEditor.GUI.Input
                 BorderColorHighlighted = Color.Transparent,
                 BackgroundColorSelected = Style.Current.ForegroundGrey,
                 BorderColorSelected = Color.Transparent,
-                BackgroundBrush = new SpriteBrush(Editor.Instance.Icons.Cross12),
+                BackgroundBrush = new CrossBrush(),
                 Visible = false,
             };
             ClearSearchButton.LocalY += 2;

--- a/Source/Editor/GUI/ItemsListContextMenu.cs
+++ b/Source/Editor/GUI/ItemsListContextMenu.cs
@@ -453,8 +453,8 @@ namespace FlaxEditor.GUI
                     var categoryPanel = new DropPanel
                     {
                         HeaderText = item.Category,
-                        ArrowImageOpened = new SpriteBrush(Editor.Instance.Icons.ArrowDown12),
-                        ArrowImageClosed = new SpriteBrush(Editor.Instance.Icons.ArrowRight12),
+                        ArrowImageOpened = new ArrowDownBrush(),
+                        ArrowImageClosed = new ArrowRightBrush(),
                         EnableDropDownIcon = true,
                         ItemsMargin = new Margin(28, 0, 2, 2),
                         HeaderColor = Style.Current.Background,

--- a/Source/Editor/GUI/Row.cs
+++ b/Source/Editor/GUI/Row.cs
@@ -105,7 +105,11 @@ namespace FlaxEditor.GUI
                             {
                                 // Tree node arrow                  
                                 var arrowRect = new Rectangle(x + leftDepthMargin - arrowSize, (Height - arrowSize) * 0.5f, arrowSize, arrowSize);
-                                Render2D.DrawSprite(row.Visible ? style.ArrowDown : style.ArrowRight, arrowRect, IsMouseOver ? style.Foreground : style.ForegroundGrey);
+                                var arrowColor = IsMouseOver ? style.Foreground : style.ForegroundGrey;
+                                if (row.Visible)
+                                    EditorGlyphs.DrawArrowDown(arrowRect, arrowColor);
+                                else
+                                    EditorGlyphs.DrawArrowRight(arrowRect, arrowColor);
                             }
                         }
                     }

--- a/Source/Editor/GUI/Timeline/Track.cs
+++ b/Source/Editor/GUI/Timeline/Track.cs
@@ -970,7 +970,11 @@ namespace FlaxEditor.GUI.Timeline
             // Draw arrow
             if (CanExpand)
             {
-                Render2D.DrawSprite(_opened ? style.ArrowDown : style.ArrowRight, ArrowRect, isMouseOver ? style.Foreground : style.ForegroundGrey);
+                var arrowColor = isMouseOver ? style.Foreground : style.ForegroundGrey;
+                if (_opened)
+                    EditorGlyphs.DrawArrowDown(ArrowRect, arrowColor);
+                else
+                    EditorGlyphs.DrawArrowRight(ArrowRect, arrowColor);
             }
 
             // Draw icon

--- a/Source/Editor/GUI/Tree/TreeNode.cs
+++ b/Source/Editor/GUI/Tree/TreeNode.cs
@@ -714,7 +714,11 @@ namespace FlaxEditor.GUI.Tree
             // Draw arrow
             if (HasAnyVisibleChild)
             {
-                Render2D.DrawSprite(_opened ? style.ArrowDown : style.ArrowRight, ArrowRect, _mouseOverHeader ? style.Foreground : style.ForegroundGrey);
+                var arrowColor = _mouseOverHeader ? style.Foreground : style.ForegroundGrey;
+                if (_opened)
+                    EditorGlyphs.DrawArrowDown(ArrowRect, arrowColor);
+                else
+                    EditorGlyphs.DrawArrowRight(ArrowRect, arrowColor);
             }
 
             // Draw icon

--- a/Source/Editor/Options/OptionsModule.cs
+++ b/Source/Editor/Options/OptionsModule.cs
@@ -129,10 +129,13 @@ namespace FlaxEditor.Options
 
                     float prevInterfaceScale = Options.Interface.InterfaceScale;
                     Options = options;
-                    OnOptionsChanged();
 
-                    // Scale interface relative to the current value (eg. when using system-provided Dpi Scale)
+                    // Scale interface relative to the current value (eg. when using system-provided Dpi Scale).
+                    // Apply this before OnOptionsChanged so newly created fonts get rasterized at the target DPI scale (avoids blurry text).
                     Platform.CustomDpiScale *= Options.Interface.InterfaceScale / prevInterfaceScale;
+                    Font.SetGlobalScale(Platform.DpiScale);
+
+                    OnOptionsChanged();
                 }
                 else
                 {

--- a/Source/Editor/Surface/Archetypes/Animation.StateMachine.cs
+++ b/Source/Editor/Surface/Archetypes/Animation.StateMachine.cs
@@ -1110,7 +1110,7 @@ namespace FlaxEditor.Surface.Archetypes
                 Render2D.DrawText(style.FontLarge, Title, _textRect, style.Foreground, TextAlignment.Center, TextAlignment.Center);
 
                 // Close button
-                Render2D.DrawSprite(style.Cross, _closeButtonRect, _closeButtonRect.Contains(_mousePosition) ? style.Foreground : style.ForegroundGrey);
+                EditorGlyphs.DrawCross(_closeButtonRect, _closeButtonRect.Contains(_mousePosition) ? style.Foreground : style.ForegroundGrey);
 
                 // Debug outline
                 if (_debugActive)

--- a/Source/Engine/Render2D/Font.cpp
+++ b/Source/Engine/Render2D/Font.cpp
@@ -3,11 +3,32 @@
 #include "Font.h"
 #include "FontAsset.h"
 #include "FontManager.h"
+#include "Engine/Content/Content.h"
 #include "Engine/Core/Log.h"
 #include "Engine/Threading/Threading.h"
 #include "IncludeFreeType.h"
 
 Array<AssetReference<FontAsset>, HeapAllocation> Font::FallbackFonts;
+
+float Font::GetGlobalScale()
+{
+    return FontManager::FontScale;
+}
+
+void Font::SetGlobalScale(float scale)
+{
+    if (scale <= 0.0f || Math::NearEqual(FontManager::FontScale, scale))
+        return;
+    FontManager::FontScale = scale;
+    // Invalidate all loaded font assets so cached glyphs are re-rasterized and Font metrics are recomputed at the new scale
+    auto assets = Content::GetAssets<FontAsset>();
+    for (auto* asset : assets)
+    {
+        if (asset)
+            asset->Invalidate();
+    }
+    FontManager::Flush();
+}
 
 Font::Font(FontAsset* parentAsset, float size)
     : ManagedScriptingObject(SpawnParams(Guid::New(), Font::TypeInitializer))

--- a/Source/Engine/Render2D/Font.h
+++ b/Source/Engine/Render2D/Font.h
@@ -262,6 +262,18 @@ public:
     API_FIELD() static Array<AssetReference<FontAsset>, HeapAllocation> FallbackFonts;
 
     /// <summary>
+    /// Gets the global font scaling factor used to rasterize font glyphs at higher resolutions (eg. for high-DPI displays or UI scaling).
+    /// </summary>
+    API_PROPERTY() static float GetGlobalScale();
+
+    /// <summary>
+    /// Sets the global font scaling factor used to rasterize font glyphs at higher resolutions (eg. for high-DPI displays or UI scaling).
+    /// Calling this rebuilds the cached glyphs and metrics of every loaded font so text rendered afterwards stays crisp at the new scale.
+    /// </summary>
+    /// <param name="scale">The new font scale (must be greater than 0).</param>
+    API_FUNCTION() static void SetGlobalScale(float scale);
+
+    /// <summary>
     /// Gets parent font asset that contains font family used by this font.
     /// </summary>
     API_PROPERTY() FORCE_INLINE FontAsset* GetAsset() const


### PR DESCRIPTION
Fix for blurry text when Scaling Interface.
Set scale on 2.0 to better see difference after image compression, but issue present on all scales expect default 1.0

Very in need for those who has 2k+ screens or even on Full HD (like me) feels interface small.
Problems were Platform.CustomDpiScale did not applied after FontManager::FontScale rasterizing.
As for Arrows, those were taken from Sprite Sheet, which was 12 x 12 initially. Either to implement Unity vector images or use Arrows as Chars (default approach for most apps).