### PR TITLE
SDL: Fix double platform event handling on Windows

### DIFF
--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -174,7 +174,7 @@ int32 Engine::OnInit(const Char* cmdLine)
     return 0;
 }
 
-void Engine::OnLoop()
+void Engine::OnLoop(bool handleEvents)
 {
     // Reduce CPU usage by introducing idle time if the engine is running very fast and has enough time to spend
     const bool useSleep = !PLATFORM_WEB; // TODO: this should probably be a platform setting
@@ -214,7 +214,8 @@ void Engine::OnLoop()
     // Update application (will gather data and other platform related events)
     {
         PROFILE_CPU_NAMED("Platform.Tick");
-        Platform::Tick();
+        if (handleEvents)
+            Platform::Tick();
 #if COMPILE_WITH_PROFILER
         extern void TickProfilerMemory();
         TickProfilerMemory();

--- a/Source/Engine/Engine/Engine.h
+++ b/Source/Engine/Engine/Engine.h
@@ -14,7 +14,6 @@ class JsonAsset;
 /// </summary>
 API_CLASS(Static) class FLAXENGINE_API Engine
 {
-    friend class PlatformMain;
     DECLARE_SCRIPTING_TYPE_NO_SPAWN(Engine);
 
 public:
@@ -136,6 +135,13 @@ public:
 
 public:
     /// <summary>
+    /// The main engine loop called in <see cref="Main"/>.
+    /// This may be called while main thread is blocked on some platforms.
+    /// </summary>
+    /// <param name="handleEvents">True if platform events should be handled.</param>
+    static void OnLoop(bool handleEvents = true);
+
+    /// <summary>
     /// Fixed update callback used by the physics simulation (fixed stepping).
     /// </summary>
     static void OnFixedUpdate();
@@ -217,7 +223,6 @@ public:
 
 private:
     static int32 OnInit(const Char* cmdLine);
-    static void OnLoop();
     static void OnPause();
     static void OnUnpause();
 };

--- a/Source/Engine/Platform/Base/DragDropHelper.h
+++ b/Source/Engine/Platform/Base/DragDropHelper.h
@@ -35,6 +35,10 @@ public:
         Scripting::GetScriptsDomain()->Dispatch();
         while (Platform::AtomicRead(&ExitFlag) == 0)
         {
+            // TODO: The engine loop can't be called here due to some services like ObjectsRemovalService needs to be run on main thread.
+            //if (!Engine::ShouldExit())
+            //    Engine::OnLoop(false);
+            
 #if USE_EDITOR
             // Flush any single-frame shapes to prevent memory leaking (eg. via terrain collision debug during scene drawing with PhysicsColliders or PhysicsDebug flag)
             DebugDraw::UpdateContext(nullptr, 0.0f);

--- a/Source/Engine/Platform/SDL/SDLPlatform.Linux.cpp
+++ b/Source/Engine/Platform/SDL/SDLPlatform.Linux.cpp
@@ -706,6 +706,10 @@ DragDropEffect Window::DoDragDropWayland(const StringView& data, Window* dragSou
 
     while (Platform::AtomicRead(&WaylandImpl::DragOverFlag) == 0)
     {
+        // TODO: Refactor the same way as in Windows EventFilterCallback
+        //if (!Engine::ShouldExit())
+        //    Engine::OnLoop();
+
         SDLPlatform::Tick();
         Engine::OnUpdate(); // For docking updates
         Engine::OnDraw();

--- a/Source/Engine/Platform/SDL/SDLPlatform.Mac.cpp
+++ b/Source/Engine/Platform/SDL/SDLPlatform.Mac.cpp
@@ -84,6 +84,13 @@ bool SDLPlatform::UsesX11()
 
 bool SDLPlatform::EventFilterCallback(void* userdata, SDL_Event* event)
 {
+    // TODO: Refactor the same way as in Windows EventFilterCallback
+    /*if (event->type == SDL_EVENT_WINDOW_EXPOSED)
+    {
+        if (!Engine::ShouldExit())
+            Engine::OnLoop();
+    }*/
+
     Window* draggedWindow = *(Window**)userdata;
     if (draggedWindow == nullptr)
     {

--- a/Source/Engine/Platform/SDL/SDLPlatform.Windows.cpp
+++ b/Source/Engine/Platform/SDL/SDLPlatform.Windows.cpp
@@ -45,9 +45,6 @@ bool SDLCALL SDLPlatform::EventMessageHook(void* userdata, MSG* msg)
         bool result = false;
         WindowHitCodes hit = static_cast<WindowHitCodes>(msg->wParam);
         window->OnHitTest(mousePosition, hit, result);
-        //if (result && hit != WindowHitCodes::Caption)
-        //    return false;
-
         if (hit == WindowHitCodes::Caption)
         {
             SDL_Event event{ 0 };
@@ -79,6 +76,15 @@ bool SDLPlatform::InitInternal()
 
 bool SDLPlatform::EventFilterCallback(void* userdata, SDL_Event* event)
 {
+    if (event->type == SDL_EVENT_WINDOW_EXPOSED)
+    {
+        // Keep the engine running, the exposed event is sent while in modal loop
+        // during window dragging or resize operations.
+        if (!Engine::ShouldExit())
+            Engine::OnLoop(false);
+        return true;
+    }
+
     Window* draggedWindow = *(Window**)userdata;
     if (draggedWindow == nullptr)
         return true;
@@ -86,31 +92,19 @@ bool SDLPlatform::EventFilterCallback(void* userdata, SDL_Event* event)
     // When the window is being dragged on Windows, the internal message loop is blocking
     // the SDL event queue. We need to handle all relevant events in this event watch callback
     // to ensure dragging related functionality doesn't break due to engine not getting updated.
-    // This also happens to fix the engine freezing during the dragging operation.
-
     SDLWindow* window = SDLWindow::GetWindowFromEvent(*event);
-    if (event->type == SDL_EVENT_WINDOW_EXPOSED)
+    if (window != nullptr)
     {
-        // The internal timer is sending exposed events every ~16ms
-        Engine::OnUpdate(); // For docking updates
-        Engine::OnDraw();
-        return false;
-    }
-    else if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN)
-    {
-        if (window)
+        if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN)
         {
             bool result = false;
             window->OnLeftButtonHit(WindowHitCodes::Caption, result);
             //if (result)
             //    return false;
             window->HandleEvent(*event);
+            return false;
         }
-        return false;
-    }
-    else if (event->type == SDL_EVENT_WINDOW_MOVED)
-    {
-        if (window)
+        else if (event->type == SDL_EVENT_WINDOW_MOVED)
         {
             window->HandleEvent(*event);
 
@@ -134,13 +128,12 @@ bool SDLPlatform::EventFilterCallback(void* userdata, SDL_Event* event)
             mouseMovedEvent.motion.x = mousePosition.X;
             mouseMovedEvent.motion.y = mousePosition.Y;
             window->HandleEvent(mouseMovedEvent);
+            return false;
         }
-        return false;
-    }
-    if (window)
         window->HandleEvent(*event);
+    }
     
-    return false;
+    return true;
 }
 
 void SDLPlatform::PreHandleEvents()

--- a/Source/Engine/Platform/SDL/SDLWindow.cpp
+++ b/Source/Engine/Platform/SDL/SDLWindow.cpp
@@ -320,10 +320,9 @@ WindowHitCodes SDLWindow::OnWindowHit(const Float2 point)
         OnHitTest(screenPosition, hit, handled);
         if (!handled)
         {
-            int margin = _settings.HasBorder ? 0 : 0;
+            // Handle native window decoration hit tests here
+            int margin = _settings.HasBorder ? 0 : 0; // Some platforms may also extend the margin outside the window edges
             auto size = GetClientSize();
-            //if (point.Y < 0)
-            //    hit = WindowHitCodes::Caption;
             if (point.Y < margin && point.X < margin)
                 hit = WindowHitCodes::TopLeft;
             else if (point.Y < margin && point.X > size.X - margin)

--- a/Source/Engine/Platform/Windows/WindowsPlatform.cpp
+++ b/Source/Engine/Platform/Windows/WindowsPlatform.cpp
@@ -841,7 +841,6 @@ void WindowsPlatform::Tick()
 {
 #if !PLATFORM_SDL
     WindowsInput::Update();
-#endif
 
     // Check to see if any messages are waiting in the queue
     MSG msg;
@@ -851,6 +850,7 @@ void WindowsPlatform::Tick()
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }
+#endif
 }
 
 void WindowsPlatform::BeforeExit()


### PR DESCRIPTION
Fixes inconsistent window dragging on Windows and possibly any other window event related issue due to two event loops racing for window events.