### PR TITLE
Quick fix to make the infinite grid infinite.

### DIFF
--- a/Source/Shaders/Editor/Grid.shader
+++ b/Source/Shaders/Editor/Grid.shader
@@ -44,6 +44,7 @@ META_VS_IN_ELEMENT(POSITION, 0, R32G32B32_FLOAT, 0, ALIGN, PER_VERTEX, 0, true)
 VertexOutput VS_Grid(ModelInput input)
 {
     VertexOutput output;
+    input.Position.xyz += float3(ViewPos.x, 0, ViewPos.z);
     output.WorldPosition = input.Position.xyz + ViewOrigin;
     float3 geoPosition = input.Position.xyz - float3(0, ViewOrigin.y, 0);
     output.Position = mul(float4(geoPosition, 1), ViewProjectionMatrix);


### PR DESCRIPTION
Realized that the infinite grid was in-fact not infinite. This adds some positional offsets to the vertex shader that should alleviate that. Closes #3876 