### PR TITLE
Fix unsafe `StringView` of managed string

### DIFF
--- a/Source/Engine/Platform/SDL/SDLPlatform.Linux.cpp
+++ b/Source/Engine/Platform/SDL/SDLPlatform.Linux.cpp
@@ -203,8 +203,11 @@ namespace WaylandImpl
             if (inputData->GetType() == IGuiData::Type::Text)
             {
                 UnixFile file(fd);
-                StringAnsi text = StringAnsi(inputData->GetAsText());
-                file.Write(text.Get(), text.Length() * sizeof(StringAnsi::CharType));
+                if (StringUtils::Compare(mime_type, "text/plain;charset=utf-8") == 0)
+                {
+                    StringAnsi text = StringAnsi(inputData->GetAsText());
+                    file.Write(text.Get(), text.Length() * sizeof(StringAnsi::CharType));
+                }
                 file.Close();
             }
         },
@@ -212,8 +215,7 @@ namespace WaylandImpl
         {
             // Clipboard: other application has replaced the content in clipboad
             wl_data_source_destroy(source);
-            
-            IGuiData* inputData = static_cast<IGuiData*>(data);
+
             Platform::AtomicStore(&WaylandImpl::DragOverFlag, 1);
         },
         [](void* data, wl_data_source* source) { }, // DnD drop performed event
@@ -222,7 +224,6 @@ namespace WaylandImpl
             // The destination has finally accepted the last given dnd_action
             wl_data_source_destroy(source);
 
-            IGuiData* inputData = static_cast<IGuiData*>(data);
             Platform::AtomicStore(&WaylandImpl::DragOverFlag, 1);
         },
         [](void* data, wl_data_source* source, uint32_t dnd_action) { }, // Action event
@@ -294,7 +295,7 @@ namespace WaylandImpl
                 wl_data_source_set_actions(dataSource, WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE | WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY);
             }
             LinuxDropTextData textData;
-            textData.Text = *DraggingData;
+            textData.Text = DraggingData;
             wl_data_source_add_listener(dataSource, &DataSourceListener, &textData);
 
             auto draggedWindow = Window->GetSDLWindow();
@@ -369,7 +370,7 @@ namespace WaylandImpl
                 wl_event_queue_destroy(WaylandQueue);
                 WaylandQueue = nullptr;
             }*/
-
+            
             return false;
         }
     };
@@ -688,7 +689,7 @@ DragDropEffect Window::DoDragDropWayland(const StringView& data, Window* dragSou
     }
     
     WaylandImpl::DraggingActive = true;
-    WaylandImpl::DraggingData = StringView(data.Get(), data.Length());
+    WaylandImpl::DraggingData = data;
     WaylandImpl::DragOverFlag = 0;
 
     auto task = New<WaylandImpl::DragDropJob>();

--- a/Source/Engine/Scripting/ManagedCLR/MUtils.cpp
+++ b/Source/Engine/Scripting/ManagedCLR/MUtils.cpp
@@ -41,11 +41,11 @@ namespace
     }
 }
 
-StringView MUtils::ToString(MString* str)
+String MUtils::ToString(MString* str)
 {
     if (str == nullptr)
         return StringView::Empty;
-    return MCore::String::GetChars(str);
+    return String(MCore::String::GetChars(str));
 }
 
 StringAnsi MUtils::ToStringAnsi(MString* str)

--- a/Source/Engine/Scripting/ManagedCLR/MUtils.h
+++ b/Source/Engine/Scripting/ManagedCLR/MUtils.h
@@ -20,7 +20,7 @@ class BitArray;
 
 namespace MUtils
 {
-    extern FLAXENGINE_API StringView ToString(MString* str);
+    extern FLAXENGINE_API String ToString(MString* str);
     extern FLAXENGINE_API StringAnsi ToStringAnsi(MString* str);
     extern FLAXENGINE_API void ToString(MString* str, String& result);
     extern FLAXENGINE_API void ToString(MString* str, StringView& result);


### PR DESCRIPTION
Accessing pinned managed string data is unsafe after pinning is over, but runtime doesn't necessarily move the data immediately, so it remains alive for a short time but (hopefully) long enough for us to make a unmanaged copy of the string. During long Wayland drag'and'drop operations, the original string data passed from managed runtime was more likely to not remain valid which often lead to crashes. 