### PR TITLE
Editor Game Window fixes

### DIFF
--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -50,7 +50,7 @@ namespace FlaxEditor.GUI.Docking
         /// <summary>
         /// Gets a value indicating whether this window is docked.
         /// </summary>
-        public bool IsDocked => _dockedTo != null;
+        public bool IsDocked => _dockedTo != null && _dockedTo.TabsCount > 1;
 
         /// <summary>
         /// Gets a value indicating whether this window is selected.

--- a/Source/Editor/GUI/Docking/DockWindow.cs
+++ b/Source/Editor/GUI/Docking/DockWindow.cs
@@ -488,7 +488,7 @@ namespace FlaxEditor.GUI.Docking
             base.Focus();
 
             SelectTab(false);
-            BringToFront();
+            _dockedTo?.RootWindow?.Focus();
         }
 
         /// <inheritdoc />

--- a/Source/Editor/GUI/Docking/FloatWindowDockPanel.cs
+++ b/Source/Editor/GUI/Docking/FloatWindowDockPanel.cs
@@ -70,7 +70,7 @@ namespace FlaxEditor.GUI.Docking
         /// </summary>
         public bool ShowDecorations
         {
-            get;
+            get => field;
             set
             {
                 if (value == field)
@@ -88,7 +88,7 @@ namespace FlaxEditor.GUI.Docking
                         decorations.Dispose();
                 }
             }
-        } = false;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FloatWindowDockPanel"/> class.

--- a/Source/Editor/GUI/Docking/FloatWindowDockPanel.cs
+++ b/Source/Editor/GUI/Docking/FloatWindowDockPanel.cs
@@ -66,6 +66,31 @@ namespace FlaxEditor.GUI.Docking
         public bool IsDragging { get; internal set; }
 
         /// <summary>
+        /// Shows client-side window decorations around this panel.
+        /// </summary>
+        public bool ShowDecorations
+        {
+            get;
+            set
+            {
+                if (value == field)
+                    return;
+                field = value;
+                if (value)
+                {
+                    var decorations = Parent.AddChild(new FloatWindowDecorations(this));
+                    decorations.SetAnchorPreset(AnchorPresets.HorizontalStretchTop, false);
+                }
+                else
+                {
+                    var decorations = Parent.GetChild<FloatWindowDecorations>();
+                    if (decorations != null)
+                        decorations.Dispose();
+                }
+            }
+        } = false;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="FloatWindowDockPanel"/> class.
         /// </summary>
         /// <param name="masterPanel">The master panel.</param>
@@ -82,11 +107,7 @@ namespace FlaxEditor.GUI.Docking
             _window.Window.Closing += OnClosing;
             _window.Window.LeftButtonHit += OnLeftButtonHit;
 
-            if (Utilities.Utils.UseCustomWindowDecorations())
-            {
-                var decorations = Parent.AddChild(new FloatWindowDecorations(this));
-                decorations.SetAnchorPreset(AnchorPresets.HorizontalStretchTop, false);
-            }
+            ShowDecorations = Utilities.Utils.UseCustomWindowDecorations();
         }
 
         /// <inheritdoc />
@@ -94,13 +115,10 @@ namespace FlaxEditor.GUI.Docking
         {
             base.PerformLayoutBeforeChildren();
 
-            var decorations = Parent.GetChild<FloatWindowDecorations>();
-            if (decorations != null)
-            {
-                // Apply offset for the title bar
-                foreach (var child in Children)
-                    child.Bounds = child.Bounds with { Y = decorations.Height, Height = Parent.Height - decorations.Height };
-            }
+            // Apply offset for the title bar
+            var decorationsHeight = Parent.GetChild<FloatWindowDecorations>()?.Height ?? 0;
+            foreach (var child in Children)
+                child.Bounds = child.Bounds with { Y = decorationsHeight, Height = Parent.Height - decorationsHeight };
         }
 
         /// <summary>

--- a/Source/Editor/States/PlayingState.cs
+++ b/Source/Editor/States/PlayingState.cs
@@ -159,11 +159,11 @@ namespace FlaxEditor.States
             SceneDuplicated?.Invoke();
             RestoreSelection();
 
+            Time.Synchronize(true);
+
             Editor.OnPlayBegin();
             IsPlayModeStarting = false;
             Profiler.EndEvent();
-
-            Time.Synchronize(true);
         }
 
         private void SetupEditorEnvOptions()

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -300,6 +300,8 @@ namespace FlaxEditor.Windows
                     _maximizeRestoreDockTo = _dockedTo;
                     _maximizeRestoreDockToParent = _dockedTo.ParentDockPanel;
                     _maximizeRestoreDockState = _dockedTo.TryGetDockState(out _maximizeRestoreSplitterValue);
+                    if (_dockedTo.Tabs.Count > 1)
+                        _maximizeRestoreDockState = DockState.DockFill;
                     if (_maximizeRestoreDockState != GUI.Docking.DockState.Float)
                     {
                         var monitorBounds = Platform.GetMonitorBounds(PointToScreen(Size * 0.5f));

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -913,7 +913,7 @@ namespace FlaxEditor.Windows
         /// </summary>
         public void FocusGameViewport()
         {
-            if (!IsDocked)
+            if (ParentDockPanel == null)
             {
                 ShowFloating();
             }
@@ -1018,7 +1018,7 @@ namespace FlaxEditor.Windows
                     Screen.CursorVisible = true;
                 Screen.CursorLock = CursorLockMode.None;
 
-                if (Editor.IsPlayMode && IsDocked && IsSelected && RootWindow.FocusedControl == null)
+                if (Editor.IsPlayMode && ParentDockPanel != null && IsSelected && RootWindow.FocusedControl == null)
                 {
                     // Game UI cleared focus so regain it to maintain UI navigation just like game window does
                     FlaxEngine.Scripting.InvokeOnUpdate(Focus);

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -133,6 +133,8 @@ namespace FlaxEditor.Windows
         private float _gameStartTime;
         private GUI.Docking.DockState _maximizeRestoreDockState;
         private GUI.Docking.DockPanel _maximizeRestoreDockTo;
+        private GUI.Docking.DockPanel _maximizeRestoreDockToParent;
+        private float _maximizeRestoreSplitterValue;
         private CursorLockMode _cursorLockMode = CursorLockMode.None;
 
         // Viewport scaling variables
@@ -296,7 +298,8 @@ namespace FlaxEditor.Windows
                 if (value)
                 {
                     _maximizeRestoreDockTo = _dockedTo;
-                    _maximizeRestoreDockState = _dockedTo.TryGetDockState(out _);
+                    _maximizeRestoreDockToParent = _dockedTo.ParentDockPanel;
+                    _maximizeRestoreDockState = _dockedTo.TryGetDockState(out _maximizeRestoreSplitterValue);
                     if (_maximizeRestoreDockState != GUI.Docking.DockState.Float)
                     {
                         var monitorBounds = Platform.GetMonitorBounds(PointToScreen(Size * 0.5f));
@@ -312,9 +315,9 @@ namespace FlaxEditor.Windows
                         rootWindow.Restore();
                     var dockTo = _maximizeRestoreDockTo;
                     if (dockTo != null && dockTo.IsDisposing)
-                        dockTo = null;
+                        dockTo = _maximizeRestoreDockToParent;
                     if (_dockedTo != dockTo)
-                        Show(_maximizeRestoreDockState, dockTo);
+                        Show(_maximizeRestoreDockState, dockTo, splitterValue: _maximizeRestoreSplitterValue);
                 }
             }
         }

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Xml;
 using FlaxEditor.Gizmo;
 using FlaxEditor.GUI.ContextMenu;
+using FlaxEditor.GUI.Docking;
 using FlaxEditor.GUI.Input;
 using FlaxEditor.Modules;
 using FlaxEditor.Options;
@@ -331,6 +332,9 @@ namespace FlaxEditor.Windows
                 {
                     IsFloating = true;
                     var rootWindow = RootWindow;
+                    var floatWin = rootWindow.GetChild<FloatWindowDockPanel>();
+                    if (floatWin != null && floatWin.ShowDecorations)
+                        floatWin.ShowDecorations = false;
                     var monitorBounds = Platform.GetMonitorBounds(rootWindow.RootWindow.Window.ClientPosition);
                     rootWindow.Window.Position = monitorBounds.Location;
                     rootWindow.Window.SetBorderless(true);
@@ -338,6 +342,9 @@ namespace FlaxEditor.Windows
                 }
                 else
                 {
+                    var floatWin = RootWindow.GetChild<FloatWindowDockPanel>();
+                    if (floatWin != null && !floatWin.ShowDecorations && Utilities.Utils.UseCustomWindowDecorations())
+                        floatWin.ShowDecorations = true;
                     IsFloating = false;
                 }
             }

--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -310,9 +310,11 @@ namespace FlaxEditor.Windows
                     // Restore
                     if (rootWindow != null)
                         rootWindow.Restore();
-                    if (_maximizeRestoreDockTo != null && _maximizeRestoreDockTo.IsDisposing)
-                        _maximizeRestoreDockTo = null;
-                    Show(_maximizeRestoreDockState, _maximizeRestoreDockTo);
+                    var dockTo = _maximizeRestoreDockTo;
+                    if (dockTo != null && dockTo.IsDisposing)
+                        dockTo = null;
+                    if (_dockedTo != dockTo)
+                        Show(_maximizeRestoreDockState, dockTo);
                 }
             }
         }


### PR DESCRIPTION
This PR contains few fixes related to Editor's default Game Window mode behavior when set to either maximized or borderless modes:
- Fixes client-side decorations on borderless floating Game Window when entering play mode
- Fixes already floating Game Window from resetting window position when leaving play mode (+ ensures already floating Game Window receives input focus)
- Fixes Game Window from getting restored back to split panels or as a tabbed window when placed in any other dock panels in the Editor
- Fixes `Time.GameTime` not getting reset before Editor `OnPlayBegin` events are called (fixes persisting unlock hint text and glowing borders in Game Window)