### PR TITLE
Added 'Expand Children' Setting To Horizontal/Vertical Panels

### DIFF
--- a/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/HorizontalPanel.cs
@@ -44,6 +44,11 @@ namespace FlaxEngine.GUI
             float h = Height - _margin.Height;
             float maxHeight = h;
             bool hasAnyLeft = false, hasAnyRight = false;
+
+            float totalGaps = (_children.Count - 1) * Spacing;
+            float availableWidth = Width - totalGaps - LeftMargin - RightMargin;
+            float itemWidth = availableWidth / _children.Count;
+
             for (int i = 0; i < _children.Count; i++)
             {
                 Control c = _children[i];
@@ -64,6 +69,11 @@ namespace FlaxEngine.GUI
                         hasAnyRight = true;
                     }
                     maxHeight = Mathf.Max(maxHeight, ch);
+
+                    if (ExpandChildren)
+                    {
+                        c.Width = itemWidth;                       
+                    }
                 }
             }
             if (hasAnyLeft)

--- a/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
+++ b/Source/Engine/UI/GUI/Panels/PanelWithMargins.cs
@@ -161,6 +161,12 @@ namespace FlaxEngine.GUI
         public bool ControlChildSize { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the value indicating whenever the panel can resize children controls (eg. auto-fit width/height).
+        /// </summary>
+        [EditorOrder(36), DefaultValue(false), Tooltip("If checked, the panel will expand all children in the relevant direction with even spacing and size. (Horizontally for Horizontal Panel, Vertically for Vertical Panel).")]
+        public bool ExpandChildren { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the panel area margin.
         /// </summary>
         [EditorOrder(40), Tooltip("The panel area margin.")]

--- a/Source/Engine/UI/GUI/Panels/VerticalPanel.cs
+++ b/Source/Engine/UI/GUI/Panels/VerticalPanel.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Wojciech Figat. All rights reserved.
 
+using System.Globalization;
+
 namespace FlaxEngine.GUI
 {
     /// <summary>
@@ -44,6 +46,11 @@ namespace FlaxEngine.GUI
             float w = Width - _margin.Width;
             float maxWidth = w;
             bool hasAnyTop = false, hasAnyBottom = false;
+
+            float totalGaps = (_children.Count - 1) * Spacing;
+            float availableHeight = Height - totalGaps - TopMargin - BottomMargin;
+            float itemHeight = availableHeight / _children.Count;
+
             for (int i = 0; i < _children.Count; i++)
             {
                 Control c = _children[i];
@@ -64,6 +71,11 @@ namespace FlaxEngine.GUI
                         hasAnyBottom = true;
                     }
                     maxWidth = Mathf.Max(maxWidth, cw);
+
+                    if (ExpandChildren)
+                    {
+                        c.Height = itemHeight;                       
+                    }
                 }
             }
             if (hasAnyTop)


### PR DESCRIPTION
Noticed there's no way to quickly layout children in Horizontal/Vertical panels in their respective directions (Horizontally for Horizontal Panels and Vertically for Vertical). This PR adds a new "Expand Children" setting that adds this with respect to the margins and spacing between items. 

https://github.com/user-attachments/assets/afde63d6-b0a6-4103-af13-a5b0d39e20c7

Would be open to changing the setting, perhaps making it a sub-setting of `ControlChildSize`.
