### PR TITLE
Add ASTC texture compression support on Linux

### DIFF
--- a/Source/ThirdParty/astc/astc.Build.cs
+++ b/Source/ThirdParty/astc/astc.Build.cs
@@ -19,6 +19,8 @@ public class astc : EngineDepsModule
             return true;
         case TargetPlatform.Mac:
             return options.Architecture == TargetArchitecture.ARM64;
+        case TargetPlatform.Linux:
+            return options.Architecture == TargetArchitecture.x64;
         default:
             return false;
         }

--- a/Source/Tools/Flax.Build/Deps/Dependencies/astc.cs
+++ b/Source/Tools/Flax.Build/Deps/Dependencies/astc.cs
@@ -28,6 +28,11 @@ namespace Flax.Deps.Dependencies
                     {
                         TargetPlatform.Mac,
                     };
+                case TargetPlatform.Linux:
+                    return new[]
+                    {
+                        TargetPlatform.Linux,
+                    };
                 default: return new TargetPlatform[0];
                 }
             }
@@ -51,6 +56,11 @@ namespace Flax.Deps.Dependencies
                     {
                         TargetArchitecture.x64,
                         TargetArchitecture.ARM64,
+                    };
+                case TargetPlatform.Linux:
+                    return new[]
+                    {
+                        TargetArchitecture.x64,
                     };
                 default: return new TargetArchitecture[0];
                 }
@@ -95,6 +105,18 @@ namespace Flax.Deps.Dependencies
                         var lib = architecture == TargetArchitecture.ARM64 ? "libastcenc-neon-static.a" : "libastcenc-sse2-static.a";
                         SetupDirectory(buildDir, true);
                         RunCmake(buildDir, platform, architecture, ".. -DCMAKE_BUILD_TYPE=Release -DASTCENC_UNIVERSAL_BUILD=OFF -DASTCENC_UNIVERSAL_BINARY=OFF -DASTCENC_INVARIANCE=OFF " + isa);
+                        BuildCmake(buildDir);
+                        var depsFolder = GetThirdPartyFolder(options, platform, architecture);
+                        Utilities.FileCopy(Path.Combine(buildDir, "Source", lib), Path.Combine(depsFolder, "libastcenc.a"));
+                        break;
+                    }
+                    case TargetPlatform.Linux:
+                    {
+                        string buildDir = Path.Combine(root, "build-" + architecture);
+                        var isa = architecture == TargetArchitecture.ARM64 ? "-DASTCENC_ISA_NEON=ON" : "-DASTCENC_ISA_SSE2=ON";
+                        var lib = architecture == TargetArchitecture.ARM64 ? "libastcenc-neon-static.a" : "libastcenc-sse2-static.a";
+                        SetupDirectory(buildDir, true);
+                        RunCmake(buildDir, platform, architecture, ".. -DCMAKE_BUILD_TYPE=Release -DASTCENC_CLI=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON " + isa);
                         BuildCmake(buildDir);
                         var depsFolder = GetThirdPartyFolder(options, platform, architecture);
                         Utilities.FileCopy(Path.Combine(buildDir, "Source", lib), Path.Combine(depsFolder, "libastcenc.a"));


### PR DESCRIPTION
Enables COMPILE_WITH_ASTC on Linux x64 so the editor can cook ASTC textures, which Android builds require.

The dep build follows the existing Mac case, since both produce a static .a archive

Differences for Linux:

- Drops the Apple-only universal build flags
  (ASTCENC_UNIVERSAL_BUILD/UNIVERSAL_BINARY/INVARIANCE).
- Adds ASTCENC_CLI=OFF, as the Windows case already does, so only the library is built.
- Adds CMAKE_POSITION_INDEPENDENT_CODE=ON, required because the archive is linked into a shared editor module.
- Registers x64 only