### PR TITLE
Disable eye adaptation and motion blur by default

### DIFF
--- a/Source/Engine/Graphics/Enums.h
+++ b/Source/Engine/Graphics/Enums.h
@@ -1152,7 +1152,7 @@ API_ENUM(Attributes="Flags") enum class ViewFlags : uint64
     /// <summary>
     /// Default flags for materials/models previews generating.
     /// </summary>
-    DefaultAssetPreview = Reflections | Decals | DirectionalLights | PointLights | SpotLights | SkyLights | SpecularLight | AntiAliasing | Bloom | ToneMapping | EyeAdaptation | CameraArtifacts | LensFlares | ContactShadows | Sky | Particles,
+    DefaultAssetPreview = Reflections | Decals | DirectionalLights | PointLights | SpotLights | SkyLights | SpecularLight | AntiAliasing | Bloom | ToneMapping | CameraArtifacts | LensFlares | ContactShadows | Sky | Particles,
 
     /// <summary>
     /// All flags enabled.

--- a/Source/Engine/Graphics/PostProcessSettings.h
+++ b/Source/Engine/Graphics/PostProcessSettings.h
@@ -986,7 +986,7 @@ API_STRUCT() struct FLAXENGINE_API EyeAdaptationSettings : ISerializable
     /// The effect rendering mode used for the exposure processing.
     /// </summary>
     API_FIELD(Attributes="EditorOrder(0), PostProcessSetting((int)EyeAdaptationSettingsOverride.Mode)")
-    EyeAdaptationMode Mode = EyeAdaptationMode::AutomaticHistogram;
+    EyeAdaptationMode Mode = EyeAdaptationMode::None;
 
     /// <summary>
     /// The speed at which the exposure changes when the scene brightness moves from a dark area to a bright area (brightness goes up).
@@ -1616,7 +1616,7 @@ API_STRUCT() struct FLAXENGINE_API MotionBlurSettings : ISerializable
     /// If checked, the motion blur effect will be rendered.
     /// </summary>
     API_FIELD(Attributes="EditorOrder(0), PostProcessSetting((int)MotionBlurSettingsOverride.Enabled)")
-    bool Enabled = true;
+    bool Enabled = false;
 
     /// <summary>
     /// The blur effect strength. A value of 0 disables it, while higher values increase the effect.


### PR DESCRIPTION
This PR disables the two effects mentioned by default. This is based on discussions in the Discord. Disabling the eye adaptation by default was a very popular choice. Disabling the motion blur received some upvotes as well, some being from core devs - so I included it as well. 