### PR TITLE
Add a new option when entering play mode to always restore to the editor window after exiting play mode.

### DIFF
--- a/Source/Editor/Modules/SimulationModule.cs
+++ b/Source/Editor/Modules/SimulationModule.cs
@@ -287,6 +287,7 @@ namespace FlaxEditor.Modules
                 case Options.InterfaceOptions.PlayModeFocus.None: break;
 
                 case Options.InterfaceOptions.PlayModeFocus.GameWindow:
+                case Options.InterfaceOptions.PlayModeFocus.GameWindowThenRestoreEditor:    
                     gameWin.FocusGameViewport();
                     break;
 
@@ -319,6 +320,11 @@ namespace FlaxEditor.Modules
                             break;
                         _previousWindow.Focus();
                     }
+                    break;
+                case Options.InterfaceOptions.PlayModeFocus.GameWindowThenRestoreEditor:
+                    var editorWin = Editor.Windows.EditWin;
+                    if (editorWin != null && !editorWin.IsDisposing)
+                        editorWin.Focus();
                     break;
                 }
             }

--- a/Source/Editor/Options/InterfaceOptions.cs
+++ b/Source/Editor/Options/InterfaceOptions.cs
@@ -179,6 +179,11 @@ namespace FlaxEditor.Options
             /// Focus the Game Window. On play mode end restore focus to the previous window.
             /// </summary>
             GameWindowThenRestore,
+            
+            /// <summary>
+            /// Focus the Game Window. On play mode end restore focus to the editor window.
+            /// </summary>
+            GameWindowThenRestoreEditor
         }
 
         /// <summary>
@@ -520,9 +525,9 @@ namespace FlaxEditor.Options
         /// <summary>
         /// Gets or sets a value indicating what panel should be focused when play mode start.
         /// </summary>
-        [DefaultValue(PlayModeFocus.GameWindow)]
+        [DefaultValue(PlayModeFocus.GameWindowThenRestoreEditor)]
         [EditorDisplay("Play In-Editor", "Focus On Play"), EditorOrder(500), Tooltip("Set what panel to focus on play mode start.")]
-        public PlayModeFocus FocusOnPlayMode { get; set; } = PlayModeFocus.GameWindow;
+        public PlayModeFocus FocusOnPlayMode { get; set; } = PlayModeFocus.GameWindowThenRestoreEditor;
 
         /// <summary>
         /// Gets or sets a value indicating what action should be taken upon pressing the play button.

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -147,21 +147,27 @@ namespace FlaxEditor.Windows
             new PlayModeFocusOptions
             {
                 Name = "None",
-                Tooltip = "Don't change focus.",
+                Tooltip = "Don't change window focus when entering play mode.",
                 FocusOption = InterfaceOptions.PlayModeFocus.None,
             },
             new PlayModeFocusOptions
             {
                 Name = "Game Window",
-                Tooltip = "Focus the Game Window.",
+                Tooltip = "Focus the Game Window when entering play mode.",
                 FocusOption = InterfaceOptions.PlayModeFocus.GameWindow,
             },
             new PlayModeFocusOptions
             {
                 Name = "Game Window Then Restore",
-                Tooltip = "Focus the Game Window. On play mode end restore focus to the previous window.",
+                Tooltip = "Focus the Game Window when entering play mode. Restore focus to the previous window when exiting play mode.",
                 FocusOption = InterfaceOptions.PlayModeFocus.GameWindowThenRestore,
             },
+            new PlayModeFocusOptions
+            {
+                Name = "Game Window Then Restore Editor",
+                Tooltip = "Focus the Game Window when entering play mode and then restore the focus to the editor window when exiting play mode.",
+                FocusOption = InterfaceOptions.PlayModeFocus.GameWindowThenRestoreEditor
+            }
         };
 
         /// <summary>


### PR DESCRIPTION
Also made it the default option on new projects as it is the most likely expected behavior of the engine. I have seen it trip many many people up in the Discord.