### PR TITLE
"Run Cooked Game" settings fixed

### DIFF
--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -844,6 +844,7 @@ namespace FlaxEditor.Windows
         private string _postBuildAction;
         private BuildPreset[] _data;
         private bool _isDataDirty, _exitOnBuildEnd, _lastBuildFailed;
+        private QueueItem? _lastBuilt = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GameCookerWindow"/> class.
@@ -1011,20 +1012,19 @@ namespace FlaxEditor.Windows
         public void RunCooked()
         {
             Editor.Log("Running cooked build");
-            GameCooker.GetCurrentPlatform(out var platform, out var buildPlatform, out _);
+            if (_lastBuilt == null)
+            {
+                Editor.LogError("No cooked build found");
+                return;
+            }
             var numberOfClients = Editor.Options.Options.Interface.NumberOfGameClientsToLaunch;
-            var buildConfig = Editor.Options.Options.Interface.CookAndRunBuildConfiguration;
             for (int i = 0; i < numberOfClients; i++)
             {
                 _buildingQueue.Enqueue(new QueueItem
                 {
-                    Target = new BuildTarget
-                    {
-                        Output = _buildTabProxy.PerPlatformOptions[platform].Output,
-                        Platform = buildPlatform,
-                        Mode = buildConfig,
-                    },
+                    Target = _lastBuilt?.Target,
                     Options = BuildOptions.AutoRun | BuildOptions.NoCook,
+                    PresetName = _lastBuilt?.PresetName,
                 });
             }
         }
@@ -1305,6 +1305,10 @@ namespace FlaxEditor.Windows
                     {
                         _exitOnBuildEnd = false;
                         Engine.RequestExit(1);
+                    }
+                    if (!failed)
+                    {
+                        _lastBuilt = item;
                     }
                 }
                 else if (_exitOnBuildEnd)

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -1000,9 +1000,23 @@ namespace FlaxEditor.Windows
         public void BuildAndRun()
         {
             Editor.Log("Building and running");
-            GameCooker.GetCurrentPlatform(out var platform, out var buildPlatform, out _);
+            if (_lastBuilt == null)
+            {
+                GameCooker.GetCurrentPlatform(out var platform, out var buildPlatform, out _);
+                var buildConfig = Editor.Options.Options.Interface.CookAndRunBuildConfiguration;
+
+                _lastBuilt = new QueueItem()
+                {
+                    Target = new BuildTarget()
+                    {
+                        Output = _buildTabProxy.PerPlatformOptions[platform].Output,
+                        Platform = buildPlatform,
+                        Mode = buildConfig,
+                    },
+                    Options = BuildOptions.AutoRun,
+                };
+            }
             var numberOfClients = Editor.Options.Options.Interface.NumberOfGameClientsToLaunch;
-            var buildConfig = Editor.Options.Options.Interface.CookAndRunBuildConfiguration;
             for (int i = 0; i < numberOfClients; i++)
             {
                 var buildOptions = BuildOptions.AutoRun;
@@ -1011,13 +1025,9 @@ namespace FlaxEditor.Windows
 
                 _buildingQueue.Enqueue(new QueueItem
                 {
-                    Target = new BuildTarget
-                    {
-                        Output = _buildTabProxy.PerPlatformOptions[platform].Output,
-                        Platform = buildPlatform,
-                        Mode = buildConfig,
-                    },
+                    Target = _lastBuilt?.Target,
                     Options = buildOptions,
+                    PresetName = _lastBuilt?.PresetName,
                 });
             }
         }

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -1023,7 +1023,7 @@ namespace FlaxEditor.Windows
         }
 
         /// <summary>
-        /// Runs the cooked game for this platform on this device.
+        /// Runs the cooked game from the last build.
         /// </summary>
         public void RunCooked()
         {

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -995,7 +995,8 @@ namespace FlaxEditor.Windows
         }
 
         /// <summary>
-        /// Builds the target for this platform and runs it on this device.
+        /// Builds the target with last used build settings if exists. Otherwise builds for this platform.
+        /// Runs the build on this device after build completes.
         /// </summary>
         public void BuildAndRun()
         {

--- a/Source/Editor/Windows/GameCookerWindow.cs
+++ b/Source/Editor/Windows/GameCookerWindow.cs
@@ -63,7 +63,13 @@ namespace FlaxEditor.Windows
                 foreach (var e in PerPlatformOptions)
                 {
                     var str = e.Key.ToString();
-                    e.Value.Init("Output/" + str, str);
+                    e.Value.Init("Output/" + str, str, (target) =>
+                    {
+                        GameCookerWin._lastBuilt = new QueueItem() {
+                            Target = target,
+                            Options = BuildOptions.None,
+                        };
+                    });
                 }
             }
 
@@ -90,6 +96,8 @@ namespace FlaxEditor.Windows
 
                 protected abstract BuildPlatform BuildPlatform { get; }
 
+                private Action<BuildTarget> OnBuild = delegate { };
+
                 protected virtual BuildOptions Options
                 {
                     get
@@ -101,7 +109,7 @@ namespace FlaxEditor.Windows
                     }
                 }
 
-                public virtual void Init(string output, string platformDataSubDir)
+                public virtual void Init(string output, string platformDataSubDir, Action<BuildTarget> onBuild)
                 {
                     Output = output;
 
@@ -152,6 +160,8 @@ namespace FlaxEditor.Windows
 
                     // Check if can find installed tools for this platform
                     IsAvailable = Directory.Exists(Path.Combine(Globals.StartupFolder, "Source", "Platforms", platformDataSubDir, "Binaries"));
+
+                    OnBuild = onBuild;
                 }
 
                 public virtual void OnNotAvailableLayout(LayoutElementsContainer layout)
@@ -207,6 +217,12 @@ namespace FlaxEditor.Windows
                 {
                     var output = StringUtils.ConvertRelativePathToAbsolute(Globals.ProjectFolder, StringUtils.NormalizePath(Output));
                     GameCooker.Build(BuildPlatform, ConfigurationMode, output, Options, CustomDefines);
+                    OnBuild?.Invoke(new BuildTarget() {
+                        Platform = BuildPlatform,
+                        Mode = ConfigurationMode,
+                        Output = output,
+                        CustomDefines = CustomDefines
+                    });
                 }
             }
 


### PR DESCRIPTION
Fixes #4192 

I've added a private variable to track last build's settings. The data from that variable is then used for RunCooked and BuildAndRun functions.

**Behavior quirks**

Since the last save data is saved in a variable restarting the editor will reset it. RunCooked function prints error in console in that case.

BuildAndRun defaults to this platform's build settings in case if during current session there was no build done.

**Possible changes**

Not sure if saving last build settings is needed between sessions. If it is needed, I would appreciate guidance on how it might be done.

In the Cooker Window build function is inside Platform class. I've decided to add an Action to indicate build button press event instead of adding GameCookerWindow variable. Not sure how fitting this solution is.