### PR TITLE
Fix terrain patch add mode not picking patches in scaled terrain

### DIFF
--- a/Source/Editor/Tools/Terrain/TerrainTools.cpp
+++ b/Source/Editor/Tools/Terrain/TerrainTools.cpp
@@ -21,7 +21,7 @@ bool TerrainTools::TryGetPatchCoordToAdd(Terrain* terrain, const Ray& ray, Int2&
 {
     CHECK_RETURN(terrain, true);
     result = Int2::Zero;
-    const float patchSize = terrain->GetChunkSize() * TERRAIN_UNITS_PER_VERTEX * Terrain::ChunksCountEdge;
+    const auto patchSize = terrain->GetChunkSize() * TERRAIN_UNITS_PER_VERTEX * Terrain::ChunksCountEdge * terrain->GetScale();
 
     // Try to pick any of the patch edges
     for (int32 patchIndex = 0; patchIndex < terrain->GetPatchesCount(); patchIndex++)
@@ -36,7 +36,7 @@ bool TerrainTools::TryGetPatchCoordToAdd(Terrain* terrain, const Ray& ray, Int2&
 #define CHECK_EDGE(dx, dz) \
 			if (terrain->GetPatch(x + dx, z + dz) == nullptr) \
 			{ \
-				if (bounds.MakeOffsetted(Vector3(patchSize * dx, 0, patchSize * dz)).Intersects(ray)) \
+				if (bounds.MakeOffsetted(Vector3(patchSize.X * dx, 0, patchSize.Z * dz)).Intersects(ray)) \
 				{ \
 					result = Int2(x + dx, z + dz); \
 					return true; \


### PR DESCRIPTION
The ray casts in terrain patch mode did not account for the scaled terrain properly, making it hard to add new patches to any scaled terrain actors.