### PR TITLE
Try to improve scripting assembly file loading when file is locked

### DIFF
--- a/Source/Engine/Engine/NativeInterop.Unmanaged.cs
+++ b/Source/Engine/Engine/NativeInterop.Unmanaged.cs
@@ -901,20 +901,21 @@ namespace FlaxEngine.Interop
 
                 Assembly assembly;
 #if FLAX_EDITOR
-                // Load assembly from loaded bytes to prevent file locking in Editor
-                var assemblyBytes = File.ReadAllBytes(assemblyPath);
-                using MemoryStream stream = new MemoryStream(assemblyBytes);
+                // Load assembly with stream to prevent runtime from locking the assembly file
+                using FileStream stream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read);
                 var pdbPath = Path.ChangeExtension(assemblyPath, "pdb");
                 if (File.Exists(pdbPath))
                 {
                     // Load including debug symbols
-                    using FileStream pdbStream = new FileStream(Path.ChangeExtension(assemblyPath, "pdb"), FileMode.Open);
+                    using FileStream pdbStream = new FileStream(Path.ChangeExtension(assemblyPath, "pdb"), FileMode.Open, FileAccess.Read);
                     assembly = scriptingAssemblyLoadContext.LoadFromStream(stream, pdbStream);
                 }
                 else
                 {
                     assembly = scriptingAssemblyLoadContext.LoadFromStream(stream);
                 }
+
+                // TODO: Use new .NET 11 AssemblyLoadContext.SetAssemblyLocationOverride to specify correct Assembly.Location
 #else
                 // Load assembly from file
                 assembly = scriptingAssemblyLoadContext.LoadFromAssemblyPath(assemblyPath);


### PR DESCRIPTION
Trying a different file access mode to possibly fix #4143 #4183 in case another process has locked down the files from writing.