### PR TITLE
Minor Visject fixes

### DIFF
--- a/Source/Editor/Surface/SurfaceNode.cs
+++ b/Source/Editor/Surface/SurfaceNode.cs
@@ -76,6 +76,11 @@ namespace FlaxEditor.Surface
         /// The footer rectangle (local space).
         /// </summary>
         protected Rectangle _footerRect;
+        
+        /// <summary>
+        /// The last mouse down position.
+        /// </summary>
+        protected Float2 _mouseDownMousePosition;
 
         /// <summary>
         /// The node archetype.
@@ -162,8 +167,6 @@ namespace FlaxEditor.Surface
         /// Gets the color of the header of the node.
         /// </summary>
         protected virtual Color ArchetypeColor => GroupArchetype.Color;
-
-        private Float2 mouseDownMousePosition;
 
         /// <summary>
         /// Calculates the size of the node including header, footer, and margins.
@@ -1166,10 +1169,9 @@ namespace FlaxEditor.Surface
             if (base.OnMouseDown(location, button))
                 return true;
 
+            _mouseDownMousePosition = location;
             if (button == MouseButton.Left && (Archetype.Flags & NodeFlags.NoCloseButton) == 0 && _closeButtonRect.Contains(ref location))
                 return true;
-            if (button == MouseButton.Right)
-                mouseDownMousePosition = Input.Mouse.Position;
 
             return false;
         }
@@ -1180,18 +1182,22 @@ namespace FlaxEditor.Surface
             if (base.OnMouseUp(location, button))
                 return true;
 
-            // Close/ delete
-            bool canDelete = !Surface.IsConnecting && !Surface.WasSelecting && !Surface.WasMovingSelection;
-            if (button == MouseButton.Left && canDelete && (Archetype.Flags & NodeFlags.NoCloseButton) == 0 && _closeButtonRect.Contains(ref location))
+            if (button == MouseButton.Left)
             {
-                Surface.Delete(this);
-                return true;
+                // Close/delete
+                bool canDelete = !Surface.IsConnecting && !Surface.WasSelecting && !Surface.WasMovingSelection;
+                if (canDelete && (Archetype.Flags & NodeFlags.NoCloseButton) == 0 &&
+                    _closeButtonRect.Contains(ref location) && _closeButtonRect.Contains(ref _mouseDownMousePosition))
+                {
+                    Surface.Delete(this);
+                    return true;
+                }
             }
 
             // Secondary Context Menu
             if (button == MouseButton.Right)
             {
-                float distance = Float2.Distance(mouseDownMousePosition, Input.Mouse.Position);
+                float distance = Float2.Distance(_mouseDownMousePosition, location);
                 if (distance > 2.5f)
                     return true;
 

--- a/Source/Editor/Surface/VisjectSurface.Connecting.cs
+++ b/Source/Editor/Surface/VisjectSurface.Connecting.cs
@@ -287,6 +287,7 @@ namespace FlaxEditor.Surface
 
             // Reset instigator list
             _connectionInstigators.Clear();
+            EndMouseCapture();
         }
     }
 }


### PR DESCRIPTION
- Fixes Visject nodes accidentally getting closed when selection or any other action involving left mouse button being held gets released over the close button.
- Fixes Visject box connection not ending the mouse capture properly, requiring extra mouse click on the window to make everything interactable again.