### PR TITLE
Fix headless editor & Roslyn analyzer include resolution

### DIFF
--- a/Source/Editor/Windows/GameWindow.cs
+++ b/Source/Editor/Windows/GameWindow.cs
@@ -672,9 +672,10 @@ namespace FlaxEditor.Windows
             IsBorderless = false;
             Cursor = CursorType.Default;
             Screen.CursorLock = CursorLockMode.None;
-            if (Screen.MainWindow.IsMouseTracking)
-                Screen.MainWindow.EndTrackingMouse();
-            RootControl.GameRoot.EndMouseCapture();
+            var mainWindow = Screen.MainWindow;
+            if (mainWindow != null && mainWindow.IsMouseTracking)
+                mainWindow.EndTrackingMouse();
+            RootControl.GameRoot?.EndMouseCapture();
         }
 
         /// <inheritdoc />

--- a/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudio/CSSDKProjectGenerator.cs
@@ -330,9 +330,7 @@ namespace Flax.Build.Projects.VisualStudio
             foreach (var analyzer in configuration.TargetBuildOptions.ScriptingAPI.Analyzers)
             {
                 csProjectFileContent.AppendLine(string.Format("  <ItemGroup Condition=\" '$(Configuration)|$(Platform)' == '{0}' \">", configuration.Name));
-                csProjectFileContent.AppendLine(string.Format("    <Analyzer Include=\"{0}\">", Path.GetFileNameWithoutExtension(analyzer)));
-                csProjectFileContent.AppendLine(string.Format("      <HintPath>{0}</HintPath>", Utilities.MakePathRelativeTo(analyzer, projectDirectory).Replace('/', '\\')));
-                csProjectFileContent.AppendLine("    </Analyzer>");
+                csProjectFileContent.AppendLine(string.Format("    <Analyzer Include=\"{0}\" />", Utilities.MakePathRelativeTo(analyzer, projectDirectory).Replace('/', '\\')));
                 csProjectFileContent.AppendLine("  </ItemGroup>");
             }
 


### PR DESCRIPTION
1) Headless runs have no main window and no game root, so leaving play mode would throw and abort the state transition, leaving the editor stuck in `PlayingState` with its update loop broken.

2) Analyzer items are resolved straight from `Include`. `HintPath` is only honoured on `Reference`, so naming the analyzer there left the IDE and `dotnet` build silently without any analyzer loaded.