### PR TITLE
Bump default C++ standard version to C++17

### DIFF
--- a/Source/Tools/Flax.Build/Build/NativeCpp/CompileEnvironment.cs
+++ b/Source/Tools/Flax.Build/Build/NativeCpp/CompileEnvironment.cs
@@ -143,7 +143,7 @@ namespace Flax.Build.NativeCpp
         /// <summary>
         /// C++ standard version to use for compilation.
         /// </summary>
-        public CppVersion CppVersion = CppVersion.Cpp14;
+        public CppVersion CppVersion = CppVersion.Cpp17;
 
         /// <summary>
         /// Selects a predefined set of options that affect the size and speed of generated code.

--- a/Source/Tools/Flax.Build/Platforms/Apple/AppleToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Apple/AppleToolchain.cs
@@ -113,10 +113,10 @@ namespace Flax.Build.Platforms
                     commonArgs.Add("-std=c++14");
                     break;
                 case CppVersion.Cpp17:
-                case CppVersion.Latest:
                     commonArgs.Add("-std=c++17");
                     break;
                 case CppVersion.Cpp20:
+                case CppVersion.Latest:
                     commonArgs.Add("-std=c++20");
                     break;
                 }

--- a/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Unix/UnixToolchain.cs
@@ -427,10 +427,10 @@ namespace Flax.Build.Platforms
                         args.Add("-std=c++14");
                         break;
                     case CppVersion.Cpp17:
-                    case CppVersion.Latest:
                         args.Add("-std=c++17");
                         break;
                     case CppVersion.Cpp20:
+                    case CppVersion.Latest:
                         args.Add("-std=c++20");
                         break;
                     }

--- a/Source/Tools/Flax.Build/Platforms/Web/WebToolchain.cs
+++ b/Source/Tools/Flax.Build/Platforms/Web/WebToolchain.cs
@@ -248,10 +248,10 @@ namespace Flax.Build.Platforms
                         args.Add("-std=c++14");
                         break;
                     case CppVersion.Cpp17:
-                    case CppVersion.Latest:
                         args.Add("-std=c++17");
                         break;
                     case CppVersion.Cpp20:
+                    case CppVersion.Latest:
                         args.Add("-std=c++20");
                         break;
                     }

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -586,11 +586,11 @@ namespace Flax.Build.Projects.VisualStudioCode
                         json.AddField("cppStandard", "c++14");
                         break;
                     case NativeCpp.CppVersion.Cpp17:
-                    case NativeCpp.CppVersion.Latest:
                         json.AddField("cStandard", "c17");
                         json.AddField("cppStandard", "c++17");
                         break;
                     case NativeCpp.CppVersion.Cpp20:
+                    case NativeCpp.CppVersion.Latest:
                         json.AddField("cStandard", "c17");
                         json.AddField("cppStandard", "c++20");
                         break;

--- a/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
+++ b/Source/Tools/Flax.Build/Projects/VisualStudioCode/VisualStudioCodeProjectGenerator.cs
@@ -545,7 +545,7 @@ namespace Flax.Build.Projects.VisualStudioCode
                     var architecture = TargetArchitecture.x64;
 
                     var compilerPath = string.Empty;
-                    var cppVersion = NativeCpp.CppVersion.Cpp14;
+                    var cppVersion = NativeCpp.CppVersion.Cpp17;
                     var includePaths = new HashSet<string>();
                     var preprocessorDefinitions = new HashSet<string>();
                     foreach (var e in mainProject.Defines)


### PR DESCRIPTION
Required by latest versions of Assimp and basis_universal for C++17 features.