### PR TITLE
Add `Start/EndTextInput` for control to toggle character input events

### DIFF
--- a/Source/Editor/Content/GUI/ContentView.cs
+++ b/Source/Editor/Content/GUI/ContentView.cs
@@ -674,6 +674,20 @@ namespace FlaxEditor.Content.GUI
         }
 
         /// <inheritdoc />
+        public override void OnGotFocus()
+        {
+            StartTextInput();
+            base.OnGotFocus();
+        }
+
+        /// <inheritdoc />
+        public override void OnLostFocus()
+        {
+            EndTextInput();
+            base.OnLostFocus();
+        }
+
+        /// <inheritdoc />
         public override bool OnMouseDown(Float2 location, MouseButton button)
         {
             if (base.OnMouseDown(location, button))

--- a/Source/Editor/GUI/ContextMenu/ContextMenu.cs
+++ b/Source/Editor/GUI/ContextMenu/ContextMenu.cs
@@ -442,6 +442,20 @@ namespace FlaxEditor.GUI.ContextMenu
         }
 
         /// <inheritdoc />
+        protected override void OnShow()
+        {
+            StartTextInput();
+            base.OnShow();
+        }
+
+        /// <inheritdoc />
+        protected override void OnHide()
+        {
+            EndTextInput();
+            base.OnHide();
+        }
+
+        /// <inheritdoc />
         public override bool OnCharInput(char c)
         {
             if (base.OnCharInput(c))

--- a/Source/Editor/Surface/VisjectSurface.Input.cs
+++ b/Source/Editor/Surface/VisjectSurface.Input.cs
@@ -401,6 +401,13 @@ namespace FlaxEditor.Surface
             base.OnMouseMove(location);
             CustomMouseMove?.Invoke(ref location);
         }
+        
+        /// <inheritdoc />
+        public override void OnGotFocus()
+        {
+            StartTextInput();
+            base.OnGotFocus();
+        }
 
         /// <inheritdoc />
         public override void OnLostFocus()
@@ -423,6 +430,7 @@ namespace FlaxEditor.Surface
             }
             _isMovingSelection = false;
             ConnectingEnd(null);
+            EndTextInput();
 
             base.OnLostFocus();
         }
@@ -834,7 +842,7 @@ namespace FlaxEditor.Surface
 
             return true;
         }
-
+        
         /// <inheritdoc />
         public override bool OnCharInput(char c)
         {

--- a/Source/Editor/Windows/OutputLogWindow.cs
+++ b/Source/Editor/Windows/OutputLogWindow.cs
@@ -144,7 +144,19 @@ namespace FlaxEditor.Windows
                 {
                     rect = new Rectangle(2, 0, Width - 4, Height);
                 }
+                
+                public override void OnGotFocus()
+                {
+                    StartTextInput();
+                    base.OnGotFocus();
+                }
 
+                public override void OnLostFocus()
+                {
+                    EndTextInput();
+                    base.OnLostFocus();
+                }
+                
                 public override bool OnCharInput(char c)
                 {
                     if (Owner != null && (!Owner._searchPopup?.Visible ?? true))

--- a/Source/Engine/Platform/Base/WindowBase.h
+++ b/Source/Engine/Platform/Base/WindowBase.h
@@ -43,6 +43,7 @@ protected:
     Rectangle _mouseOffsetScreenSize;
     bool _isUsingMouseOffset = false;
     bool _isTrackingMouse = false;
+    bool _isTextInputEnabled = false;
     bool _isHorizontalFlippingMouse = false;
     bool _isVerticalFlippingMouse = false;
     bool _isClippingCursor = false;
@@ -493,6 +494,20 @@ public:
     /// Ends the mouse tracking.
     /// </summary>
     API_FUNCTION() virtual void EndTrackingMouse()
+    {
+    }
+    
+    /// <summary>
+    /// Enables character input events.
+    /// </summary>
+    API_FUNCTION() virtual void StartTextInput()
+    {
+    }
+    
+    /// <summary>
+    /// Disables character input events.
+    /// </summary>
+    API_FUNCTION() virtual void EndTextInput()
     {
     }
 

--- a/Source/Engine/Platform/SDL/SDLPlatform.cpp
+++ b/Source/Engine/Platform/SDL/SDLPlatform.cpp
@@ -157,8 +157,6 @@ bool SDLPlatform::Init()
 
     SDLImpl::SystemDpi = (int)(SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay()) * DefaultDPI);
 
-    //SDL_StartTextInput(); // TODO: Call this only when text input is expected (shows virtual keyboard in some cases)
-
     return SDLPlatformBase::Init();
 }
 

--- a/Source/Engine/Platform/SDL/SDLWindow.cpp
+++ b/Source/Engine/Platform/SDL/SDLWindow.cpp
@@ -298,7 +298,7 @@ SDLWindow::~SDLWindow()
 
     // The text input events seems to be controlled globally on macOS,
     // calling this for closing window seems to remove keyboard focus from other windows...
-#if !PLATFORM_MAC
+#if !PLATFORM_MAC // TODO: Verify if this is still needed
     if (_settings.AllowInput && SDL_TextInputActive(_window))
         SDL_StopTextInput(_window);
 #endif
@@ -514,7 +514,11 @@ void SDLWindow::HandleEvent(SDL_Event& event)
     case SDL_EVENT_WINDOW_FOCUS_GAINED:
     {
         OnGotFocus();
+#if PLATFORM_MAC // TODO: Verify if this is still needed
         if (_settings.AllowInput && !SDLPlatform::UsesX11())
+            SDL_StartTextInput(_window);
+#endif
+        if (_isTextInputEnabled)
             SDL_StartTextInput(_window);
         if (_isClippingCursor)
         {
@@ -537,7 +541,11 @@ void SDLWindow::HandleEvent(SDL_Event& event)
     }
     case SDL_EVENT_WINDOW_FOCUS_LOST:
     {
+#if PLATFORM_MAC // TODO: Verify if this is still needed
         if (_settings.AllowInput && !SDLPlatform::UsesX11())
+            SDL_StopTextInput(_window);
+#endif
+        if (_isTextInputEnabled)
             SDL_StopTextInput(_window);
         if (_isClippingCursor)
             SDL_SetWindowMouseRect(_window, nullptr);
@@ -908,6 +916,28 @@ void SDLWindow::EndTrackingMouse()
 
     Input::Mouse->SetRelativeMode(false, this);
     _restoreRelativeMode = false;
+}
+
+void SDLWindow::StartTextInput()
+{
+#if !PLATFORM_MAC // TODO: Verify if this is still needed
+    if (_isTextInputEnabled || !_settings.AllowInput || SDLPlatform::UsesX11())
+        return;
+    
+    _isTextInputEnabled = true;
+    SDL_StartTextInput(_window);
+#endif
+}
+
+void SDLWindow::EndTextInput()
+{
+#if !PLATFORM_MAC // TODO: Verify if this is still needed
+    if (!_isTextInputEnabled || !_settings.AllowInput || SDLPlatform::UsesX11())
+        return;
+    
+    _isTextInputEnabled = false;
+    SDL_StopTextInput(_window);
+#endif
 }
 
 void SDLWindow::StartClippingCursor(const Rectangle& bounds)

--- a/Source/Engine/Platform/SDL/SDLWindow.h
+++ b/Source/Engine/Platform/SDL/SDLWindow.h
@@ -103,6 +103,8 @@ public:
     DragDropEffect DoDragDrop(const StringView& data, const Float2& offset, Window* dragSourceWindow) override;
     void StartTrackingMouse(bool useMouseScreenOffset) override;
     void EndTrackingMouse() override;
+    void StartTextInput() override;
+    void EndTextInput() override;
     void StartClippingCursor(const Rectangle& bounds) override;
     void EndClippingCursor() override;
     void SetMousePosition(const Float2& position) const override;

--- a/Source/Engine/UI/GUI/CanvasRootControl.cs
+++ b/Source/Engine/UI/GUI/CanvasRootControl.cs
@@ -121,6 +121,20 @@ namespace FlaxEngine.GUI
         }
 
         /// <inheritdoc />
+        public override void StartTextInput()
+        {
+            var parent = Parent?.Root;
+            parent?.StartTextInput();
+        }
+
+        /// <inheritdoc />
+        public override void EndTextInput()
+        {
+            var parent = Parent?.Root;
+            parent?.EndTextInput();
+        }
+
+        /// <inheritdoc />
         public override bool GetKey(KeyboardKeys key)
         {
             return Input.GetKey(key);
@@ -292,6 +306,20 @@ namespace FlaxEngine.GUI
             {
                 heldTime = rateTime = 0;
             }
+        }
+        
+        /// <inheritdoc />
+        public override void OnGotFocus()
+        {
+            StartTextInput();
+            base.OnGotFocus();
+        }
+
+        /// <inheritdoc />
+        public override void OnLostFocus()
+        {
+            EndTextInput();
+            base.OnLostFocus();
         }
 
         /// <inheritdoc />

--- a/Source/Engine/UI/GUI/Common/TextBoxBase.cs
+++ b/Source/Engine/UI/GUI/Common/TextBoxBase.cs
@@ -1223,6 +1223,8 @@ namespace FlaxEngine.GUI
 
             if (IsReadOnly)
                 return;
+            
+            StartTextInput();
             OnEditBegin();
         }
 
@@ -1233,6 +1235,8 @@ namespace FlaxEngine.GUI
 
             if (IsReadOnly)
                 return;
+            
+            EndTextInput();
             OnEditEnd();
         }
 

--- a/Source/Engine/UI/GUI/Control.cs
+++ b/Source/Engine/UI/GUI/Control.cs
@@ -598,6 +598,26 @@ namespace FlaxEngine.GUI
         public virtual void OnEndMouseCapture()
         {
         }
+        
+        /// <summary>
+        /// Enables <see cref="OnCharInput"/> events.
+        /// </summary>
+        [NoAnimate]
+        public virtual void StartTextInput()
+        {
+            var parent = Root;
+            parent?.StartTextInput();
+        }
+        
+        /// <summary>
+        /// Disables <see cref="OnCharInput"/> events.
+        /// </summary>
+        [NoAnimate]
+        public virtual void EndTextInput()
+        {
+            var parent = Root;
+            parent?.EndTextInput();
+        }
 
         #endregion
 
@@ -853,8 +873,12 @@ namespace FlaxEngine.GUI
         #region Keyboard
 
         /// <summary>
-        /// On input character
+        /// On character input
         /// </summary>
+        /// <remarks>
+        /// Requires text input enabled in order to receive character input events.
+        /// See <see cref="StartTextInput"/>.
+        /// </remarks>
         /// <param name="c">Input character</param>
         /// <returns>True if event has been handled, otherwise false</returns>
         [NoAnimate]

--- a/Source/Engine/UI/GUI/WindowRootControl.cs
+++ b/Source/Engine/UI/GUI/WindowRootControl.cs
@@ -195,6 +195,18 @@ namespace FlaxEngine.GUI
                 _window.EndTrackingMouse();
             }
         }
+        
+        /// <inheritdoc />
+        public override void StartTextInput()
+        {
+            _window.StartTextInput();
+        }
+
+        /// <inheritdoc />
+        public override void EndTextInput()
+        {
+            _window.EndTextInput();
+        }
 
         /// <inheritdoc />
         public override bool GetKey(KeyboardKeys key)


### PR DESCRIPTION
Some platforms may show virtual keyboard popups when text input is expected (like in KDE Plasma's Wayland compositor), which may alter how the input is passed to the applications.

This PR tries to improve the support with virtual keyboard by requiring character input events to be explicitly enabled when the UI control expects text input from the user by toggling the events with `StartTextInput` and `EndTextInput` methods. When the text input mode is disabled, keyboard input is expected to be passed down to the controls and input events with no interference from any system virtual keyboards.

Fixes #4198.