### PR TITLE
Fix mesh collider updates after recooking collision data

### DIFF
--- a/Source/Engine/Physics/Colliders/MeshCollider.cpp
+++ b/Source/Engine/Physics/Colliders/MeshCollider.cpp
@@ -3,6 +3,7 @@
 #include "MeshCollider.h"
 #include "Engine/Core/Math/Matrix.h"
 #include "Engine/Core/Math/Ray.h"
+#include "Engine/Core/ScopeExit.h"
 #include "Engine/Physics/Physics.h"
 #include "Engine/Physics/PhysicsScene.h"
 #if USE_EDITOR || !BUILD_RELEASE
@@ -22,19 +23,29 @@ void MeshCollider::OnCollisionDataChanged()
 
     if (CollisionData)
     {
+        _isChangingCollisionData = true;
+        SCOPE_EXIT { _isChangingCollisionData = false; };
+
         // Ensure that collision asset is loaded (otherwise objects might fall though collider that is not yet loaded on play begin)
-        CollisionData->WaitForLoaded();
+        // OnSet sends Loaded after Changed returns, so let that notification update the collider once.
+        if (!CollisionData->WaitForLoaded())
+            return;
     }
 
+    // Clearing the reference or failing to load won't send Loaded, so clear the old geometry here.
     UpdateGeometry();
     UpdateBounds();
 }
 
 void MeshCollider::OnCollisionDataLoaded()
 {
-    // Not needed as OnCollisionDataChanged waits for it to be loaded
-    //UpdateGeometry();
-    //UpdateBounds();
+    // WaitForLoaded can dispatch Loaded while Changed is still waiting. OnSet will send it again afterwards.
+    if (_isChangingCollisionData)
+        return;
+
+    // Virtual collision data can be recooked without changing the asset reference.
+    UpdateGeometry();
+    UpdateBounds();
 }
 
 bool MeshCollider::CanAttach(RigidBody* rigidBody) const

--- a/Source/Engine/Physics/Colliders/MeshCollider.h
+++ b/Source/Engine/Physics/Colliders/MeshCollider.h
@@ -23,6 +23,8 @@ public:
     AssetReference<CollisionData> CollisionData;
 
 private:
+    bool _isChangingCollisionData = false;
+
     void OnCollisionDataChanged();
     void OnCollisionDataLoaded();
 


### PR DESCRIPTION
Re-cooking a virtual `CollisionData` leaves existing `MeshCollider`s using the old physics geometry and cached bounds because the loaded callback does not refresh them.

Refresh geometry and bounds on `Loaded`. During a reference change, wait for loading and let the final `Loaded` notification perform the refresh. Suppress notifications dispatched synchronously inside `WaitForLoaded()` to avoid duplicate updates, and keep the `Changed` fallback for cleared references or failed loads.

Fixes #4248.

Validation:
- Built the Windows x64 Development native test target with .NET 9 and MSVC v144.
- Local native suite passed: 27 test cases and 377,723 assertions, including regression coverage for shared collision assets, triangle and convex meshes, repeated recooking, transforms, ray hits, update counts, cleared references, and failed loads.
- Validation was performed on the local checkout based on `9943959e7` with this fix and local regression tests. Those test files are not included in this PR; the PR contains only `MeshCollider.h` and `MeshCollider.cpp`.